### PR TITLE
release: v0.6.8 native screen-share restart fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.6.8
+
+- Fix native screen-share restart churn: stop commands now wait for the previous native capture task to exit before a new `$screen` publisher connects
+- Fix viewer native stop-listener cleanup so repeated restarts do not stack duplicate listeners
+- Fix remote screen-share watching after reconnect/reload by normalizing `$screen` companion identities consistently across late join, watch/unwatch, and adaptive stats paths
+- Fix `Start Watching` for remote screen shares so existing live shares attach correctly instead of staying hidden or unsubscribed
+- Fix the false "New Version Available" banner when running prerelease-style local builds
+- Win10 picker now blocks unsupported native `Windows` capture entries and directs users to `Screen`/`Game`
+- Native pipeline now includes the WGC heartbeat/static-frame duplication fix and keeps native publish pacing aligned to the 30fps target
+
 ## 0.4.1
 
 - Fix: "Update available" banner no longer shows after updating (version sync between Cargo.toml and tauri.conf.json)

--- a/CURRENT_SESSION.md
+++ b/CURRENT_SESSION.md
@@ -1,5 +1,24 @@
 # Echo Chamber - Current Session Handover
 
+## 2026-04-10 Codex Handover Override
+
+This block supersedes the older v0.6.6 summary below it.
+
+**Last Updated**: 2026-04-10
+**Current Version**: **v0.6.7 SHIPPED**
+**Status**: Codex now follows the repo operating rules pinned in `AGENTS.md`. Work stays under `core/`. PR `#143` (`fix/heartbeat-frame-duplication`) must remain unmerged until Sam manually validates the installed client against the static browser-window freeze case.
+
+### Current Priorities
+- Browser audio extraction from browser-window shares
+- Outbound NACK and packet-loss signals in capture health
+- Tauri signing key recovery
+
+### Known Bugs
+- GPU driver flicker on Sam's RTX 4090 setup
+- Static WGC browser-window streams can freeze without the heartbeat fix
+- Browser audio remains silent for browser-window shares
+- Encoder detection still has edge-case lag
+
 **Last Updated**: 2026-04-09 (v0.6.6 shipped after v0.6.5 false-ship; first 4-friend session; Jeff crash post-mortem; share chime bug fixed)
 **Current Version**: **v0.6.6 SHIPPED ✅** (GitHub release only — latest.json still points at v0.6.5 until next session updates it)
 **Status**: v0.6.6 has working delay-load nvcuda.dll (verified via dumpbin — nvcuda in DELAY IMPORTS section). AMD/Intel friends can install and run. First real 4-publisher test ran for ~54 min before Jeff's AMD machine crashed under software-encoder load; post-mortem written. Share chime bug fixed live via force-reload (PR #147). Substantial v0.6.7 backlog queued.
@@ -906,3 +925,99 @@ This session ran very long and accumulated a lot of context. Key discipline note
 3. **Update this file at session end.** Non-negotiable.
 4. **Do not bisect NVENC.** Pattern-match OBS wholesale.
 5. **Do not test WGC monitor capture on Sam's daily driver.** Ever. See DO NOT TOUCH.
