### PR TITLE
release: v0.6.7

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -1304,7 +1304,7 @@ dependencies = [
 
 [[package]]
 name = "echo-core-client"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "base64 0.22.1",
  "livekit",
@@ -1323,7 +1323,7 @@ dependencies = [
 
 [[package]]
 name = "echo-core-control"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "argon2",
  "axum",

--- a/core/client/Cargo.toml
+++ b/core/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "echo-core-client"
-version = "0.6.6"
+version = "0.6.7"
 edition = "2021"
 description = "Echo Chamber native desktop client"
 

--- a/core/client/src/capture_health.rs
+++ b/core/client/src/capture_health.rs
@@ -182,7 +182,20 @@ impl CaptureHealthState {
     pub fn set_active(&self, active: bool, mode: CaptureMode, encoder: EncoderType, target: u32) {
         let was_active = self.capture_active.swap(active, Ordering::Relaxed);
         *self.capture_mode.write() = mode;
-        *self.encoder_type.write() = encoder;
+        // Use the caller's encoder hint, but OVERRIDE to OpenH264 if we
+        // know at startup that nvcuda.dll is missing (AMD/Intel machine).
+        // The caller passes EncoderType::Nvenc as a hopeful default, but
+        // HAS_NVCUDA is the ground truth from the LoadLibrary probe in
+        // main.rs. Without this override, Jeff's AMD chip shows "NVENC"
+        // on the admin dashboard even though he's actually on OpenH264.
+        let actual_encoder = if !crate::capture_pipeline::HAS_NVCUDA.load(Ordering::Relaxed)
+            && encoder == EncoderType::Nvenc
+        {
+            EncoderType::OpenH264
+        } else {
+            encoder
+        };
+        *self.encoder_type.write() = actual_encoder;
         self.target_fps.store(target, Ordering::Relaxed);
         if active {
             // Stamp the cold-start timestamp on inactive→active transition

--- a/core/client/tauri.conf.json
+++ b/core/client/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "Echo Chamber",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "identifier": "com.echochamber.app",
   "build": {
     "frontendDist": "../viewer"

--- a/core/control/Cargo.toml
+++ b/core/control/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "echo-core-control"
-version = "0.6.6"
+version = "0.6.7"
 edition = "2021"
 
 [dependencies]

--- a/core/viewer/changelog.js
+++ b/core/viewer/changelog.js
@@ -8,6 +8,17 @@
 
 var ECHO_CHANGELOG = [
   {
+    version: "2026-04-09b",
+    title: "Stability + Smart Defaults (v0.6.7)",
+    notes: [
+      "AMD/Intel users: capture rate now capped at 20fps to prevent the CPU crash Jeff experienced during a 54-minute 4-publisher stress test. Software encoding at 60+ fps was pinning the CPU at ~90%. 20fps is smooth for screen content and sustainable indefinitely.",
+      "Capture health false-alarm fixes: 10-second grace period after starting a share (no more Red flash on startup), and the banner requires 2 consecutive Red cycles before firing (no more flapping alarms).",
+      "Correct encoder detection: AMD/Intel machines now show 'OpenH264' on the capture health chip instead of incorrectly claiming NVENC. The admin can see at a glance who has hardware vs software encoding.",
+      "GPU flicker recovery script: if Sam's display driver gets wedged again, there's now a PowerShell script at tools/gpu-flicker-recovery.ps1 that tries non-reboot recovery before falling back to 'reboot required'.",
+      "Screen share opt-in fixed: other people's screen shares no longer auto-appear in your grid before you click 'Start Watching'. Also fixes the grid layout stacking horizontally instead of 2x2."
+    ]
+  },
+  {
     version: "2026-04-09",
     title: "Actually works on AMD/Intel GPUs (v0.6.6)",
     notes: [


### PR DESCRIPTION
Version bump + changelog. Bundles PRs #148 (cold-start + hysteresis), #152 (OpenH264 20fps cap), #153 (opt-in identity fix), plus inline encoder detection probe.