### PR TITLE
fix: revert dangerous WASAPI output switching, keep enumeration

### DIFF
--- a/core/client/src/main.rs
+++ b/core/client/src/main.rs
@@ -180,10 +180,9 @@ fn list_audio_output_devices() -> Vec<audio_output::OutputDevice> {
     audio_output::list_output_devices()
 }
 
-#[tauri::command]
-fn set_audio_output_device(device_id: String) -> Result<(), String> {
-    audio_output::set_output_device(&device_id)
-}
+// set_audio_output_device removed — changing system-wide default is too dangerous.
+// Force-kill/crash loses the saved previous default, leaving user's audio broken.
+// Output device switching is a known WebView2 limitation (setSinkId is a silent no-op).
 
 fn settings_path(app: &tauri::AppHandle) -> Result<std::path::PathBuf, String> {
     let dir = app.path().app_data_dir().map_err(|e| e.to_string())?;
@@ -274,7 +273,6 @@ fn main() {
             start_audio_capture,
             stop_audio_capture,
             list_audio_output_devices,
-            set_audio_output_device,
             check_for_updates,
         ])
         .setup(move |app| {
@@ -340,9 +338,5 @@ fn main() {
         })
         .build(tauri::generate_context!())
         .expect("Error while building Echo Chamber")
-        .run(|_app, event| {
-            if let tauri::RunEvent::Exit = event {
-                audio_output::restore_default_output();
-            }
-        });
+        .run(|_app, _event| {});
 }

--- a/core/viewer/changelog.js
+++ b/core/viewer/changelog.js
@@ -9,12 +9,12 @@
 var ECHO_CHANGELOG = [
   {
     version: "2026-03-15",
-    title: "Bug Fixes + Audio Output Switching",
+    title: "Bug Fixes + Device Switching",
     notes: [
-      "Audio output device switching now works on Windows — uses native WASAPI routing (requires client update)",
-      "Previous output device automatically restored when Echo Chamber closes",
-      "Fixed PG-13 Mode not syncing to late joiners — new users now query for room state on connect",
       "Fixed mic/camera switching while connected — no longer requires disconnect/reconnect",
+      "Fixed stale device fallback — if saved mic/camera is unplugged, falls back to default instead of failing",
+      "Output device dropdown now shows native Windows device names (switching is still a known WebView2 limitation)",
+      "Fixed PG-13 Mode not syncing to late joiners — new users now query for room state on connect",
       "Fixed screenshots in bug reports — now embedded directly in GitHub issues"
     ]
   },

--- a/core/viewer/media-controls.js
+++ b/core/viewer/media-controls.js
@@ -230,17 +230,10 @@ async function switchSpeaker(deviceId) {
   selectedSpeakerId = deviceId || "";
   echoSet("echo-device-speaker", selectedSpeakerId);
   debugLog("[speaker] switching to: " + (selectedSpeakerId || "default"));
-  // On native Tauri (Windows): use WASAPI to switch system default audio output.
-  // WebView2's setSinkId resolves OK but silently fails to change output.
-  if (hasTauriIPC()) {
-    try {
-      await tauriInvoke("set_audio_output_device", { deviceId: selectedSpeakerId });
-      debugLog("[speaker] native WASAPI switch OK");
-    } catch (err) {
-      debugLog("[speaker] native switch failed: " + (err.message || err));
-    }
-  }
-  // Also apply setSinkId for browser viewers and as best-effort in WebView2
+  // Note: WebView2's setSinkId is broken (resolves OK but doesn't change output).
+  // Native WASAPI system-default switching was too dangerous (force-kill loses restore state).
+  // For now, output device must be changed in Windows Sound settings.
+  // Native device enumeration still populates the dropdown with correct device names.
   await applySpeakerToMedia();
 }
 
@@ -378,9 +371,20 @@ async function toggleMic() {
   const desired = !micEnabled;
   micBtn.disabled = true;
   try {
-    await room.localParticipant.setMicrophoneEnabled(desired, {
-      deviceId: selectedMicId || undefined,
-    });
+    try {
+      await room.localParticipant.setMicrophoneEnabled(desired, {
+        deviceId: selectedMicId || undefined,
+      });
+    } catch (devErr) {
+      if (devErr.name === "NotFoundError" && selectedMicId) {
+        debugLog("[mic] saved device not found, falling back to default");
+        selectedMicId = "";
+        echoSet("echo-device-mic", "");
+        await room.localParticipant.setMicrophoneEnabled(desired);
+      } else {
+        throw devErr;
+      }
+    }
     micEnabled = desired;
 
     // Apply or remove noise cancellation
@@ -428,7 +432,18 @@ async function toggleCam() {
     var camOpts = _isMobileDevice
       ? { facingMode: _camFacingMode }
       : { deviceId: selectedCamId || undefined };
-    await room.localParticipant.setCameraEnabled(desired, camOpts);
+    try {
+      await room.localParticipant.setCameraEnabled(desired, camOpts);
+    } catch (devErr) {
+      if (devErr.name === "NotFoundError" && selectedCamId) {
+        debugLog("[cam] saved device not found, falling back to default");
+        selectedCamId = "";
+        echoSet("echo-device-cam", "");
+        await room.localParticipant.setCameraEnabled(desired);
+      } else {
+        throw devErr;
+      }
+    }
 
     // Use the SDK's authoritative state rather than checking publications.
     // Publication objects retain muted/ended tracks, so !!pub.track gives


### PR DESCRIPTION
## Summary
- Reverts system-wide audio default switching via IPolicyConfig — force-kill skips restore, leaving user audio broken
- Keeps native device enumeration (dropdown shows real Windows device names)
- Adds stale device fallback for mic/camera (NotFoundError → fall back to default)

## Test plan
- [x] Sam's audio was broken by the WASAPI switching, confirmed fixed after revert
- [x] Client rebuilt and relaunched

🤖 Generated with [Claude Code](https://claude.com/claude-code)