### PR TITLE
release: v0.6.9 native game-share headroom

### DIFF
--- a/CURRENT_SESSION.md
+++ b/CURRENT_SESSION.md
@@ -1065,3 +1065,27 @@ This session reproduced a third class of display instability on Sam's main RTX 4
 - Release impact for this branch is `both`:
   - desktop binary required for the new native publish profile
   - server-served viewer update required for the new `publishProfile` wiring and changelog note
+
+### Post-midnight crash isolation for the experimental client (2026-04-12 00:30 ET)
+- The experimental high-motion client build that had been side-loaded into the installed path was restored off the live machine after it caused sign-in crashes.
+- Windows crash records proved the failure was real and stable:
+  - `Application Error 1000`
+  - `BEX64 / 0xc0000409`
+  - faulting application/module: `echo-core-client.exe`
+  - repeated offset: `0x0000000001e7d27d`
+  - crash path: `C:\Users\Sam\AppData\Local\Echo Chamber\echo-core-client.exe`
+- Important isolation result:
+  - the exact same bad binary runs successfully when copied to an isolated probe path
+  - it signed in successfully as both:
+    - `crashprobe\echo-core-client-probe.exe`
+    - `crashprobe\echo-core-client.exe`
+  - that means the failure is not “this build cannot sign in” in general
+  - the failure is specific to the installed-path identity/workflow
+- Strongest current suspect is the updater/startup path, not the native game-share publish-profile logic itself.
+- Safety hardening added on this branch:
+  - client version bumped to `0.6.8-test.2`
+  - auto-updater is now disabled automatically for prerelease/test builds
+  - manual `check_for_updates` also returns `disabled` on prerelease/test builds
+- Operational rule from here:
+  - never side-load experimental builds over the live installed release path with the same release version again
+  - risky client tests must use prerelease versioning and updater-disabled behavior

--- a/CURRENT_SESSION.md
+++ b/CURRENT_SESSION.md
@@ -1089,3 +1089,33 @@ This session reproduced a third class of display instability on Sam's main RTX 4
 - Operational rule from here:
   - never side-load experimental builds over the live installed release path with the same release version again
   - risky client tests must use prerelease versioning and updater-disabled behavior
+
+### v0.6.9 release-candidate prep (2026-04-12 01:35 ET)
+- Created a clean release-candidate branch/worktree from the shipped `v0.6.8` manifest baseline:
+  - branch: `codex/release-v0.6.9-rc`
+  - worktree: `F:\Codex AI\The Echo Chamber\.codex\worktrees\release-v0.6.9-rc`
+- Cherry-picked the two validated native-game-share commits from the experimental branch:
+  - `449f4a9` — native game/window shares use a high-motion publish profile
+  - `62ce553` — prerelease desktop builds disable the auto-updater and manual update check
+- Normalized the release-candidate version to `0.6.9-rc.1` in the desktop and control manifests:
+  - `core/client/Cargo.toml`
+  - `core/client/tauri.conf.json`
+  - `core/control/Cargo.toml`
+- Added a clean top-level changelog entry for the native game-share improvement so the next release is no longer mixed into the `v0.6.8` notes.
+- Release impact for this branch remains `both`:
+  - desktop binary required for the native publish-profile change
+  - server-served viewer update required for the `publishProfile` viewer wiring and changelog entry
+- Verification on the clean RC worktree:
+  - `node --check core/viewer/screen-share-native.js`
+  - `node --check core/viewer/changelog.js`
+  - `cargo check -p echo-core-client`
+  - `cargo test -p echo-core-client capture_pipeline::tests -- --nocapture`
+  - `cargo build -p echo-core-client --release`
+- Clean-worktree build note:
+  - the first raw `cargo check` failed because this new worktree did not have a complete local WebRTC include payload on its own
+  - rerunning with `LK_CUSTOM_WEBRTC` pointed at the known-good local prebuilt payload under `F:\Codex AI\The Echo Chamber\core\target\release\build\scratch-df3657cc50cd1baa\out\livekit_webrtc\livekit\win-x64-release-webrtc-7af9351\win-x64-release` fixed that immediately
+  - this was a local build-environment issue, not a code regression in the RC branch
+- Additional generated files changed during RC prep:
+  - `core/Cargo.lock`
+  - `core/client/gen/schemas/desktop-schema.json`
+  - `core/client/gen/schemas/windows-schema.json`

--- a/CURRENT_SESSION.md
+++ b/CURRENT_SESSION.md
@@ -1034,3 +1034,34 @@ This session reproduced a third class of display instability on Sam's main RTX 4
 - Server verification after deploy:
   - `/api/update/latest.json` now serves `version = 0.6.8`
   - updater URL points at `https://github.com/SamWatson86/echo-chamber/releases/download/v0.6.8/Echo.Chamber_0.6.8_x64-setup.exe`
