### PR TITLE
release: sync v0.6.8 updater manifest

### DIFF
--- a/CURRENT_SESSION.md
+++ b/CURRENT_SESSION.md
@@ -1021,3 +1021,16 @@ This session reproduced a third class of display instability on Sam's main RTX 4
   - `core\target\release\bundle\nsis\Echo Chamber_0.6.8_x64-setup.exe`
   - `core\target\release\bundle\nsis\Echo Chamber_0.6.8_x64-setup.exe.sig`
   - `core\target\release\bundle\nsis\latest.json`
+
+### v0.6.8 shipped
+- PR `#157` merged to `main`.
+- Tag `v0.6.8` pushed.
+- GitHub release workflow `Release #24287070238` completed successfully:
+  - Windows installer built and uploaded
+  - release `latest.json` published
+  - macOS job stayed disabled
+- Live server checkout updated with the committed viewer files plus the published `core/deploy/latest.json`.
+- `POST /admin/api/force-reload` succeeded and kicked `sam-pc-2513` from `main`.
+- Server verification after deploy:
+  - `/api/update/latest.json` now serves `version = 0.6.8`
+  - updater URL points at `https://github.com/SamWatson86/echo-chamber/releases/download/v0.6.8/Echo.Chamber_0.6.8_x64-setup.exe`

--- a/core/deploy/latest.json
+++ b/core/deploy/latest.json
@@ -1,15 +1,11 @@
 {
-  "version": "0.6.7",
-  "notes": "Echo Chamber v0.6.7 \u2014 AMD 20fps capture cap, cold-start grace, classifier hysteresis, correct encoder detection, screen opt-in fix, GPU flicker recovery script",
-  "pub_date": "2026-04-09T18:00:00Z",
+  "version": "0.6.8",
+  "notes": "Update to v0.6.8",
+  "pub_date": "2026-04-11T17:17:48Z",
   "platforms": {
     "windows-x86_64": {
-      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVSQ3ByNFJuZlpjME1lckVtN1psczAraGVXOVJFcGlucmdTcldvOG9jSDRUS3hHR21FdFJTbU9mMTNKTldCSSthTnFqcU5YdDdZQkQraWlMdldNZHNBa0NmSGJqeSs0L0FvPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzc1NzU3NTA5CWZpbGU6RWNobyBDaGFtYmVyXzAuNi43X3g2NC1zZXR1cC5leGUKQzZNUGZBY1dYWHlVczRlU2xFYk9ueWIvcXNVYU9SMjRzQ2ZWQ2FHV3B2U2NIeUtOMW5KNFMzLzduY1orcTZzUG84N3c4dkEyRGFibnlsZEo2MEpVRHc9PQo=",
-      "url": "https://github.com/SamWatson86/echo-chamber/releases/download/v0.6.7/Echo.Chamber_0.6.7_x64-setup.exe"
-    },
-    "darwin-aarch64": {
-      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVSQ3ByNFJuZlpjME8xL0hXdkExVDQ3enhQWVRIaHBCVjQ4eGlCd0d6a3dGTVh4bSttMkZNNW5wS1dnVUlwc1g2WTFmNzgwejZoVXA5Y242c1dUNFlMRURjalRYS01vWkFZPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzc1Njg2MTI5CWZpbGU6RWNobyBDaGFtYmVyLmFwcC50YXIuZ3oKWlB6ZzVWckhCdTJqd21QZ2hROVhhdkZ2cmRlRDhjZ2FvOCsyVStqK1hoTk0zT3REeDVGaVZabFJGQzZxM0dZNzQ2TENUMU1YOS9LT0dnd29HdGZaQnc9PQo=",
-      "url": "https://github.com/SamWatson86/echo-chamber/releases/download/v0.6.4/Echo.Chamber.app.tar.gz"
+      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVSQ3ByNFJuZlpjMEMwWTZHSDdmalNtVkhSbm5SMEliZUV5Wk5GY215K1hiSjRNdTZrVjJ6VEZDcHRzL0pVbG5lQTd4YW5VUkZWalFpOHNOSjF1VEM2a2MvR1g4V1M0QndvPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzc1OTI3ODAyCWZpbGU6RWNobyBDaGFtYmVyXzAuNi44X3g2NC1zZXR1cC5leGUKOFMwWS9ZbVc4ZDJnWUIwejY4N1o2VFpWclIvS3ZMRjdLUFB5NzlsYWdxeVFHdEpRa2hyb2ZUMTJuNkRqV3lpdkpBVU8rYnQzbm15TmlkZFNodkF2Q1E9PQo=",
+      "url": "https://github.com/SamWatson86/echo-chamber/releases/download/v0.6.8/Echo.Chamber_0.6.8_x64-setup.exe"
     }
   }
 }


### PR DESCRIPTION
## Release impact\n- [x] Server-only\n- [ ] Desktop binary required\n- [ ] Both\n\n## What changed\n- sync core/deploy/latest.json to the published v0.6.8 release manifest\n- append the final v0.6.8 ship/deploy note to CURRENT_SESSION.md\n\n## Verification\n- GitHub release workflow 24287070238 completed successfully\n- https://127.0.0.1:9443/api/update/latest.json serves version 0.6.8\n- admin force-reload succeeded after updating the live checkout