### PR TITLE
feat: dashboard visible to all connected users

### DIFF
--- a/core/viewer/app.js
+++ b/core/viewer/app.js
@@ -8040,6 +8040,9 @@ async function connectToRoom({ controlUrl, sfuUrl, roomId, identity, name, reuse
     currentRoomName = roomId;
   }
   setPublishButtonsEnabled(true);
+  // Show dashboard button for all connected users
+  var dashBtn = document.getElementById("open-admin-dash");
+  if (dashBtn) dashBtn.classList.remove("hidden");
   reconcileLocalPublishIndicators("post-connect");
   if (reuseAdmin && micEnabled) {
     // Room switch: mic was already on, re-enable immediately without permission dance
@@ -8421,6 +8424,10 @@ async function disconnect() {
   connectPanel.classList.remove("hidden");
   startOnlineUsersPolling();
   setPublishButtonsEnabled(false);
+  // Hide dashboard button and close panel on disconnect
+  var dashBtn = document.getElementById("open-admin-dash");
+  if (dashBtn) dashBtn.classList.add("hidden");
+  if (_adminDashOpen) toggleAdminDash();
   micEnabled = false;
   camEnabled = false;
   screenEnabled = false;

--- a/core/viewer/index.html
+++ b/core/viewer/index.html
@@ -77,7 +77,7 @@
           </div>
           <div id="jam-banner" class="jam-banner hidden"></div>
           <div class="room-actions">
-            <button id="open-admin-dash" type="button" class="admin-only hidden" onclick="toggleAdminDash()">Admin</button>
+            <button id="open-admin-dash" type="button" class="hidden" onclick="toggleAdminDash()">Dashboard</button>
             <button id="open-settings" type="button" disabled>Settings</button>
             <button id="open-bug-report" type="button" class="bug-report-btn" disabled>Report Bug</button>
             <button id="disconnect-top" type="button" disabled>Disconnect</button>
@@ -328,10 +328,10 @@
           <div id="jam-status" class="jam-status"></div>
         </div>
       </div>
-      <!-- Admin Dashboard Panel (admin-only) -->
-      <div id="admin-dash-panel" class="admin-only hidden admin-dash-panel">
+      <!-- Dashboard Panel (visible to all connected users) -->
+      <div id="admin-dash-panel" class="hidden admin-dash-panel">
         <div class="admin-dash-header">
-          <h3>Admin Dashboard</h3>
+          <h3>Dashboard</h3>
           <button type="button" class="admin-dash-close" onclick="toggleAdminDash()">&times;</button>
         </div>
         <div class="admin-dash-tabs">

--- a/docs/plans/2026-02-25-dashboard-for-all-users-design.md
+++ b/docs/plans/2026-02-25-dashboard-for-all-users-design.md
@@ -1,0 +1,59 @@
+# Dashboard for All Users — Design
+
+**Date**: 2026-02-25
+**Status**: Approved
+
+## Goal
+
+Make the admin dashboard visible to all connected users (Sam's friends) in the regular Tauri client, without requiring admin credentials. Admin-only actions (kick/mute) stay restricted.
+
+## Current State
+
+- Admin dashboard exists in two forms:
+  1. Standalone browser page at `/admin` (password login)
+  2. In-app panel in the Tauri client, gated behind `__ECHO_ADMIN__` flag (admin-client build only)
+- All `/admin/api/*` endpoints require admin JWT via `ensure_admin()`
+- Regular Tauri client hides all `admin-only` CSS class elements
+- Friends currently have zero visibility into dashboard data
+
+## Design
+
+### New Viewer-Level API Endpoints (Rust)
+
+Create `/v1/dashboard/*` endpoints that mirror `/admin/api/*` but use participant auth:
+
+| New Endpoint | Mirrors | Auth |
+|---|---|---|
+| `GET /v1/dashboard/live` | `/admin/api/dashboard` | Participant JWT |
+| `GET /v1/dashboard/sessions` | `/admin/api/sessions` | Participant JWT |
+| `GET /v1/dashboard/metrics` | `/admin/api/metrics` | Participant JWT |
+| `GET /v1/dashboard/bugs` | `/admin/api/bugs` | Participant JWT |
+| `GET /v1/dashboard/deploys` | `/admin/api/deploys` | Participant JWT |
+| `POST /v1/dashboard/stats` | `/admin/api/stats` | Participant JWT |
+
+Implementation: Each new handler calls the same internal logic as the admin handler, but uses `ensure_participant()` for auth instead of `ensure_admin()`.
+
+### Participant Auth (Rust)
+
+Add `ensure_participant()` function — validates that the request has a valid LiveKit-compatible JWT token (the same token every connected user already has from the `/v1/token` endpoint). This proves the caller is a connected user without requiring admin credentials.
+
+### Client-Side Changes (app.js)
+
+1. Remove `isAdminMode()` gate on the dashboard panel — show to all users
+2. Dashboard API calls use `/v1/dashboard/*` endpoints (participant JWT, no admin token needed)
+3. Kick/mute buttons remain gated behind `isAdminMode()` (admin-client only)
+4. Dashboard button visible in the main toolbar for all users
+
+### What Does NOT Change
+
+- Admin kick/mute requires admin JWT (no change)
+- Standalone `/admin` browser page (no change)
+- `/admin/api/*` endpoints (no change)
+- Tauri client binary (no rebuild — viewer loads from server)
+
+## Security
+
+- Read-only data exposure to authenticated participants only
+- No admin actions exposed
+- Server is private (friends-only) — no public access concern
+- Participant JWT already validated by LiveKit token format

--- a/docs/plans/2026-02-25-dashboard-for-all-users-plan.md
+++ b/docs/plans/2026-02-25-dashboard-for-all-users-plan.md
@@ -1,0 +1,125 @@
+# Dashboard for All Users — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make the admin dashboard visible to all connected users, not just the admin-client build.
+
+**Architecture:** Pure client-side change. Every user already has an `adminToken` (they all log in with the room password, which IS the admin password). The dashboard panel is hidden solely by the `admin-only` CSS class, gated behind `isAdminMode()` which checks `window.__ECHO_ADMIN__`. We remove that gate for dashboard elements while preserving it for kick/mute controls.
+
+**Tech Stack:** JavaScript (app.js), HTML (index.html), CSS (style.css)
+
+---
+
+### Task 1: Show Dashboard Button to All Users (index.html)
+
+**Files:**
+- Modify: `core/viewer/index.html` (~line 331)
+
+**Step 1: Remove `admin-only` class from dashboard panel**
+
+In `core/viewer/index.html`, the dashboard panel div and the dashboard toggle button both have `class="admin-only"`. Change the panel to remove that class so it's always in the DOM (still hidden by default via `hidden` class):
+
+Find the admin dashboard panel section (~line 331):
+```html
+<div id="admin-dash-panel" class="admin-only hidden admin-dash-panel">
+```
+Change to:
+```html
+<div id="admin-dash-panel" class="hidden admin-dash-panel">
+```
+
+**Step 2: Add a dashboard toggle button visible to all users**
+
+Find the toolbar area where other buttons live. Add a dashboard toggle button that does NOT have `admin-only` class. The existing admin dashboard button is in the admin toolbar — we need a new one in the main toolbar area that all users can see.
+
+Search for the existing admin-dash toggle button in index.html — it may be generated in JS or in HTML. If it's in HTML with `admin-only`, create a parallel button without that class. If it's generated in JS inside an `isAdminMode()` check, we move it outside.
+
+---
+
+### Task 2: Show Dashboard Panel for All Users (app.js)
+
+**Files:**
+- Modify: `core/viewer/app.js`
+
+**Step 1: Find the dashboard button generation**
+
+Search for where the admin dashboard button/icon is created or shown. This may be:
+- In the `isAdminMode()` block that reveals `admin-only` elements
+- A dynamically generated button in the toolbar
+- An HTML element with `admin-only` class
+
+**Step 2: Show dashboard button for all users**
+
+Whatever creates/shows the dashboard toggle button, make it run for ALL users (not just `isAdminMode()`). The button calls `toggleAdminDash()` which is already a global function.
+
+**Step 3: Keep kick/mute admin-only**
+
+Verify that kick/mute buttons are generated inside `isAdminMode()` checks in the video tile rendering code. These must stay gated. Do NOT touch them.
+
+**Step 4: Stats reporting for all users**
+
+The stats reporting code (~line 2043) already runs for all users who have `adminToken`:
+```javascript
+if (adminToken) {
+  fetch(apiUrl("/admin/api/stats"), ...
+```
+All users have `adminToken` since they all log in. No change needed here.
+
+---
+
+### Task 3: Rename UI Label (Optional Polish)
+
+**Files:**
+- Modify: `core/viewer/index.html`
+- Modify: `core/viewer/app.js`
+
+**Step 1: Rename "Admin Dashboard" to "Dashboard"**
+
+Since it's no longer admin-exclusive, update the header text:
+
+In `index.html` (~line 333):
+```html
+<h3>Admin Dashboard</h3>
+```
+Change to:
+```html
+<h3>Dashboard</h3>
+```
+
+Also search `app.js` for any references to "Admin Dashboard" in rendered HTML strings and change to "Dashboard".
+
+---
+
+### Task 4: Build, Test, Commit
+
+**Step 1: Kill running server**
+```powershell
+Start-Process powershell -ArgumentList '-Command "taskkill /F /IM echo-core-control.exe"' -Verb RunAs
+```
+
+**Step 2: Rebuild** (only if Rust changes were made — likely not needed)
+```powershell
+cd "F:\Codex AI\The Echo Chamber\core"
+cargo build -p echo-core-control
+```
+
+**Step 3: Restart server**
+```powershell
+Start-Process -FilePath .\target\debug\echo-core-control.exe -WorkingDirectory "F:\Codex AI\The Echo Chamber\core" -WindowStyle Hidden
+```
+
+**Step 4: Verify**
+- Open viewer in browser: `https://127.0.0.1:9443/viewer/`
+- Connect as regular user (NOT admin-client)
+- Dashboard button should be visible in toolbar
+- Click dashboard → all 5 tabs should load data
+- Kick/mute buttons should NOT appear on participant tiles
+
+**Step 5: Commit + PR**
+```bash
+git checkout -b feat/dashboard-for-all-users
+git add core/viewer/index.html core/viewer/app.js core/viewer/style.css
+git commit -m "feat: show dashboard to all connected users, not just admin"
+git push -u origin feat/dashboard-for-all-users
+gh pr create --title "feat: dashboard visible to all users" --body "..."
+```


### PR DESCRIPTION
## Summary
- Dashboard button + panel now visible to **all connected users**, not just the admin-client build
- Removed `admin-only` CSS class gate from dashboard button and panel
- Dashboard button appears after connecting, hides on disconnect
- Renamed "Admin Dashboard" → "Dashboard" in header
- Kick/mute controls remain admin-only (still gated behind `isAdminMode()`)
- **No Rust changes** — all users already have valid admin tokens from login

## Test plan
- [ ] Connect as regular user → "Dashboard" button visible in toolbar
- [ ] Click Dashboard → all 5 tabs load data (Live, History, Metrics, Bugs, Deploys)
- [ ] Kick/mute buttons NOT visible on participant tiles (admin-client only)
- [ ] Disconnect → dashboard button hides, panel closes

🤖 Generated with [Claude Code](https://claude.com/claude-code)