+
+### Native game-share publish profile hardening (2026-04-11 20:41 ET)
+- New task branch/worktree created from the shipped `v0.6.8` baseline:
+  - branch: `codex/native-game-publish-profile`
+  - worktree: `F:\Codex AI\The Echo Chamber\.codex\worktrees\native-game-publish-profile`
+- Trigger for this work: live `Crimson Desert` testing showed the native game/window share path only delivering roughly `16-18 fps` to `SAM-PC` at about `2.45 Mbps`, which is too low for a high-motion title.
+- Root cause found in the native Rust publisher path:
+  - `CapturePublisher` was hard-wired to the desktop-share profile for all native shares
+  - game/window shares were incorrectly capped at `4 Mbps` and `30 fps`
+  - desktop heartbeats were also being applied to game/window shares even though they are a poor fit for high-motion content
+- Fix implemented:
+  - added `PublishProfile::{Desktop, Game}` in `core/client/src/capture_pipeline.rs`
+  - desktop shares keep the conservative profile: `30 fps`, `4 Mbps max`, `2.5 Mbps min`, heartbeat enabled
+  - native game/window shares now use a high-motion profile: `60 fps`, `8 Mbps max`, `3 Mbps min`, heartbeat disabled
+  - `screen_capture.rs` and `desktop_capture.rs` now pass the publish profile through to the native publisher and to capture-health targets
+  - `main.rs` Tauri commands now accept an optional `publishProfile` argument and default older viewers to `Desktop`
+  - `screen-share-native.js` now sends `publishProfile: 'game'` for native `game` sources and `publishProfile: 'desktop'` for monitor/window/desktop paths
+  - `core/viewer/changelog.js` updated with the user-facing note
+- Validation completed on this branch:
+  - `node --check core/viewer/screen-share-native.js`
+  - `node --check core/viewer/changelog.js`
+  - `cargo check -p echo-core-client`
+  - `cargo test -p echo-core-client capture_pipeline::tests -- --nocapture`
+  - `cargo build -p echo-core-client --release`
+- Runtime status:
+  - build-verified only
+  - not yet side-loaded into the installed client
+  - no live before/after `Crimson Desert` receiver comparison yet
+- Release impact for this branch is `both`:
+  - desktop binary required for the new native publish profile
+  - server-served viewer update required for the new `publishProfile` wiring and changelog note

--- a/CURRENT_SESSION.md
+++ b/CURRENT_SESSION.md
@@ -1119,3 +1119,36 @@ This session reproduced a third class of display instability on Sam's main RTX 4
   - `core/Cargo.lock`
   - `core/client/gen/schemas/desktop-schema.json`
   - `core/client/gen/schemas/windows-schema.json`