+
+---
+
+## 2026-04-11 flicker recurrence: idle/input-triggered compositor wedge
+
+This session reproduced a third class of display instability on Sam's main RTX 4090 box while live-testing screen share and viewer watch/unwatch flows.
+
+### Exact symptom pattern
+- Main PC was publishing a WGC window share; `SAM-PC` could see it.
+- After repeated watch/unwatch churn on the receiver side, Sam's main PC began flickering again.
+- Flicker appeared on Monitor 1, then later on Monitor 2.
+- The strongest trigger was **idle -> first input**: after stepping away briefly, the moment Sam touched the mouse or clicked a window, the monitors started flickering again.
+- A UAC secure-desktop transition also caused an immediate flicker pulse on both monitors.
+- Elevated recovery script did **not** clear it; full reboot was required again.
+
+### What this rules out
+- Receiver-side `Start Watching` / `Stop Watching` in `core/viewer/participants-avatar.js` does **not** call native capture start/stop. It only toggles LiveKit subscription and tile visibility.
+- So this specific repro does **not** fit the older broad theory that viewer watch churn was directly restarting native capture tasks.
+
+### What Windows showed
+- During reboot, Windows showed a shutdown blocker labeled something like `Media Capture`, and Sam had to click `restart anyway`.
+- System event log did **not** record a literal `Media Capture` process name. The only concrete shutdown-delay warnings at `2026-04-11 11:46:40 ET` were:
+  - `F:\Codex AI\The Echo Chamber\core\sfu\livekit-server.exe`
+  - `G:\Steam\bin\cef\cef.win64\steamwebhelper.exe`
+- This machine does have the built-in Windows system app `Microsoft.Windows.CapturePicker` (`C:\Windows\SystemApps\Microsoft.Windows.CapturePicker_cw5n1h2txyewy`), so the reboot UI label could have been Windows capture infrastructure rather than Echo itself.
+- CapabilityAccessManager entries confirm non-packaged graphics-capture access for:
+  - installed Echo client: `C:\Users\Sam\AppData\Local\Echo Chamber\echo-core-client.exe`
+  - packaged Echo desktop launcher
+  - multiple WebView2 builds
+
+### Current best diagnosis
+- Treat this as a **local Windows compositor / MPO / power-state / display-present path problem** on Sam's daily-driver machine.
+- Media/watch churn may poison the stack, but the visible failure is exposed by:
+  - idle-to-active transitions
+  - focus/input activity
+  - secure-desktop transitions
+- The `Media Capture` shutdown prompt is relevant because it suggests Windows still believed a capture session/broker was alive during reboot, but it is **not** yet proof that Echo alone was the blocker.
+
+### Operating rule from here
+- Do not continue churn/flicker stress testing on Sam's daily-driver PC.
+- Use `SAM-PC` as the primary watcher/secondary endpoint for live validation.
+- If this needs deeper root-cause work later, isolate with safer experiments first:
+  - disable hardware-accelerated viewer composition / safe viewer mode
+  - keep publish active without repeated watch churn
+  - inspect DxgKrnl / GPU watchdog data separately from room media logic
+
+### Post-reboot validation on the same machine
+- Full reboot cleared the poisoned flicker state.
+- After reboot, Echo was launched normally and Sam logged in with **no flicker while idle or on input** before sharing.
+- Native `Windows` share (WGC window capture) of the Codex app was validated successfully:
+  - `SAM-PC` could watch it
+  - David could watch it
+  - one clean stop/start cycle succeeded
+  - no flicker during active use
+  - no flicker after stepping away for ~2-3 minutes and resuming input
+- Native `Screens` share (desktop/DXGI path) was also validated successfully:
+  - `SAM-PC` could watch it
+  - David could watch it
+  - no flicker during active use
+  - no flicker after brief idle/resume
+- One follow-up UX note: after stopping a share, the screen-share tile took roughly **10 seconds** to disappear from the grid. That suggests stop/unpublish propagation lag still exists even though the machine remained stable.
+
+### Current confidence after reboot
+- Main PC is presently back in a **stable** state.
+- Both major publish paths on the main PC are working with both LAN (`SAM-PC`) and WAN (David) receivers.
+- The earlier display flicker now looks like a state-poisoning/churn problem rather than an always-on failure of normal publish/watch use.
+- Reverse-direction receive path also passed: after Sam stopped sharing, David published a full-screen share and Sam could watch it locally with no flicker.
+- Stop-behavior nuance now looks path-specific:
+  - `Screens` / desktop share cleared from the grid immediately on stop.
+  - Earlier `Windows` / WGC window share stop took roughly ~10 seconds to disappear.
+  - Treat that as a separate stop/unpublish propagation bug to investigate before release, but **not** a blocker for the main post-reboot stability result.
+
+### Release branch and packaging (v0.6.8)
+- Clean release worktree created at `F:\Codex AI\The Echo Chamber\.codex\worktrees\release-v0.6.8` on branch `codex/release-v0.6.8`.
+- Release set intentionally combines:
+  - native/client changes from the reconnect branch (`main.rs`, `screen_capture.rs`, `desktop_capture.rs`, `capture_pipeline.rs`)
+  - live-tested viewer fixes from the root checkout (`connect.js`, `identity.js`, `participants-avatar.js`, `screen-share-adaptive.js`, `screen-share-native.js`, `screen-share-state.js`, plus picker/update-banner support files)
+- Release metadata bumped to `0.6.8` in:
+  - `core/client/Cargo.toml`
+  - `core/client/tauri.conf.json`
+  - `core/control/Cargo.toml`
+- In-app changelog and GitHub `CHANGELOG.md` updated for `0.6.8`.
+- Local release script `core/deploy/build-release.ps1` updated to stay Windows-only and generate a Windows-only updater manifest.
+
+### Verification on the release branch
+- `node --check` passed for the touched viewer JS files.
+- `cargo check -p echo-core-client` passed in `core/`.
+- `cargo build -p echo-core-client --release` passed with:
+  - `LK_CUSTOM_WEBRTC=F:\Codex AI\The Echo Chamber\core\target\debug\build\scratch-2a0faabf5e80148f\out\livekit_webrtc\livekit\win-x64-release-webrtc-7af9351\win-x64-release`
+  - `RUSTFLAGS=-C target-feature=+crt-static`
+- Produced EXE: `core\target\release\echo-core-client.exe`
+- `dumpbin /imports` check confirmed `nvcuda.dll` is still in the **delay load imports** section of the shipped EXE.
+- Signed NSIS bundle built successfully:
+  - `core\target\release\bundle\nsis\Echo Chamber_0.6.8_x64-setup.exe`
+  - `core\target\release\bundle\nsis\Echo Chamber_0.6.8_x64-setup.exe.sig`
+  - `core\target\release\bundle\nsis\latest.json`

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -1304,7 +1304,7 @@ dependencies = [
 
 [[package]]
 name = "echo-core-client"
-version = "0.6.6"
+version = "0.6.8"
 dependencies = [
  "base64 0.22.1",
  "livekit",
@@ -1323,7 +1323,7 @@ dependencies = [
 
 [[package]]
 name = "echo-core-control"
-version = "0.6.6"
+version = "0.6.8"
 dependencies = [
  "argon2",
  "axum",

--- a/core/client/Cargo.toml
+++ b/core/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "echo-core-client"
-version = "0.6.7"
+version = "0.6.8"
 edition = "2021"
 description = "Echo Chamber native desktop client"
 

--- a/core/client/src/capture_pipeline.rs
+++ b/core/client/src/capture_pipeline.rs
@@ -6,8 +6,8 @@
 //! DXGI OutputDuplication, GPU shaders, anti-MPO) stays in its own module.
 
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
-use std::time::Instant;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
 
 use serde::Serialize;
 use tauri::{AppHandle, Emitter};
@@ -32,12 +32,13 @@ pub struct CaptureStats {
 // ── CapturePublisher ──
 
 /// Hard cap for the capture push rate when NVENC hardware encode is active.
-/// Set to 240fps so 144Hz/165Hz/240Hz monitors push their full native rate
-/// without being throttled. NVENC is initialized at the same rate via
-/// VideoEncoding.max_framerate so its bitrate-per-frame budget matches reality.
-const TARGET_ENCODE_FPS_HARDWARE: f64 = 240.0;
-const MIN_FRAME_INTERVAL_HARDWARE: std::time::Duration =
-    std::time::Duration::from_nanos((1_000_000_000.0 / TARGET_ENCODE_FPS_HARDWARE) as u64);
+/// This must match the intended wire publish cap for native screen share.
+/// The previous 240fps cap let WGC/DXGI push far above the 30fps publish target
+/// in real sessions, which drove Sam's local FPS hit while still reporting a
+/// nominal 30fps target in capture-health.
+const TARGET_ENCODE_FPS_HARDWARE: f64 = PUBLISH_TARGET_FPS as f64;
+const MIN_FRAME_INTERVAL_HARDWARE: Duration =
+    Duration::from_nanos((1_000_000_000.0 / TARGET_ENCODE_FPS_HARDWARE) as u64);
 
 /// Soft cap for the capture push rate when OpenH264 software encode is active.
 /// Software H264 at 1080p at 60+ fps pins the CPU at ~90-100% and caused
@@ -48,8 +49,8 @@ const MIN_FRAME_INTERVAL_HARDWARE: std::time::Duration =
 /// The WGC/DXGI capture loops still run at native refresh for responsive
 /// frame delivery; this cap just drops excess frames before conversion.
 const TARGET_ENCODE_FPS_SOFTWARE: f64 = 20.0;
-const MIN_FRAME_INTERVAL_SOFTWARE: std::time::Duration =
-    std::time::Duration::from_nanos((1_000_000_000.0 / TARGET_ENCODE_FPS_SOFTWARE) as u64);
+const MIN_FRAME_INTERVAL_SOFTWARE: Duration =
+    Duration::from_nanos((1_000_000_000.0 / TARGET_ENCODE_FPS_SOFTWARE) as u64);
 
 /// Global flag: true if nvcuda.dll loaded successfully at client startup.
 /// When false, the capture pipeline uses MIN_FRAME_INTERVAL_SOFTWARE to
@@ -57,12 +58,49 @@ const MIN_FRAME_INTERVAL_SOFTWARE: std::time::Duration =
 /// main.rs's startup probe and never changes after that.
 pub static HAS_NVCUDA: AtomicBool = AtomicBool::new(false);
 
-/// Wire-level publish framerate cap. The capture loop runs at native display
-/// refresh rate (often 144+ Hz) but NVENC's frame_drop=1 throttles the wire
-/// output to this rate. This is the "target" the capture-health classifier
-/// compares current capture FPS against — if capture drops far below this
-/// number something upstream is starving the pipeline.
+/// Wire-level publish framerate cap for native screen share.
+/// Keep the capture-side pacing aligned with this number so native publishers
+/// don't push 100+ fps into WebRTC while the rest of the stack thinks the
+/// target is 30fps.
 pub const PUBLISH_TARGET_FPS: u32 = 30;
+
+/// Heartbeat interval for WGC/static-content frame duplication.
+/// If the real capture path has not pushed a new frame in this long, re-push
+/// the most recent BGRA frame so the wire stream stays alive at ~30fps.
+const HEARTBEAT_INTERVAL: Duration = Duration::from_millis(33);
+
+/// Shared heartbeat state.
+///
+/// WGC window capture is event-driven: `on_frame_arrived` only fires when the
+/// captured window repaints. Some windows can go effectively wire-silent when
+/// their redraw pattern changes even though the user still expects a live
+/// stream. The heartbeat thread re-pushes the most recent BGRA frame whenever
+/// the real capture path has been idle for longer than HEARTBEAT_INTERVAL.
+struct HeartbeatState {
+    last_frame: Option<LastFrameBuffer>,
+    last_real_push: Instant,
+}
+
+struct LastFrameBuffer {
+    bgra: Vec<u8>,
+    stride: u32,
+    width: u32,
+    height: u32,
+}
+
+struct HeartbeatHandle {
+    running: Arc<AtomicBool>,
+    thread: Option<std::thread::JoinHandle<()>>,
+}
+
+impl Drop for HeartbeatHandle {
+    fn drop(&mut self) {
+        self.running.store(false, Ordering::Relaxed);
+        if let Some(thread) = self.thread.take() {
+            let _ = thread.join();
+        }
+    }
+}
 
 /// Shared publisher that connects to the LiveKit SFU, creates a NativeVideoSource,
 /// publishes a Camera track, and provides helpers to push BGRA frames and emit stats.
@@ -72,6 +110,8 @@ pub struct CapturePublisher {
     start_time: Instant,
     frame_count: u64,
     last_pushed: Option<Instant>,
+    heartbeat_state: Arc<Mutex<HeartbeatState>>,
+    heartbeat_handle: Option<HeartbeatHandle>,
 }
 
 impl CapturePublisher {
@@ -147,14 +187,28 @@ impl CapturePublisher {
             .map_err(|e| format!("publish failed: {}", e))?;
 
         eprintln!("[{}] track published, waiting for negotiation...", log_prefix);
-        tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+        tokio::time::sleep(Duration::from_secs(3)).await;
+
+        let start_time = Instant::now();
+        let heartbeat_state = Arc::new(Mutex::new(HeartbeatState {
+            last_frame: None,
+            last_real_push: start_time,
+        }));
+        let heartbeat_handle = Self::spawn_heartbeat(
+            heartbeat_state.clone(),
+            source.clone(),
+            start_time,
+            log_prefix,
+        );
 
         Ok(Self {
             room,
             source,
-            start_time: Instant::now(),
+            start_time,
             frame_count: 0,
             last_pushed: None,
+            heartbeat_state,
+            heartbeat_handle: Some(heartbeat_handle),
         })
     }
 
@@ -231,15 +285,114 @@ impl CapturePublisher {
         .map_err(|e| format!("publish failed: {}", e))?;
 
         eprintln!("[{}] track published, waiting for negotiation...", log_prefix);
-        std::thread::sleep(std::time::Duration::from_secs(3));
+        std::thread::sleep(Duration::from_secs(3));
+
+        let start_time = Instant::now();
+        let heartbeat_state = Arc::new(Mutex::new(HeartbeatState {
+            last_frame: None,
+            last_real_push: start_time,
+        }));
+        let heartbeat_handle = Self::spawn_heartbeat(
+            heartbeat_state.clone(),
+            source.clone(),
+            start_time,
+            log_prefix,
+        );
 
         Ok(Self {
             room,
             source,
-            start_time: Instant::now(),
+            start_time,
             frame_count: 0,
             last_pushed: None,
+            heartbeat_state,
+            heartbeat_handle: Some(heartbeat_handle),
         })
+    }
+
+    fn spawn_heartbeat(
+        state: Arc<Mutex<HeartbeatState>>,
+        source: NativeVideoSource,
+        start_time: Instant,
+        log_prefix: &str,
+    ) -> HeartbeatHandle {
+        let running = Arc::new(AtomicBool::new(true));
+        let running_clone = running.clone();
+        let log_prefix = log_prefix.to_string();
+        let thread = std::thread::Builder::new()
+            .name(format!("heartbeat-{}", log_prefix))
+            .spawn(move || {
+                eprintln!("[{}] heartbeat watchdog started", log_prefix);
+                let mut heartbeat_pushes: u64 = 0;
+                let mut last_log = Instant::now();
+
+                while running_clone.load(Ordering::Relaxed) {
+                    std::thread::sleep(HEARTBEAT_INTERVAL);
+                    if !running_clone.load(Ordering::Relaxed) {
+                        break;
+                    }
+
+                    let snapshot = {
+                        let state = match state.lock() {
+                            Ok(guard) => guard,
+                            Err(poisoned) => poisoned.into_inner(),
+                        };
+                        if state.last_real_push.elapsed() < HEARTBEAT_INTERVAL {
+                            None
+                        } else {
+                            state.last_frame.as_ref().map(|frame| LastFrameBuffer {
+                                bgra: frame.bgra.clone(),
+                                stride: frame.stride,
+                                width: frame.width,
+                                height: frame.height,
+                            })
+                        }
+                    };
+
+                    let Some(frame) = snapshot else { continue };
+
+                    let mut i420 = I420Buffer::new(frame.width, frame.height);
+                    let (sy, su, sv) = i420.strides();
+                    let (y, u, v) = i420.data_mut();
+                    yuv_helper::argb_to_i420(
+                        &frame.bgra,
+                        frame.stride,
+                        y,
+                        sy,
+                        u,
+                        su,
+                        v,
+                        sv,
+                        frame.width as i32,
+                        frame.height as i32,
+                    );
+
+                    let vf = VideoFrame {
+                        rotation: VideoRotation::VideoRotation0,
+                        buffer: i420,
+                        timestamp_us: start_time.elapsed().as_micros() as i64,
+                    };
+                    source.capture_frame(&vf);
+                    heartbeat_pushes += 1;
+
+                    if last_log.elapsed() >= Duration::from_secs(10) {
+                        eprintln!(
+                            "[{}] heartbeat: {} duplicate frames pushed in last 10s",
+                            log_prefix, heartbeat_pushes
+                        );
+                        heartbeat_pushes = 0;
+                        last_log = Instant::now();
+                    }
+                }
+
+                eprintln!("[{}] heartbeat watchdog stopped", log_prefix);
+            })
+            .expect("spawn heartbeat thread");
+
+        HeartbeatHandle {
+            running,
+            thread: Some(thread),
+        }
     }
 
     /// Convert a BGRA frame to I420 via libyuv and push it to the NativeVideoSource.
@@ -252,12 +405,8 @@ impl CapturePublisher {
 
     /// Convert a BGRA frame with explicit stride to I420 and push to the video source.
     pub fn push_frame_strided(&mut self, bgra: &[u8], stride: u32, width: u32, height: u32) {
-        // Frame rate limiter — choose the interval based on whether we have
-        // hardware (NVENC) or software (OpenH264) encoding. NVENC can handle
-        // 240fps input because it's a dedicated ASIC. OpenH264 runs on CPU
-        // and pins ~90-100% at 60+ fps 1080p — which crashed Jeff's AMD
-        // machine after ~54 min of sustained load. Cap software encode at
-        // 20fps to keep CPU at a sustainable ~30%.
+        // Pace native capture to the real publish target. Without this, WGC/DXGI
+        // can still push well above 30fps on NVENC systems and drag local FPS down.
         let min_interval = if HAS_NVCUDA.load(Ordering::Relaxed) {
             MIN_FRAME_INTERVAL_HARDWARE
         } else {
@@ -287,6 +436,16 @@ impl CapturePublisher {
         };
         self.source.capture_frame(&vf);
         self.frame_count += 1;
+
+        if let Ok(mut state) = self.heartbeat_state.lock() {
+            state.last_real_push = now;
+            state.last_frame = Some(LastFrameBuffer {
+                bgra: bgra.to_vec(),
+                stride,
+                width,
+                height,
+            });
+        }
     }
 
     /// Emit stats via Tauri event every `every_n` frames. Returns current FPS.
@@ -329,17 +488,29 @@ impl CapturePublisher {
     }
 
     /// Elapsed time since the publisher was created.
-    pub fn elapsed(&self) -> std::time::Duration {
+    pub fn elapsed(&self) -> Duration {
         self.start_time.elapsed()
     }
 
     /// Close the SFU room connection.
     pub async fn shutdown(self) {
-        self.room.close().await.ok();
+        let Self {
+            room,
+            heartbeat_handle,
+            ..
+        } = self;
+        drop(heartbeat_handle);
+        room.close().await.ok();
     }
 
     /// Blocking variant of shutdown for use inside `spawn_blocking`.
     pub fn shutdown_blocking(self, rt: &tokio::runtime::Handle) {
-        rt.block_on(self.room.close()).ok();
+        let Self {
+            room,
+            heartbeat_handle,
+            ..
+        } = self;
+        drop(heartbeat_handle);
+        rt.block_on(room.close()).ok();
     }
 }

--- a/core/client/src/desktop_capture.rs
+++ b/core/client/src/desktop_capture.rs
@@ -14,7 +14,7 @@
 //!               → libwebrtc H264 encoder (NVENC on RTX 4090)
 //!                 → RTP → SFU
 
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{Duration, Instant};
 use tauri::AppHandle;
@@ -23,38 +23,35 @@ use tauri::Emitter;
 use windows::core::{Interface, PCSTR};
 use windows::Win32::Foundation::{HWND, RECT};
 use windows::Win32::Graphics::Direct3D::D3D_DRIVER_TYPE_UNKNOWN;
-use windows::Win32::Graphics::Direct3D11::{
-    D3D11CreateDevice, D3D11_CREATE_DEVICE_BGRA_SUPPORT, D3D11_MAPPED_SUBRESOURCE,
-    D3D11_MAP_READ, D3D11_SDK_VERSION, D3D11_TEXTURE2D_DESC, D3D11_USAGE_STAGING,
-    D3D11_USAGE_DEFAULT, D3D11_CPU_ACCESS_READ,
-    ID3D11Device, ID3D11Texture2D,
-};
 use windows::Win32::Graphics::Direct3D::D3D_FEATURE_LEVEL_11_0;
-use windows::Win32::Graphics::Dxgi::Common::{DXGI_FORMAT_B8G8R8A8_UNORM, DXGI_FORMAT_R8G8B8A8_UNORM, DXGI_FORMAT_R16G16B16A16_FLOAT, DXGI_SAMPLE_DESC};
+use windows::Win32::Graphics::Direct3D11::{
+    D3D11CreateDevice, ID3D11Device, ID3D11Texture2D, D3D11_CPU_ACCESS_READ,
+    D3D11_CREATE_DEVICE_BGRA_SUPPORT, D3D11_MAPPED_SUBRESOURCE, D3D11_MAP_READ, D3D11_SDK_VERSION,
+    D3D11_TEXTURE2D_DESC, D3D11_USAGE_DEFAULT, D3D11_USAGE_STAGING,
+};
+use windows::Win32::Graphics::Dxgi::Common::{
+    DXGI_FORMAT_B8G8R8A8_UNORM, DXGI_FORMAT_R16G16B16A16_FLOAT, DXGI_FORMAT_R8G8B8A8_UNORM,
+    DXGI_SAMPLE_DESC,
+};
 use windows::Win32::Graphics::Dxgi::{
     CreateDXGIFactory1, IDXGIAdapter1, IDXGIFactory1, IDXGIOutput, IDXGIOutput1,
     IDXGIOutputDuplication, IDXGIResource, DXGI_OUTDUPL_FRAME_INFO,
-    DXGI_OUTDUPL_POINTER_SHAPE_INFO,
-    DXGI_OUTDUPL_POINTER_SHAPE_TYPE_COLOR,
-    DXGI_OUTDUPL_POINTER_SHAPE_TYPE_MONOCHROME,
-    DXGI_OUTDUPL_POINTER_SHAPE_TYPE_MASKED_COLOR,
+    DXGI_OUTDUPL_POINTER_SHAPE_INFO, DXGI_OUTDUPL_POINTER_SHAPE_TYPE_COLOR,
+    DXGI_OUTDUPL_POINTER_SHAPE_TYPE_MASKED_COLOR, DXGI_OUTDUPL_POINTER_SHAPE_TYPE_MONOCHROME,
 };
-use windows::Win32::UI::WindowsAndMessaging::{
-    GetWindowRect, GetWindowThreadProcessId,
-    CreateWindowExW, DefWindowProcW, DestroyWindow, RegisterClassExW, SetWindowPos,
-    SetLayeredWindowAttributes,
-    WNDCLASSEXW, WS_POPUP, WS_EX_TOPMOST, WS_EX_TRANSPARENT, WS_EX_LAYERED,
-    WS_EX_TOOLWINDOW, WS_EX_NOACTIVATE, HWND_TOPMOST,
-    SWP_NOMOVE, SWP_NOSIZE, SWP_NOACTIVATE, SWP_SHOWWINDOW,
-    LWA_ALPHA,
-};
-use windows::Win32::System::LibraryLoader::GetModuleHandleW;
 use windows::Win32::Graphics::Gdi::{
     GetMonitorInfoW, MonitorFromWindow, MONITORINFO, MONITOR_DEFAULTTONEAREST,
 };
+use windows::Win32::System::LibraryLoader::GetModuleHandleW;
+use windows::Win32::UI::WindowsAndMessaging::{
+    CreateWindowExW, DefWindowProcW, DestroyWindow, GetWindowRect, GetWindowThreadProcessId,
+    RegisterClassExW, SetLayeredWindowAttributes, SetWindowPos, HWND_TOPMOST, LWA_ALPHA,
+    SWP_NOACTIVATE, SWP_NOMOVE, SWP_NOSIZE, SWP_SHOWWINDOW, WNDCLASSEXW, WS_EX_LAYERED,
+    WS_EX_NOACTIVATE, WS_EX_TOOLWINDOW, WS_EX_TOPMOST, WS_EX_TRANSPARENT, WS_POPUP,
+};
 
-use crate::capture_pipeline::CapturePublisher;
 use crate::capture_health::{CaptureHealthState, CaptureMode, EncoderType};
+use crate::capture_pipeline::CapturePublisher;
 
 // ── GPU HDR→SDR Conversion Pipeline (shared module) ──
 
@@ -63,12 +60,26 @@ use crate::gpu_converter::GpuConverter;
 // ── Global State ──
 
 struct DesktopShareHandle {
+    task_id: u64,
     running: Arc<AtomicBool>,
+    task: tokio::task::JoinHandle<()>,
 }
 
 fn global_state() -> &'static Mutex<Option<DesktopShareHandle>> {
     static STATE: OnceLock<Mutex<Option<DesktopShareHandle>>> = OnceLock::new();
     STATE.get_or_init(|| Mutex::new(None))
+}
+
+fn next_task_id() -> u64 {
+    static NEXT_TASK_ID: AtomicU64 = AtomicU64::new(1);
+    NEXT_TASK_ID.fetch_add(1, Ordering::Relaxed)
+}
+
+fn clear_task_if_current(task_id: u64) {
+    let mut state = global_state().lock().unwrap();
+    if state.as_ref().map(|handle| handle.task_id) == Some(task_id) {
+        *state = None;
+    }
 }
 
 // ── Public API ──
@@ -93,15 +104,22 @@ pub fn check_available() -> (bool, String) {
 
         if let Ok(desc) = output.GetDesc() {
             let name = String::from_utf16_lossy(
-                &desc.DeviceName[..desc.DeviceName.iter().position(|&c| c == 0).unwrap_or(desc.DeviceName.len())],
+                &desc.DeviceName[..desc
+                    .DeviceName
+                    .iter()
+                    .position(|&c| c == 0)
+                    .unwrap_or(desc.DeviceName.len())],
             );
             let r = desc.DesktopCoordinates;
-            (true, format!(
-                "DXGI DD available: {} ({}x{})",
-                name,
-                r.right - r.left,
-                r.bottom - r.top,
-            ))
+            (
+                true,
+                format!(
+                    "DXGI DD available: {} ({}x{})",
+                    name,
+                    r.right - r.left,
+                    r.bottom - r.top,
+                ),
+            )
         } else {
             (true, "DXGI DD available".into())
         }
@@ -121,16 +139,10 @@ pub async fn start(
     app: AppHandle,
     health: Arc<CaptureHealthState>,
 ) -> Result<(), String> {
-    stop();
+    stop().await?;
 
     let running = Arc::new(AtomicBool::new(true));
-
-    {
-        let mut state = global_state().lock().unwrap();
-        *state = Some(DesktopShareHandle {
-            running: running.clone(),
-        });
-    }
+    let task_id = next_task_id();
 
     // Get game PID for audio capture
     let target_pid = unsafe {
@@ -142,35 +154,73 @@ pub async fn start(
 
     let _ = app.emit("desktop-capture-started", target_pid);
 
+    let app_for_capture = app.clone();
     let r2 = running.clone();
     let health_clone = Arc::clone(&health);
-    tokio::spawn(async move {
+    let task = tokio::spawn(async move {
         // Run DXGI capture on a blocking thread — it uses COM and blocking waits
         let result = tokio::task::spawn_blocking(move || {
-            capture_loop_blocking(&sfu_url, &token, &app, &r2, hwnd, fullscreen, health_clone)
+            capture_loop_blocking(
+                &sfu_url,
+                &token,
+                &app_for_capture,
+                &r2,
+                hwnd,
+                fullscreen,
+                health_clone,
+            )
         })
-        .await
-        .map_err(|e| format!("spawn_blocking: {e}"))?;
+        .await;
 
-        if let Err(e) = result {
+        if let Err(e) = match result {
+            Ok(inner) => inner,
+            Err(e) => Err(format!("spawn_blocking: {e}")),
+        } {
             eprintln!("[desktop-capture] error: {e}");
+            let _ = app.emit("desktop-capture-error", e);
         }
 
-        let mut state = global_state().lock().unwrap();
-        *state = None;
-        Ok::<(), String>(())
+        let _ = app.emit("desktop-capture-stopped", ());
+        eprintln!("[desktop-capture] task exited");
+        clear_task_if_current(task_id);
     });
+
+    {
+        let mut state = global_state().lock().unwrap();
+        *state = Some(DesktopShareHandle {
+            task_id,
+            running,
+            task,
+        });
+        if state
+            .as_ref()
+            .map(|handle| handle.task.is_finished())
+            .unwrap_or(false)
+        {
+            *state = None;
+        }
+    }
 
     Ok(())
 }
 
 /// Stop the current desktop capture.
-pub fn stop() {
-    let mut state = global_state().lock().unwrap();
-    if let Some(handle) = state.take() {
+pub async fn stop() -> Result<(), String> {
+    let handle = {
+        let mut state = global_state().lock().unwrap();
+        state.take()
+    };
+
+    if let Some(handle) = handle {
         handle.running.store(false, Ordering::SeqCst);
         eprintln!("[desktop-capture] stop requested");
+        handle
+            .task
+            .await
+            .map_err(|e| format!("desktop capture task join failed: {e}"))?;
     }
+
+    Ok(())
 }
 
 /// Returns true if a desktop capture is currently running.
@@ -205,7 +255,10 @@ fn find_output_for_window(
     };
     unsafe {
         if !GetMonitorInfoW(monitor, &mut mi).as_bool() {
-            return Err(format!("GetMonitorInfoW failed (is_monitor={}, handle={})", is_monitor, hwnd_or_hmonitor));
+            return Err(format!(
+                "GetMonitorInfoW failed (is_monitor={}, handle={})",
+                is_monitor, hwnd_or_hmonitor
+            ));
         }
     }
     let mon_w = (mi.rcMonitor.right - mi.rcMonitor.left) as u32;
@@ -291,7 +344,9 @@ static ANTI_MPO_CLASS_REGISTERED: std::sync::atomic::AtomicBool =
     std::sync::atomic::AtomicBool::new(false);
 
 unsafe extern "system" fn anti_mpo_wndproc(
-    hwnd: HWND, msg: u32, wparam: windows::Win32::Foundation::WPARAM,
+    hwnd: HWND,
+    msg: u32,
+    wparam: windows::Win32::Foundation::WPARAM,
     lparam: windows::Win32::Foundation::LPARAM,
 ) -> windows::Win32::Foundation::LRESULT {
     DefWindowProcW(hwnd, msg, wparam, lparam)
@@ -301,9 +356,8 @@ unsafe extern "system" fn anti_mpo_wndproc(
 /// Returns the HWND which must be destroyed when capture stops.
 unsafe fn create_anti_mpo_window(monitor_rect: &RECT) -> Option<HWND> {
     // Register window class once
-    let hinstance = windows::Win32::Foundation::HINSTANCE(
-        GetModuleHandleW(None).unwrap_or_default().0
-    );
+    let hinstance =
+        windows::Win32::Foundation::HINSTANCE(GetModuleHandleW(None).unwrap_or_default().0);
     if !ANTI_MPO_CLASS_REGISTERED.swap(true, Ordering::SeqCst) {
         let class_name = windows::core::w!("EchoAntiMPO");
         let wc = WNDCLASSEXW {
@@ -317,8 +371,8 @@ unsafe fn create_anti_mpo_window(monitor_rect: &RECT) -> Option<HWND> {
     }
 
     let class_name = windows::core::w!("EchoAntiMPO");
-    let ex_style = WS_EX_TOPMOST | WS_EX_TRANSPARENT | WS_EX_LAYERED
-        | WS_EX_TOOLWINDOW | WS_EX_NOACTIVATE;
+    let ex_style =
+        WS_EX_TOPMOST | WS_EX_TRANSPARENT | WS_EX_LAYERED | WS_EX_TOOLWINDOW | WS_EX_NOACTIVATE;
 
     // Place the 1x1 window at the top-left of the monitor containing the game
     let hwnd = CreateWindowExW(
@@ -345,8 +399,12 @@ unsafe fn create_anti_mpo_window(monitor_rect: &RECT) -> Option<HWND> {
         let _ = SetLayeredWindowAttributes(hwnd, None, 0, LWA_ALPHA);
         // Ensure topmost + visible
         let _ = SetWindowPos(
-            hwnd, HWND_TOPMOST,
-            0, 0, 0, 0,
+            hwnd,
+            HWND_TOPMOST,
+            0,
+            0,
+            0,
+            0,
             SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE | SWP_SHOWWINDOW,
         );
         eprintln!("[anti-mpo] overlay window created — DWM forced to Composed Flip");
@@ -360,8 +418,12 @@ unsafe fn create_anti_mpo_window(monitor_rect: &RECT) -> Option<HWND> {
 /// Reassert topmost status — games can temporarily promote themselves above other windows.
 unsafe fn refresh_anti_mpo_window(hwnd: HWND) {
     let _ = SetWindowPos(
-        hwnd, HWND_TOPMOST,
-        0, 0, 0, 0,
+        hwnd,
+        HWND_TOPMOST,
+        0,
+        0,
+        0,
+        0,
         SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE | SWP_SHOWWINDOW,
     );
 }
@@ -605,7 +667,8 @@ fn capture_loop_blocking(
     };
 
     // 2. Create D3D11 device on the same adapter
-    let adapter_base: windows::Win32::Graphics::Dxgi::IDXGIAdapter = adapter.cast()
+    let adapter_base: windows::Win32::Graphics::Dxgi::IDXGIAdapter = adapter
+        .cast()
         .map_err(|e| format!("cast IDXGIAdapter: {e}"))?;
     let mut device: Option<ID3D11Device> = None;
     unsafe {
@@ -623,8 +686,8 @@ fn capture_loop_blocking(
         .map_err(|e| format!("D3D11CreateDevice: {e}"))?;
     }
     let device = device.ok_or("D3D11CreateDevice returned null")?;
-    let context = unsafe { device.GetImmediateContext() }
-        .map_err(|e| format!("GetImmediateContext: {e}"))?;
+    let context =
+        unsafe { device.GetImmediateContext() }.map_err(|e| format!("GetImmediateContext: {e}"))?;
 
     // 3. Create output duplication — as a closure so we can reinit on
     // recoverable stalls (5+ seconds of AcquireNextFrame timeouts from
@@ -697,7 +760,12 @@ fn capture_loop_blocking(
     // 4. Connect to LiveKit and publish track via shared pipeline
     let rt = tokio::runtime::Handle::current();
     let mut publisher = CapturePublisher::connect_and_publish_blocking(
-        &rt, sfu_url, token, enc_w, enc_h, "desktop-capture",
+        &rt,
+        sfu_url,
+        token,
+        enc_w,
+        enc_h,
+        "desktop-capture",
     )?;
 
     health.set_active(
@@ -798,14 +866,12 @@ fn capture_loop_blocking(
 
     // 7. Frame loop
     while running.load(Ordering::SeqCst) {
-
         // Acquire next frame from compositor (blocks up to 100ms)
         let mut frame_info = DXGI_OUTDUPL_FRAME_INFO::default();
         let mut resource: Option<IDXGIResource> = None;
 
-        let acquire_result = unsafe {
-            duplication.AcquireNextFrame(100, &mut frame_info, &mut resource)
-        };
+        let acquire_result =
+            unsafe { duplication.AcquireNextFrame(100, &mut frame_info, &mut resource) };
 
         match acquire_result {
             Err(e) => {
@@ -898,14 +964,18 @@ fn capture_loop_blocking(
 
         // Skip frames with no visual update
         if frame_info.LastPresentTime == 0 {
-            unsafe { duplication.ReleaseFrame().ok(); }
+            unsafe {
+                duplication.ReleaseFrame().ok();
+            }
             continue;
         }
 
         let resource = match resource {
             Some(r) => r,
             None => {
-                unsafe { duplication.ReleaseFrame().ok(); }
+                unsafe {
+                    duplication.ReleaseFrame().ok();
+                }
                 continue;
             }
         };
@@ -915,14 +985,18 @@ fn capture_loop_blocking(
             Ok(t) => t,
             Err(e) => {
                 eprintln!("[desktop-capture] cast texture: {e}");
-                unsafe { duplication.ReleaseFrame().ok(); }
+                unsafe {
+                    duplication.ReleaseFrame().ok();
+                }
                 continue;
             }
         };
 
         // Get actual frame dimensions
         let mut frame_desc = D3D11_TEXTURE2D_DESC::default();
-        unsafe { frame_texture.GetDesc(&mut frame_desc); }
+        unsafe {
+            frame_texture.GetDesc(&mut frame_desc);
+        }
         let frame_w = frame_desc.Width;
         let frame_h = frame_desc.Height;
 
@@ -939,7 +1013,9 @@ fn capture_loop_blocking(
         };
 
         if out_w == 0 || out_h == 0 {
-            unsafe { duplication.ReleaseFrame().ok(); }
+            unsafe {
+                duplication.ReleaseFrame().ok();
+            }
             continue;
         }
 
@@ -949,13 +1025,18 @@ fn capture_loop_blocking(
             staging = create_staging_texture_fmt(&device, frame_w, frame_h, frame_fmt).ok();
             staging_w = frame_w;
             staging_h = frame_h;
-            eprintln!("[desktop-capture] staging: {frame_w}x{frame_h} fmt={}", frame_fmt.0);
+            eprintln!(
+                "[desktop-capture] staging: {frame_w}x{frame_h} fmt={}",
+                frame_fmt.0
+            );
         }
 
         let staging_tex = match &staging {
             Some(s) => s,
             None => {
-                unsafe { duplication.ReleaseFrame().ok(); }
+                unsafe {
+                    duplication.ReleaseFrame().ok();
+                }
                 continue;
             }
         };
@@ -963,14 +1044,17 @@ fn capture_loop_blocking(
         let is_hdr = frame_fmt == DXGI_FORMAT_R16G16B16A16_FLOAT;
 
         // Initialize GPU converter on first HDR frame (or when dimensions change)
-        if is_hdr && (gpu_converter.is_none()
-            || gpu_converter.as_ref().map(|c| c.src_w) != Some(frame_w)
-            || gpu_converter.as_ref().map(|c| c.src_h) != Some(frame_h))
+        if is_hdr
+            && (gpu_converter.is_none()
+                || gpu_converter.as_ref().map(|c| c.src_w) != Some(frame_w)
+                || gpu_converter.as_ref().map(|c| c.src_h) != Some(frame_h))
         {
             match GpuConverter::new(&device, frame_w, frame_h, frame_fmt, enc_w, enc_h) {
                 Ok(c) => {
-                    eprintln!("[desktop-capture] GPU converter ready: {}x{} HDR → {}x{} SDR",
-                        frame_w, frame_h, enc_w, enc_h);
+                    eprintln!(
+                        "[desktop-capture] GPU converter ready: {}x{} HDR → {}x{} SDR",
+                        frame_w, frame_h, enc_w, enc_h
+                    );
                     gpu_converter = Some(c);
                 }
                 Err(e) => {
@@ -998,7 +1082,15 @@ fn capture_loop_blocking(
             // === GPU PATH: HDR->SDR + downscale via compute shader ===
             if is_hdr && gpu_converter.is_some() {
                 let converter = gpu_converter.as_ref().unwrap();
-                match converter.convert(&context, &frame_texture, crop_x, crop_y, crop_w, crop_h, Some(&*health)) {
+                match converter.convert(
+                    &context,
+                    &frame_texture,
+                    crop_x,
+                    crop_y,
+                    crop_w,
+                    crop_h,
+                    Some(&*health),
+                ) {
                     Ok((bgra_ptr, stride, w, h)) => {
                         duplication.ReleaseFrame().ok();
                         // GPU path is intentionally zero-copy — the mapped GPU
@@ -1011,16 +1103,16 @@ fn capture_loop_blocking(
                         // for HDR/GPU captures will land in v0.6.3 via a
                         // proper in-shader composite pass on the GPU side.
                         // CPU fallback path below DOES composite cursor.
-                        let bgra_data = std::slice::from_raw_parts(
-                            bgra_ptr,
-                            (stride * h) as usize,
-                        );
+                        let bgra_data = std::slice::from_raw_parts(bgra_ptr, (stride * h) as usize);
                         publisher.push_frame_strided(bgra_data, stride, w, h);
                         converter.unmap(&context);
                     }
                     Err(e) => {
                         duplication.ReleaseFrame().ok();
-                        eprintln!("[desktop-capture] GPU convert error (frame {}): {e}", publisher.frame_count());
+                        eprintln!(
+                            "[desktop-capture] GPU convert error (frame {}): {e}",
+                            publisher.frame_count()
+                        );
                         // Disable GPU path, fall back to CPU next frame
                         gpu_converter = None;
                         continue;
@@ -1032,22 +1124,32 @@ fn capture_loop_blocking(
                     staging = create_staging_texture_fmt(&device, frame_w, frame_h, frame_fmt).ok();
                     staging_w = frame_w;
                     staging_h = frame_h;
-                    eprintln!("[desktop-capture] CPU staging: {frame_w}x{frame_h} fmt={}", frame_fmt.0);
+                    eprintln!(
+                        "[desktop-capture] CPU staging: {frame_w}x{frame_h} fmt={}",
+                        frame_fmt.0
+                    );
                 }
                 let staging_tex = match &staging {
                     Some(s) => s,
-                    None => { duplication.ReleaseFrame().ok(); continue; }
+                    None => {
+                        duplication.ReleaseFrame().ok();
+                        continue;
+                    }
                 };
                 context.CopyResource(staging_tex, &frame_texture);
                 duplication.ReleaseFrame().ok();
 
                 let mut mapped = D3D11_MAPPED_SUBRESOURCE::default();
-                if context.Map(staging_tex, 0, D3D11_MAP_READ, 0, Some(&mut mapped)).is_err() {
+                if context
+                    .Map(staging_tex, 0, D3D11_MAP_READ, 0, Some(&mut mapped))
+                    .is_err()
+                {
                     continue;
                 }
                 let src_stride = mapped.RowPitch;
                 let src_data = std::slice::from_raw_parts(
-                    mapped.pData as *const u8, (src_stride * frame_h) as usize,
+                    mapped.pData as *const u8,
+                    (src_stride * frame_h) as usize,
                 );
 
                 if is_hdr {
@@ -1061,7 +1163,8 @@ fn capture_loop_blocking(
                     let sh = crop_h as usize;
                     for dy in 0..eh {
                         let sy_idx = (dy * sh / eh).min(sh - 1);
-                        let src_row = src_ptr.add((crop_y as usize + sy_idx) * src_row_stride + crop_x as usize * 8);
+                        let src_row = src_ptr
+                            .add((crop_y as usize + sy_idx) * src_row_stride + crop_x as usize * 8);
                         let dst_row = dst_ptr.add(dy * dst_stride as usize);
                         let src16 = src_row as *const u16;
                         for dx in 0..ew {
@@ -1084,7 +1187,8 @@ fn capture_loop_blocking(
                     let sh = crop_h as usize;
                     for dy in 0..eh {
                         let sy_idx = (dy * sh / eh).min(sh - 1);
-                        let sr = (crop_y as usize + sy_idx) * src_stride as usize + crop_x as usize * 4;
+                        let sr =
+                            (crop_y as usize + sy_idx) * src_stride as usize + crop_x as usize * 4;
                         let dr = dy * dst_stride as usize;
                         for dx in 0..ew {
                             let sx_idx = (dx * sw / ew).min(sw - 1);
@@ -1094,7 +1198,8 @@ fn capture_loop_blocking(
                     }
                 } else {
                     for y in 0..enc_h as usize {
-                        let src_off = (crop_y as usize + y) * src_stride as usize + crop_x as usize * 4;
+                        let src_off =
+                            (crop_y as usize + y) * src_stride as usize + crop_x as usize * 4;
                         let dst_off = y * dst_stride as usize;
                         let row_bytes = (enc_w * 4) as usize;
                         scale_buf[dst_off..dst_off + row_bytes]
@@ -1112,14 +1217,21 @@ fn capture_loop_blocking(
         // Games can temporarily promote themselves above our overlay.
         if frame_count % 60 == 0 {
             if let Some(h) = anti_mpo_hwnd {
-                unsafe { refresh_anti_mpo_window(h); }
+                unsafe {
+                    refresh_anti_mpo_window(h);
+                }
             }
         }
 
         // Stats every 60 frames
         if frame_count % 60 == 0 {
             if let Some(fps) = publisher.maybe_emit_stats(
-                app, "desktop-capture-stats", "dxgi-dd", enc_w, enc_h, 60,
+                app,
+                "desktop-capture-stats",
+                "dxgi-dd",
+                enc_w,
+                enc_h,
+                60,
             ) {
                 eprintln!("[desktop-capture] {enc_w}x{enc_h} @ {fps}fps ({frame_count} frames)");
                 health.record_capture_fps(fps);
@@ -1130,11 +1242,16 @@ fn capture_loop_blocking(
     health.set_active(false, CaptureMode::None, EncoderType::None, 0);
 
     running.store(false, Ordering::SeqCst);
-    eprintln!("[desktop-capture] shutting down, {} frames captured", publisher.frame_count());
+    eprintln!(
+        "[desktop-capture] shutting down, {} frames captured",
+        publisher.frame_count()
+    );
 
     // Destroy anti-MPO overlay -- restore normal DWM flip behavior
     if let Some(h) = anti_mpo_hwnd {
-        unsafe { let _ = DestroyWindow(h); }
+        unsafe {
+            let _ = DestroyWindow(h);
+        }
         eprintln!("[anti-mpo] overlay window destroyed");
     }
 
@@ -1165,8 +1282,8 @@ unsafe fn fast_f16_to_u8(h: u16) -> u8 {
     // value = (1 + mantissa/1024) * 2^(exp-15)
     let mantissa = (h & 0x3FF) as u32;
     let frac = 1024 + mantissa; // 1.mantissa in fixed point (11 bits, [1024..2047])
-    // Shift to get value * 255: frac * 255 >> (25 - exp)
-    // exp=14 → shift=11, exp=13 → shift=12, etc.
+                                // Shift to get value * 255: frac * 255 >> (25 - exp)
+                                // exp=14 → shift=11, exp=13 → shift=12, etc.
     let shift = 25u32.saturating_sub(exp as u32);
     if shift >= 32 {
         return 0;

--- a/core/client/src/main.rs
+++ b/core/client/src/main.rs
@@ -12,17 +12,17 @@ use audio_capture_stub as audio_capture;
 mod screen_capture;
 
 #[cfg(target_os = "windows")]
-mod gpu_converter;
+mod audio_output;
+#[cfg(not(target_os = "windows"))]
+mod audio_output_stub;
+#[cfg(target_os = "windows")]
+mod capture_health;
 #[cfg(target_os = "windows")]
 mod capture_pipeline;
 #[cfg(target_os = "windows")]
 mod desktop_capture;
 #[cfg(target_os = "windows")]
-mod capture_health;
-#[cfg(target_os = "windows")]
-mod audio_output;
-#[cfg(not(target_os = "windows"))]
-mod audio_output_stub;
+mod gpu_converter;
 #[cfg(not(target_os = "windows"))]
 use audio_output_stub as audio_output;
 
@@ -284,9 +284,8 @@ fn get_os_build_number() -> u32 {
         }
 
         unsafe {
-            let lib = windows::Win32::System::LibraryLoader::LoadLibraryW(
-                windows::core::w!("ntdll.dll"),
-            );
+            let lib =
+                windows::Win32::System::LibraryLoader::LoadLibraryW(windows::core::w!("ntdll.dll"));
             if let Ok(h) = lib {
                 let proc = windows::Win32::System::LibraryLoader::GetProcAddress(
                     h,
@@ -296,8 +295,7 @@ fn get_os_build_number() -> u32 {
                     let func: extern "system" fn(*mut OsVersionInfoExW) -> i32 =
                         std::mem::transmute(rtl_get_version);
                     let mut info: OsVersionInfoExW = std::mem::zeroed();
-                    info.dw_os_version_info_size =
-                        std::mem::size_of::<OsVersionInfoExW>() as u32;
+                    info.dw_os_version_info_size = std::mem::size_of::<OsVersionInfoExW>() as u32;
                     func(&mut info);
                     eprintln!(
                         "[os] Windows {}.{} build {}",
@@ -338,8 +336,8 @@ async fn start_screen_share(
 
 #[cfg(target_os = "windows")]
 #[tauri::command]
-fn stop_screen_share() {
-    screen_capture::stop_share();
+async fn stop_screen_share() -> Result<(), String> {
+    screen_capture::stop_share().await
 }
 
 #[cfg(target_os = "windows")]
@@ -388,8 +386,8 @@ async fn start_screen_share_monitor(
 
 #[cfg(target_os = "windows")]
 #[tauri::command]
-fn stop_desktop_capture() {
-    desktop_capture::stop();
+async fn stop_desktop_capture() -> Result<(), String> {
+    desktop_capture::stop().await
 }
 
 #[cfg(target_os = "windows")]
@@ -398,15 +396,16 @@ fn get_capture_health(
     state: tauri::State<Arc<CaptureHealthState>>,
 ) -> Option<CaptureHealthSnapshot> {
     let snap = state.snapshot();
-    if !snap.capture_active { None } else { Some(snap) }
+    if !snap.capture_active {
+        None
+    } else {
+        Some(snap)
+    }
 }
 
 #[cfg(target_os = "windows")]
 #[tauri::command]
-fn report_encoder_implementation(
-    state: tauri::State<Arc<CaptureHealthState>>,
-    encoder: String,
-) {
+fn report_encoder_implementation(state: tauri::State<Arc<CaptureHealthState>>, encoder: String) {
     state.set_encoder_type_from_string(&encoder);
 }
 

--- a/core/client/src/screen_capture.rs
+++ b/core/client/src/screen_capture.rs
@@ -12,12 +12,12 @@
 //!         → libwebrtc H264 encoder (MFT → NVENC)
 //!           → RTP → SFU
 
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 use tauri::{AppHandle, Emitter};
 
-use crate::capture_pipeline::CapturePublisher;
 use crate::capture_health::{CaptureHealthState, CaptureMode, EncoderType};
+use crate::capture_pipeline::CapturePublisher;
 
 // ── Types ──
 
@@ -35,7 +35,9 @@ pub struct CaptureSource {
 // ── Global State ──
 
 struct ShareHandle {
+    task_id: u64,
     running: Arc<AtomicBool>,
+    task: tokio::task::JoinHandle<()>,
 }
 
 fn global_state() -> &'static Mutex<Option<ShareHandle>> {
@@ -43,17 +45,31 @@ fn global_state() -> &'static Mutex<Option<ShareHandle>> {
     STATE.get_or_init(|| Mutex::new(None))
 }
 
+fn next_task_id() -> u64 {
+    static NEXT_TASK_ID: AtomicU64 = AtomicU64::new(1);
+    NEXT_TASK_ID.fetch_add(1, Ordering::Relaxed)
+}
+
+fn clear_task_if_current(task_id: u64) {
+    let mut state = global_state().lock().unwrap();
+    if state.as_ref().map(|handle| handle.task_id) == Some(task_id) {
+        *state = None;
+    }
+}
+
 // ── Public API (called from Tauri IPC) ──
 
 /// List available capture sources (monitors + windows).
 pub fn list_sources() -> Vec<CaptureSource> {
     use windows::Win32::Foundation::{BOOL, LPARAM, RECT, TRUE};
-    use windows::Win32::Graphics::Gdi::{EnumDisplayMonitors, GetMonitorInfoW, HDC, HMONITOR, MONITORINFOEXW};
+    use windows::Win32::Graphics::Gdi::{
+        EnumDisplayMonitors, GetMonitorInfoW, HDC, HMONITOR, MONITORINFOEXW,
+    };
+    use windows::Win32::System::ProcessStatus::GetModuleFileNameExW;
+    use windows::Win32::System::Threading::{OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION};
     use windows::Win32::UI::WindowsAndMessaging::{
         GetWindowLongW, GetWindowThreadProcessId, IsWindowVisible, GWL_EXSTYLE, WS_EX_TOOLWINDOW,
     };
-    use windows::Win32::System::Threading::{OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION};
-    use windows::Win32::System::ProcessStatus::GetModuleFileNameExW;
 
     let mut sources = Vec::new();
 
@@ -69,7 +85,11 @@ pub fn list_sources() -> Vec<CaptureSource> {
         info.monitorInfo.cbSize = std::mem::size_of::<MONITORINFOEXW>() as u32;
         if GetMonitorInfoW(hmonitor, &mut info as *mut _ as *mut _).as_bool() {
             let device = String::from_utf16_lossy(
-                &info.szDevice[..info.szDevice.iter().position(|&c| c == 0).unwrap_or(info.szDevice.len())],
+                &info.szDevice[..info
+                    .szDevice
+                    .iter()
+                    .position(|&c| c == 0)
+                    .unwrap_or(info.szDevice.len())],
             );
             let idx = monitors.iter().filter(|s| s.is_monitor).count() + 1;
             let title = format!("Monitor {} ({})", idx, device);
@@ -97,28 +117,61 @@ pub fn list_sources() -> Vec<CaptureSource> {
 
     // Known non-game executables for classification heuristic
     const NON_GAME_EXES: &[&str] = &[
-        "explorer.exe", "chrome.exe", "msedge.exe", "firefox.exe", "brave.exe",
-        "opera.exe", "vivaldi.exe", "discord.exe", "slack.exe", "teams.exe",
-        "code.exe", "devenv.exe", "rider64.exe", "idea64.exe",
-        "notepad.exe", "notepad++.exe", "sublime_text.exe",
-        "spotify.exe", "wmplayer.exe", "vlc.exe",
-        "powershell.exe", "pwsh.exe", "cmd.exe", "windowsterminal.exe",
-        "taskmgr.exe", "mmc.exe", "regedit.exe", "control.exe",
-        "outlook.exe", "winword.exe", "excel.exe", "powerpnt.exe",
-        "onenote.exe", "thunderbird.exe",
-        "filezilla.exe", "putty.exe", "winscp.exe",
-        "obs64.exe", "obs.exe", "streamlabs.exe",
-        "echo-core-client.exe", "echo-core-control.exe",
-        "applicationframehost.exe", "systemsettings.exe",
-        "searchhost.exe", "shellexperiencehost.exe",
-        "textinputhost.exe", "lockapp.exe",
+        "explorer.exe",
+        "chrome.exe",
+        "msedge.exe",
+        "firefox.exe",
+        "brave.exe",
+        "opera.exe",
+        "vivaldi.exe",
+        "discord.exe",
+        "slack.exe",
+        "teams.exe",
+        "code.exe",
+        "devenv.exe",
+        "rider64.exe",
+        "idea64.exe",
+        "notepad.exe",
+        "notepad++.exe",
+        "sublime_text.exe",
+        "spotify.exe",
+        "wmplayer.exe",
+        "vlc.exe",
+        "powershell.exe",
+        "pwsh.exe",
+        "cmd.exe",
+        "windowsterminal.exe",
+        "taskmgr.exe",
+        "mmc.exe",
+        "regedit.exe",
+        "control.exe",
+        "outlook.exe",
+        "winword.exe",
+        "excel.exe",
+        "powerpnt.exe",
+        "onenote.exe",
+        "thunderbird.exe",
+        "filezilla.exe",
+        "putty.exe",
+        "winscp.exe",
+        "obs64.exe",
+        "obs.exe",
+        "streamlabs.exe",
+        "echo-core-client.exe",
+        "echo-core-control.exe",
+        "applicationframehost.exe",
+        "systemsettings.exe",
+        "searchhost.exe",
+        "shellexperiencehost.exe",
+        "textinputhost.exe",
+        "lockapp.exe",
     ];
 
     /// Get the executable name for a process ID.
     fn exe_name_for_pid(pid: u32) -> Option<String> {
-        use windows::Win32::System::Threading::{OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION};
-        use windows::Win32::System::ProcessStatus::GetModuleFileNameExW;
         use windows::Win32::Foundation::HMODULE;
+        use windows::Win32::System::ProcessStatus::GetModuleFileNameExW;
+        use windows::Win32::System::Threading::{OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION};
 
         unsafe {
             let handle = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, pid).ok()?;
@@ -148,7 +201,10 @@ pub fn list_sources() -> Vec<CaptureSource> {
 
                 // Filter: skip tool windows
                 let ex_style = unsafe {
-                    GetWindowLongW(windows::Win32::Foundation::HWND(hwnd as *mut _), GWL_EXSTYLE)
+                    GetWindowLongW(
+                        windows::Win32::Foundation::HWND(hwnd as *mut _),
+                        GWL_EXSTYLE,
+                    )
                 } as u32;
                 if ex_style & WS_EX_TOOLWINDOW.0 != 0 {
                     continue;
@@ -179,7 +235,11 @@ pub fn list_sources() -> Vec<CaptureSource> {
                     id: hwnd as u64,
                     title,
                     is_monitor: false,
-                    source_type: if is_game { "game".to_string() } else { "window".to_string() },
+                    source_type: if is_game {
+                        "game".to_string()
+                    } else {
+                        "window".to_string()
+                    },
                     pid,
                 });
             }
@@ -198,40 +258,59 @@ pub async fn start_share(
     app: AppHandle,
     health: Arc<CaptureHealthState>,
 ) -> Result<(), String> {
-    stop_share();
+    stop_share().await?;
 
     let running = Arc::new(AtomicBool::new(true));
-
-    {
-        let mut state = global_state().lock().unwrap();
-        *state = Some(ShareHandle {
-            running: running.clone(),
-        });
-    }
+    let task_id = next_task_id();
 
     let app2 = app.clone();
     let r2 = running.clone();
-    tokio::spawn(async move {
+    let task = tokio::spawn(async move {
         if let Err(e) = share_loop(source_id, &sfu_url, &token, &app2, &r2, health).await {
             eprintln!("[screen-capture] error: {}", e);
             let _ = app2.emit("screen-capture-error", format!("{}", e));
         }
         let _ = app2.emit("screen-capture-stopped", ());
         eprintln!("[screen-capture] task exited");
-        let mut state = global_state().lock().unwrap();
-        *state = None;
+        clear_task_if_current(task_id);
     });
+
+    {
+        let mut state = global_state().lock().unwrap();
+        *state = Some(ShareHandle {
+            task_id,
+            running,
+            task,
+        });
+        if state
+            .as_ref()
+            .map(|handle| handle.task.is_finished())
+            .unwrap_or(false)
+        {
+            *state = None;
+        }
+    }
 
     Ok(())
 }
 
 /// Stop the current screen share.
-pub fn stop_share() {
-    let mut state = global_state().lock().unwrap();
-    if let Some(handle) = state.take() {
+pub async fn stop_share() -> Result<(), String> {
+    let handle = {
+        let mut state = global_state().lock().unwrap();
+        state.take()
+    };
+
+    if let Some(handle) = handle {
         handle.running.store(false, Ordering::SeqCst);
         eprintln!("[screen-capture] stop requested");
+        handle
+            .task
+            .await
+            .map_err(|e| format!("screen capture task join failed: {e}"))?;
     }
+
+    Ok(())
 }
 
 // ── Thumbnail Generation ──
@@ -241,10 +320,9 @@ pub fn get_thumbnail(source_id: u64, is_monitor: bool) -> Option<String> {
     use base64::Engine;
     use windows::Win32::Foundation::{HWND, RECT};
     use windows::Win32::Graphics::Gdi::{
-        BitBlt, CreateCompatibleBitmap, CreateCompatibleDC, DeleteDC, DeleteObject,
-        GetDIBits, GetDC, ReleaseDC, SelectObject, SetStretchBltMode,
-        StretchBlt, BITMAPINFO, BITMAPINFOHEADER, BI_RGB, DIB_RGB_COLORS,
-        HALFTONE, SRCCOPY,
+        BitBlt, CreateCompatibleBitmap, CreateCompatibleDC, DeleteDC, DeleteObject, GetDC,
+        GetDIBits, ReleaseDC, SelectObject, SetStretchBltMode, StretchBlt, BITMAPINFO,
+        BITMAPINFOHEADER, BI_RGB, DIB_RGB_COLORS, HALFTONE, SRCCOPY,
     };
     use windows::Win32::Storage::Xps::{PrintWindow, PRINT_WINDOW_FLAGS};
     use windows::Win32::UI::WindowsAndMessaging::GetClientRect;
@@ -330,10 +408,9 @@ pub fn get_thumbnail(source_id: u64, is_monitor: bool) -> Option<String> {
 
         SetStretchBltMode(thumb_dc, HALFTONE);
         StretchBlt(
-            thumb_dc, 0, 0, THUMB_W, THUMB_H,
-            src_dc, 0, 0, src_w, src_h,
-            SRCCOPY,
-        ).ok();
+            thumb_dc, 0, 0, THUMB_W, THUMB_H, src_dc, 0, 0, src_w, src_h, SRCCOPY,
+        )
+        .ok();
 
         // Read pixels from thumbnail
         let mut bmi = BITMAPINFO {
@@ -449,9 +526,8 @@ async fn share_loop(
     health: Arc<CaptureHealthState>,
 ) -> Result<(), String> {
     // 1. Connect to SFU and publish track via shared pipeline
-    let mut publisher = CapturePublisher::connect_and_publish(
-        sfu_url, token, 1920, 1080, "screen-capture",
-    ).await?;
+    let mut publisher =
+        CapturePublisher::connect_and_publish(sfu_url, token, 1920, 1080, "screen-capture").await?;
 
     // Resolve HWND -> PID for WASAPI audio auto-start
     let target_pid = unsafe {
@@ -479,12 +555,12 @@ async fn share_loop(
     let capture_running = running.clone();
 
     std::thread::spawn(move || {
+        use crate::gpu_converter::GpuConverter;
+        use windows::Win32::Graphics::Direct3D11::{ID3D11Device, ID3D11DeviceContext};
+        use windows::Win32::Graphics::Dxgi::Common::DXGI_FORMAT_B8G8R8A8_UNORM;
         use windows_capture::capture::{Context, GraphicsCaptureApiHandler};
         use windows_capture::settings::*;
         use windows_capture::window::Window;
-        use windows::Win32::Graphics::Direct3D11::{ID3D11Device, ID3D11DeviceContext};
-        use windows::Win32::Graphics::Dxgi::Common::DXGI_FORMAT_B8G8R8A8_UNORM;
-        use crate::gpu_converter::GpuConverter;
 
         const ENC_W: u32 = 1920;
         const ENC_H: u32 = 1080;
@@ -508,7 +584,8 @@ async fn share_loop(
             fn new(ctx: Context<Self::Flags>) -> Result<Self, Self::Error> {
                 let (tx, running) = ctx.flags;
                 Ok(Self {
-                    tx, running,
+                    tx,
+                    running,
                     wgc_frame_count: 0,
                     wgc_start: std::time::Instant::now(),
                     gpu: None,
@@ -532,31 +609,46 @@ async fn share_loop(
                 // Log WGC callback FPS every 60 frames
                 if self.wgc_frame_count % 60 == 0 {
                     let elapsed = self.wgc_start.elapsed().as_secs_f64();
-                    let fps = if elapsed > 0.0 { (self.wgc_frame_count as f64 / elapsed) as u32 } else { 0 };
-                    eprintln!("[wgc-callback] {}x{} @ {}fps ({} frames)", w, h, fps, self.wgc_frame_count);
+                    let fps = if elapsed > 0.0 {
+                        (self.wgc_frame_count as f64 / elapsed) as u32
+                    } else {
+                        0
+                    };
+                    eprintln!(
+                        "[wgc-callback] {}x{} @ {}fps ({} frames)",
+                        w, h, fps, self.wgc_frame_count
+                    );
                 }
 
                 // Get the GPU texture directly (no CPU copy!)
                 // windows-capture uses windows v0.61, we use v0.58.
                 // Both are #[repr(transparent)] COM wrappers for the same interface.
                 // Safe to transmute the reference.
-                let frame_texture: &windows::Win32::Graphics::Direct3D11::ID3D11Texture2D = unsafe {
-                    std::mem::transmute(frame.as_raw_texture())
-                };
+                let frame_texture: &windows::Win32::Graphics::Direct3D11::ID3D11Texture2D =
+                    unsafe { std::mem::transmute(frame.as_raw_texture()) };
 
                 // Lazily initialize GPU pipeline on WGC's own device
                 if self.gpu.is_none() {
                     unsafe {
-                        let device: ID3D11Device = frame_texture.GetDevice()
+                        let device: ID3D11Device = frame_texture
+                            .GetDevice()
                             .map_err(|e| format!("GetDevice: {e}"))?;
-                        let context = device.GetImmediateContext()
+                        let context = device
+                            .GetImmediateContext()
                             .map_err(|e| format!("GetImmediateContext: {e}"))?;
                         let converter = GpuConverter::new(
-                            &device, w, h,
+                            &device,
+                            w,
+                            h,
                             DXGI_FORMAT_B8G8R8A8_UNORM,
-                            ENC_W, ENC_H,
-                        ).map_err(|e| format!("GpuConverter: {e}"))?;
-                        eprintln!("[wgc-gpu] pipeline initialized on WGC device: {}x{} -> {}x{}", w, h, ENC_W, ENC_H);
+                            ENC_W,
+                            ENC_H,
+                        )
+                        .map_err(|e| format!("GpuConverter: {e}"))?;
+                        eprintln!(
+                            "[wgc-gpu] pipeline initialized on WGC device: {}x{} -> {}x{}",
+                            w, h, ENC_W, ENC_H
+                        );
                         self.gpu = Some((device, context, converter));
                     }
                 }
@@ -565,10 +657,9 @@ async fn share_loop(
 
                 // GPU pipeline: CopyResource -> compute shader -> staging -> Map -> CPU buffer
                 unsafe {
-                    let (ptr, pitch, out_w, out_h) = converter.convert(
-                        context, frame_texture,
-                        0, 0, w, h, None,
-                    ).map_err(|e| format!("convert: {e}"))?;
+                    let (ptr, pitch, out_w, out_h) = converter
+                        .convert(context, frame_texture, 0, 0, w, h, None)
+                        .map_err(|e| format!("convert: {e}"))?;
 
                     // Copy from mapped staging to owned buffer
                     let row_bytes = (out_w * 4) as usize;
@@ -652,18 +743,33 @@ async fn share_loop(
 
         if fc % 30 == 0 {
             let elapsed = publisher.elapsed().as_secs_f64();
-            let fps = if elapsed > 0.0 { (fc as f64 / elapsed) as u32 } else { 0 };
-            let avg_yuv_ms = if fc > 0 { yuv_total_us as f64 / fc as f64 / 1000.0 } else { 0.0 };
-            eprintln!("[wgc-publish] {}x{} @ {}fps ({} frames, {} skipped, yuv={:.1}ms)",
-                width, height, fps, fc, drop_count, avg_yuv_ms);
-            if let Some(emit_fps) = publisher.maybe_emit_stats(app, "screen-capture-stats", "wgc", width, height, 30) {
+            let fps = if elapsed > 0.0 {
+                (fc as f64 / elapsed) as u32
+            } else {
+                0
+            };
+            let avg_yuv_ms = if fc > 0 {
+                yuv_total_us as f64 / fc as f64 / 1000.0
+            } else {
+                0.0
+            };
+            eprintln!(
+                "[wgc-publish] {}x{} @ {}fps ({} frames, {} skipped, yuv={:.1}ms)",
+                width, height, fps, fc, drop_count, avg_yuv_ms
+            );
+            if let Some(emit_fps) =
+                publisher.maybe_emit_stats(app, "screen-capture-stats", "wgc", width, height, 30)
+            {
                 health.record_capture_fps(emit_fps);
             }
         }
     }
 
     running.store(false, Ordering::SeqCst);
-    eprintln!("[screen-capture] shutting down, {} frames captured", publisher.frame_count());
+    eprintln!(
+        "[screen-capture] shutting down, {} frames captured",
+        publisher.frame_count()
+    );
     health.set_active(false, CaptureMode::None, EncoderType::None, 0);
     publisher.shutdown().await;
     Ok(())
@@ -683,29 +789,38 @@ pub async fn start_share_monitor(
     app: AppHandle,
     health: Arc<CaptureHealthState>,
 ) -> Result<(), String> {
-    stop_share();
+    stop_share().await?;
 
     let running = Arc::new(AtomicBool::new(true));
-
-    {
-        let mut state = global_state().lock().unwrap();
-        *state = Some(ShareHandle {
-            running: running.clone(),
-        });
-    }
+    let task_id = next_task_id();
 
     let app2 = app.clone();
     let r2 = running.clone();
-    tokio::spawn(async move {
+    let task = tokio::spawn(async move {
         if let Err(e) = share_loop_monitor(hmonitor, &sfu_url, &token, &app2, &r2, health).await {
             eprintln!("[screen-capture-monitor] error: {}", e);
             let _ = app2.emit("screen-capture-error", format!("{}", e));
         }
         let _ = app2.emit("screen-capture-stopped", ());
         eprintln!("[screen-capture-monitor] task exited");
-        let mut state = global_state().lock().unwrap();
-        *state = None;
+        clear_task_if_current(task_id);
     });
+
+    {
+        let mut state = global_state().lock().unwrap();
+        *state = Some(ShareHandle {
+            task_id,
+            running,
+            task,
+        });
+        if state
+            .as_ref()
+            .map(|handle| handle.task.is_finished())
+            .unwrap_or(false)
+        {
+            *state = None;
+        }
+    }
 
     Ok(())
 }
@@ -719,11 +834,14 @@ async fn share_loop_monitor(
     health: Arc<CaptureHealthState>,
 ) -> Result<(), String> {
     // 1. Connect to SFU and publish track via shared pipeline
-    let mut publisher = CapturePublisher::connect_and_publish(
-        sfu_url, token, 1920, 1080, "screen-capture-monitor",
-    ).await?;
+    let mut publisher =
+        CapturePublisher::connect_and_publish(sfu_url, token, 1920, 1080, "screen-capture-monitor")
+            .await?;
 
-    eprintln!("[screen-capture-monitor] starting WGC monitor capture for HMONITOR {}", hmonitor);
+    eprintln!(
+        "[screen-capture-monitor] starting WGC monitor capture for HMONITOR {}",
+        hmonitor
+    );
     // No PID for monitor capture — system-wide audio not per-process
     let _ = app.emit("screen-capture-started", 0u32);
     health.set_active(
@@ -737,12 +855,12 @@ async fn share_loop_monitor(
     let capture_running = running.clone();
 
     std::thread::spawn(move || {
-        use windows_capture::capture::{Context, GraphicsCaptureApiHandler};
-        use windows_capture::settings::*;
-        use windows_capture::monitor::Monitor;
+        use crate::gpu_converter::GpuConverter;
         use windows::Win32::Graphics::Direct3D11::{ID3D11Device, ID3D11DeviceContext};
         use windows::Win32::Graphics::Dxgi::Common::DXGI_FORMAT_R16G16B16A16_FLOAT;
-        use crate::gpu_converter::GpuConverter;
+        use windows_capture::capture::{Context, GraphicsCaptureApiHandler};
+        use windows_capture::monitor::Monitor;
+        use windows_capture::settings::*;
 
         const ENC_W: u32 = 1920;
         const ENC_H: u32 = 1080;
@@ -765,7 +883,8 @@ async fn share_loop_monitor(
             fn new(ctx: Context<Self::Flags>) -> Result<Self, Self::Error> {
                 let (tx, running) = ctx.flags;
                 Ok(Self {
-                    tx, running,
+                    tx,
+                    running,
                     wgc_frame_count: 0,
                     wgc_start: std::time::Instant::now(),
                     gpu: None,
@@ -788,30 +907,45 @@ async fn share_loop_monitor(
 
                 if self.wgc_frame_count % 60 == 0 {
                     let elapsed = self.wgc_start.elapsed().as_secs_f64();
-                    let fps = if elapsed > 0.0 { (self.wgc_frame_count as f64 / elapsed) as u32 } else { 0 };
-                    eprintln!("[wgc-monitor-callback] {}x{} @ {}fps ({} frames)", w, h, fps, self.wgc_frame_count);
+                    let fps = if elapsed > 0.0 {
+                        (self.wgc_frame_count as f64 / elapsed) as u32
+                    } else {
+                        0
+                    };
+                    eprintln!(
+                        "[wgc-monitor-callback] {}x{} @ {}fps ({} frames)",
+                        w, h, fps, self.wgc_frame_count
+                    );
                 }
 
-                let frame_texture: &windows::Win32::Graphics::Direct3D11::ID3D11Texture2D = unsafe {
-                    std::mem::transmute(frame.as_raw_texture())
-                };
+                let frame_texture: &windows::Win32::Graphics::Direct3D11::ID3D11Texture2D =
+                    unsafe { std::mem::transmute(frame.as_raw_texture()) };
 
                 if self.gpu.is_none() {
                     unsafe {
-                        let device: ID3D11Device = frame_texture.GetDevice()
+                        let device: ID3D11Device = frame_texture
+                            .GetDevice()
                             .map_err(|e| format!("GetDevice: {e}"))?;
-                        let context = device.GetImmediateContext()
+                        let context = device
+                            .GetImmediateContext()
                             .map_err(|e| format!("GetImmediateContext: {e}"))?;
                         // Capture in HDR scRGB float — avoids forcing Windows to do
                         // HDR->SDR mode conversion (which causes monitor flicker on
                         // HDR displays). Our GpuConverter detects this format and
                         // applies linear->sRGB gamma correction in the shader.
                         let converter = GpuConverter::new(
-                            &device, w, h,
+                            &device,
+                            w,
+                            h,
                             DXGI_FORMAT_R16G16B16A16_FLOAT,
-                            ENC_W, ENC_H,
-                        ).map_err(|e| format!("GpuConverter: {e}"))?;
-                        eprintln!("[wgc-monitor-gpu] pipeline initialized: {}x{} HDR -> {}x{} SDR", w, h, ENC_W, ENC_H);
+                            ENC_W,
+                            ENC_H,
+                        )
+                        .map_err(|e| format!("GpuConverter: {e}"))?;
+                        eprintln!(
+                            "[wgc-monitor-gpu] pipeline initialized: {}x{} HDR -> {}x{} SDR",
+                            w, h, ENC_W, ENC_H
+                        );
                         self.gpu = Some((device, context, converter));
                     }
                 }
@@ -819,10 +953,9 @@ async fn share_loop_monitor(
                 let (_, context, converter) = self.gpu.as_ref().unwrap();
 
                 unsafe {
-                    let (ptr, pitch, out_w, out_h) = converter.convert(
-                        context, frame_texture,
-                        0, 0, w, h, None,
-                    ).map_err(|e| format!("convert: {e}"))?;
+                    let (ptr, pitch, out_w, out_h) = converter
+                        .convert(context, frame_texture, 0, 0, w, h, None)
+                        .map_err(|e| format!("convert: {e}"))?;
 
                     let row_bytes = (out_w * 4) as usize;
                     let mut bgra = vec![0u8; (out_w * out_h * 4) as usize];
@@ -858,7 +991,7 @@ async fn share_loop_monitor(
         // our shader eliminates the mode-switch flicker entirely.
         let settings = Settings::new(
             monitor,
-            CursorCaptureSettings::Default,  // cursor INCLUDED — this is the win
+            CursorCaptureSettings::Default, // cursor INCLUDED — this is the win
             DrawBorderSettings::WithoutBorder,
             SecondaryWindowSettings::Default,
             MinimumUpdateIntervalSettings::Custom(std::time::Duration::from_millis(1)),
@@ -867,7 +1000,10 @@ async fn share_loop_monitor(
             (frame_tx, capture_running),
         );
 
-        eprintln!("[screen-capture-monitor] WGC starting for HMONITOR {}", hmonitor);
+        eprintln!(
+            "[screen-capture-monitor] WGC starting for HMONITOR {}",
+            hmonitor
+        );
         match Handler::start_free_threaded(settings) {
             Ok(ctrl) => {
                 let _ = ctrl.wait();
@@ -903,18 +1039,38 @@ async fn share_loop_monitor(
 
         if fc % 30 == 0 {
             let elapsed = publisher.elapsed().as_secs_f64();
-            let fps = if elapsed > 0.0 { (fc as f64 / elapsed) as u32 } else { 0 };
-            let avg_yuv_ms = if fc > 0 { yuv_total_us as f64 / fc as f64 / 1000.0 } else { 0.0 };
-            eprintln!("[wgc-monitor-publish] {}x{} @ {}fps ({} frames, {} skipped, yuv={:.1}ms)",
-                width, height, fps, fc, drop_count, avg_yuv_ms);
-            if let Some(emit_fps) = publisher.maybe_emit_stats(app, "screen-capture-stats", "wgc-monitor", width, height, 30) {
+            let fps = if elapsed > 0.0 {
+                (fc as f64 / elapsed) as u32
+            } else {
+                0
+            };
+            let avg_yuv_ms = if fc > 0 {
+                yuv_total_us as f64 / fc as f64 / 1000.0
+            } else {
+                0.0
+            };
+            eprintln!(
+                "[wgc-monitor-publish] {}x{} @ {}fps ({} frames, {} skipped, yuv={:.1}ms)",
+                width, height, fps, fc, drop_count, avg_yuv_ms
+            );
+            if let Some(emit_fps) = publisher.maybe_emit_stats(
+                app,
+                "screen-capture-stats",
+                "wgc-monitor",
+                width,
+                height,
+                30,
+            ) {
                 health.record_capture_fps(emit_fps);
             }
         }
     }
 
     running.store(false, Ordering::SeqCst);
-    eprintln!("[screen-capture-monitor] shutting down, {} frames captured", publisher.frame_count());
+    eprintln!(
+        "[screen-capture-monitor] shutting down, {} frames captured",
+        publisher.frame_count()
+    );
     health.set_active(false, CaptureMode::None, EncoderType::None, 0);
     publisher.shutdown().await;
     Ok(())

--- a/core/client/tauri.conf.json
+++ b/core/client/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "Echo Chamber",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "identifier": "com.echochamber.app",
   "build": {
     "frontendDist": "../viewer"

--- a/core/control/Cargo.toml
+++ b/core/control/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "echo-core-control"
-version = "0.6.7"
+version = "0.6.8"
 edition = "2021"
 
 [dependencies]

--- a/core/deploy/build-release.ps1
+++ b/core/deploy/build-release.ps1
@@ -44,7 +44,7 @@ if (!$SkipBuild) {
     $env:CI = "true"
 
     Push-Location $clientDir
-    cargo tauri build 2>&1
+    cargo tauri build --bundles nsis 2>&1
     $buildResult = $LASTEXITCODE
     Pop-Location
 
@@ -79,9 +79,6 @@ if ($setupExe -and $setupSig) {
     # GitHub converts spaces to dots in asset filenames
     $ghFileName = $setupExe.Name -replace ' ', '.'
 
-    # macOS updater artifact name (built by CI, not locally)
-    $macTarGz = "Echo.Chamber.app.tar.gz"
-
     $manifest = @{
         version = $version
         notes = "Echo Chamber v$version"
@@ -90,10 +87,6 @@ if ($setupExe -and $setupSig) {
             "windows-x86_64" = @{
                 signature = $sig.Trim()
                 url = "https://github.com/SamWatson86/echo-chamber/releases/download/v$version/$ghFileName"
-            }
-            "darwin-aarch64" = @{
-                signature = ""
-                url = "https://github.com/SamWatson86/echo-chamber/releases/download/v$version/$macTarGz"
             }
         }
     } | ConvertTo-Json -Depth 4
@@ -122,7 +115,3 @@ Write-Status "     - latest.json (update manifest)"
 Write-Status ""
 Write-Status "Or use gh CLI:"
 Write-Status "  gh release create v$version --title 'Echo Chamber v$version' $bundleDir\*"
-Write-Status ""
-Write-Status "After CI completes the macOS build:" Yellow
-Write-Status "  Download latest.json from the GitHub Release and copy to core\deploy\" Yellow
-Write-Status "  Or run: gh release download v$version -p latest.json -D core\deploy\ --clobber" Yellow

--- a/core/viewer/audio-routing.js
+++ b/core/viewer/audio-routing.js
@@ -408,6 +408,9 @@ function handleTrackSubscribed(track, publication, participant) {
     const existingTile = screenTileByIdentity.get(identity) || (screenTrackSid ? screenTileBySid.get(screenTrackSid) : null);
     if (existingTile && existingTile.isConnected) {
       const existingVideo = existingTile.querySelector("video");
+      if (!hiddenScreens.has(identity)) {
+        existingTile.style.display = "";
+      }
       if (cardRef && cardRef.watchToggleBtn) {
         cardRef.watchToggleBtn.style.display = "";
         cardRef.watchToggleBtn.textContent = hiddenScreens.has(identity) ? "Start Watching" : "Stop Watching";

--- a/core/viewer/capture-picker.css
+++ b/core/viewer/capture-picker.css
@@ -112,6 +112,16 @@
     background: rgba(124, 58, 237, 0.12);
 }
 
+.capture-source-card.disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+}
+
+.capture-source-card.disabled:hover {
+    background: rgba(255, 255, 255, 0.05);
+    border-color: transparent;
+}
+
 .capture-source-thumb {
     width: 100%;
     aspect-ratio: 16 / 9;

--- a/core/viewer/capture-picker.js
+++ b/core/viewer/capture-picker.js
@@ -5,6 +5,7 @@
 var _capturePickerResolve = null;
 var _capturePickerReject = null;
 var _selectedSource = null;
+var _capturePickerSupport = null;
 
 /**
  * Show the capture source picker modal.
@@ -102,6 +103,9 @@ async function _loadSources() {
     if (!body) return;
 
     try {
+        if (!_capturePickerSupport) {
+            _capturePickerSupport = await _detectCaptureSupport();
+        }
         var sources = await tauriInvoke('list_screen_sources');
         if (!sources || sources.length === 0) {
             body.innerHTML = '<div class="capture-source-empty">No capture sources found</div>';
@@ -112,6 +116,11 @@ async function _loadSources() {
         var monitors = sources.filter(function(s) { return s.source_type === 'monitor'; });
         var games = sources.filter(function(s) { return s.source_type === 'game'; });
         var windows = sources.filter(function(s) { return s.source_type === 'window'; });
+        var unsupportedWindows = [];
+        if (!_capturePickerSupport.windowCaptureSupported) {
+            unsupportedWindows = windows;
+            windows = [];
+        }
 
         var html = '';
 
@@ -124,11 +133,20 @@ async function _loadSources() {
         if (windows.length > 0) {
             html += _renderSection('Windows', null, windows);
         }
+        if (unsupportedWindows.length > 0) {
+            html += _renderSection('Windows', 'Requires Win11 24H2+', unsupportedWindows, true);
+        }
 
         body.innerHTML = html;
 
         // Bind click handlers
         body.querySelectorAll('.capture-source-card').forEach(function(card) {
+            if (card.dataset.unsupported === '1') {
+                card.onclick = function() {
+                    showToast('Window capture on this PC requires Windows 11 24H2+. Use a Screen or Game source instead.', 6000);
+                };
+                return;
+            }
             card.onclick = function() {
                 body.querySelectorAll('.capture-source-card').forEach(function(c) {
                     c.classList.remove('selected');
@@ -159,7 +177,26 @@ async function _loadSources() {
     }
 }
 
-function _renderSection(title, badge, sources) {
+async function _detectCaptureSupport() {
+    var support = {
+        osBuild: null,
+        windowCaptureSupported: true,
+    };
+    if (!window.__ECHO_NATIVE__ || typeof tauriInvoke !== 'function') {
+        return support;
+    }
+    try {
+        var osBuild = await tauriInvoke('get_os_build_number');
+        support.osBuild = osBuild;
+        support.windowCaptureSupported = osBuild >= 26100;
+    } catch (err) {
+        // Older binaries may not expose build detection yet. Leave the picker permissive
+        // and let the start path produce the fallback/error instead.
+    }
+    return support;
+}
+
+function _renderSection(title, badge, sources, disabled) {
     var badgeHtml = badge ? ' <span class="badge">' + badge + '</span>' : '';
     var html = '<div class="capture-picker-section">' +
         '<div class="capture-picker-section-title">' + title + badgeHtml + '</div>' +
@@ -167,10 +204,11 @@ function _renderSection(title, badge, sources) {
 
     for (var i = 0; i < sources.length; i++) {
         var s = sources[i];
-        html += '<div class="capture-source-card" data-id="' + s.id +
+        html += '<div class="capture-source-card' + (disabled ? ' disabled' : '') + '" data-id="' + s.id +
             '" data-title="' + _escHtml(s.title) +
             '" data-type="' + s.source_type +
-            '" data-pid="' + (s.pid || 0) + '">' +
+            '" data-pid="' + (s.pid || 0) +
+            '" data-unsupported="' + (disabled ? '1' : '0') + '">' +
             '<div class="capture-source-thumb" id="thumb-container-' + s.id + '">' +
                 '<div class="shimmer" id="thumb-' + s.id + '"></div>' +
             '</div>' +

--- a/core/viewer/changelog.js
+++ b/core/viewer/changelog.js
@@ -8,6 +8,16 @@
 
 var ECHO_CHANGELOG = [
   {
+    version: "2026-04-11",
+    title: "Reliable Screen Share Restarts (v0.6.8)",
+    notes: [
+      "Native screen sharing now shuts the previous capture task down cleanly before a new $screen publisher connects. Rapid stop/start no longer creates duplicate identities or reconnect churn.",
+      "Watching remote screen shares is much more reliable after reconnects and reloads. Existing live shares attach correctly, Start Watching resolves the real $screen companion, and native stop listeners no longer stack across repeated restarts.",
+      "The app no longer shows a false New Version Available banner on prerelease-style local builds, and Win10 machines now block unsupported native Windows capture choices instead of failing silently.",
+      "Static native window shares keep their stream alive with heartbeat frames, and native publish pacing is aligned to the intended 30fps wire target."
+    ]
+  },
+  {
     version: "2026-04-09b",
     title: "Stability + Smart Defaults (v0.6.7)",
     notes: [

--- a/core/viewer/connect.js
+++ b/core/viewer/connect.js
@@ -770,7 +770,8 @@ async function connectToRoom({ controlUrl, sfuUrl, roomId, identity, name, reuse
       const source = publication.source;
       // $screen merging: resolve companion to parent for cleanup
       // Identity suffix is the authoritative signal — no source check needed
-      var identity = participant.identity;
+      var publicationIdentity = participant.identity;
+      var identity = publicationIdentity;
       if (isScreenIdentity(identity)) {
         identity = getParentIdentity(identity);
       }
@@ -779,8 +780,8 @@ async function connectToRoom({ controlUrl, sfuUrl, roomId, identity, name, reuse
       // Helper: get remaining publications for this participant
       var remoteP = null;
       if (room && room.remoteParticipants) {
-        remoteP = room.remoteParticipants.get?.(identity);
-        if (!remoteP) room.remoteParticipants.forEach(function(p) { if (p.identity === identity) remoteP = p; });
+        remoteP = room.remoteParticipants.get?.(publicationIdentity);
+        if (!remoteP) room.remoteParticipants.forEach(function(p) { if (p.identity === publicationIdentity) remoteP = p; });
       }
       var pubs = remoteP ? getParticipantPublications(remoteP) : [];
 
@@ -1336,13 +1337,23 @@ async function connectToRoom({ controlUrl, sfuUrl, roomId, identity, name, reuse
     attachParticipantTracks(participant);
     // Opt-in: detect existing screen shares and show "Start Watching" button
     var pubs = getParticipantPublications(participant);
+    pubs.forEach(function(pub) {
+      patchScreenCompanionSource(pub, pub?.track, participant);
+    });
     var hasScreen = pubs.some(function(pub) {
       return pub && pub.source === LK.Track.Source.ScreenShare;
     });
     if (hasScreen) {
+      var effectiveIdentity = isScreenIdentity(participant.identity)
+        ? getParentIdentity(participant.identity)
+        : participant.identity;
       // Auto-subscribe to existing screen shares — don't force opt-in for late joiners.
       // The "Stop Watching" button is available if they want to unsubscribe later.
-      var cardRef = participantCards.get(participant.identity);
+      hiddenScreens.delete(effectiveIdentity);
+      watchedScreens.add(effectiveIdentity);
+      resubscribeParticipantTracks(participant);
+      reconcileParticipantMedia(participant);
+      var cardRef = participantCards.get(effectiveIdentity);
       if (cardRef && cardRef.watchToggleBtn) {
         cardRef.watchToggleBtn.style.display = "";
         cardRef.watchToggleBtn.textContent = "Stop Watching";

--- a/core/viewer/identity.js
+++ b/core/viewer/identity.js
@@ -82,17 +82,24 @@ function buildIdentity(name) {
 }
 
 function getParticipantPublications(participant) {
+  function normalizePublications(pubs) {
+    if (!Array.isArray(pubs)) return [];
+    pubs.forEach(function(pub) {
+      patchScreenCompanionSource(pub, pub?.track, participant);
+    });
+    return pubs;
+  }
   if (!participant) return [];
   if (typeof participant.getTrackPublications === "function") {
-    return participant.getTrackPublications();
+    return normalizePublications(participant.getTrackPublications());
   }
   if (participant.trackPublications?.values) {
-    return Array.from(participant.trackPublications.values());
+    return normalizePublications(Array.from(participant.trackPublications.values()));
   }
   if (participant.tracks?.values) {
-    return Array.from(participant.tracks.values());
+    return normalizePublications(Array.from(participant.tracks.values()));
   }
-  return Array.from(participant.tracks || []);
+  return normalizePublications(Array.from(participant.tracks || []));
 }
 
 function wasRecentlyHandled(key, windowMs = 200) {

--- a/core/viewer/participants-avatar.js
+++ b/core/viewer/participants-avatar.js
@@ -27,6 +27,33 @@ function iconSvg(name) {
 
 // ── Participant card ──
 
+function getRemoteParticipantsForScreenIdentity(identity) {
+  var matches = [];
+  if (!identity || !room || !room.remoteParticipants) return matches;
+  var seen = new Set();
+
+  function addCandidate(candidateIdentity) {
+    if (!candidateIdentity || seen.has(candidateIdentity)) return;
+    var participant = null;
+    if (room.remoteParticipants.get) {
+      participant = room.remoteParticipants.get(candidateIdentity);
+    }
+    if (!participant) {
+      room.remoteParticipants.forEach(function(p) {
+        if (!participant && p.identity === candidateIdentity) participant = p;
+      });
+    }
+    if (participant && !seen.has(participant.identity)) {
+      seen.add(participant.identity);
+      matches.push(participant);
+    }
+  }
+
+  addCandidate(identity);
+  addCandidate(identity + "$screen");
+  return matches;
+}
+
 function ensureParticipantCard(participant, isLocal = false) {
   const key = participant.identity;
   // Hide ghost subscriber from UI
@@ -145,6 +172,10 @@ function ensureParticipantCard(participant, isLocal = false) {
       var identity = participant.identity;
       var pState = participantState.get(identity);
       var LK_wt = getLiveKitClient();
+      function getWatchSource(pub, remoteParticipant) {
+        patchScreenCompanionSource(pub, pub?.track, remoteParticipant);
+        return pub ? (pub.source || (pub.track ? pub.track.source : null)) : null;
+      }
 
       if (hiddenScreens.has(identity)) {
         // === START WATCHING: subscribe to screen share tracks ===
@@ -155,81 +186,66 @@ function ensureParticipantCard(participant, isLocal = false) {
         debugLog("[opt-in] user opted in to watch " + identity);
 
         // Find the remote participant and subscribe to their screen share tracks
-        var remote = null;
-        if (room && room.remoteParticipants) {
-          if (room.remoteParticipants.get) {
-            remote = room.remoteParticipants.get(identity);
-          }
-          if (!remote) {
-            room.remoteParticipants.forEach(function(p) {
-              if (p.identity === identity) remote = p;
-            });
-          }
-        }
-        if (remote) {
-          var pubs = getParticipantPublications(remote);
-          pubs.forEach(function(pub) {
-            var src = pub ? (pub.source || (pub.track ? pub.track.source : null)) : null;
-            if (src === LK_wt.Track.Source.ScreenShare || src === LK_wt.Track.Source.ScreenShareAudio) {
-              // Subscribe to the track on the SFU
-              if (pub.setSubscribed) pub.setSubscribed(true);
-              // Ensure publication is hooked (event listeners registered)
-              hookPublication(pub, remote);
-              // If the track is already available (SDK cached it), process immediately
-              if (pub.track && pub.isSubscribed) {
-                debugLog("[opt-in] track already available for " + src + " " + identity + " — processing immediately");
-                handleTrackSubscribed(pub.track, pub, remote);
-              } else {
-                debugLog("[opt-in] subscribed to " + src + " for " + identity + " — waiting for track (subscribed=" + (pub.isSubscribed ?? "?") + " hasTrack=" + !!pub.track + ")");
+        var remotes = getRemoteParticipantsForScreenIdentity(identity);
+        if (remotes.length > 0) {
+          remotes.forEach(function(remote) {
+            var pubs = getParticipantPublications(remote);
+            pubs.forEach(function(pub) {
+              var src = getWatchSource(pub, remote);
+              if (src === LK_wt.Track.Source.ScreenShare || src === LK_wt.Track.Source.ScreenShareAudio) {
+                // Subscribe to the track on the SFU
+                if (pub.setSubscribed) pub.setSubscribed(true);
+                // Ensure publication is hooked (event listeners registered)
+                hookPublication(pub, remote);
+                // If the track is already available (SDK cached it), process immediately
+                if (pub.track && pub.isSubscribed) {
+                  debugLog("[opt-in] track already available for " + src + " " + remote.identity + " → " + identity + " — processing immediately");
+                  handleTrackSubscribed(pub.track, pub, remote);
+                } else {
+                  debugLog("[opt-in] subscribed to " + src + " for " + remote.identity + " → " + identity + " — waiting for track (subscribed=" + (pub.isSubscribed ?? "?") + " hasTrack=" + !!pub.track + ")");
+                }
               }
-            }
+            });
           });
           // Fallback at 500ms: check if tracks arrived and process them
           setTimeout(function() {
-            var remoteFb = null;
-            if (room && room.remoteParticipants) {
-              if (room.remoteParticipants.get) remoteFb = room.remoteParticipants.get(identity);
-              if (!remoteFb) room.remoteParticipants.forEach(function(p) { if (p.identity === identity) remoteFb = p; });
-            }
-            if (!remoteFb) return;
-            var fbPubs = getParticipantPublications(remoteFb);
-            fbPubs.forEach(function(pub) {
-              var src = pub ? (pub.source || (pub.track ? pub.track.source : null)) : null;
-              if (src === LK_wt.Track.Source.ScreenShare) {
-                if (pub.track && pub.isSubscribed && !screenTileByIdentity.has(identity)) {
-                  debugLog("[opt-in] fallback@500ms: processing screen track for " + identity);
-                  handleTrackSubscribed(pub.track, pub, remoteFb);
+            var remoteFbs = getRemoteParticipantsForScreenIdentity(identity);
+            if (remoteFbs.length === 0) return;
+            remoteFbs.forEach(function(remoteFb) {
+              var fbPubs = getParticipantPublications(remoteFb);
+              fbPubs.forEach(function(pub) {
+                var src = getWatchSource(pub, remoteFb);
+                if (src === LK_wt.Track.Source.ScreenShare) {
+                  if (pub.track && pub.isSubscribed && !screenTileByIdentity.has(identity)) {
+                    debugLog("[opt-in] fallback@500ms: processing screen track for " + remoteFb.identity + " → " + identity);
+                    handleTrackSubscribed(pub.track, pub, remoteFb);
+                  }
+                  if (!pub.isSubscribed && pub.setSubscribed) {
+                    debugLog("[opt-in] fallback@500ms: re-subscribing screen for " + remoteFb.identity + " → " + identity);
+                    pub.setSubscribed(true);
+                  }
                 }
-                // If still not subscribed, force re-subscribe
-                if (!pub.isSubscribed && pub.setSubscribed) {
-                  debugLog("[opt-in] fallback@500ms: re-subscribing screen for " + identity);
-                  pub.setSubscribed(true);
+                if (src === LK_wt.Track.Source.ScreenShareAudio) {
+                  var fbState = participantState.get(identity);
+                  if (pub.track && pub.isSubscribed && fbState && fbState.screenAudioEls.size === 0) {
+                    debugLog("[opt-in] fallback@500ms: processing screen audio for " + remoteFb.identity + " → " + identity);
+                    handleTrackSubscribed(pub.track, pub, remoteFb);
+                  }
+                  if (!pub.isSubscribed && pub.setSubscribed) {
+                    debugLog("[opt-in] fallback@500ms: re-subscribing screen audio for " + remoteFb.identity + " → " + identity);
+                    pub.setSubscribed(true);
+                  }
                 }
-              }
-              if (src === LK_wt.Track.Source.ScreenShareAudio) {
-                var fbState = participantState.get(identity);
-                if (pub.track && pub.isSubscribed && fbState && fbState.screenAudioEls.size === 0) {
-                  debugLog("[opt-in] fallback@500ms: processing screen audio for " + identity);
-                  handleTrackSubscribed(pub.track, pub, remoteFb);
-                }
-                if (!pub.isSubscribed && pub.setSubscribed) {
-                  debugLog("[opt-in] fallback@500ms: re-subscribing screen audio for " + identity);
-                  pub.setSubscribed(true);
-                }
-              }
+              });
             });
           }, 500);
           // Fallback at 1500ms: full reconcile to catch anything still missing
           setTimeout(function() {
-            var remoteFb2 = null;
-            if (room && room.remoteParticipants) {
-              if (room.remoteParticipants.get) remoteFb2 = room.remoteParticipants.get(identity);
-              if (!remoteFb2) room.remoteParticipants.forEach(function(p) { if (p.identity === identity) remoteFb2 = p; });
-            }
-            if (remoteFb2) {
-              debugLog("[opt-in] fallback@1500ms: full reconcile for " + identity);
+            var remoteFb2s = getRemoteParticipantsForScreenIdentity(identity);
+            remoteFb2s.forEach(function(remoteFb2) {
+              debugLog("[opt-in] fallback@1500ms: full reconcile for " + remoteFb2.identity + " → " + identity);
               reconcileParticipantMedia(remoteFb2);
-            }
+            });
           }, 1500);
           // Schedule reconcile waves to ensure everything settles
           scheduleReconcileWaves("opt-in-watch");
@@ -254,26 +270,16 @@ function ensureParticipantCard(participant, isLocal = false) {
         debugLog("[opt-in] user stopped watching " + identity);
 
         // Find the remote participant and unsubscribe from their screen share tracks
-        var remote = null;
-        if (room && room.remoteParticipants) {
-          if (room.remoteParticipants.get) {
-            remote = room.remoteParticipants.get(identity);
-          }
-          if (!remote) {
-            room.remoteParticipants.forEach(function(p) {
-              if (p.identity === identity) remote = p;
-            });
-          }
-        }
-        if (remote) {
+        var remotes = getRemoteParticipantsForScreenIdentity(identity);
+        remotes.forEach(function(remote) {
           var pubs = getParticipantPublications(remote);
           pubs.forEach(function(pub) {
-            var src = pub ? (pub.source || (pub.track ? pub.track.source : null)) : null;
+            var src = getWatchSource(pub, remote);
             if (src === LK_wt.Track.Source.ScreenShare || src === LK_wt.Track.Source.ScreenShareAudio) {
               if (pub.setSubscribed) pub.setSubscribed(false);
             }
           });
-        }
+        });
         // Hide tile
         var tile = screenTileByIdentity.get(identity);
         if (tile) {

--- a/core/viewer/room-status.js
+++ b/core/viewer/room-status.js
@@ -155,15 +155,64 @@ function startUpdateCheckPolling() {
   setTimeout(checkForUpdateNotification, 10000);
   _updateCheckTimer = setInterval(checkForUpdateNotification, 5 * 60 * 1000);
 }
-function isNewerVersion(latest, current) {
-  var a = latest.split(".").map(Number);
-  var b = current.split(".").map(Number);
-  for (var i = 0; i < Math.max(a.length, b.length); i++) {
-    var x = a[i] || 0, y = b[i] || 0;
-    if (x > y) return true;
-    if (x < y) return false;
+function parseVersionIdentifier(value) {
+  if (/^\d+$/.test(value)) return { numeric: true, value: parseInt(value, 10) };
+  return { numeric: false, value: String(value || "").toLowerCase() };
+}
+
+function parseVersionTag(version) {
+  var normalized = String(version || "").trim();
+  var match = normalized.match(/^v?([0-9]+(?:\.[0-9]+)*)(?:-([0-9A-Za-z.-]+))?$/);
+  if (!match) {
+    return { core: [0], prerelease: [] };
   }
-  return false;
+  return {
+    core: match[1].split(".").map(function(part) {
+      return parseInt(part, 10) || 0;
+    }),
+    prerelease: match[2]
+      ? match[2].split(".").map(parseVersionIdentifier)
+      : [],
+  };
+}
+
+function compareVersionTags(left, right) {
+  var a = parseVersionTag(left);
+  var b = parseVersionTag(right);
+  var coreLen = Math.max(a.core.length, b.core.length);
+  for (var i = 0; i < coreLen; i++) {
+    var x = a.core[i] || 0;
+    var y = b.core[i] || 0;
+    if (x > y) return 1;
+    if (x < y) return -1;
+  }
+
+  var aPre = a.prerelease;
+  var bPre = b.prerelease;
+  if (aPre.length === 0 && bPre.length === 0) return 0;
+  if (aPre.length === 0) return 1;
+  if (bPre.length === 0) return -1;
+
+  var preLen = Math.max(aPre.length, bPre.length);
+  for (var j = 0; j < preLen; j++) {
+    var aId = aPre[j];
+    var bId = bPre[j];
+    if (!aId) return -1;
+    if (!bId) return 1;
+    if (aId.numeric && bId.numeric) {
+      if (aId.value > bId.value) return 1;
+      if (aId.value < bId.value) return -1;
+      continue;
+    }
+    if (aId.numeric !== bId.numeric) return aId.numeric ? -1 : 1;
+    if (aId.value > bId.value) return 1;
+    if (aId.value < bId.value) return -1;
+  }
+  return 0;
+}
+
+function isNewerVersion(latest, current) {
+  return compareVersionTags(latest, current) > 0;
 }
 async function checkForUpdateNotification() {
   if (_updateDismissed) return;

--- a/core/viewer/screen-share-adaptive.js
+++ b/core/viewer/screen-share-adaptive.js
@@ -37,6 +37,9 @@ function startInboundScreenStatsMonitor() {
         }
       } catch (e) { /* ignore ICE stats errors */ }
       room.remoteParticipants.forEach(async (participant) => {
+        const effectiveIdentity = isScreenIdentity(participant.identity)
+          ? getParentIdentity(participant.identity)
+          : participant.identity;
         const pubs = getParticipantPublications(participant);
         for (const pub of pubs) {
           // Monitor both screen shares and cameras (video only)
@@ -45,7 +48,7 @@ function startInboundScreenStatsMonitor() {
           if (pub?.kind !== LK?.Track?.Kind?.Video) continue;
           if (!pub.track || !pub.isSubscribed) continue;
           // Skip unwatched screen shares
-          if (pub.source === LK?.Track?.Source?.ScreenShare && hiddenScreens.has(participant.identity)) continue;
+          if (pub.source === LK?.Track?.Source?.ScreenShare && hiddenScreens.has(effectiveIdentity)) continue;
           // Get receiver stats from the track's mediaStreamTrack
           const mst = pub.track.mediaStreamTrack;
           if (!mst) continue;
@@ -64,7 +67,7 @@ function startInboundScreenStatsMonitor() {
               const h = report.frameHeight || 0;
               const now = Date.now();
               // Source-aware key so camera + screen for same participant are tracked independently
-              const key = participant.identity + "-" + sourceLabel;
+              const key = effectiveIdentity + "-" + sourceLabel;
               const prev = _inboundScreenLastBytes.get(key);
               let kbps = 0;
               if (prev) {

--- a/core/viewer/screen-share-native.js
+++ b/core/viewer/screen-share-native.js
@@ -4,6 +4,63 @@
    and per-process audio capture via WASAPI.
    ========================================================= */
 
+function _stopNativeCaptureStopListeners() {
+  if (_nativeCaptureStopUnlisten) {
+    try { _nativeCaptureStopUnlisten(); } catch (e) {}
+    _nativeCaptureStopUnlisten = null;
+  }
+}
+
+async function _finalizeNativeCaptureStop(stopMessage) {
+  var wasActive = !!(window._echoNativeCaptureActive || window._echoNativeCaptureMode || screenEnabled);
+  window._echoNativeCaptureActive = false;
+  window._echoNativeCaptureMode = null;
+  screenEnabled = false;
+  _stopNativeCaptureStopListeners();
+  _stopQualityWarnListener();
+  await stopNativeAudioCapture();
+  renderPublishButtons();
+  if (stopMessage && wasActive) showToast(stopMessage, 3000);
+}
+
+async function _startNativeCaptureStopListeners() {
+  _stopNativeCaptureStopListeners();
+  if (typeof tauriListen !== 'function') return;
+
+  var stopEvents = {
+    'screen-capture-stopped': 'Screen capture ended',
+    'desktop-capture-stopped': 'Desktop capture ended',
+  };
+  var unlisteners = [];
+
+  try {
+    for (var eventName in stopEvents) {
+      if (!Object.prototype.hasOwnProperty.call(stopEvents, eventName)) continue;
+      var unlisten = await tauriListen(eventName, function(name) {
+        return function() {
+          debugLog('[' + name + '] stopped by Rust');
+          _finalizeNativeCaptureStop(stopEvents[name]).catch(function(err) {
+            debugLog('[screen-share] native stop cleanup failed: ' + (err.message || err));
+          });
+        };
+      }(eventName));
+      unlisteners.push(unlisten);
+    }
+  } catch (err) {
+    unlisteners.forEach(function(unlisten) {
+      try { unlisten(); } catch (e) {}
+    });
+    throw err;
+  }
+
+  _nativeCaptureStopUnlisten = function() {
+    unlisteners.forEach(function(unlisten) {
+      try { unlisten(); } catch (e) {}
+    });
+    unlisteners.length = 0;
+  };
+}
+
 async function startScreenShareManual() {
   const LK = getLiveKitClient();
 
@@ -52,6 +109,12 @@ async function startScreenShareManual() {
       debugLog('[os] build detection unavailable (older client), assuming WGC supported');
     }
     var wgcSupported = osBuild >= 26100;
+
+    try {
+      await _startNativeCaptureStopListeners();
+    } catch (listenErr) {
+      debugLog('[screen-share] native stop listener registration failed: ' + (listenErr.message || listenErr));
+    }
 
     // Step 3: start capture
     try {
@@ -155,22 +218,8 @@ async function startScreenShareManual() {
         debugLog('[audio] skipped — type=' + source.sourceType + ' pid=' + (source.pid || 'none'));
       }
 
-      // Listen for Rust-side auto-stop (e.g. game exited, timeouts)
-      if (typeof tauriListen === 'function') {
-        tauriListen('desktop-capture-stopped', function() {
-          debugLog('[desktop-dd] stopped by Rust');
-          window._echoNativeCaptureActive = false;
-          window._echoNativeCaptureMode = null;
-          screenEnabled = false;
-          _stopQualityWarnListener();
-          renderPublishButtons();
-          showToast('Desktop capture ended', 3000);
-        }).catch(function() {});
-        // NOTE: WASAPI audio auto-start is handled by the immediate startNativeAudioCapture()
-        // call above using the picker's PID. No event-based listeners needed — they would
-        // double-start and kill the first capture.
-      }
     } catch (err) {
+      var fallbackStarted = false;
       showToast('Capture failed: ' + (err.message || err), 8000);
       // If game capture failed, try WGC fallback (only on 24H2+)
       if (source.sourceType === 'game' && screenToken && wgcSupported) {
@@ -184,11 +233,13 @@ async function startScreenShareManual() {
           screenEnabled = true;
           window._echoNativeCaptureActive = true;
           renderPublishButtons();
+          fallbackStarted = true;
           showToast('Using standard capture (game hook unavailable)', 5000);
         } catch (e2) {
           showToast('Fallback capture also failed: ' + (e2.message || e2), 8000);
         }
       }
+      if (!fallbackStarted) _stopNativeCaptureStopListeners();
     }
     return;
   }
@@ -885,22 +936,17 @@ async function startScreenShareManual() {
 
 async function stopScreenShareManual() {
   // ── Native capture stop path ──
-  if (window._echoNativeCaptureActive) {
+  if (window._echoNativeCaptureActive || window._echoNativeCaptureMode) {
+    var stopCommand = window._echoNativeCaptureMode === 'desktop-dd'
+      ? 'stop_desktop_capture'
+      : 'stop_screen_share';
+    _stopNativeCaptureStopListeners();
     try {
-      if (window._echoNativeCaptureMode === 'desktop-dd') {
-        await tauriInvoke('stop_desktop_capture');
-      } else {
-        await tauriInvoke('stop_screen_share');
-      }
+      await tauriInvoke(stopCommand);
     } catch (e) {
       console.error('[screen-share] native stop error:', e);
     }
-    window._echoNativeCaptureActive = false;
-    window._echoNativeCaptureMode = null;
-    screenEnabled = false;
-    _stopQualityWarnListener();
-    await stopNativeAudioCapture();
-    renderPublishButtons();
+    await _finalizeNativeCaptureStop(null);
     return; // Don't fall through to browser path
   }
 

--- a/core/viewer/screen-share-state.js
+++ b/core/viewer/screen-share-state.js
@@ -40,6 +40,7 @@ var _nativeAudioDest = null;        // MediaStreamDestination
 var _nativeAudioTrack = null;       // Published LiveKit track
 var _nativeAudioUnlisten = null;    // Tauri event unlisten function
 var _nativeAudioActive = false;
+var _nativeCaptureStopUnlisten = null; // Tauri stop-event unlisten function
 
 // NOTE: The following state variables are declared in state.js (loaded earlier):
 //   _latestScreenStats, _cameraReducedForScreenShare, _bwLimitedCount,


### PR DESCRIPTION
## Release impact\n- [ ] Server-only\n- [ ] Desktop binary required\n- [x] Both\n\n## What changed\n- make native screen-share stop/start wait for the previous capture task to exit before reconnecting\n- normalize screen companion identities across reconnect, late-join, watch/unwatch, and adaptive viewer paths\n- clean up native stop listeners and fix remote Start Watching attachment after reloads\n- restore the static-window heartbeat/pacing protections and block unsupported Win10 window capture choices\n- fix false prerelease update-banner comparisons\n- bump release metadata to v0.6.8 and keep local release packaging Windows-only\n\n## Verification\n- node --check on touched viewer JS files\n- cargo check -p echo-core-client\n- cargo build -p echo-core-client --release\n- dumpbin /imports confirms nvcuda.dll remains delay-loaded\n- built signed NSIS installer + updater manifest locally\n- live runtime validation on Sam main PC, SAM-PC, and David for window share, full-screen share, reverse-direction receive, stop/start, and idle/resume stability