### PR TITLE
fix: v0.4.1 bugfixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.4.1
+
+- Fix: "Update available" banner no longer shows after updating (version sync between Cargo.toml and tauri.conf.json)
+- Fix: Camera card no longer glitches after stopping camera on macOS (guard against dead track re-attach)
+- Fix: Jam queue no longer empties when searching for new songs (server was draining queue when Spotify played non-queued tracks)
+- Chat: Clicking images now opens a fullscreen lightbox overlay (ESC or click to close)
+
 ## 0.4.0
 
 - macOS Apple Silicon (aarch64) DMG now included in releases

--- a/core/client/Cargo.toml
+++ b/core/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "echo-core-client"
-version = "0.3.1"
+version = "0.4.1"
 edition = "2021"
 description = "Echo Chamber native desktop client"
 

--- a/core/client/tauri.conf.json
+++ b/core/client/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "Echo Chamber",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "identifier": "com.echochamber.app",
   "build": {
     "frontendDist": "../viewer"

--- a/core/control/Cargo.toml
+++ b/core/control/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "echo-core-control"
-version = "0.3.1"
+version = "0.4.1"
 edition = "2021"
 
 [dependencies]

--- a/core/viewer/audio-routing.js
+++ b/core/viewer/audio-routing.js
@@ -481,6 +481,11 @@ function handleTrackSubscribed(track, publication, participant) {
     }
     if (track?.mediaStreamTrack) {
       track.mediaStreamTrack.onunmute = () => {
+        // Guard: don't re-attach if the track has ended or been unsubscribed
+        if (track.mediaStreamTrack?.readyState === "ended" || !publication?.isSubscribed) {
+          debugLog(`camera onunmute ignored ${participant.identity} (track ended or unsubscribed)`);
+          return;
+        }
         requestVideoKeyFrame(publication, track);
         ensureCameraVideo(cardRef, track, publication);
       };

--- a/core/viewer/participants.js
+++ b/core/viewer/participants.js
@@ -1902,6 +1902,11 @@ function scheduleCameraRecovery(identity, cardRef, publication) {
   const attempt = cameraRecoveryAttempts.get(key) || 0;
   if (attempt >= 2) return;
   setTimeout(() => {
+    // Guard: don't recover if the track has ended or been unsubscribed
+    if (!publication?.isSubscribed || publication?.track?.mediaStreamTrack?.readyState === "ended") {
+      debugLog(`camera recovery skipped ${identity} (track ended or unsubscribed)`);
+      return;
+    }
     const video = cardRef.avatar.querySelector("video");
     if (!video || !video.isConnected) return;
     const lastFrame = video._lastFrameTs || 0;

--- a/core/viewer/style.css
+++ b/core/viewer/style.css
@@ -2488,6 +2488,45 @@ video {
   transform: scale(1.02);
 }
 
+.image-lightbox {
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+  background: rgba(0, 0, 0, 0.92);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+}
+
+.image-lightbox img {
+  max-width: 90vw;
+  max-height: 90vh;
+  width: auto;
+  height: auto;
+  object-fit: contain;
+  border-radius: var(--radius-md);
+}
+
+.image-lightbox-hint {
+  position: absolute;
+  bottom: 40px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(0, 0, 0, 0.7);
+  color: rgba(255, 255, 255, 0.9);
+  padding: 10px 24px;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 500;
+  pointer-events: none;
+  transition: opacity 0.6s ease;
+}
+
+.image-lightbox-hint.fade-out {
+  opacity: 0;
+}
+
 .chat-message-file {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- Fix "Update available" banner stuck after updating (#79) — Cargo.toml versions synced to 0.4.1
- Fix camera card glitch on macOS after stopping camera — guard dead track re-attach
- Fix jam queue draining when searching for new songs (#77) — server auto-remove was too aggressive
- Add chat image fullscreen lightbox (#75) — CSS for existing JS infrastructure

## Closes
Closes #79, closes #77, closes #75

## Test plan
- [ ] Verify control plane builds (`cargo build -p echo-core-control`)
- [ ] Verify version reported by `/api/version` matches after rebuild
- [ ] Test jam queue: add songs, search for others, confirm queue persists
- [ ] Test chat image click opens fullscreen overlay
- [ ] Test camera stop/start on macOS doesn't glitch

🤖 Generated with [Claude Code](https://claude.com/claude-code)