+
+### v0.6.9 final release-branch prep (2026-04-12 01:42 ET)
+- Promoted the RC work onto the final release task branch:
+  - branch: `codex/release-v0.6.9`
+- Dropped the prerelease suffix and normalized the release version to `0.6.9` in:
+  - `core/client/Cargo.toml`
+  - `core/client/tauri.conf.json`
+  - `core/control/Cargo.toml`
+  - `core/Cargo.lock`
+- Installed-path smoke test completed against the real app location:
+  - live install backed up to `C:\Users\Sam\AppData\Local\Echo Chamber\_lab-artifacts\2026-04-12\installed-path-rc-smoke\echo-core-client.v0.6.8-backup.exe`
+  - `0.6.9-rc.1` was copied to `C:\Users\Sam\AppData\Local\Echo Chamber\echo-core-client.exe`
+  - the old instant installed-path crash did **not** reproduce
+  - the app stayed alive from the real installed path and was brought forward for taskbar pinning
+- Release posture now:
+  - code is being treated as the final `0.6.9` branch, not a local-only RC
+  - next steps are final Windows artifact build, branch push, and PR creation
+- Final `0.6.9` verification/build results:
+  - `node --check core/viewer/screen-share-native.js`
+  - `node --check core/viewer/changelog.js`
+  - `cargo check -p echo-core-client`
+  - `cargo build -p echo-core-client --release`
+  - `powershell -ExecutionPolicy Bypass -File core/deploy/build-release.ps1`
+- Local release artifacts generated successfully:
+  - `core\target\release\bundle\nsis\Echo Chamber_0.6.9_x64-setup.exe`
+  - `core\target\release\bundle\nsis\Echo Chamber_0.6.9_x64-setup.exe.sig`
+  - `core\target\release\bundle\nsis\latest.json`
+- Release-build environment note:
+  - copied the existing signing key from `F:\Codex AI\The Echo Chamber\core\client\.tauri-keys` into this clean worktree so the NSIS installer and updater signature could be produced
+  - reused the known-good local WebRTC payload via `LK_CUSTOM_WEBRTC` during the final build
+- Installed app updated to the final release executable for live use:
+  - copied `core\target\release\echo-core-client.exe` to `C:\Users\Sam\AppData\Local\Echo Chamber\echo-core-client.exe`
+  - relaunched the installed app successfully from the real live path

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -1304,7 +1304,7 @@ dependencies = [
 
 [[package]]
 name = "echo-core-client"
-version = "0.6.9-rc.1"
+version = "0.6.9"
 dependencies = [
  "base64 0.22.1",
  "livekit",
@@ -1323,7 +1323,7 @@ dependencies = [
 
 [[package]]
 name = "echo-core-control"
-version = "0.6.9-rc.1"
+version = "0.6.9"
 dependencies = [
  "argon2",
  "axum",

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -1304,7 +1304,7 @@ dependencies = [
 
 [[package]]
 name = "echo-core-client"
-version = "0.6.8-test.2"
+version = "0.6.9-rc.1"
 dependencies = [
  "base64 0.22.1",
  "livekit",
@@ -1323,7 +1323,7 @@ dependencies = [
 
 [[package]]
 name = "echo-core-control"
-version = "0.6.8"
+version = "0.6.9-rc.1"
 dependencies = [
  "argon2",
  "axum",

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -1304,7 +1304,7 @@ dependencies = [
 
 [[package]]
 name = "echo-core-client"
-version = "0.6.8"
+version = "0.6.8-test.2"
 dependencies = [
  "base64 0.22.1",
  "livekit",

--- a/core/client/Cargo.toml
+++ b/core/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "echo-core-client"
-version = "0.6.9-rc.1"
+version = "0.6.9"
 edition = "2021"
 description = "Echo Chamber native desktop client"
 

--- a/core/client/Cargo.toml
+++ b/core/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "echo-core-client"
-version = "0.6.8"
+version = "0.6.8-test.2"
 edition = "2021"
 description = "Echo Chamber native desktop client"
 

--- a/core/client/Cargo.toml
+++ b/core/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "echo-core-client"
-version = "0.6.8-test.2"
+version = "0.6.9-rc.1"
 edition = "2021"
 description = "Echo Chamber native desktop client"
 

--- a/core/client/src/capture_pipeline.rs
+++ b/core/client/src/capture_pipeline.rs
@@ -9,7 +9,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Emitter};
 
 use livekit::prelude::*;
@@ -30,15 +30,6 @@ pub struct CaptureStats {
 }
 
 // ── CapturePublisher ──
-
-/// Hard cap for the capture push rate when NVENC hardware encode is active.
-/// This must match the intended wire publish cap for native screen share.
-/// The previous 240fps cap let WGC/DXGI push far above the 30fps publish target
-/// in real sessions, which drove Sam's local FPS hit while still reporting a
-/// nominal 30fps target in capture-health.
-const TARGET_ENCODE_FPS_HARDWARE: f64 = PUBLISH_TARGET_FPS as f64;
-const MIN_FRAME_INTERVAL_HARDWARE: Duration =
-    Duration::from_nanos((1_000_000_000.0 / TARGET_ENCODE_FPS_HARDWARE) as u64);
 
 /// Soft cap for the capture push rate when OpenH264 software encode is active.
 /// Software H264 at 1080p at 60+ fps pins the CPU at ~90-100% and caused
@@ -63,6 +54,7 @@ pub static HAS_NVCUDA: AtomicBool = AtomicBool::new(false);
 /// don't push 100+ fps into WebRTC while the rest of the stack thinks the
 /// target is 30fps.
 pub const PUBLISH_TARGET_FPS: u32 = 30;
+pub const GAME_PUBLISH_TARGET_FPS: u32 = 60;
 
 /// Heartbeat interval for WGC/static-content frame duplication.
 /// If the real capture path has not pushed a new frame in this long, re-push
@@ -102,6 +94,53 @@ impl Drop for HeartbeatHandle {
     }
 }
 
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum PublishProfile {
+    Desktop,
+    Game,
+}
+
+impl Default for PublishProfile {
+    fn default() -> Self {
+        Self::Desktop
+    }
+}
+
+impl PublishProfile {
+    pub fn target_fps(self) -> u32 {
+        match self {
+            Self::Desktop => PUBLISH_TARGET_FPS,
+            Self::Game => GAME_PUBLISH_TARGET_FPS,
+        }
+    }
+
+    fn max_bitrate(self) -> u64 {
+        match self {
+            Self::Desktop => 4_000_000,
+            Self::Game => 8_000_000,
+        }
+    }
+
+    fn min_bitrate(self) -> u64 {
+        match self {
+            Self::Desktop => 2_500_000,
+            Self::Game => 3_000_000,
+        }
+    }
+
+    fn hardware_min_frame_interval(self) -> Duration {
+        Duration::from_nanos((1_000_000_000.0 / self.target_fps() as f64) as u64)
+    }
+
+    fn heartbeat_interval(self) -> Option<Duration> {
+        match self {
+            Self::Desktop => Some(HEARTBEAT_INTERVAL),
+            Self::Game => None,
+        }
+    }
+}
+
 /// Shared publisher that connects to the LiveKit SFU, creates a NativeVideoSource,
 /// publishes a Camera track, and provides helpers to push BGRA frames and emit stats.
 pub struct CapturePublisher {
@@ -110,6 +149,7 @@ pub struct CapturePublisher {
     start_time: Instant,
     frame_count: u64,
     last_pushed: Option<Instant>,
+    hardware_min_frame_interval: Duration,
     heartbeat_state: Arc<Mutex<HeartbeatState>>,
     heartbeat_handle: Option<HeartbeatHandle>,
 }
@@ -124,6 +164,7 @@ impl CapturePublisher {
         token: &str,
         enc_w: u32,
         enc_h: u32,
+        publish_profile: PublishProfile,
         log_prefix: &str,
     ) -> Result<Self, String> {
         eprintln!("[{}] connecting to SFU: {}", log_prefix, sfu_url);
@@ -156,27 +197,9 @@ impl CapturePublisher {
             video_codec: VideoCodec::H264,
             simulcast: false,
             video_encoding: Some(VideoEncoding {
-                // Capped at 4 Mbps for multi-publisher rooms. Validated 2026-04-07
-                // with 3 simultaneous 1080p shares and a residential-WAN viewer
-                // (David) who saw 0fps at 8Mbps. 4Mbps × 3 publishers = 12Mbps
-                // aggregate, comfortably under most residential downloads. Per-stream
-                // quality at 1080p30 H264 is still excellent for screen content.
-                // Twitch source quality reference: 6 Mbps at 1080p60 gameplay.
-                max_bitrate: 4_000_000,
-                // 2.5 Mbps hard floor — prevents libwebrtc GoogCC from throttling
-                // to zero under packet loss / RTT spikes, so the stream stays
-                // visible instead of dropping to 0fps and slowly probing back up.
-                min_bitrate: 2_500_000,
-                // 60fps for safe stable testing with David (remote friend).
-                // The level=AUTOSELECT fix is still in h264_encoder_impl.cpp
-                // for later 144fps retest on SAM-PC — harmless at 60fps.
-                // Capped at 30fps for multi-publisher rooms. With 3 simultaneous
-                // 1920x1080 H264 publishers, the cumulative NVDEC decode load
-                // and SFU forwarding pressure makes 60fps unsustainable —
-                // receivers see 10fps after pacing kicks in. 30fps gives
-                // headroom for all parties and is plenty for screen content.
-                // Spencer's recommendation, validated 2026-04-07 with 3 sharers.
-                max_framerate: PUBLISH_TARGET_FPS as f64,
+                max_bitrate: publish_profile.max_bitrate(),
+                min_bitrate: publish_profile.min_bitrate(),
+                max_framerate: publish_profile.target_fps() as f64,
             }),
             ..Default::default()
         };
@@ -198,6 +221,7 @@ impl CapturePublisher {
             heartbeat_state.clone(),
             source.clone(),
             start_time,
+            publish_profile.heartbeat_interval(),
             log_prefix,
         );
 
@@ -207,8 +231,9 @@ impl CapturePublisher {
             start_time,
             frame_count: 0,
             last_pushed: None,
+            hardware_min_frame_interval: publish_profile.hardware_min_frame_interval(),
             heartbeat_state,
-            heartbeat_handle: Some(heartbeat_handle),
+            heartbeat_handle,
         })
     }
 
@@ -222,6 +247,7 @@ impl CapturePublisher {
         token: &str,
         enc_w: u32,
         enc_h: u32,
+        publish_profile: PublishProfile,
         log_prefix: &str,
     ) -> Result<Self, String> {
         eprintln!("[{}] connecting to SFU: {}", log_prefix, sfu_url);
@@ -253,27 +279,9 @@ impl CapturePublisher {
             video_codec: VideoCodec::H264,
             simulcast: false,
             video_encoding: Some(VideoEncoding {
-                // Capped at 4 Mbps for multi-publisher rooms. Validated 2026-04-07
-                // with 3 simultaneous 1080p shares and a residential-WAN viewer
-                // (David) who saw 0fps at 8Mbps. 4Mbps × 3 publishers = 12Mbps
-                // aggregate, comfortably under most residential downloads. Per-stream
-                // quality at 1080p30 H264 is still excellent for screen content.
-                // Twitch source quality reference: 6 Mbps at 1080p60 gameplay.
-                max_bitrate: 4_000_000,
-                // 2.5 Mbps hard floor — prevents libwebrtc GoogCC from throttling
-                // to zero under packet loss / RTT spikes, so the stream stays
-                // visible instead of dropping to 0fps and slowly probing back up.
-                min_bitrate: 2_500_000,
-                // 60fps for safe stable testing with David (remote friend).
-                // The level=AUTOSELECT fix is still in h264_encoder_impl.cpp
-                // for later 144fps retest on SAM-PC — harmless at 60fps.
-                // Capped at 30fps for multi-publisher rooms. With 3 simultaneous
-                // 1920x1080 H264 publishers, the cumulative NVDEC decode load
-                // and SFU forwarding pressure makes 60fps unsustainable —
-                // receivers see 10fps after pacing kicks in. 30fps gives
-                // headroom for all parties and is plenty for screen content.
-                // Spencer's recommendation, validated 2026-04-07 with 3 sharers.
-                max_framerate: PUBLISH_TARGET_FPS as f64,
+                max_bitrate: publish_profile.max_bitrate(),
+                min_bitrate: publish_profile.min_bitrate(),
+                max_framerate: publish_profile.target_fps() as f64,
             }),
             ..Default::default()
         };
@@ -296,6 +304,7 @@ impl CapturePublisher {
             heartbeat_state.clone(),
             source.clone(),
             start_time,
+            publish_profile.heartbeat_interval(),
             log_prefix,
         );
 
@@ -305,8 +314,9 @@ impl CapturePublisher {
             start_time,
             frame_count: 0,
             last_pushed: None,
+            hardware_min_frame_interval: publish_profile.hardware_min_frame_interval(),
             heartbeat_state,
-            heartbeat_handle: Some(heartbeat_handle),
+            heartbeat_handle,
         })
     }
 
@@ -314,8 +324,12 @@ impl CapturePublisher {
         state: Arc<Mutex<HeartbeatState>>,
         source: NativeVideoSource,
         start_time: Instant,
+        heartbeat_interval: Option<Duration>,
         log_prefix: &str,
-    ) -> HeartbeatHandle {
+    ) -> Option<HeartbeatHandle> {
+        let Some(heartbeat_interval) = heartbeat_interval else {
+            return None;
+        };
         let running = Arc::new(AtomicBool::new(true));
         let running_clone = running.clone();
         let log_prefix = log_prefix.to_string();
@@ -327,7 +341,7 @@ impl CapturePublisher {
                 let mut last_log = Instant::now();
 
                 while running_clone.load(Ordering::Relaxed) {
-                    std::thread::sleep(HEARTBEAT_INTERVAL);
+                    std::thread::sleep(heartbeat_interval);
                     if !running_clone.load(Ordering::Relaxed) {
                         break;
                     }
@@ -337,7 +351,7 @@ impl CapturePublisher {
                             Ok(guard) => guard,
                             Err(poisoned) => poisoned.into_inner(),
                         };
-                        if state.last_real_push.elapsed() < HEARTBEAT_INTERVAL {
+                        if state.last_real_push.elapsed() < heartbeat_interval {
                             None
                         } else {
                             state.last_frame.as_ref().map(|frame| LastFrameBuffer {
@@ -389,10 +403,10 @@ impl CapturePublisher {
             })
             .expect("spawn heartbeat thread");
 
-        HeartbeatHandle {
+        Some(HeartbeatHandle {
             running,
             thread: Some(thread),
-        }
+        })
     }
 
     /// Convert a BGRA frame to I420 via libyuv and push it to the NativeVideoSource.
@@ -408,7 +422,7 @@ impl CapturePublisher {
         // Pace native capture to the real publish target. Without this, WGC/DXGI
         // can still push well above 30fps on NVENC systems and drag local FPS down.
         let min_interval = if HAS_NVCUDA.load(Ordering::Relaxed) {
-            MIN_FRAME_INTERVAL_HARDWARE
+            self.hardware_min_frame_interval
         } else {
             MIN_FRAME_INTERVAL_SOFTWARE
         };
@@ -512,5 +526,26 @@ impl CapturePublisher {
         } = self;
         drop(heartbeat_handle);
         rt.block_on(room.close()).ok();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn desktop_profile_stays_conservative() {
+        assert_eq!(PublishProfile::Desktop.target_fps(), PUBLISH_TARGET_FPS);
+        assert_eq!(PublishProfile::Desktop.max_bitrate(), 4_000_000);
+        assert_eq!(PublishProfile::Desktop.min_bitrate(), 2_500_000);
+        assert!(PublishProfile::Desktop.heartbeat_interval().is_some());
+    }
+
+    #[test]
+    fn game_profile_is_high_motion() {
+        assert_eq!(PublishProfile::Game.target_fps(), GAME_PUBLISH_TARGET_FPS);
+        assert_eq!(PublishProfile::Game.max_bitrate(), 8_000_000);
+        assert_eq!(PublishProfile::Game.min_bitrate(), 3_000_000);
+        assert!(PublishProfile::Game.heartbeat_interval().is_none());
     }
 }

--- a/core/client/src/desktop_capture.rs
+++ b/core/client/src/desktop_capture.rs
@@ -51,7 +51,7 @@ use windows::Win32::UI::WindowsAndMessaging::{
 };
 
 use crate::capture_health::{CaptureHealthState, CaptureMode, EncoderType};
-use crate::capture_pipeline::CapturePublisher;
+use crate::capture_pipeline::{CapturePublisher, PublishProfile};
 
 // ── GPU HDR→SDR Conversion Pipeline (shared module) ──
 
@@ -136,6 +136,7 @@ pub async fn start(
     fullscreen: bool,
     sfu_url: String,
     token: String,
+    publish_profile: PublishProfile,
     app: AppHandle,
     health: Arc<CaptureHealthState>,
 ) -> Result<(), String> {
@@ -163,6 +164,7 @@ pub async fn start(
             capture_loop_blocking(
                 &sfu_url,
                 &token,
+                publish_profile,
                 &app_for_capture,
                 &r2,
                 hwnd,
@@ -629,6 +631,7 @@ fn composite_cursor(
 fn capture_loop_blocking(
     sfu_url: &str,
     token: &str,
+    publish_profile: PublishProfile,
     app: &AppHandle,
     running: &Arc<AtomicBool>,
     hwnd: u64,
@@ -765,6 +768,7 @@ fn capture_loop_blocking(
         token,
         enc_w,
         enc_h,
+        publish_profile,
         "desktop-capture",
     )?;
 
@@ -772,7 +776,7 @@ fn capture_loop_blocking(
         true,
         CaptureMode::DxgiDd,
         EncoderType::Nvenc,
-        crate::capture_pipeline::PUBLISH_TARGET_FPS,
+        publish_profile.target_fps(),
     );
 
     // 6. Prepare GPU converter (shader pipeline) or CPU fallback

--- a/core/client/src/main.rs
+++ b/core/client/src/main.rs
@@ -50,6 +50,22 @@ struct AppInfo {
     server: String,
 }
 
+fn updater_enabled() -> bool {
+    let version = env!("CARGO_PKG_VERSION");
+    if version.contains('-') {
+        eprintln!(
+            "[updater] disabled for prerelease/test build v{}",
+            version
+        );
+        return false;
+    }
+    if std::env::var_os("ECHO_DISABLE_AUTO_UPDATER").is_some() {
+        eprintln!("[updater] disabled by ECHO_DISABLE_AUTO_UPDATER");
+        return false;
+    }
+    true
+}
+
 /// Load config.json from next to the executable.
 /// Falls back to defaults if missing or invalid.
 fn load_config() -> String {
@@ -139,6 +155,9 @@ fn get_control_url(server: tauri::State<'_, String>) -> String {
 
 #[tauri::command]
 async fn check_for_updates(app: tauri::AppHandle) -> Result<String, String> {
+    if !updater_enabled() {
+        return Ok("disabled".to_string());
+    }
     let updater = app.updater_builder().build().map_err(|e| e.to_string())?;
     match updater.check().await {
         Ok(Some(update)) => {
@@ -542,46 +561,48 @@ fn main() {
             .build()?;
 
             // Check for updates in the background
-            let handle = app.handle().clone();
-            tauri::async_runtime::spawn(async move {
-                // Small delay so the window is visible before any update dialog
-                tokio::time::sleep(std::time::Duration::from_secs(3)).await;
-                let updater = match handle.updater_builder().build() {
-                    Ok(u) => u,
-                    Err(e) => {
-                        eprintln!("[updater] build failed: {}", e);
-                        return;
-                    }
-                };
-                match updater.check().await {
-                    Ok(Some(update)) => {
-                        eprintln!(
-                            "[updater] update available: v{} -> v{}",
-                            env!("CARGO_PKG_VERSION"),
-                            update.version
-                        );
-                        match update
-                            .download_and_install(
-                                |ev, _| {
-                                    eprintln!("[updater] download progress: {:?}", ev);
-                                },
-                                || {
-                                    eprintln!("[updater] ready to install, app will restart...");
-                                },
-                            )
-                            .await
-                        {
-                            Ok(_) => {
-                                eprintln!("[updater] install complete, restarting...");
-                                handle.restart();
-                            }
-                            Err(e) => eprintln!("[updater] install failed: {}", e),
+            if updater_enabled() {
+                let handle = app.handle().clone();
+                tauri::async_runtime::spawn(async move {
+                    // Small delay so the window is visible before any update dialog
+                    tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+                    let updater = match handle.updater_builder().build() {
+                        Ok(u) => u,
+                        Err(e) => {
+                            eprintln!("[updater] build failed: {}", e);
+                            return;
                         }
+                    };
+                    match updater.check().await {
+                        Ok(Some(update)) => {
+                            eprintln!(
+                                "[updater] update available: v{} -> v{}",
+                                env!("CARGO_PKG_VERSION"),
+                                update.version
+                            );
+                            match update
+                                .download_and_install(
+                                    |ev, _| {
+                                        eprintln!("[updater] download progress: {:?}", ev);
+                                    },
+                                    || {
+                                        eprintln!("[updater] ready to install, app will restart...");
+                                    },
+                                )
+                                .await
+                            {
+                                Ok(_) => {
+                                    eprintln!("[updater] install complete, restarting...");
+                                    handle.restart();
+                                }
+                                Err(e) => eprintln!("[updater] install failed: {}", e),
+                            }
+                        }
+                        Ok(None) => eprintln!("[updater] up to date (v{})", env!("CARGO_PKG_VERSION")),
+                        Err(e) => eprintln!("[updater] check failed: {}", e),
                     }
-                    Ok(None) => eprintln!("[updater] up to date (v{})", env!("CARGO_PKG_VERSION")),
-                    Err(e) => eprintln!("[updater] check failed: {}", e),
-                }
-            });
+                });
+            }
 
             Ok(())
         })

--- a/core/client/src/main.rs
+++ b/core/client/src/main.rs
@@ -327,11 +327,19 @@ async fn start_screen_share(
     source_id: u64,
     sfu_url: String,
     token: String,
+    publish_profile: Option<capture_pipeline::PublishProfile>,
     app: tauri::AppHandle,
     health: tauri::State<'_, std::sync::Arc<CaptureHealthState>>,
 ) -> Result<(), String> {
     let health_arc = std::sync::Arc::clone(&*health);
-    screen_capture::start_share(source_id, sfu_url, token, app, health_arc).await
+    screen_capture::start_share(
+        source_id,
+        sfu_url,
+        token,
+        publish_profile.unwrap_or_default(),
+        app,
+        health_arc,
+    ).await
 }
 
 #[cfg(target_os = "windows")]
@@ -361,11 +369,20 @@ async fn start_desktop_capture(
     fullscreen: bool,
     sfu_url: String,
     token: String,
+    publish_profile: Option<capture_pipeline::PublishProfile>,
     app: tauri::AppHandle,
     health: tauri::State<'_, std::sync::Arc<CaptureHealthState>>,
 ) -> Result<(), String> {
     let health_arc = std::sync::Arc::clone(&*health);
-    desktop_capture::start(hwnd, fullscreen, sfu_url, token, app, health_arc).await
+    desktop_capture::start(
+        hwnd,
+        fullscreen,
+        sfu_url,
+        token,
+        publish_profile.unwrap_or_default(),
+        app,
+        health_arc,
+    ).await
 }
 
 /// Start WGC monitor capture (entire screen). Includes the cursor automatically

--- a/core/client/src/screen_capture.rs
+++ b/core/client/src/screen_capture.rs
@@ -17,7 +17,7 @@ use std::sync::{Arc, Mutex, OnceLock};
 use tauri::{AppHandle, Emitter};
 
 use crate::capture_health::{CaptureHealthState, CaptureMode, EncoderType};
-use crate::capture_pipeline::CapturePublisher;
+use crate::capture_pipeline::{CapturePublisher, PublishProfile};
 
 // ── Types ──
 
@@ -255,6 +255,7 @@ pub async fn start_share(
     source_id: u64,
     sfu_url: String,
     token: String,
+    publish_profile: PublishProfile,
     app: AppHandle,
     health: Arc<CaptureHealthState>,
 ) -> Result<(), String> {
@@ -266,7 +267,7 @@ pub async fn start_share(
     let app2 = app.clone();
     let r2 = running.clone();
     let task = tokio::spawn(async move {
-        if let Err(e) = share_loop(source_id, &sfu_url, &token, &app2, &r2, health).await {
+        if let Err(e) = share_loop(source_id, &sfu_url, &token, publish_profile, &app2, &r2, health).await {
             eprintln!("[screen-capture] error: {}", e);
             let _ = app2.emit("screen-capture-error", format!("{}", e));
         }
@@ -521,13 +522,20 @@ async fn share_loop(
     source_id: u64,
     sfu_url: &str,
     token: &str,
+    publish_profile: PublishProfile,
     app: &AppHandle,
     running: &Arc<AtomicBool>,
     health: Arc<CaptureHealthState>,
 ) -> Result<(), String> {
     // 1. Connect to SFU and publish track via shared pipeline
-    let mut publisher =
-        CapturePublisher::connect_and_publish(sfu_url, token, 1920, 1080, "screen-capture").await?;
+    let mut publisher = CapturePublisher::connect_and_publish(
+        sfu_url,
+        token,
+        1920,
+        1080,
+        publish_profile,
+        "screen-capture",
+    ).await?;
 
     // Resolve HWND -> PID for WASAPI audio auto-start
     let target_pid = unsafe {
@@ -546,7 +554,7 @@ async fn share_loop(
         true,
         CaptureMode::Wgc,
         EncoderType::Nvenc,
-        crate::capture_pipeline::PUBLISH_TARGET_FPS,
+        publish_profile.target_fps(),
     );
 
     // 2. Start WGC capture -- callback sends BGRA frames via channel
@@ -834,9 +842,14 @@ async fn share_loop_monitor(
     health: Arc<CaptureHealthState>,
 ) -> Result<(), String> {
     // 1. Connect to SFU and publish track via shared pipeline
-    let mut publisher =
-        CapturePublisher::connect_and_publish(sfu_url, token, 1920, 1080, "screen-capture-monitor")
-            .await?;
+    let mut publisher = CapturePublisher::connect_and_publish(
+        sfu_url,
+        token,
+        1920,
+        1080,
+        PublishProfile::Desktop,
+        "screen-capture-monitor",
+    ).await?;
 
     eprintln!(
         "[screen-capture-monitor] starting WGC monitor capture for HMONITOR {}",
@@ -848,7 +861,7 @@ async fn share_loop_monitor(
         true,
         CaptureMode::Wgc,
         EncoderType::Nvenc,
-        crate::capture_pipeline::PUBLISH_TARGET_FPS,
+        PublishProfile::Desktop.target_fps(),
     );
 
     let (frame_tx, frame_rx) = std::sync::mpsc::sync_channel::<(Vec<u8>, u32, u32)>(4);

--- a/core/client/tauri.conf.json
+++ b/core/client/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "Echo Chamber",
-  "version": "0.6.8-test.2",
+  "version": "0.6.9-rc.1",
   "identifier": "com.echochamber.app",
   "build": {
     "frontendDist": "../viewer"

--- a/core/client/tauri.conf.json
+++ b/core/client/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "Echo Chamber",
-  "version": "0.6.9-rc.1",
+  "version": "0.6.9",
   "identifier": "com.echochamber.app",
   "build": {
     "frontendDist": "../viewer"

--- a/core/client/tauri.conf.json
+++ b/core/client/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "Echo Chamber",
-  "version": "0.6.8",
+  "version": "0.6.8-test.2",
   "identifier": "com.echochamber.app",
   "build": {
     "frontendDist": "../viewer"

--- a/core/control/Cargo.toml
+++ b/core/control/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "echo-core-control"
-version = "0.6.9-rc.1"
+version = "0.6.9"
 edition = "2021"
 
 [dependencies]

--- a/core/control/Cargo.toml
+++ b/core/control/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "echo-core-control"
-version = "0.6.8"
+version = "0.6.9-rc.1"
 edition = "2021"
 
 [dependencies]

--- a/core/viewer/changelog.js
+++ b/core/viewer/changelog.js
@@ -12,7 +12,7 @@ var ECHO_CHANGELOG = [
     title: "High-Motion Native Game Shares (v0.6.9)",
     notes: [
       "Native game and app-window shares now use a dedicated high-motion publish profile instead of the conservative desktop limits. Heavy games have more bitrate and frame-rate headroom than ordinary desktop sharing.",
-      "This release also hardens prerelease desktop builds so test clients do not try to auto-update over the top of the live installed app."
+      "Test desktop builds are now hardened so prerelease clients do not auto-update over the top of the live installed app."
     ]
   },
   {

--- a/core/viewer/changelog.js
+++ b/core/viewer/changelog.js
@@ -14,7 +14,8 @@ var ECHO_CHANGELOG = [
       "Native screen sharing now shuts the previous capture task down cleanly before a new $screen publisher connects. Rapid stop/start no longer creates duplicate identities or reconnect churn.",
       "Watching remote screen shares is much more reliable after reconnects and reloads. Existing live shares attach correctly, Start Watching resolves the real $screen companion, and native stop listeners no longer stack across repeated restarts.",
       "The app no longer shows a false New Version Available banner on prerelease-style local builds, and Win10 machines now block unsupported native Windows capture choices instead of failing silently.",
-      "Static native window shares keep their stream alive with heartbeat frames, and native publish pacing is aligned to the intended 30fps wire target."
+      "Static native window shares keep their stream alive with heartbeat frames, and native publish pacing is aligned to the intended 30fps wire target.",
+      "Native game shares no longer inherit desktop-share limits. High-motion window/game capture now uses a dedicated 60fps profile with a higher bitrate ceiling, so heavy games have more headroom than ordinary desktop sharing."
     ]
   },
   {

--- a/core/viewer/changelog.js
+++ b/core/viewer/changelog.js
@@ -8,6 +8,14 @@
 
 var ECHO_CHANGELOG = [
   {
+    version: "2026-04-12",
+    title: "High-Motion Native Game Shares (v0.6.9)",
+    notes: [
+      "Native game and app-window shares now use a dedicated high-motion publish profile instead of the conservative desktop limits. Heavy games have more bitrate and frame-rate headroom than ordinary desktop sharing.",
+      "This release also hardens prerelease desktop builds so test clients do not try to auto-update over the top of the live installed app."
+    ]
+  },
+  {
     version: "2026-04-11",
     title: "Reliable Screen Share Restarts (v0.6.8)",
     notes: [

--- a/core/viewer/screen-share-native.js
+++ b/core/viewer/screen-share-native.js
@@ -132,6 +132,7 @@ async function startScreenShareManual() {
               sourceId: source.id,
               sfuUrl: sfuUrl,
               token: screenToken,
+              publishProfile: 'game',
             });
             window._echoNativeCaptureMode = 'wgc';
             captureStarted = true;
@@ -153,6 +154,7 @@ async function startScreenShareManual() {
                 fullscreen: source.isMonitor || false,
                 sfuUrl: sfuUrl,
                 token: screenToken,
+                publishProfile: 'game',
               });
               window._echoNativeCaptureMode = 'desktop-dd';
               captureStarted = true;
@@ -181,6 +183,7 @@ async function startScreenShareManual() {
               fullscreen: true,
               sfuUrl: sfuUrl,
               token: screenToken,
+              publishProfile: 'desktop',
             });
             window._echoNativeCaptureMode = 'desktop-dd';
           } else {
@@ -191,6 +194,7 @@ async function startScreenShareManual() {
             sourceId: source.id,
             sfuUrl: sfuUrl,
             token: screenToken,
+            publishProfile: 'desktop',
           });
           window._echoNativeCaptureMode = 'wgc';
         } else {


### PR DESCRIPTION
## Summary
- carry the shipped v0.6.8 screen-share restart/watch fixes onto `main`
- add a dedicated high-motion native publish profile for game/window shares
- harden prerelease desktop builds so test clients do not auto-update over the live installed app
- prepare the final `0.6.9` desktop/control versioning and changelog entry

## Release impact
- [ ] Server-only
- [ ] Desktop binary required
- [x] Both

## Verification
- `node --check core/viewer/screen-share-native.js`
- `node --check core/viewer/changelog.js`
- `cargo check -p echo-core-client`
- `cargo test -p echo-core-client capture_pipeline::tests -- --nocapture`
- `cargo build -p echo-core-client --release`
- `powershell -ExecutionPolicy Bypass -File core/deploy/build-release.ps1`
- installed-path smoke test passed from `C:\Users\Sam\AppData\Local\Echo Chamber\echo-core-client.exe`

## Runtime notes
- heavy-game testing with `Crimson Desert` confirmed the previous desktop-style publish cap was a real bug
- remaining low-FPS behavior under a fully focused uncapped game is a single-PC GPU contention limit, not an unresolved reconnect/publish defect