### PR TITLE
chore: bump to v0.4.3

### DIFF
--- a/core/client/Cargo.toml
+++ b/core/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "echo-core-client"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2021"
 description = "Echo Chamber native desktop client"
 

--- a/core/client/tauri.conf.json
+++ b/core/client/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "Echo Chamber",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "identifier": "com.echochamber.app",
   "build": {
     "frontendDist": "../viewer"


### PR DESCRIPTION
Version bump for safe release (reverts WASAPI output switching from v0.4.2)