### PR TITLE
fix: resolve 5 open issues (#67, #68, #28, #57, #59)

### DIFF
--- a/core/viewer/index.html
+++ b/core/viewer/index.html
@@ -79,7 +79,7 @@
           <div class="room-actions">
             <button id="open-admin-dash" type="button" class="hidden" onclick="toggleAdminDash()">Dashboard</button>
             <button id="open-settings" type="button" disabled>Settings</button>
-            <button id="open-bug-report" type="button" class="bug-report-btn" disabled>Report Bug</button>
+            <button id="open-bug-report" type="button" class="bug-report-btn" disabled>Feedback</button>
             <button id="disconnect-top" type="button" disabled>Disconnect</button>
           </div>
         </div>
@@ -261,14 +261,25 @@
           </div>
         </div>
       </div>
-  <div id="bug-report-modal" class="bug-report-modal hidden" role="dialog" aria-label="Bug Report">
+  <div id="bug-report-modal" class="bug-report-modal hidden" role="dialog" aria-label="Send Feedback">
     <div class="bug-report-content">
       <div class="bug-report-header">
-        <h3>Report a Bug</h3>
+        <h3>Send Feedback</h3>
         <button id="close-bug-report" type="button">Close</button>
       </div>
       <div class="bug-report-body">
-        <textarea id="bug-report-desc" class="bug-report-textarea" placeholder="Describe what happened..." rows="4" maxlength="1000"></textarea>
+        <div class="feedback-type-row">
+          <label class="feedback-type-option">
+            <input type="radio" name="feedback-type" value="bug" checked /> Bug
+          </label>
+          <label class="feedback-type-option">
+            <input type="radio" name="feedback-type" value="enhancement" /> Enhancement
+          </label>
+          <label class="feedback-type-option">
+            <input type="radio" name="feedback-type" value="idea" /> Idea
+          </label>
+        </div>
+        <textarea id="bug-report-desc" class="bug-report-textarea" placeholder="Tell us what's on your mind..." rows="4" maxlength="1000"></textarea>
         <div class="bug-report-screenshot-row">
           <button id="bug-report-screenshot-btn" type="button" class="bug-report-screenshot-btn">Attach Screenshot</button>
           <input type="file" id="bug-report-file" class="hidden" accept="image/*" />

--- a/core/viewer/style.css
+++ b/core/viewer/style.css
@@ -2013,6 +2013,23 @@ video {
   gap: 12px;
 }
 
+.feedback-type-row {
+  display: flex;
+  gap: 16px;
+  margin-bottom: 10px;
+}
+.feedback-type-option {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  color: rgba(255,255,255,0.85);
+  font-size: 13px;
+  cursor: pointer;
+}
+.feedback-type-option input[type="radio"] {
+  accent-color: var(--accent, #60a5fa);
+}
+
 .bug-report-textarea {
   width: 100%;
   padding: 10px 12px;


### PR DESCRIPTION
## Summary
Batch fix for all open issues:

- **#67 (High)** — Disconnect now invalidates in-flight connect/switch by incrementing `connectSequence`
- **#68 (Medium)** — Null guards on delayed ParticipantConnected callbacks prevent crash after disconnect
- **#28 (High)** — Already fixed previously (`stopNativeAudioCapture` in disconnect) — closing
- **#57 (High)** — "Report Bug" → "Send Feedback" with Bug/Enhancement/Idea category selector. GitHub issues now labeled and prefixed by type
- **#59 (Low)** — Noise suppression defaults to ON for new users

Also closes **#30** (architecture issue) — the disconnect race fixes address the core session-transition concerns raised there.

## Test plan
- [ ] Connect → switch rooms → hit Disconnect mid-switch → should NOT reconnect (#67)
- [ ] Connect → disconnect quickly → no console errors from delayed callbacks (#68)
- [ ] Click Feedback button → category selector (Bug/Enhancement/Idea) visible (#57)
- [ ] Submit feedback → GitHub issue created with correct label (#57)
- [ ] Fresh user → noise suppression ON by default (#59)

Closes #67, closes #68, closes #28, closes #57, closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)