### PR TITLE
feat: expand admin dashboard to 30 days + persist quality stats

### DIFF
--- a/core/viewer/app.js
+++ b/core/viewer/app.js
@@ -10826,14 +10826,14 @@ function renderAdminDashboard() {
         heatmap[dateKey][hour] = (heatmap[dateKey][hour] || 0) + 1;
       }
     });
-    var heatDays = Object.keys(_admHeatmapUsers).sort().slice(-7);
+    var heatDays = Object.keys(_admHeatmapUsers).sort().slice(-30);
     var heatMax = 1;
     heatDays.forEach(function(dk) {
       if (!heatmap[dk]) return;
       Object.keys(heatmap[dk]).forEach(function(h) { if (heatmap[dk][h] > heatMax) heatMax = heatmap[dk][h]; });
     });
 
-    html += '<div class="adm-section"><div class="adm-section-title">Activity Heatmap (7d)</div>';
+    html += '<div class="adm-section"><div class="adm-section-title">Activity Heatmap (30d)</div>';
     if (_admSelectedUser) {
       html += '<div style="margin-bottom:8px;"><button class="adm-show-all-btn" onclick="_admSelectUser(null)">Show All</button> Filtered: <strong>' + escAdm(_admSelectedUser) + '</strong></div>';
     }


### PR DESCRIPTION
## Summary
- **History tab**: expanded from 2 days to 30 days of session data, with event limit raised from 200 to 1000
- **Heatmap**: expanded from 7 days to 30 days (both Rust endpoint and JS slice/title)
- **Quality stats persistence**: `StatsSnapshot` now written to daily `stats-YYYY-MM-DD.json` files alongside session logs. The `admin_metrics` endpoint reads from 30 days of files + in-memory data with dedup, so quality data survives server restarts

## Test plan
- [x] `cargo build -p echo-core-control` passes
- [x] `cargo test -p echo-core-control` passes
- [ ] History tab shows events back to Feb 12
- [ ] Heatmap shows 30 days of data
- [ ] Quality stats persist across server restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)