### PR TITLE
chore: bump client version to v0.4.2

### DIFF
--- a/core/client/Cargo.toml
+++ b/core/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "echo-core-client"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 description = "Echo Chamber native desktop client"
 

--- a/core/client/tauri.conf.json
+++ b/core/client/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "Echo Chamber",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "identifier": "com.echochamber.app",
   "build": {
     "frontendDist": "../viewer"


### PR DESCRIPTION
## Summary
- Version bump for release v0.4.2

## Test plan
- [x] All changes already merged and verified in PR #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)