### PR TITLE
Clickable PR links and details in Deploys tab

### DIFF
--- a/core/viewer/app.js
+++ b/core/viewer/app.js
@@ -11136,7 +11136,11 @@ function renderAdminDeploys(commits, container) {
     html += '<div class="adm-deploy-row">';
     html += '<div class="adm-deploy-status"><span class="adm-deploy-badge ' + statusClass + '">' + escAdm(statusLabel) + '</span></div>';
     html += '<div class="adm-deploy-info">';
-    html += '<div class="adm-deploy-msg">' + escAdm(c.message || "(no message)") + '</div>';
+    if (c.pr_number) {
+      html += '<div class="adm-deploy-msg"><a href="https://github.com/SamWatson86/echo-chamber/pull/' + c.pr_number + '" target="_blank" class="adm-deploy-link">' + escAdm(c.message || "(no message)") + '</a></div>';
+    } else {
+      html += '<div class="adm-deploy-msg">' + escAdm(c.message || "(no message)") + '</div>';
+    }
     html += '<div class="adm-deploy-meta">';
     html += '<span class="adm-deploy-sha">' + escAdm(c.short_sha || c.sha || "") + '</span>';
     html += '<span class="adm-deploy-author">' + escAdm(c.author || "unknown") + '</span>';
@@ -11146,6 +11150,11 @@ function renderAdminDeploys(commits, container) {
     }
     if (c.deploy_error) {
       html += '<div class="adm-deploy-err">' + escAdm(c.deploy_error) + '</div>';
+    }
+    if (c.body) {
+      var bodyId = 'deploy-body-' + escAdm(c.short_sha || c.sha || "");
+      html += '<span class="adm-deploy-toggle" onclick="var el=document.getElementById(\'' + bodyId + '\');el.classList.toggle(\'hidden\');this.textContent=el.classList.contains(\'hidden\')?\'\u25B6 Details\':\'\u25BC Details\'">&#9654; Details</span>';
+      html += '<pre class="adm-deploy-body hidden" id="' + bodyId + '">' + escAdm(c.body) + '</pre>';
     }
     html += '</div></div></div>';
   });

--- a/core/viewer/style.css
+++ b/core/viewer/style.css
@@ -4516,6 +4516,7 @@ body.admin-mode .room-top {
 .adm-deploy-failed { background: rgba(214,87,87,0.2); color: #d65757; }
 .adm-deploy-rollback { background: rgba(201,184,62,0.2); color: #c9b83e; }
 .adm-deploy-pending { background: rgba(255,255,255,0.08); color: rgba(255,255,255,0.5); }
+.adm-deploy-historical { background: rgba(255,255,255,0.04); color: rgba(255,255,255,0.25); font-style: italic; }
 .adm-deploy-info { flex: 1; min-width: 0; }
 .adm-deploy-msg { font-size: 12px; color: rgba(255,255,255,0.9); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; margin-bottom: 3px; }
 .adm-deploy-meta { display: flex; flex-wrap: wrap; gap: 8px; font-size: 11px; color: rgba(255,255,255,0.4); align-items: center; }
@@ -4523,3 +4524,9 @@ body.admin-mode .room-top {
 .adm-deploy-author { color: rgba(255,255,255,0.55); }
 .adm-deploy-dur { color: rgba(255,255,255,0.35); }
 .adm-deploy-err { margin-top: 4px; font-size: 11px; color: #d65757; background: rgba(214,87,87,0.08); padding: 4px 8px; border-radius: 4px; }
+.adm-deploy-link { color: #7eb8ff; text-decoration: none; }
+.adm-deploy-link:hover { text-decoration: underline; color: #a8d4ff; }
+.adm-deploy-toggle { cursor: pointer; color: rgba(255,255,255,0.45); font-size: 11px; margin-left: 8px; user-select: none; }
+.adm-deploy-toggle:hover { color: rgba(255,255,255,0.75); }
+.adm-deploy-body { margin-top: 6px; font-size: 11px; color: rgba(255,255,255,0.6); background: rgba(255,255,255,0.04); padding: 8px 10px; border-radius: 4px; white-space: pre-wrap; word-break: break-word; font-family: monospace; max-height: 200px; overflow-y: auto; }
+.adm-deploy-body.hidden { display: none; }


### PR DESCRIPTION
## Summary
- Merge commits in the Deploys tab now link directly to their GitHub PR
- Expandable "Details" toggle shows the full PR description/body
- Git log parsing uses null-byte record separator to handle multi-line commit bodies

## Test plan
- [ ] Open admin Deploys tab
- [ ] Verify merge commits show as clickable blue links
- [ ] Click a merge commit to open the PR on GitHub
- [ ] Click "Details" toggle to expand/collapse PR description

🤖 Generated with [Claude Code](https://claude.com/claude-code)