### PR TITLE
Prepare v0.6.11 Windows release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,12 @@
 # Changelog
 
-## 0.6.8
+## 0.6.11
 
-- Fix native screen-share restart churn: stop commands now wait for the previous native capture task to exit before a new `$screen` publisher connects
-- Fix viewer native stop-listener cleanup so repeated restarts do not stack duplicate listeners
-- Fix remote screen-share watching after reconnect/reload by normalizing `$screen` companion identities consistently across late join, watch/unwatch, and adaptive stats paths
-- Fix `Start Watching` for remote screen shares so existing live shares attach correctly instead of staying hidden or unsubscribed
-- Fix the false "New Version Available" banner when running prerelease-style local builds
-- Win10 picker now blocks unsupported native `Windows` capture entries and directs users to `Screen`/`Game`
-- Native pipeline now includes the WGC heartbeat/static-frame duplication fix and keeps native publish pacing aligned to the 30fps target
+- Fix: Windows 10 native Entire Screen sharing now auto-falls back to software H264 on the native DXGI Desktop Duplication path when no encoder override is configured, eliminating the blank `0fps` viewer tile on Win10 publishers like `SAM-PC`
+- Fix: Native Win10 software H264 screen publishers now negotiate the browser-friendly H264 packetization path that actually renders for viewers instead of stalling on a dead hardware/adapter route
+- Fix: New remote screen shares auto-watch on first publish, so already-connected viewers no longer miss startup keyframes behind a manual watch prompt
+- Fix: Remote screen tiles prefer the SDK attach path for screen video, reducing blank first-attach edge cases on live screen shares
+- Maintenance: Windows release packaging is explicitly NSIS-only again; no macOS artifact or updater manifest baggage in the release path
 
 ## 0.4.1
 

--- a/CURRENT_SESSION.md
+++ b/CURRENT_SESSION.md
@@ -937,6 +937,7 @@ This session reproduced a third class of display instability on Sam's main RTX 4
 - After repeated watch/unwatch churn on the receiver side, Sam's main PC began flickering again.
 - Flicker appeared on Monitor 1, then later on Monitor 2.
 - The strongest trigger was **idle -> first input**: after stepping away briefly, the moment Sam touched the mouse or clicked a window, the monitors started flickering again.
+- New refinement: the most reliable trigger appears to be **monitor power-off -> wake**. Sam reported that the flicker shows up when Windows turns the monitors off after inactivity and he wakes them back up.
 - A UAC secure-desktop transition also caused an immediate flicker pulse on both monitors.
 - Elevated recovery script did **not** clear it; full reboot was required again.
 
@@ -954,11 +955,17 @@ This session reproduced a third class of display instability on Sam's main RTX 4
   - installed Echo client: `C:\Users\Sam\AppData\Local\Echo Chamber\echo-core-client.exe`
   - packaged Echo desktop launcher
   - multiple WebView2 builds
+- `powercfg` on the active `Echo Gaming` plan shows `Turn off display after = 0x384` seconds on AC/DC, i.e. **900 seconds / 15 minutes**. That matches the monitor sleep timing Sam described.
+- Immediate host mitigation applied: `powercfg /change monitor-timeout-ac 0` on the active `Echo Gaming` plan, so AC display sleep is now disabled while this issue is being worked. System sleep and hibernate were already `Never`.
+- Additional system mitigation applied: `HKLM\SOFTWARE\Microsoft\Windows\Dwm\OverlayTestMode = 5` to disable MPO (Multiplane Overlay). Reboot required before judging whether this reduces the wake/flicker issue.
+- Additional host mitigation applied after reboot: blank screensaver configured at 5 minutes (`C:\Windows\System32\scrnsave.scr`) so the PC can stay awake for Echo while avoiding the risky monitor sleep/wake transition.
+- Important nuance: registry-only screensaver writes did not take effect live; the working fix was applying the same settings through `user32!SystemParametersInfo`, which now reports `ScreenSaverActive=1` and `ScreenSaverTimeout=300`.
 
 ### Current best diagnosis
 - Treat this as a **local Windows compositor / MPO / power-state / display-present path problem** on Sam's daily-driver machine.
 - Media/watch churn may poison the stack, but the visible failure is exposed by:
   - idle-to-active transitions
+  - monitor sleep/wake transitions
   - focus/input activity
   - secure-desktop transitions
 - The `Media Capture` shutdown prompt is relevant because it suggests Windows still believed a capture session/broker was alive during reboot, but it is **not** yet proof that Echo alone was the blocker.
@@ -1035,223 +1042,1117 @@ This session reproduced a third class of display instability on Sam's main RTX 4
   - `/api/update/latest.json` now serves `version = 0.6.8`
   - updater URL points at `https://github.com/SamWatson86/echo-chamber/releases/download/v0.6.8/Echo.Chamber_0.6.8_x64-setup.exe`
 
-### Native game-share publish profile hardening (2026-04-11 20:41 ET)
-- New task branch/worktree created from the shipped `v0.6.8` baseline:
-  - branch: `codex/native-game-publish-profile`
-  - worktree: `F:\Codex AI\The Echo Chamber\.codex\worktrees\native-game-publish-profile`
-- Trigger for this work: live `Crimson Desert` testing showed the native game/window share path only delivering roughly `16-18 fps` to `SAM-PC` at about `2.45 Mbps`, which is too low for a high-motion title.
-- Root cause found in the native Rust publisher path:
-  - `CapturePublisher` was hard-wired to the desktop-share profile for all native shares
-  - game/window shares were incorrectly capped at `4 Mbps` and `30 fps`
-  - desktop heartbeats were also being applied to game/window shares even though they are a poor fit for high-motion content
-- Fix implemented:
-  - added `PublishProfile::{Desktop, Game}` in `core/client/src/capture_pipeline.rs`
-  - desktop shares keep the conservative profile: `30 fps`, `4 Mbps max`, `2.5 Mbps min`, heartbeat enabled
-  - native game/window shares now use a high-motion profile: `60 fps`, `8 Mbps max`, `3 Mbps min`, heartbeat disabled
-  - `screen_capture.rs` and `desktop_capture.rs` now pass the publish profile through to the native publisher and to capture-health targets
-  - `main.rs` Tauri commands now accept an optional `publishProfile` argument and default older viewers to `Desktop`
-  - `screen-share-native.js` now sends `publishProfile: 'game'` for native `game` sources and `publishProfile: 'desktop'` for monitor/window/desktop paths
-  - `core/viewer/changelog.js` updated with the user-facing note
-- Validation completed on this branch:
-  - `node --check core/viewer/screen-share-native.js`
-  - `node --check core/viewer/changelog.js`
-  - `cargo check -p echo-core-client`
-  - `cargo test -p echo-core-client capture_pipeline::tests -- --nocapture`
-  - `cargo build -p echo-core-client --release`
-- Runtime status:
-  - build-verified only
-  - not yet side-loaded into the installed client
-  - no live before/after `Crimson Desert` receiver comparison yet
-- Release impact for this branch is `both`:
-  - desktop binary required for the new native publish profile
-  - server-served viewer update required for the new `publishProfile` wiring and changelog note
+### Additional host power-plan correction
+- Re-verified the live `Echo Gaming` power plan after Sam reported the monitors still powering down while away.
+- Confirmed the normal desktop display timeout was already disabled:
+  - `Turn off display after (AC) = 0`
+  - `Sleep after (AC) = 0`
+  - `Hibernate after (AC) = 0`
+- Found the remaining culprit: hidden `Console lock display off timeout` was still set to `60s`.
+- Applied the fix directly:
+  - `VIDEOCONLOCK (AC) = 0`
+  - `VIDEOCONLOCK (DC) = 0`
+  - `VIDEOIDLE (DC) = 0`
+- Current expected behavior:
+  - blank screensaver still activates after `300s`
+  - Windows should no longer power the monitors down through either the normal desktop timeout or the locked/secure-desktop timeout path
 
-### Post-midnight crash isolation for the experimental client (2026-04-12 00:30 ET)
-- The experimental high-motion client build that had been side-loaded into the installed path was restored off the live machine after it caused sign-in crashes.
-- Windows crash records proved the failure was real and stable:
+### Desktop launcher normalization (2026-04-12 00:46 ET)
+- Cleaned the live Windows install back into an official `v0.6.8` state by re-running the shipped installer:
+  - `F:\Codex AI\The Echo Chamber\.codex\worktrees\release-v0.6.8\core\target\release\bundle\nsis\Echo Chamber_0.6.8_x64-setup.exe`
+- Confirmed the live installed client path is once again:
+  - `C:\Users\Sam\AppData\Local\Echo Chamber\echo-core-client.exe`
+- Important launcher root cause found:
+  - the Start Menu shortcut `Echo Chamber.lnk` was **not** pointing at the Tauri client
+  - it was pointing at an old Electron install under `C:\Users\Sam\AppData\Local\Programs\@echodesktop\Echo Chamber.exe`
+- Normalized the launcher surface:
+  - `Start Menu -> Echo Chamber.lnk` now points at `C:\Users\Sam\AppData\Local\Echo Chamber\echo-core-client.exe`
+  - the legacy Electron shortcut was renamed to `Echo Chamber (Legacy Electron).lnk`
+  - the dev tray helper was renamed to `Echo Chamber Tray Tool (Dev).lnk`
+  - a matching taskbar pinned shortcut now exists at:
+    - `C:\Users\Sam\AppData\Roaming\Microsoft\Internet Explorer\Quick Launch\User Pinned\TaskBar\Echo Chamber.lnk`
+  - that taskbar shortcut also points at `C:\Users\Sam\AppData\Local\Echo Chamber\echo-core-client.exe`
+- Restarted Explorer and launched Echo through the corrected taskbar-pinned shortcut.
+- Verified the running process path after launch:
+  - `C:\Users\Sam\AppData\Local\Echo Chamber\echo-core-client.exe`
+- Moved experimental leftovers out of the live install folder into:
+  - `C:\Users\Sam\AppData\Local\Echo Chamber\_lab-artifacts\2026-04-12`
+- Current live install folder is intentionally simple again:
+  - `echo-core-client.exe`
+  - `config.json`
+  - `uninstall.exe`
+  - `_lab-artifacts\...`
+
+### v0.6.9 ship (2026-04-12 02:20 ET)
+- Merged PR `#159` (`release: v0.6.9 native game-share headroom`) into `main`.
+- Tagged the merged `main` commit `886dc5e2d6c9e97e62828f4a72882cb2ec94b810` as `v0.6.9` and pushed the tag to GitHub.
+- GitHub release workflow `24299866115` completed successfully for the Windows path:
+  - release `Echo Chamber v0.6.9` published
+  - assets present:
+    - `Echo.Chamber_0.6.9_x64-setup.exe`
+    - `Echo.Chamber_0.6.9_x64-setup.exe.sig`
+    - `latest.json`
+  - macOS remained skipped/disabled and did not block release
+- Synced the published updater manifest into the live checkout:
+  - `core/deploy/latest.json` now serves `version = 0.6.9`
+  - updater URL points at `https://github.com/SamWatson86/echo-chamber/releases/download/v0.6.9/Echo.Chamber_0.6.9_x64-setup.exe`
+- Live server-served viewer update for this release was limited to:
+  - `core/viewer/changelog.js`
+  - `core/viewer/screen-share-native.js` was already effectively current for `publishProfile` wiring
+- Built the final `v0.6.9` desktop binary locally and copied it into the installed live path:
+  - `C:\Users\Sam\AppData\Local\Echo Chamber\echo-core-client.exe`
+- This release's major user-facing change:
+  - native game/window shares now use a dedicated high-motion publish profile instead of inheriting the conservative desktop-share limits
+- Completed the final live server step after syncing the release artifacts:
+  - `POST /admin/api/force-reload` succeeded
+  - kicked `1` connected client (`sam-pc-2513`) from `main`
+  - returned viewer stamp `0.6.7.1775974919`
+- Post-reload verification:
+  - `https://127.0.0.1:9443/api/update/latest.json` serves `version = 0.6.9`
+  - updater URL points at `https://github.com/SamWatson86/echo-chamber/releases/download/v0.6.9/Echo.Chamber_0.6.9_x64-setup.exe`
+
+### Idle blackout watcher install (2026-04-12 14:45 ET)
+- Re-verified the blank screensaver configuration itself was correct:
+  - `SCRNSAVE.EXE = C:\Windows\System32\scrnsave.scr`
+  - `ScreenSaveActive = 1`
+  - `ScreenSaveTimeOut = 300`
+  - no screensaver policy override keys were present
+- Proved the built-in Windows auto-screensaver path was still broken in this session:
+  - applied settings through `user32!SystemParametersInfo`
+  - forced a short `15s` idle timeout test
+  - `scrnsave.scr` still did not auto-launch on its own
+- Investigated `powercfg /requests` under elevation:
+  - active media/session blockers included `msedge.exe`, `msedgewebview2.exe`, `USB Audio Device ... An audio stream is currently in use`, and `Legacy Kernel Caller`
+  - temporary `powercfg /requestsoverride` entries were added during diagnosis, then fully removed after the new fix was installed
+- Added a user-space fallback watcher under `tools/`:
+  - `tools/idle-blackout.ps1`
+  - `tools/install-idle-blackout.ps1`
+  - `tools/uninstall-idle-blackout.ps1`
+- The watcher uses `GetLastInputInfo` directly and launches `C:\Windows\System32\scrnsave.scr /s` after real input idle time, bypassing the unreliable built-in Windows auto-screensaver trigger.
+- Installed persistent startup entry:
+  - `C:\Users\Sam\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Startup\Echo Idle Blackout.vbs`
+- Started the watcher immediately in the current session with:
+  - idle threshold `300s`
+  - poll interval `5s`
+- Functional proof:
+  - a controlled zero-second test instance logged repeated `Launched blank screensaver` events, proving the fallback watcher can invoke the black screensaver correctly even though Windows would not auto-launch it on its own
+- Current expected behavior:
+  - after `5` minutes of no mouse/keyboard input, the custom watcher should black the displays by launching `scrnsave.scr`
+  - manual move/click should dismiss it normally
+- Follow-up correction after reboot:
+  - the first generated startup wrapper `Echo Idle Blackout.vbs` had malformed quote escaping and threw a Windows Script Host compilation error on login
+  - fixed `tools/install-idle-blackout.ps1` to emit a single properly quoted command string
+  - regenerated the startup file and verified it executes cleanly via `cscript.exe`
+- Smarter suppression pass:
+  - updated `tools/idle-blackout.ps1` so it does **not** trigger the blank screensaver while `Echo Chamber` is the active foreground window
+  - suppression requires a real visible non-minimized Echo window, so ordinary away-from-PC blackout behavior still applies when Echo is not the thing being actively watched
+  - restarted the watcher and reinstalled the startup entry after the change
+
+### v0.6.9 emergency rollback on Sam workstation (2026-04-12 14:55 ET)
+- After reboot, the installed live `v0.6.9` client started crashing on connect/sign-in instead of joining the room.
+- Event Viewer showed a stable repeatable crash signature for the installed binary at `C:\Users\Sam\AppData\Local\Echo Chamber\echo-core-client.exe`:
   - `Application Error 1000`
-  - `BEX64 / 0xc0000409`
-  - faulting application/module: `echo-core-client.exe`
-  - repeated offset: `0x0000000001e7d27d`
-  - crash path: `C:\Users\Sam\AppData\Local\Echo Chamber\echo-core-client.exe`
-- Important isolation result:
-  - the exact same bad binary runs successfully when copied to an isolated probe path
-  - it signed in successfully as both:
-    - `crashprobe\echo-core-client-probe.exe`
-    - `crashprobe\echo-core-client.exe`
-  - that means the failure is not “this build cannot sign in” in general
-  - the failure is specific to the installed-path identity/workflow
-- Strongest current suspect is the updater/startup path, not the native game-share publish-profile logic itself.
-- Safety hardening added on this branch:
-  - client version bumped to `0.6.8-test.2`
-  - auto-updater is now disabled automatically for prerelease/test builds
-  - manual `check_for_updates` also returns `disabled` on prerelease/test builds
-- Operational rule from here:
-  - never side-load experimental builds over the live installed release path with the same release version again
-  - risky client tests must use prerelease versioning and updater-disabled behavior
+  - `Windows Error Reporting 1001`
+  - `Event Name: BEX64`
+  - `Exception code: 0xc0000409`
+  - `Fault offset: 0x0000000001e7d0dd`
+  - `Version: 0.6.9.0`
+- Immediate recovery action:
+  - stopped using the installed `v0.6.9` binary on Sam's box
+  - restored the known-good local backup:
+    - source: `C:\Users\Sam\AppData\Local\Echo Chamber\_lab-artifacts\2026-04-12\installed-path-rc-smoke\echo-core-client.v0.6.8-backup.exe`
+    - destination: `C:\Users\Sam\AppData\Local\Echo Chamber\echo-core-client.exe`
+  - saved the crashing installed `v0.6.9` EXE for forensics at:
+    - `C:\Users\Sam\AppData\Local\Echo Chamber\_lab-artifacts\2026-04-12\v0.6.9-crash-rollback\echo-core-client.v0.6.9-crashing.exe`
+- Rollout freeze:
+  - reverted the live updater manifest back to `v0.6.8` by replacing `core/deploy/latest.json` with the published `v0.6.8` manifest
+  - this prevents additional installs from pulling `v0.6.9` while the regression is unresolved
+- Crash forensics hardening:
+  - enabled Windows WER LocalDumps for `echo-core-client.exe`
+  - dump folder: `C:\Users\Sam\AppData\Local\Echo Chamber\crashdumps`
+  - dump type: full dump (`DumpType = 2`)
+  - dump count: `10`
 
-### v0.6.9 release-candidate prep (2026-04-12 01:35 ET)
-- Created a clean release-candidate branch/worktree from the shipped `v0.6.8` manifest baseline:
-  - branch: `codex/release-v0.6.9-rc`
-  - worktree: `F:\Codex AI\The Echo Chamber\.codex\worktrees\release-v0.6.9-rc`
-- Cherry-picked the two validated native-game-share commits from the experimental branch:
-  - `449f4a9` — native game/window shares use a high-motion publish profile
-  - `62ce553` — prerelease desktop builds disable the auto-updater and manual update check
-- Normalized the release-candidate version to `0.6.9-rc.1` in the desktop and control manifests:
-  - `core/client/Cargo.toml`
-  - `core/client/tauri.conf.json`
-  - `core/control/Cargo.toml`
-- Added a clean top-level changelog entry for the native game-share improvement so the next release is no longer mixed into the `v0.6.8` notes.
-- Release impact for this branch remains `both`:
-  - desktop binary required for the native publish-profile change
-  - server-served viewer update required for the `publishProfile` viewer wiring and changelog entry
-- Verification on the clean RC worktree:
-  - `node --check core/viewer/screen-share-native.js`
-  - `node --check core/viewer/changelog.js`
-  - `cargo check -p echo-core-client`
-  - `cargo test -p echo-core-client capture_pipeline::tests -- --nocapture`
-  - `cargo build -p echo-core-client --release`
-- Clean-worktree build note:
-  - the first raw `cargo check` failed because this new worktree did not have a complete local WebRTC include payload on its own
-  - rerunning with `LK_CUSTOM_WEBRTC` pointed at the known-good local prebuilt payload under `F:\Codex AI\The Echo Chamber\core\target\release\build\scratch-df3657cc50cd1baa\out\livekit_webrtc\livekit\win-x64-release-webrtc-7af9351\win-x64-release` fixed that immediately
-  - this was a local build-environment issue, not a code regression in the RC branch
-- Additional generated files changed during RC prep:
-  - `core/Cargo.lock`
-  - `core/client/gen/schemas/desktop-schema.json`
-  - `core/client/gen/schemas/windows-schema.json`
+### Safe-path v0.6.9 probe result (2026-04-12 15:15 ET)
+- Launched the exact same `v0.6.9` release EXE from a non-installed safe probe path:
+  - `C:\Users\Sam\AppData\Local\Echo Chamber\_lab-artifacts\2026-04-12\v0.6.9-safe-probe\echo-core-client.exe`
+- Sam connected successfully from that probe build; no crash on join.
+- This proves the `v0.6.9` binary is not universally broken.
+- Current working theory:
+  - the crash is tied to installed-path/live-install state on Sam's workstation after the reboot/session churn
+  - not to the raw `v0.6.9` executable itself
+- Brad's missing game audio during this probe session was resolved by having Brad restart/rejoin and re-share.
+- That audio issue appears to have been stale room/share state, not a new regression in the probe client.
 
-### v0.6.9 final release-branch prep (2026-04-12 01:42 ET)
-- Promoted the RC work onto the final release task branch:
-  - branch: `codex/release-v0.6.9`
-- Dropped the prerelease suffix and normalized the release version to `0.6.9` in:
-  - `core/client/Cargo.toml`
-  - `core/client/tauri.conf.json`
-  - `core/control/Cargo.toml`
-  - `core/Cargo.lock`
-- Installed-path smoke test completed against the real app location:
-  - live install backed up to `C:\Users\Sam\AppData\Local\Echo Chamber\_lab-artifacts\2026-04-12\installed-path-rc-smoke\echo-core-client.v0.6.8-backup.exe`
-  - `0.6.9-rc.1` was copied to `C:\Users\Sam\AppData\Local\Echo Chamber\echo-core-client.exe`
-  - the old instant installed-path crash did **not** reproduce
-  - the app stayed alive from the real installed path and was brought forward for taskbar pinning
-- Release posture now:
-  - code is being treated as the final `0.6.9` branch, not a local-only RC
-  - next steps are final Windows artifact build, branch push, and PR creation
-- Final `0.6.9` verification/build results:
-  - `node --check core/viewer/screen-share-native.js`
-  - `node --check core/viewer/changelog.js`
-  - `cargo check -p echo-core-client`
-  - `cargo build -p echo-core-client --release`
-  - `powershell -ExecutionPolicy Bypass -File core/deploy/build-release.ps1`
-- Local release artifacts generated successfully:
-  - `core\target\release\bundle\nsis\Echo Chamber_0.6.9_x64-setup.exe`
-  - `core\target\release\bundle\nsis\Echo Chamber_0.6.9_x64-setup.exe.sig`
-  - `core\target\release\bundle\nsis\latest.json`
-- Release-build environment note:
-  - copied the existing signing key from `F:\Codex AI\The Echo Chamber\core\client\.tauri-keys` into this clean worktree so the NSIS installer and updater signature could be produced
-  - reused the known-good local WebRTC payload via `LK_CUSTOM_WEBRTC` during the final build
-- Installed app updated to the final release executable for live use:
-  - copied `core\target\release\echo-core-client.exe` to `C:\Users\Sam\AppData\Local\Echo Chamber\echo-core-client.exe`
-  - relaunched the installed app successfully from the real live path
+### Installed-path v0.6.9 round-two repro (2026-04-12 15:25 ET)
+- Armed WER LocalDumps correctly for `echo-core-client.exe`:
+  - `DumpFolder = C:\Users\Sam\AppData\Local\Echo Chamber\crashdumps`
+  - `DumpType = 2`
+  - `DumpCount = 10`
+- Swapped the real installed path back to the exact published `v0.6.9` EXE:
+  - `C:\Users\Sam\AppData\Local\Echo Chamber\echo-core-client.exe`
+- Sam launched and connected successfully from the installed path on this second controlled repro.
+- Current interpretation:
+  - the earlier installed-path crashes were real, but they are not currently reproducible after the safe-path `0.6.9` run warmed shared state
+  - `v0.6.9` itself remains usable on Sam's machine
+- Operational nuance still in effect:
+  - the live updater manifest was previously frozen back to `v0.6.8` as a safety stop
+  - Sam's local installed client is now on `v0.6.9`, but global updater re-enablement should be a deliberate follow-up decision
 
-### Installed-path reboot/connect crash root cause and hotfix branch (2026-04-12 19:00 ET)
-- Created a clean hotfix worktree from the real live release tip:
-  - worktree: `F:\Codex AI\The Echo Chamber\.codex\worktrees\fix-v069-installed-crash-live`
-  - branch: `codex/fix-v069-installed-crash-live`
-- Collected real crash evidence from:
-  - Windows Event Viewer `Application Error`
-  - `C:\Users\Sam\AppData\Local\CrashDumps\echo-core-client.exe.*.dmp`
-  - WER archive entries under `C:\ProgramData\Microsoft\Windows\WER\ReportArchive\AppCrash_echo-core-client_*`
-- Installed WinDbg locally via `winget` to stop guessing and inspect the minidumps directly.
-- Root-cause finding from WinDbg:
-  - the crash is **not** specific to `v0.6.9`
-  - `v0.6.8` and `v0.6.9` both hit the same fail-fast bucket after reboot/connect
-  - failure hash matches across both versions
-  - stack shape is the same on both builds:
-    - `std::panicking::panic_with_hook`
-    - `core::panicking::panic_cannot_unwind`
-    - `webview2_com_sys::...ICoreWebView2FocusChangedEventHandler...Invoke`
-    - `EmbeddedBrowserWebView!...FireWebResourceRequestedEvent`
-    - `tao::platform_impl::platform::event_loop::lose_active_focus`
-  - practical meaning: a Rust panic is escaping a Windows WebView2 COM focus callback, which forces a fatal abort on Windows
-- Hotfix strategy implemented:
-  - vendored `tauri-runtime-wry 2.10.0` into `core/vendor/tauri-runtime-wry-2.10.0`
-  - patched workspace `core/Cargo.toml` with `[patch.crates-io] tauri-runtime-wry = { path = "vendor/tauri-runtime-wry-2.10.0" }`
-  - hardened the Windows focus/fullscreen WebView2 callbacks in `core/vendor/tauri-runtime-wry-2.10.0/src/lib.rs`:
-    - recover poisoned `std::sync::Mutex` state with `into_inner()` instead of `unwrap()` panics
-    - wrap non-critical WebView2 COM callbacks in `catch_unwind`
-    - swallow/log those callback panics instead of aborting the process
-    - also removed the same poison-sensitive `focused_webview.lock().unwrap()` in `WindowEventWrapper::Focused`
-- Verification:
-  - `cargo tree -p echo-core-client -i tauri-runtime-wry` now resolves to the vendored `tauri-runtime-wry v2.10.0`
-  - `cargo check -p echo-core-client` passed with `LK_CUSTOM_WEBRTC=F:\Codex AI\The Echo Chamber\core\target\debug\build\scratch-2a0faabf5e80148f\out\livekit_webrtc\livekit\win-x64-release-webrtc-7af9351\win-x64-release`
-  - `cargo build -p echo-core-client --release` passed with the same `LK_CUSTOM_WEBRTC`
-- Runtime status:
-  - first safe probe connect succeeded in-session
-  - first post-reboot repro on the initial hotfix still crashed, but the fault offset changed from `0x1e7d0dd` / `0x1e749ad` to `0x1e7e8bd`
-  - that proved the first patch changed the failure mode but did not eliminate the panic path
+### v0.6.9 release withdrawal (2026-04-12 15:35 ET)
+- New field report: Brad rebooted and then hit the same connect-time crash pattern that Sam saw earlier.
+- Treated this as a release incident, not a local-machine-only curiosity.
+- Containment state confirmed:
+  - live updater manifest `core/deploy/latest.json` is still pinned to `v0.6.8`
+  - `v0.6.9` is no longer spreading through the normal updater path
+- GitHub release was explicitly marked withdrawn:
+  - title changed to `Echo Chamber v0.6.9 (withdrawn)`
+  - release flipped to `prerelease = true`
+  - release notes updated to warn users to stay on `v0.6.8` until a hotfix lands
+- Current policy after withdrawal:
+  - `v0.6.8` remains the globally supported release
+  - any `v0.6.9` use should be treated as controlled local testing only until the reboot/connect crash is root-caused
 
-### Focus-callback hotfix round two: `webview2-com` proc-macro containment (2026-04-12 19:35 ET)
-- Used the fresh post-reboot full dump:
-  - `C:\Users\Sam\AppData\Local\Echo Chamber\crashdumps\echo-core-client.exe.35604.dmp`
-- WinDbg on the new dump showed the crash was still a `panic_cannot_unwind` through:
-  - `webview2_com_sys::...ICoreWebView2FocusChangedEventHandler_Vtbl::new::Invoke`
-  - `EmbeddedBrowserWebView!...FireWebResourceRequestedEvent`
-  - `tao::platform_impl::platform::event_loop::lose_active_focus`
-- Key new finding:
-  - the runtime-side callback wrappers were not sufficient because `webview2-com-macros` still generated `Invoke` thunks that called Rust closures directly with zero `catch_unwind`
-  - any panic inside those WebView2 COM event closures still crossed the FFI boundary and hard-aborted the process
-- Implemented second-stage hotfix:
-  - vendored `webview2-com-macros 0.8.1` into `core/vendor/webview2-com-macros-0.8.1`
-  - patched workspace `core/Cargo.toml` with:
-    - `webview2-com-macros = { path = "vendor/webview2-com-macros-0.8.1" }`
-  - modified the generated `event_callback` macro so all COM event-handler `Invoke` thunks now:
-    - wrap the Rust closure in `std::panic::catch_unwind(AssertUnwindSafe(...))`
-    - swallow/log the panic
-    - return `Ok(())` instead of letting the panic unwind across COM
-- Verification:
-  - `cargo tree -p echo-core-client -i webview2-com-macros` resolves to the vendored proc-macro crate
-  - `cargo check -p echo-core-client` passed
-  - `cargo build -p echo-core-client --release` passed
-- Runtime proof:
-  - rebuilt the safe probe at:
-    - `C:\Users\Sam\AppData\Local\Echo Chamber\_lab-artifacts\2026-04-12\focus-callback-hotfix-probe\echo-core-client.exe`
-  - launched that rebuilt probe in the same post-reboot session
-  - user connected successfully
-  - this cleared the actual crash gate that was hitting both Sam and Brad after reboot
-- Follow-up note:
-  - sharing the Codex desktop app from the hotfix probe showed poor performance, while sharing a browser window was fine
-  - that is being treated as a separate source/capture performance issue, not part of the reboot/connect crash hotfix
-
-### `v0.6.10` patch release candidate prep (2026-04-12 20:05 ET)
-- Promoted the hotfix work onto a proper patch release branch:
+### v0.6.10 hotfix shipped (2026-04-12 20:10 ET)
+- Root cause of the reboot/connect crash was confirmed with WinDbg:
+  - Rust panic escaping a WebView2 COM callback after reboot
+  - hotfix landed by hardening both vendored `tauri-runtime-wry` and the `webview2-com-macros` callback thunk layer
+- Validation completed before ship:
+  - post-reboot hotfix probe connect succeeded on Sam's machine
+  - installed-path `0.6.10` connect succeeded from `C:\Users\Sam\AppData\Local\Echo Chamber\echo-core-client.exe`
+  - live runtime check with David showed active screen-share delivery from Sam at roughly `47 fps` inbound on David with clean packet health
+- Release branch and merge:
   - branch: `codex/release-v0.6.10`
-- Bumped the three required desktop release version files:
-  - `core/client/Cargo.toml` -> `0.6.10`
-  - `core/client/tauri.conf.json` -> `0.6.10`
-  - `core/control/Cargo.toml` -> `0.6.10`
-- Updated `core/viewer/changelog.js` with a new top entry:
-  - `Post-Reboot Connect Hotfix (v0.6.10)`
-  - this keeps the `v0.6.9` game-share headroom but makes the desktop runtime safe again after reboot
-- Verification gate rerun on the release branch:
-  - `node --check core/viewer/changelog.js`
-  - `node --check core/viewer/screen-share-native.js`
-  - `cargo check -p echo-core-client`
-  - `cargo build -p echo-core-client --release`
-- Windows release artifacts generated successfully:
-  - `core\target\release\bundle\nsis\Echo Chamber_0.6.10_x64-setup.exe`
-  - `core\target\release\bundle\nsis\Echo Chamber_0.6.10_x64-setup.exe.sig`
-  - `core\target\release\bundle\nsis\latest.json`
-- Packaging note:
-  - copied the existing signing key from `F:\Codex AI\The Echo Chamber\core\client\.tauri-keys` into this clean worktree locally to build/sign the installer
-  - the key copy is operational only and should not be committed
-- Installed-path smoke test:
-  - backed up the previous installed EXE to:
-    - `C:\Users\Sam\AppData\Local\Echo Chamber\_lab-artifacts\2026-04-12\installed-path-v0.6.10-smoke\echo-core-client.pre-v0.6.10.exe`
-  - copied the `0.6.10` release EXE to:
-    - `C:\Users\Sam\AppData\Local\Echo Chamber\echo-core-client.exe`
-  - relaunched the real installed app from that exact path
-  - user connected successfully on the installed build
+  - PR: `#160`
+  - merged to `main` with admin override because branch policy blocked a normal merge path during the hotfix ship
+- GitHub release published:
+  - tag: `v0.6.10`
+  - title: `Echo Chamber v0.6.10`
+- Desktop release artifacts:
+  - `Echo.Chamber_0.6.10_x64-setup.exe`
+  - `Echo.Chamber_0.6.10_x64-setup.exe.sig`
+  - `latest.json`
+- Live rollout actions:
+  - updater manifest advanced from `0.6.8` to `0.6.10`
+  - server-served viewer changelog updated with the `v0.6.10` entry
+  - connected clients force-reloaded after the server-state update
 - Release impact:
   - `both`
-  - desktop binary required for the WebView2 callback panic hotfix
-  - server-served viewer update required for the new changelog entry
+  - desktop binary release for the post-reboot connect hotfix
+  - server-served viewer update for the changelog/live viewer assets
+
+### Idle blackout browser playback suppression (2026-04-12 20:32 ET)
+- The fallback blank-screen watcher in `tools/idle-blackout.ps1` was too narrow:
+  - it only suppressed blackout when `Echo Chamber` itself was the visible foreground window
+  - result: the blank screensaver could still trigger while Sam was actively watching browser media like Crunchyroll
+- Added media-session-aware suppression:
+  - loads the Windows Global System Media Transport Controls session manager through `System.Runtime.WindowsRuntime`
+  - queries active media sessions and matches them against visible browser/media-player windows
+  - continues to suppress when `Echo Chamber` is foreground, but now also suppresses when a visible media app window is actively playing media
+- Fixed a PowerShell bug in the first pass:
+  - the watcher initially logged `Media session detection unavailable: WinRT AsTask overload not found`
+  - root cause was a bad string literal around `IAsyncOperation\`1`
+  - corrected the filter, restarted the watcher, and confirmed the new watcher logs `Media session detection enabled`
+- Live watcher state after restart:
+  - startup entry still installed via `tools/install-idle-blackout.ps1`
+  - active hidden watcher process points at `tools/idle-blackout.ps1`
+  - current validation still needs a real idle pass while browser playback is actively in `Playing` state
+
+### SAM-PC deploy-agent startup hardening (2026-04-13 08:35 ET)
+- SAM-PC came back on the LAN after a real reboot, but the deploy agent on `192.168.5.149:8080` did not.
+- This broke the remote test pipeline even though the machine itself was alive and reachable.
+- Root symptom:
+  - app restart/deploy via agent worked before reboot
+  - after reboot, `ping/ARP` reached SAM-PC but `http://192.168.5.149:8080/health` stayed down
+- Hardening change in `core/deploy/setup-agent.ps1`:
+  - scheduled task now runs with both `AtStartup` and `AtLogOn` triggers
+  - task action now uses `powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -WindowStyle Hidden`
+  - task settings now explicitly use `-MultipleInstances IgnoreNew`
+- Rationale:
+  - if the startup trigger is missed or races boot, the user logon trigger should still restore the agent
+  - this matches the real failure mode seen on SAM-PC after reboot
+- Current machine state:
+  - SAM-PC is on `0.6.10`
+  - remote app deploy/restart worked before the reboot
+  - after reboot, the agent itself needs to be reinstalled or restarted locally once before the pipeline is healthy again
+
+### SAM-PC client-launch pipeline root cause (2026-04-13 09:20 ET)
+- After the agent was restored, remotely launching the client on SAM-PC produced a WebView2 startup dialog:
+  - `Microsoft Edge can't read and write to its data directory`
+  - path pointed at `C:\Windows\System32\config\systemprofile\AppData\Local\com.echochamber.app\EBWebView`
+- Root cause:
+  - the deploy agent runs as `SYSTEM`
+  - it was launching `echo-core-client.exe` directly with `Start-Process`
+  - the Tauri/WebView2 shell therefore inherited the `SYSTEM` account and tried to use `systemprofile` for its browser data dir
+  - that is the wrong execution context for the actual desktop client UI
+- Pipeline fix in repo:
+  - `core/deploy/agent.ps1`
+    - now prefers launching the client through a dedicated scheduled task named `EchoChamberClient`
+    - falls back to direct `Start-Process` only if that task does not exist
+    - `Get-ClientProcess` also falls back to process-name lookup instead of only trusting the pid file
+  - `core/deploy/setup-agent.ps1`
+    - still installs the agent task as `SYSTEM`
+    - now also installs a second scheduled task `EchoChamberClient`
+    - that client task runs as the interactive logged-in user via `Interactive` logon type
+    - agent startup task remains `AtStartup + AtLogOn`
+- Validation:
+  - both modified PowerShell scripts parse successfully via `[scriptblock]::Create(...)`
+  - live SAM-PC still needs the one-time local task repair so the running machine matches the repo fix
+- Live repair result on SAM-PC:
+  - reinstalled the deploy agent scheduled task locally under the interactive `Sam` session instead of `SYSTEM`
+  - agent came back at `http://192.168.5.149:8080/health`
+  - remote launch now works again; client reported running with `client_pid = 18076`
+  - the previous WebView2 `systemprofile` data-directory popup did not recur after the repair
+
+### v0.6.10 reboot-crash validation status (2026-04-13 09:50 ET)
+- The critical bug remains the post-reboot desktop connect crash that previously hit both `v0.6.8` and `v0.6.9`.
+- Validation now cleanly splits from the separate screen-share viewer issue:
+  - this PC:
+    - rebooted after the hotfix work
+    - installed `0.6.10` at `C:\Users\Sam\AppData\Local\Echo Chamber\echo-core-client.exe` launched and connected successfully
+    - no fresh `Application Error` events for `echo-core-client.exe` were found in the local `Application` log during this pass
+    - no new crash dumps were written under `C:\Users\Sam\AppData\Local\Echo Chamber\crashdumps`; only the old pre-hotfix dump `echo-core-client.exe.35604.dmp` remained
+  - SAM-PC:
+    - was fully rebooted for the test (real OS reboot, not just app restart)
+    - after the login/account detour, Echo launched manually from `C:\EchoChamber\echo-core-client.exe`
+    - client connected successfully after reboot, which means the original `reboot -> launch -> connect` crash path did not reproduce there either
+- Current read:
+  - the `v0.6.10` WebView2 callback hotfix is materially validated on two machines for the reboot/connect crash class
+  - remaining SAM-PC problems are in remote screen-share view/attach state, not the reboot crash
+
+### SAM-PC remote screen-share attach investigation (2026-04-13 10:05 ET)
+- Reconfirmed the publish side is healthy:
+  - LiveKit `ListParticipants` for room `main` shows:
+    - `sam-pc-2513`
+    - `sam-pc-2513$screen`
+    - `sam-7475`
+  - the `$screen` companion is active with a live `1920x1080` H.264 video track
+  - control-plane dashboard simultaneously shows `sam-pc-2513` capture health as:
+    - `capture_active = true`
+    - `capture_mode = DXGI-DD`
+    - `encoder_type = NVENC`
+    - `current_fps = 21`
+    - `target_fps = 30`
+- That proves the failure is not Win10 native screen capture and not the reboot crash hotfix.
+- Viewer-side hardening applied in the server-served JS:
+  - `core/viewer/state.js`
+    - added `knownRemoteParticipants` cache plus helpers so `$screen` companions seen via events remain resolvable later by watch/unwatch logic
+  - `core/viewer/participants-avatar.js`
+    - `getRemoteParticipantsForScreenIdentity()` now resolves through the cache instead of relying only on `room.remoteParticipants`
+  - `core/viewer/connect.js`
+    - companion participants are remembered on track/publish/connect events and cleared on disconnect cleanup
+    - room switches now clear the cache explicitly
+  - `core/viewer/identity.js`
+    - `patchScreenCompanionSource()` now infers video for `$screen` companion publications even when LiveKit omits `kind`, instead of leaving them as raw `CAMERA`
+  - `core/viewer/audio-routing.js`
+    - `handleTrackSubscribed()` now force-normalizes subscribed `$screen` companion tracks to `ScreenShare` / `ScreenShareAudio` before routing
+    - this closes the remaining hole where an already-subscribed companion track could still be treated like a camera and never create a screen tile
+- Validation at code level:
+  - `node --check` passed for:
+    - `core/viewer/state.js`
+    - `core/viewer/participants-avatar.js`
+    - `core/viewer/connect.js`
+    - `core/viewer/identity.js`
+- Live rollout:
+  - forced client reload after the viewer patch
+  - latest viewer stamp after the final reload: `0.6.7.1776091257`
+- Pending runtime proof:
+  - both clients must reconnect on the fresh stamp
+  - SAM-PC must start full-screen share again
+  - then confirm whether this PC and SAM-PC can now see the stream
+## 2026-04-13 Viewer watch attach follow-up
+- Issue narrowed: clicking Start Watching flipped to Stop Watching, but no screen tile attached on either this PC or SAM-PC even though sam-pc-2513 was live in LiveKit as 1920x1080 H.264 and dashboard stats showed active DXGI-DD capture (21/30 fps, NVENC).
+- Root cause hypothesis: opt-in path and publication hook were still waiting on publication.isSubscribed === true before processing a track object that was already cached locally, leaving remote screen shares stuck in a subscribed-but-never-attached state.
+- Fix: updated core/viewer/participants-avatar.js and core/viewer/connect.js so watched screen-share publications with an existing pub.track are processed immediately, regardless of transient isSubscribed state, and added hook-side logging for existing-track attach.
+- Validation pending live retest after force-reload.
+- Added temporary viewer attach instrumentation in core/viewer/audio-routing.js, core/viewer/connect.js, and core/viewer/participants-avatar.js so remote screen-share attach failures surface as [attach-error] debug lines plus visible status/toast instead of silently aborting.
+- Added Start Watching self-diagnostics in core/viewer/participants-avatar.js: if no screen tile exists after 2.2s, the client now surfaces a toast/status with emotes, screenPubs, 	racks, and subscribed counts for that identity.
+- Extended Start Watching diagnostics to report whether a tile object exists and whether its video element has dimensions/frames (	ile, display, ideo, size, eady, paused, rames, lack) when a watched screen share still looks blank.
+- Extended watch diagnostics again to include underlying MediaStreamTrack state and subscriber receiver presence: mstMuted, mstReady, eceiver.
+## 2026-04-13 Viewer attach semantics fix
+- Latest diagnostic toast on this PC for `sam-pc-2513` was:
+  - `Watch failed for sam-pc-2513 remotes=2 screenPubs=1 tracks=1 subscribed=1 tile=true display=(default) video=true size=0x0 ready=0 paused=false frames=0 black=false mstMuted=true mstReady=live receiver=true`
+- Interpretation:
+  - watch state and tile creation were working
+  - LiveKit receiver existed
+  - underlying MediaStreamTrack was live but stayed muted forever
+  - the video element never got metadata or frames
+- Root cause hypothesis tightened:
+  - viewer code was creating many remote video elements via `new MediaStream([track.mediaStreamTrack])`
+  - that bypasses `track.attach(element)` bookkeeping that LiveKit expects for attached remote renders
+  - this exactly matches the observed state: subscribed receiver exists, but the SDK still treats the stream like it has no active render target, so no frames arrive
+- Fix applied:
+  - `core/viewer/participants.js`
+    - `createLockedVideoElement(track)` now uses `track.attach(element)` first, then falls back to manual `srcObject` only if needed
+    - added `detachMediaElement(element)` helper
+  - `core/viewer/participants-grid.js`
+    - screen tile removal and `clearMedia()` now detach attached media elements before DOM removal
+  - `core/viewer/participants-avatar.js`
+    - avatar video cleanup now detaches old media elements before replacing avatar contents
+  - `core/viewer/participants-fullscreen.js`
+    - screen video replacement now detaches the old attached element before inserting the new one
+- Validation:
+  - `node --check` passed for:
+    - `core/viewer/participants.js`
+    - `core/viewer/participants-grid.js`
+    - `core/viewer/participants-avatar.js`
+    - `core/viewer/participants-fullscreen.js`
+- Pending runtime proof:
+  - force-reload clients
+  - reconnect this PC and SAM-PC
+  - retest SAM-PC full-screen share and watch flow
+- Follow-up diagnostics added after the attach patch still produced the same no-frame toast.
+- Added receiver RTP stats to the watch-failed diagnostic in `core/viewer/participants-avatar.js` so the next repro reports:
+  - receiver bytes
+  - packets
+  - decoded frames
+  - keyframes
+  - fps
+  - codec
+- Purpose: distinguish `zero RTP arriving` from `RTP arriving but decode/render stalled`.
+## 2026-04-13 Version-state normalization
+- User correctly called out that the session had become incoherent: desktop clients were on official `0.6.10`, while the server-served viewer was still a locally patched lab build stamped `0.6.7.x`.
+- Action taken:
+  - backed up the current modified viewer files to `.codex/viewer-baseline-backup-20260413-131754`
+  - restored all `core/viewer/*` files that diverged from tag `v0.6.10`
+  - restored `core/control/Cargo.toml` to `v0.6.10`
+  - rebuilt `echo-core-control` in release mode
+  - restarted the control plane on the rebuilt binary
+  - forced a client reload through `/admin/api/force-reload`
+- Verified live state after normalization:
+  - `core/viewer/index.html` now stamps assets as `0.6.10.1776101108`
+  - `/admin/api/force-reload` now returns `viewer_stamp = 0.6.10.1776101103`
+  - this PC desktop binary remains official `0.6.10`
+  - `SAM-PC` desktop binary remains official `0.6.10`
+- Operational conclusion:
+  - further share/watch results should only be trusted after reconnecting both clients on this normalized `0.6.10` baseline
+  - any remaining `SAM-PC` full-screen failure after that is a real post-normalization bug, not version-state confusion
+## 2026-04-13 Avatar regression after control-plane restart
+- User reported that avatars had regressed into broken image icons while cards/names still rendered.
+- Root cause:
+  - I restarted the control plane from an inconsistent process state.
+  - A stale `echo-core-control.exe` instance was still holding `:9443`, so my first restart attempts never actually took over the port.
+  - That left the system serving a stale process state while I believed a corrected process was active.
+  - Separately, relative path resolution for chat/avatar storage depends on startup context; the intended live avatar store is `F:\Codex AI\The Echo Chamber\logs\avatars`.
+- Evidence:
+  - direct avatar route initially returned `404` for `/api/avatar/sam`
+  - `logs/avatars` contained the real avatar files
+  - once the stale control process was killed and the corrected one took over `:9443`, startup logs showed `loaded existing avatar: sam -> avatar-sam.gif`
+  - direct route then returned `HTTP=200 TYPE=image/gif`
+- Fix:
+  - killed the stale control-plane process that was still bound to `9443`
+  - restarted `echo-core-control.exe` cleanly
+  - verified startup log load of existing avatars/chimes from the real `logs/` tree
+  - forced a client reload after the corrected server was live
+
+## 2026-04-13 Launch hygiene and deploy-agent boundary
+- User correctly called out that live testing had become confusing because too many Echo binaries existed at once:
+  - installed app on this PC: `C:\Users\Sam\AppData\Local\Echo Chamber\echo-core-client.exe`
+  - watchdog sandbox on `SAM-PC`: `C:\EchoChamber\echo-core-client.exe`
+  - multiple local probes / rollback artifacts
+- Operational conclusion:
+  - all future live retests must explicitly name the binary path on each machine
+  - stale Echo windows/processes must be closed before trusting a retest
+  - the `C:\EchoChamber` watchdog binary is a sandbox path, not the same thing as the normal installed app
+- Repo hardening:
+  - updated `core/deploy/agent.ps1` to understand the distinction between:
+    - sandbox binary under `C:\EchoChamber\echo-core-client.exe`
+    - normal installed app under `%LOCALAPPDATA%\Echo Chamber\echo-core-client.exe`
+  - added:
+    - `Get-InstalledClientPath`
+    - `client_path`, `sandbox_exe_path`, `installed_exe_path`, `installed_exe_exists` to `/health`
+    - new `POST /launch-installed` endpoint to launch the normal installed app explicitly
+  - updated `core/deploy/setup-agent.ps1` comments to reflect the explicit installed-vs-sandbox launch model
+- Verification:
+  - PowerShell parser passed for:
+    - `core/deploy/agent.ps1`
+    - `core/deploy/setup-agent.ps1`
+- Important live limitation:
+  - the currently running deploy agent on `SAM-PC` could not be self-updated remotely because remote disk access to `\\SAM-PC\c$` is denied and the existing HTTP agent does not support self-update
+  - so the new `/launch-installed` endpoint is in repo now, but not yet installed on `SAM-PC`
+
+## 2026-04-13 Handoff status
+- Start a fresh session. The current thread became too long and operationally noisy.
+- Reboot/connect crash status:
+  - treat this as fixed unless a new regression appears
+  - validated on this PC and `SAM-PC` after real reboot
+  - hotfix shipped as `v0.6.10`
+  - do not reopen this bug without a fresh reproducible crash
+- Current active bug:
+  - `SAM-PC` on Windows 10 can connect, but `Entire Screen` share stays blank for viewers
+  - this PC can successfully publish full-screen share to `SAM-PC`
+  - so the remaining issue is specific to `SAM-PC` as publisher, not the general viewer path
+- Clean baseline facts:
+  - server-served viewer files were restored to tagged `v0.6.10`
+  - avatars were repaired after killing a stale `echo-core-control.exe`
+  - this PC should use installed app `C:\Users\Sam\AppData\Local\Echo Chamber\echo-core-client.exe`
+  - `SAM-PC` product tests should use installed app `C:\Users\Sam\AppData\Local\Echo Chamber\echo-core-client.exe`
+  - do not trust `C:\EchoChamber\echo-core-client.exe` for product behavior; that is the watchdog sandbox path
+- Open technical hypothesis:
+  - native Win10 full-screen publish on `SAM-PC` appears broken
+- Operational rule for next session:
+  - explicitly close stale Echo windows and relaunch the intended binary on each machine before every retest
+
+## 2026-04-13 Win10 browser fallback rejection
+- We did verify one important narrowing fact:
+  - when `SAM-PC` used the browser/WebView share path for `Entire Screen`, this PC could see the stream
+  - that proves the viewer/watch side is not the blocker
+- User explicitly rejected that path as a product regression:
+  - the desktop client should keep using the custom/native picker
+  - Win10 full-screen sharing should stay on the native monitor-capture path, not Chromium `getDisplayMedia`
+  - the `DX****` path Sam was referring to is `DXGI Desktop Duplication`
+- Repo correction applied:
+  - removed the forced Win10 `monitor -> browser fallback` branch from `core/viewer/screen-share-native.js`
+  - `Entire Screen` on native desktop clients now routes back to the native `DXGI Desktop Duplication` monitor path
+  - updated `core/viewer/changelog.js` so the viewer no longer claims browser fallback is the intended Win10 fix
+- Current bug framing after that correction:
+  - browser fallback working was only a diagnostic datapoint
+  - the real remaining bug is native Win10 `DXGI Desktop Duplication` publish from `SAM-PC` if it still blanks for viewers
+
+## 2026-04-13 SAM-PC launch workaround
+- The live deploy agent on `SAM-PC` is still the old build and does not yet expose `/launch-installed`.
+- Operational workaround used during this session:
+  - temporarily replaced `C:\EchoChamber\echo-core-client.exe` on `SAM-PC` with a tiny launcher shim
+  - that shim starts the real installed app at `C:\Users\Sam\AppData\Local\Echo Chamber\echo-core-client.exe`
+  - this is only to let the old HTTP agent restart the installed product binary remotely
+- Important boundary:
+  - this does **not** make the sandbox path a product binary again
+  - it is only a remote-launch bridge until the real agent update lands on `SAM-PC`
+
+## 2026-04-13 Persistent memory update
+- Added a hard persistent-memory rule under `C:\Users\Sam\.claude\projects\f--Codex-AI-The-Echo-Chamber\memory\`:
+  - never recommend Chromium/WebView `getDisplayMedia` as the fix for native desktop capture regressions in Echo Chamber
+  - browser capture may be used only as a diagnostic narrowing datapoint
+  - shipped behavior must stay on the native picker + native capture stack (`WGC` where supported, `DXGI Desktop Duplication` on Win10/older)
+
+## 2026-04-13 SAM-PC installed-app relaunch bridge hardened
+- Built a fresh release client locally with the current Win10 native capture changes still in place:
+  - `core/target/release/echo-core-client.exe`
+  - SHA-256: `028D295FB8A7D23C86C9A32CC6BCE377FFE4C696A375EA8512D9B1E14202C224`
+- Relaunched this PC cleanly on the installed app path:
+  - killed stale local `echo-core-client.exe`
+  - relaunched `C:\Users\Sam\AppData\Local\Echo Chamber\echo-core-client.exe`
+- Updated `SAM-PC` installed app directly:
+  - copied the fresh release binary to `C:\Users\Sam\AppData\Local\Echo Chamber\echo-core-client.exe`
+  - wrote `C:\Users\Sam\AppData\Local\Echo Chamber\config.json` with `{"server":"https://192.168.5.70:9443"}`
+- Hardened the temporary launcher shim at `C:\EchoChamber\echo-core-client.exe` so the old deploy agent can still manage the real installed app:
+  - shim now kills stale `echo-core-client.exe` processes on `SAM-PC`
+  - shim applies a staged update from `C:\EchoChamber\installed-update\echo-core-client.exe` into the installed app path with retry/backoff
+  - shim launches the real installed app detached so it no longer inherits and locks `C:\EchoChamber\client-stdout.log`
+- Verified live bridge behavior from `\\SAM-PC\EchoChamber\client-stdout.log`:
+  - `staged update applied to C:\Users\Sam\AppData\Local\Echo Chamber\echo-core-client.exe`
+  - `launching C:\Users\Sam\AppData\Local\Echo Chamber\echo-core-client.exe`
+  - `child pid 8816`
+- Important boundary:
+  - this is still only an operational bridge because the live `SAM-PC` deploy agent is old
+  - product behavior remains the installed app under `C:\Users\Sam\AppData\Local\Echo Chamber\echo-core-client.exe`
+  - the old agent `/health` is still not trustworthy for the installed child because the shim exits after launch
+- Immediate next retest:
+  - connect both installed clients
+  - on `SAM-PC`, run native `Share -> Entire Screen`
+  - confirm whether this PC now receives non-blank video from the Win10 `DXGI Desktop Duplication` path
+
+## 2026-04-13 Persistent memory update: Claude owns app relaunches
+- Added a new hard persistent-memory rule under `C:\Users\Sam\.claude\projects\f--Codex-AI-The-Echo-Chamber\memory\`:
+  - Sam should never have to guess which Echo Chamber binary/version is open
+  - before meaningful retests, Claude should close stale Echo clients and relaunch the exact intended installed app on both this PC and `SAM-PC`
+  - the watchdog sandbox path may still be used as an operational bridge, but the installed app remains the real product binary
+
+## 2026-04-13 Win10 native publish status clarified
+- Instrumented the installed client on `SAM-PC` with a temporary file log at:
+  - `C:\Users\Sam\AppData\Local\Echo Chamber\capture-debug.log`
+- Critical finding from native Win10 `Entire Screen` retest:
+  - `SAM-PC` native `DXGI Desktop Duplication` capture is **not** failing anymore
+  - after restoring `config.json` to the domain URL, the native `$screen` publisher:
+    - starts DXGI DD
+    - connects to SFU successfully
+    - publishes the track successfully
+    - enters the frame loop at ~21 fps
+- Evidence from `capture-debug.log`:
+  - `connected as sam-pc-2513$screen`
+  - `track published`
+  - repeated `stats 1920x1080 fps=21`
+- The earlier LAN-IP config on `SAM-PC` was a real blocker for native publish:
+  - `https://192.168.5.70:9443` caused Rust/native `$screen` connect to fail TLS hostname validation
+  - fixed by restoring `SAM-PC` to `https://echo.fellowshipoftheboatrace.party:9443`
+- Live dashboard evidence after the fix:
+  - Jeff was receiving `SAM-PC`'s screen track while this PC was not
+  - that means the remaining issue is now selective viewer subscription/render behavior, not Win10 native publish
+- Code evidence for the current viewer behavior:
+  - `core/viewer/connect.js` currently treats newly published remote screen shares as opt-in and adds them to `hiddenScreens` at publish time
+  - the same file later auto-subscribes existing screen shares for late joiners
+- Practical conclusion:
+  - do **not** reopen the Win10 native `DXGI DD` publisher as the root bug without new evidence
+  - the active bug has shifted to viewer-side screen-share subscription / opt-in consistency across already-connected clients vs late joiners
+
+## 2026-04-13 Viewer-side screen watch parity patch
+- New viewer-only patch applied for the active bug where this PC showed a blank `0fps` tile after clicking `Start Watching` on an already-live `SAM-PC` screen share.
+- Root cause hypothesis for the patch:
+  - the manual `Start Watching` handler in `core/viewer/participants-avatar.js` was running its own bespoke subscribe flow
+  - late joiners used a different `resubscribeParticipantTracks(...)` + `reconcileParticipantMedia(...)` path that already worked
+  - the bug appeared to live in that split behavior, not in Win10 native publish
+- Repo changes made:
+  - added shared helper `startWatchingScreenIdentity(...)` in `core/viewer/participants-avatar.js`
+  - manual `Start Watching` now routes through that helper instead of the older custom resubscribe branch
+  - late-join auto-watch in `core/viewer/connect.js` now routes through the same helper so both paths stay aligned
+  - updated `core/viewer/changelog.js` with a new `2026-04-13b / Screen Watch Sync` entry
+- Verification after patch:
+  - `node --check` passed for:
+    - `core/viewer/participants-avatar.js`
+    - `core/viewer/connect.js`
+    - `core/viewer/changelog.js`
+  - forced live viewer reload through `POST /admin/api/force-reload`
+  - control plane returned `viewer_stamp = 0.6.10.1776113561`
+- Relaunch hygiene completed before retest:
+  - relaunched this PC on installed app `C:\Users\Sam\AppData\Local\Echo Chamber\echo-core-client.exe`
+  - remotely restarted `SAM-PC` through the old agent bridge so it launched the installed app path again
+  - dashboard then showed connected clients on `viewer_version = 0.6.10.1776113576`
+- Live state right after relaunch:
+  - `SAM-PC` was again publishing native `DXGI-DD` with `capture_active = true`, `capture_mode = DXGI-DD`, `current_fps = 21`
+  - next live check is whether clicking `Start Watching` on this PC now produces actual inbound media instead of the old blank tile
+
+## 2026-04-13 Watch-debug escalation: receiver vs tile
+- Continued live testing after the watch-parity patch narrowed the failure further:
+  - this PC (`sam-7475`) did click into the `SAM-PC` share path
+  - dashboard `watch_debug` then reported:
+    - `identity=sam-pc-2513 stage=fallback@1500ms hidden=false watched=true remotes=sam-pc-2513:microphone:audio:sub=true:track=true;sam-pc-2513$screen:screen_share:video:sub=true:track=true`
+  - at the same time, `\\SAM-PC\Users\Sam\AppData\Local\Echo Chamber\capture-debug.log` still showed:
+    - native `DXGI-DD` capture alive at ~`21 fps`
+    - transport connected
+    - sender stats stuck at `bytes=0 packets=0 frames_sent=0 frames_encoded=0`
+- Practical conclusion from that pairing:
+  - the active bug is **not** screen-companion discovery anymore
+  - this PC can now find the right `sam-pc-2513$screen` publication and mark it subscribed
+  - the remaining break is later than `setSubscribed(true)` and earlier than real RTP demand reaching the `SAM-PC` publisher
+- New instrumentation patch applied in `core/viewer/participants-avatar.js`:
+  - extended `watch_debug` summaries to include whether the subscriber `RTCRtpReceiver` exists for the publication's `mediaStreamTrack`
+  - added current screen-tile DOM state to the same debug string:
+    - tile presence
+    - tile `display`
+    - tile client size
+    - video `videoWidth`/`videoHeight`
+    - paused state
+    - `readyState`
+- Verification / rollout:
+  - `node --check core/viewer/participants-avatar.js` passed
+  - forced another live viewer reload through `POST /admin/api/force-reload`
+  - control plane returned `viewer_stamp = 0.6.10.1776114696`
+  - relaunched this PC on installed app `C:\Users\Sam\AppData\Local\Echo Chamber\echo-core-client.exe`
+  - remotely restarted `SAM-PC` again through the bridge to relaunch the installed app
+  - stamped a fresh remote marker into `capture-debug.log`:
+    - `==== receiver-tile-retest 2026-04-13 17:11:48 ====`
+- Current next retest:
+  - get `SAM-PC` back into `main`
+  - on `SAM-PC`, start native `Share -> Entire Screen`
+  - on this PC, click `Start Watching`
+  - read the new `watch_debug` value to determine:
+    - whether the subscriber PC has a real receiver for the `SAM-PC` screen track
+    - whether the screen tile/video element exists but is effectively dead (`0x0`, paused, no decoded frames, etc.)
+
+## 2026-04-13 Native Win10 DXGI publish narrowed further, then paused for live room safety
+- Additional live repros after the receiver/tile instrumentation established that the remaining failure is specific to the `SAM-PC` native Win10 `Entire Screen` publish path, not the general viewer/watch stack:
+  - this PC and Jeff both reached the same watch state for `sam-pc-2513$screen`
+  - dashboard `watch_debug` for both viewers showed:
+    - real receiver present (`recv=true`)
+    - real tile present in DOM
+    - video element still `video=0x0` / `readyState=0`
+    - remote media stream track still `live/muted`
+  - at the same time, `SAM-PC` could successfully watch Jeff's share with normal decoded video dimensions and ready state
+- Native publisher-side proof was added in `core/client/src/capture_pipeline.rs`:
+  - now logs `RoomEvent::LocalTrackPublished`
+  - now logs `RoomEvent::LocalTrackSubscribed`
+  - live `SAM-PC` log proved the SFU does create a real subscriber for the native `$screen` track
+  - despite that, the publisher stayed stuck at:
+    - `sender-stats bytes=0 packets=0 frames_sent=0 frames_encoded=0`
+- Practical conclusion from that evidence:
+  - the active bug is no longer companion discovery or viewer subscription
+  - the active bug is later than successful subscription and earlier than actual RTP emission from the Win10 native `DXGI Desktop Duplication` publisher
+- New scoped fix attempt was applied to the native client:
+  - `core/client/src/capture_pipeline.rs` now accepts caller-controlled `track_source` and `is_screencast`
+  - `core/client/src/desktop_capture.rs` (`DXGI DD`) now publishes as:
+    - `TrackSource::Screenshare`
+    - `is_screencast=true`
+  - `core/client/src/screen_capture.rs` (`WGC`) explicitly stays on:
+    - `TrackSource::Camera`
+    - `is_screencast=false`
+  - intent: change only the Win10 DXGI full-screen semantics without risking regressions in the working WGC paths
+- Build / deploy state for that fix attempt:
+  - `cargo check -p echo-core-client` passed
+  - `cargo build -p echo-core-client --release` passed
+  - updated `core/viewer/changelog.js` with `2026-04-13c / Win10 DXGI Screen Share Signal`
+  - relaunched this PC on installed app:
+    - `C:\Users\Sam\AppData\Local\Echo Chamber\echo-core-client.exe`
+  - staged and relaunched the same release binary to `SAM-PC` through the installed-app bridge
+  - both installed binaries verified identical:
+    - size `45,358,592`
+    - timestamp `2026-04-13 17:23:57`
+  - fresh remote log marker written:
+    - `==== dxgi-screencast-retest 2026-04-13 17:25:47 ====`
+- Operational pause ordered by Sam because multiple friends are actively using the room:
+  - stop disruptive retests for now
+  - **do not reboot the server again unless Sam explicitly says to**
+  - keep the current live room stable over further experimentation
+- Current live inference at pause time:
+  - Jeff and David appear to be sharing successfully on the current room/build
+  - the unresolved problem still appears isolated to older Windows 10 native `Entire Screen` / `DXGI DD` publishers such as `SAM-PC`
+  - the next resume point is to retest the fresh `DXGI screencast` patch only when the room is clear enough for another controlled repro
+
+## 2026-04-13 Manual watch re-subscribe patch after native DXGI sender recovery
+- Follow-up retests after the direct H26x encoder factory patch proved the native Win10 sender is no longer the zero-RTP bottleneck:
+  - `\\SAM-PC\Users\Sam\AppData\Local\Echo Chamber\capture-debug.log` showed continuous native `DXGI DD` publish with:
+    - `encoder=OpenH264`
+    - `frames_sent` / `frames_encoded` rising normally
+    - `bytes` and transport `bytes_sent` climbing into multi-megabyte range
+  - this shifted the remaining blank-share problem to the already-connected viewer hot-watch path on this PC
+- Fresh receive-side symptom at that point:
+  - manual `Start Watching` still produced a blank tile on this PC
+  - prior `watch_debug` had already shown the screen publication and track object were present
+  - the remaining suspicion became: hot watch was stuck on a weak `setSubscribed(true)` path that never forced a clean inbound subscription reset
+- New viewer-only patch applied:
+  - `core/viewer/participants-avatar.js`
+    - added `pulseScreenWatchSubscription(...)`
+    - manual `Start Watching` now does a one-shot screen-track unsubscribe/re-subscribe pulse on the immediate manual opt-in stage
+    - the pulse uses existing `markResubscribeIntent(...)` suppression so the screen tile is not torn down during the deliberate reset
+    - after the pulse, the existing `resubscribeParticipantTracks(...)` + `reconcileParticipantMedia(...)` path still settles the participant normally
+    - `watch_debug` now records whether the manual stage used `pulse=manual-reset`
+  - `core/viewer/changelog.js`
+    - added `2026-04-13e / Screen Watch Re-Subscribe`
+- Verification / rollout:
+  - `node --check core/viewer/participants-avatar.js` passed
+  - `node --check core/viewer/changelog.js` passed
+  - forced live viewer reload via `POST /admin/api/force-reload`
+    - returned `viewer_stamp = 0.6.10-local.1.1776124809`
+    - kicked stale `main` participants:
+      - `sam-7475`
+      - `sam-pc-2513`
+      - `sam-pc-2513$screen`
+  - relaunched this PC on the installed binary:
+    - `C:\Users\Sam\AppData\Local\Echo Chamber\echo-core-client.exe`
+    - verified running process path exactly matches installed app
+  - restarted `SAM-PC` through the bridge launcher again so it re-opened the installed binary
+  - confirmed fresh `SAM-PC` startup log:
+    - `[1776124817] [startup] echo-core-client boot server=https://echo.fellowshipoftheboatrace.party:9443 force_software_encoder=false`
+  - wrote fresh remote marker:
+    - `==== manual-watch-resubscribe-retest 2026-04-13 20:00:40 ====`
+- Current exact next retest:
+  - connect this PC and `SAM-PC`
+  - on `SAM-PC`, start native `Share -> Entire Screen`
+  - on this PC, click `Start Watching` once
+  - leave it up about 10 seconds
+  - then determine whether the new manual re-subscribe pulse finally converts the blank tile into actual inbound video
+
+## 2026-04-13 SDK screen-tile attach patch after blank hot-watch persisted
+- The manual watch re-subscribe pulse did **not** fix the remaining blank tile on this PC.
+- Fresh evidence from the failed retest:
+  - `SAM-PC` sender log still showed healthy native publish on the same repro:
+    - `connected as sam-pc-2513$screen`
+    - `room-event local-track-published`
+    - `room-event local-track-subscribed`
+    - `encoder=OpenH264`
+    - `bytes`, `frames_sent`, and `frames_encoded` all rising normally
+  - admin dashboard for `sam-7475` showed:
+    - `watch_debug = identity=sam-pc-2513 stage=fallback@1500ms pulse=none hidden=false watched=true tile=present:display=auto:client=316x177:video=0x0:paused=false:rs=0 remotes=sam-pc-2513:microphone:audio:sub=true:track=true:recv=true:mst=live/live;sam-pc-2513$screen:screen_share:video:sub=true:track=true:recv=true:mst=live/muted`
+    - `inbound = null`
+  - practical meaning:
+    - this PC still got a receiver object and remote `MediaStreamTrack`
+    - but real inbound media never lit up on the tile
+- New viewer-side hypothesis and fix:
+  - the remote screen-tile code path was still creating video elements manually from:
+    - `new MediaStream([track.mediaStreamTrack])`
+  - the working recovery path elsewhere already used the SDK-managed:
+    - `track.attach()`
+  - that difference became the best remaining explanation for:
+    - receiver exists
+    - track exists
+    - tile exists
+    - no real inbound media on hot watch
+- New patch applied:
+  - `core/viewer/participants.js`
+    - added `createAttachedVideoElement(track)` helper
+    - prefers `track.attach()` and falls back to the older manual element path only if attach fails
+  - `core/viewer/audio-routing.js`
+    - remote screen-share tile creation now uses `createAttachedVideoElement(track)`
+    - existing screen-tile/same-track path now also re-requests a keyframe and ensures the inbound stats monitor is running
+  - `core/viewer/participants-fullscreen.js`
+    - `replaceScreenVideoElement(...)` now also uses `createAttachedVideoElement(track)`
+  - `core/viewer/changelog.js`
+    - added `2026-04-13f / SDK Screen Tile Attach`
+- Verification / rollout:
+  - `node --check` passed for:
+    - `core/viewer/participants.js`
+    - `core/viewer/audio-routing.js`
+    - `core/viewer/participants-fullscreen.js`
+  - forced live viewer reload again:
+    - `viewer_stamp = 0.6.10-local.1.1776125124`
+  - relaunched this PC on:
+    - `C:\Users\Sam\AppData\Local\Echo Chamber\echo-core-client.exe`
+  - restarted `SAM-PC` through the bridge again
+  - confirmed fresh remote startup:
+    - `[1776125130] [startup] echo-core-client boot server=https://echo.fellowshipoftheboatrace.party:9443 force_software_encoder=false`
+- Current next retest after this patch:
+  - connect both clients
+  - on `SAM-PC`, start native `Share -> Entire Screen`
+  - on this PC, click `Start Watching`
+  - leave it 10 seconds
+  - determine whether the SDK-managed video attach path finally breaks the blank-tile hot-watch failure
+
+## 2026-04-13 Risk reduction rollback: remove dead-end viewer experiments before broader smoke
+- After the `2026-04-13e` and `2026-04-13f` viewer experiments both still produced `blank`, the regression risk was no longer justified.
+- Practical product decision:
+  - do **not** keep widening the live viewer path for one isolated Win10 failure without first protecting the known-good majority
+  - treat the latest two viewer experiments as dead ends and roll them back before broader validation
+- Viewer rollback applied:
+  - removed the manual `Start Watching` pulse-resubscribe experiment from `core/viewer/participants-avatar.js`
+  - removed the SDK-attach screen tile experiment from:
+    - `core/viewer/participants.js`
+    - `core/viewer/audio-routing.js`
+    - `core/viewer/participants-fullscreen.js`
+  - removed changelog entries:
+    - `2026-04-13e / Screen Watch Re-Subscribe`
+    - `2026-04-13f / SDK Screen Tile Attach`
+- Verification / rollout after rollback:
+  - `node --check` passed for:
+    - `core/viewer/participants-avatar.js`
+    - `core/viewer/participants.js`
+    - `core/viewer/audio-routing.js`
+    - `core/viewer/participants-fullscreen.js`
+    - `core/viewer/changelog.js`
+  - forced live viewer reload:
+    - `viewer_stamp = 0.6.10-local.1.1776125515`
+  - relaunched this PC on installed app:
+    - `C:\Users\Sam\AppData\Local\Echo Chamber\echo-core-client.exe`
+  - restarted `SAM-PC` through the bridge again
+  - confirmed fresh `SAM-PC` startup:
+    - `[1776125524] [startup] echo-core-client boot server=https://echo.fellowshipoftheboatrace.party:9443 force_software_encoder=false`
+- Current risk posture after rollback:
+  - the last two viewer-side hot-watch experiments are no longer in the served build
+  - the main remaining cross-user-risk candidate is now the direct-H26x encoder factory change in:
+    - `core/webrtc-sys-local/src/video_encoder_factory.cpp`
+  - that change still has real value because it objectively converted `SAM-PC` from `0 bytes / 0 frames_encoded` into a genuinely sending native publisher
+- Best immediate next move:
+  - re-smoke a known-good sharing path before doing more Win10-specific surgery
+  - if the known-good path fails on the current build, revert the encoder-factory change too and keep the public baseline clean
+
+## 2026-04-13 Encoder-factory rollback after canary regression
+- Canary result after the viewer rollbacks:
+  - this PC -> `Share -> Entire Screen` -> `SAM-PC`
+  - result reported by Sam: `broken`
+- Product decision:
+  - treat the direct-H26x encoder-factory change as broad-risk, not safe-to-ship
+  - revert it immediately before doing any more Win10-specific experimentation
+- Reverted:
+  - `core/webrtc-sys-local/src/video_encoder_factory.cpp`
+    - removed the direct `internal_factory_->Create(...)` H26x path
+    - restored the previous `SimulcastEncoderAdapter` behavior
+- Build / deploy after rollback:
+  - `cargo build -p echo-core-client --release` passed
+  - redeployed the rebuilt client to this PC installed path:
+    - `C:\Users\Sam\AppData\Local\Echo Chamber\echo-core-client.exe`
+  - staged the same rebuilt EXE to:
+    - `\\SAM-PC\EchoChamber\installed-update\echo-core-client.exe`
+  - restarted `SAM-PC` through the bridge again
+  - verified fresh local process path:
+    - `C:\Users\Sam\AppData\Local\Echo Chamber\echo-core-client.exe`
+  - verified fresh remote startup:
+    - `[1776125737] [startup] echo-core-client boot server=https://echo.fellowshipoftheboatrace.party:9443 force_software_encoder=false`
+- Risk posture after this rollback:
+  - broad-risk viewer experiments are gone
+  - broad-risk encoder-factory experiment is now gone too
+  - current build is back on the safer publish baseline
+- Current immediate next test:
+  - rerun the same canary:
+    - this PC shares `Entire Screen`
+    - `SAM-PC` watches it
+  - if that comes back working again, the baseline is re-established and the Win10 `SAM-PC` native full-screen failure can be treated as an isolated fringe path without shipping the risky regressions
+
+## 2026-04-13 Narrow encoder fix: software H264 fallback bypasses SimulcastEncoderAdapter
+- After the rollback canary still came back `broken`, the fresh evidence did **not** support another broad rollback-only conclusion:
+  - the remote `SAM-PC` log still showed the original Win10 native sender failure had returned on the rollback build:
+    - `encoder=SimulcastEncoderAdapter`
+    - `bytes=0`
+    - `frames_sent=0`
+    - `frames_encoded=0`
+  - that means the rollback definitely restored the old `SAM-PC` zero-RTP sender bug
+  - the earlier successful native sender repros on the direct-H26x experiment had specifically shown:
+    - `encoder=OpenH264`
+    - rising `bytes`
+    - rising `frames_sent`
+    - rising `frames_encoded`
+- New conclusion:
+  - the useful part of the old experiment was not "all H264 should bypass the adapter"
+  - the useful part was narrower:
+    - the **software H264 fallback** path can dead-stick when wrapped in `SimulcastEncoderAdapter`
+    - NVENC-backed H264 should stay on the existing path until explicitly disproven
+- Narrow patch applied:
+  - `core/webrtc-sys-local/include/livekit/video_encoder_factory.h`
+    - added `HasHardwareEncoderForFormat(...)`
+  - `core/webrtc-sys-local/src/video_encoder_factory.cpp`
+    - keep existing `SimulcastEncoderAdapter` behavior for the normal/hardware-backed paths
+    - **only** bypass the adapter when:
+      - codec is `H264`
+      - no hardware encoder factory matches the requested format
+    - in that case, create the software encoder directly through `InternalFactory::Create(...)`
+  - `core/viewer/changelog.js`
+    - added `2026-04-13h / Software H264 Screen-Share Fallback`
+- Verification / rollout:
+  - `cargo build -p echo-core-client --release` passed
+  - redeployed this PC installed client:
+    - `C:\Users\Sam\AppData\Local\Echo Chamber\echo-core-client.exe`
+    - size `45,360,128`
+    - timestamp `2026-04-13 20:24:43`
+  - staged the same rebuilt EXE to the `SAM-PC` bridge update path:
+    - `\\SAM-PC\EchoChamber\installed-update\echo-core-client.exe`
+  - restarted `SAM-PC` through the existing bridge shim (the live agent there is still the old one, so `/launch-installed` is still unavailable)
+  - verified the staged bridge applied the update into the real installed app path:
+    - `\\SAM-PC\Users\Sam\AppData\Local\Echo Chamber\echo-core-client.exe`
+    - size `45,360,128`
+    - timestamp `2026-04-13 20:24:43`
+  - verified fresh remote startup:
+    - `[1776126415] [startup] echo-core-client boot server=https://echo.fellowshipoftheboatrace.party:9443 force_software_encoder=false`
+- Current risk posture:
+  - no server reboot
+  - no Chromium/WebView fallback
+  - no viewer hot-watch experiments reintroduced
+  - the new encoder change is materially narrower than the reverted all-H264 experiment
+- Current immediate next retest:
+  - connect this PC and `SAM-PC`
+  - on this PC, start `Share -> Entire Screen`
+  - confirm whether `SAM-PC` can now watch it successfully on the narrowed fix
+  - then retest:
+    - on `SAM-PC`, start `Share -> Entire Screen`
+    - on this PC, click `Start Watching`
+  - use those two back-to-back canaries to determine whether the narrow software-H264-only bypass preserved the good path while restoring the Win10 native sender
+
+## 2026-04-13 Canary clarification + restored full H26x bypass
+- Sam clarified the earlier `broken` canary that triggered the encoder rollback was most likely run in the wrong direction:
+  - the requested canary was:
+    - this PC publishes `Entire Screen`
+    - `SAM-PC` watches it
+  - later, the same canary was rerun correctly and came back:
+    - `works`
+- That clarification materially changes the risk assessment:
+  - the only concrete reason the broader direct-H26x publish fix was rolled back is no longer trustworthy
+  - meanwhile, every real `SAM-PC` Win10 native repro on the rollback build still showed:
+    - `encoder=SimulcastEncoderAdapter`
+    - `bytes=0`
+    - `frames_sent=0`
+    - `frames_encoded=0`
+  - so the rollback clearly reintroduced the original sender-side failure
+- Fresh evidence before restoring the broader fix:
+  - `SAM-PC` real repro with the narrowed build still failed the same way:
+    - remote log continued to show `encoder=SimulcastEncoderAdapter`
+    - sender counters stayed at zero despite healthy DXGI capture and a connected transport
+  - dashboard on both viewers still showed the same dead remote screen-track signature:
+    - subscribed
+    - receiver exists
+    - `MediaStreamTrack = live/muted`
+    - blank 0fps tile
+  - Jeff's entire-screen share worked on both this PC and `SAM-PC`, which is strong evidence the room/viewer side is still broadly healthy
+- Restored effective fix:
+  - `core/webrtc-sys-local/src/video_encoder_factory.cpp`
+    - restored the broader direct H26x path
+    - `H264`, `H265`, and `HEVC` now bypass `SimulcastEncoderAdapter` again and create directly through `InternalFactory::Create(...)`
+  - removed the now-unneeded narrow helper from:
+    - `core/webrtc-sys-local/include/livekit/video_encoder_factory.h`
+  - `core/viewer/changelog.js`
+    - added `2026-04-13i / H26x Screen-Share Encoder Path`
+- Verification / rollout:
+  - `cargo build -p echo-core-client --release` passed
+  - `node --check core/viewer/changelog.js` passed
+  - redeployed this PC installed client:
+    - `C:\Users\Sam\AppData\Local\Echo Chamber\echo-core-client.exe`
+    - size `45,360,128`
+    - timestamp `2026-04-13 20:34:37`
+  - staged the same rebuilt EXE to:
+    - `\\SAM-PC\EchoChamber\installed-update\echo-core-client.exe`
+  - restarted `SAM-PC` through the existing bridge again
+  - verified fresh remote installed EXE:
+    - `\\SAM-PC\Users\Sam\AppData\Local\Echo Chamber\echo-core-client.exe`
+    - size `45,360,128`
+    - timestamp `2026-04-13 20:34:37`
+  - verified fresh startups:
+    - local:
+      - `C:\Users\Sam\AppData\Local\Echo Chamber\echo-core-client.exe`
+    - remote:
+      - `[1776126886] [startup] echo-core-client boot server=https://echo.fellowshipoftheboatrace.party:9443 force_software_encoder=false`
+- Current immediate next retest:
+  - connect this PC and `SAM-PC`
+  - on `SAM-PC`, start `Share -> Entire Screen`
+  - on this PC, click `Start Watching`
+  - leave it 10 seconds
+  - determine whether the restored H26x path puts `SAM-PC` back on a real outgoing sender instead of the zero-byte `SimulcastEncoderAdapter` stall
+
+## 2026-04-13 Sender restored again; watch path narrowed to SDK attach
+- Retest result after restoring the full H26x bypass:
+  - `SAM-PC` native `Entire Screen` still looked `blank` to viewers
+  - but the sender-side failure was now clearly gone again
+- Fresh `SAM-PC` sender evidence from `\\SAM-PC\Users\Sam\AppData\Local\Echo Chamber\capture-debug.log`:
+  - `encoder=OpenH264`
+  - `bytes`, `packets`, `frames_sent`, and `frames_encoded` all rising normally
+  - example:
+    - `bytes=178942 packets=373 frames_sent=64 frames_encoded=64`
+    - later rising to:
+      - `bytes=551182 packets=947 frames_sent=291 frames_encoded=291`
+- Fresh dashboard evidence at the same time:
+  - both this PC and Jeff still showed the same dead remote screen-track state for `SAM-PC`
+  - `watch_debug` on both viewers reported:
+    - `sam-pc-2513$screen:screen_share:video:sub=true:track=true:recv=true:mst=live/muted`
+    - tile present
+    - `video=0x0`
+    - `rs=0`
+  - practical meaning:
+    - `SAM-PC` is sending real RTP again
+    - the remaining break is back in the watch/tile attach path, not the sender
+- New narrow viewer patch:
+  - `core/viewer/participants.js`
+    - added `createAttachedVideoElement(track)`
+    - prefers SDK-managed `track.attach()` first
+    - falls back to the old locked-manual `MediaStream` path only if attach fails
+  - `core/viewer/audio-routing.js`
+    - new remote screen tile creation now uses `createAttachedVideoElement(track)`
+  - `core/viewer/participants-fullscreen.js`
+    - `replaceScreenVideoElement(...)` now also uses `createAttachedVideoElement(track)`
+  - `core/viewer/changelog.js`
+    - added `2026-04-13j / SDK Screen Tile Attach`
+- Verification / rollout:
+  - `node --check` passed for:
+    - `core/viewer/participants.js`
+    - `core/viewer/audio-routing.js`
+    - `core/viewer/participants-fullscreen.js`
+    - `core/viewer/changelog.js`
+  - relaunched this PC installed app:
+    - startup `[1776127086]`
+  - restarted `SAM-PC` through the bridge again:
+    - startup `[1776127085]`
+- Current immediate next retest:
+  - connect this PC and `SAM-PC`
+  - on `SAM-PC`, start `Share -> Entire Screen`
+  - on this PC, click `Start Watching`
+  - leave it 10 seconds
+  - determine whether the SDK-managed first-attach path finally converts the live-but-muted remote screen track into real rendered video
+
+## 2026-04-13 Win10 full-screen fix confirmed
+- Final successful repro:
+  - `SAM-PC` -> `Share -> Entire Screen`
+  - this PC reported: `visible`
+- The successful path is now confirmed to be the real product fix, not a stale manual override:
+  - `\\SAM-PC\Users\Sam\AppData\Local\Echo Chamber\config.json` only contains:
+    - `{"server":"https://echo.fellowshipoftheboatrace.party:9443"}`
+  - no explicit `force_software_encoder` flag remains in the installed config
+  - both installed clients were refreshed to the same rebuilt EXE:
+    - size `45,409,792`
+    - timestamp `2026-04-13 21:25:11`
+- Root cause that actually mattered:
+  - Rust-side Win10 auto-fallback was already setting:
+    - `force_software_encoder=true`
+    - `auto_force_software_encoder=true`
+  - but the native encoder factory was still registering hardware factories on `SAM-PC`
+  - that left Win10 in a split-brain state where the app thought software fallback was active while the C++ encoder side still walked the hardware path
+- Winning fix:
+  - `core/client/src/main.rs`
+    - keep `force_software_encoder` optional in config
+    - auto-force software H264 when Windows build `< 22000` and no explicit override is set
+    - log the exact startup decision:
+      - `force_software_encoder`
+      - `auto_force_software_encoder`
+      - `windows_build`
+  - `core/webrtc-sys-local/src/nvidia/cuda_context.cpp`
+    - teach native `IsSoftwareEncoderForced()` to read installed `config.json`
+    - also auto-force on Win10 builds `< 22000`
+  - `core/webrtc-sys-local/src/nvidia/nvidia_encoder_factory.cpp`
+    - skip NVENC factory registration when native `IsSoftwareEncoderForced()` is true
+  - `core/webrtc-sys-local/src/video_encoder_factory.cpp`
+    - keep the direct H26x path
+    - normalize software H264 to `packetization-mode=1`
+- Final proof from the successful build on `SAM-PC`:
+  - startup log:
+    - `[1776130126] [startup] echo-core-client boot server=https://echo.fellowshipoftheboatrace.party:9443 force_software_encoder=true auto_force_software_encoder=true windows_build=19045`
+  - native encoder-factory trace:
+    - `[encoder-factory] ctor hw_factories=0 force_software=1`
+    - `software-match ... packetization-mode=1 ... profile-level-id=42e01f`
+  - native capture/publish trace:
+    - `connected as sam-pc-2513$screen`
+    - `track published sid=TR_VSjzZeMAtKVaze source=Screenshare`
+    - `encoder=OpenH264`
+    - `frames_sent`, `frames_encoded`, and `bytes` all rising normally
+    - example:
+      - `bytes=213014 packets=411 frames_sent=89 frames_encoded=89 ... fps=17.0`
+      - later:
+        - `bytes=814215 packets=1244 frames_sent=457 frames_encoded=457 ... fps=17.0`
+- Practical product conclusion:
+  - Win10 native `Entire Screen` / `DXGI Desktop Duplication` should now auto-fall back to software H264 without requiring a manual config override
+  - this preserves the native picker/native capture direction and avoids the Chromium regression path Sam explicitly rejected
+  - expected tradeoff on Win10:
+    - visible and stable full-screen share
+    - OpenH264 software encode around `16-18 fps`
+    - lower peak performance than NVENC, but no more blank `0fps` dead air
+- Operational notes:
+  - no server reboot was needed for the fix
+  - the temporary `SAM-PC` bridge/shim is still only an operational launch path until the remote agent is modernized
+
+## 2026-04-13 v0.6.11 release prep completed
+- Release candidate version bump is in place across all required desktop release files:
+  - `core/client/Cargo.toml` -> `0.6.11`
+  - `core/client/tauri.conf.json` -> `0.6.11`
+  - `core/control/Cargo.toml` -> `0.6.11`
+- Windows-only release cleanup applied:
+  - `core/client/tauri.conf.json`
+    - bundle targets now `["nsis"]`
+  - `core/deploy/build-release.ps1`
+    - now builds with `cargo tauri build --bundles nsis`
+    - now generates a Windows-only `latest.json`
+    - now prints a safe exact-file `gh release create ...` command instead of the dangerous `bundleDir\*` wildcard (the bundle dir contains old installers)
+- Release notes updated in `CHANGELOG.md` with a new `0.6.11` entry covering:
+  - Win10 native `Entire Screen` auto software-H264 fallback
+  - software H264 packetization / render fix
+  - auto-watch / screen attach hardening
+  - Windows-only packaging cleanup
+- Build verification:
+  - `cargo build -p echo-core-client --release` passed on `0.6.11`
+  - `cargo build -p echo-core-control --release` passed on `0.6.11`
+  - local signed NSIS bundle built successfully via:
+    - `powershell -ExecutionPolicy Bypass -File core/deploy/build-release.ps1`
+- Fresh release artifacts produced locally:
+  - `core/target/release/bundle/nsis/Echo Chamber_0.6.11_x64-setup.exe`
+  - `core/target/release/bundle/nsis/Echo Chamber_0.6.11_x64-setup.exe.sig`
+  - `core/target/release/bundle/nsis/latest.json`
+- Generated updater manifest is Windows-only and points at:
+  - `https://github.com/SamWatson86/echo-chamber/releases/download/v0.6.11/Echo.Chamber_0.6.11_x64-setup.exe`
+- Important deployment boundary:
+  - `core/deploy/latest.json` in the repo still points at public `0.6.10`
+  - do **not** replace the live repo manifest until the `v0.6.11` GitHub release exists and its `latest.json` has been uploaded/downloaded
+- Exact publish command prepared by the release script:
+  - `gh release create v0.6.11 --title 'Echo Chamber v0.6.11' "F:\Codex AI\The Echo Chamber\core\target\release\bundle\nsis\Echo Chamber_0.6.11_x64-setup.exe" "F:\Codex AI\The Echo Chamber\core\target\release\bundle\nsis\Echo Chamber_0.6.11_x64-setup.exe.sig" "F:\Codex AI\The Echo Chamber\core\target\release\bundle\nsis\latest.json"`
+- After publishing:
+  - download the release `latest.json`
+  - copy it to `core/deploy/latest.json`
+  - verify `https://echo.fellowshipoftheboatrace.party:9443/api/update/latest.json` serves `0.6.11`
+
+## 2026-04-13 final 0.6.11 release-candidate smoke green
+- Final live smoke on the exact `0.6.11` release-candidate build came back green:
+  - `SAM-PC` Win10 `Entire Screen` -> visible on this PC
+  - this PC `Entire Screen` -> visible on `SAM-PC`
+  - Jeff `Entire Screen` -> visible on both machines
+- User confirmation:
+  - `all three work!`
+- Clean release-branch packaging also passed from the short-path `main`-based worktree:
+  - branch: `codex/release-v0.6.11-short`
+  - worktree: `F:\EC-r611`
+  - reason for short path:
+    - the first clean worktree under `.codex\worktrees\release-v0.6.11` hit path-length trouble in libwebrtc scratch includes
+    - moving the clean branch to `F:\EC-r611` fixed packaging without changing source
+  - local signing key had to be copied into the clean worktree as untracked local release material:
+    - `core/client/.tauri-keys`
+    - do not commit it
+- Clean-branch artifact verification:
+  - `powershell -ExecutionPolicy Bypass -File F:\EC-r611\core\deploy\build-release.ps1` passed
+  - produced:
+    - `F:\EC-r611\core\target\release\bundle\nsis\Echo Chamber_0.6.11_x64-setup.exe`
+    - `F:\EC-r611\core\target\release\bundle\nsis\Echo Chamber_0.6.11_x64-setup.exe.sig`
+    - `F:\EC-r611\core\target\release\bundle\nsis\latest.json`
+  - manifest verification:
+    - `version=0.6.11`
+    - GitHub URL points at `v0.6.11`
+- Release state:
+  - functionally ready to publish after staging/commit on the clean release branch
+  - still do not update repo `core/deploy/latest.json` until the GitHub release exists

--- a/CURRENT_SESSION.md
+++ b/CURRENT_SESSION.md
@@ -2156,3 +2156,24 @@ This session reproduced a third class of display instability on Sam's main RTX 4
 - Release state:
   - functionally ready to publish after staging/commit on the clean release branch
   - still do not update repo `core/deploy/latest.json` until the GitHub release exists
+
+## 2026-04-13 v0.6.11 published
+- GitHub release published successfully:
+  - tag: `v0.6.11`
+  - URL: `https://github.com/SamWatson86/echo-chamber/releases/tag/v0.6.11`
+  - target branch at publish time:
+    - `codex/release-v0.6.11-short`
+    - commit `5f76ee3`
+- Published assets:
+  - `Echo Chamber_0.6.11_x64-setup.exe`
+  - `Echo Chamber_0.6.11_x64-setup.exe.sig`
+  - `latest.json`
+- Post-publish manifest sync completed:
+  - downloaded release `latest.json` into `core/deploy/latest.json`
+  - copied the published manifest into the live checkout deploy dir
+- Live updater verification:
+  - `https://echo.fellowshipoftheboatrace.party:9443/api/update/latest.json` now serves:
+    - `version=0.6.11`
+    - GitHub asset URL for `v0.6.11`
+- Release status:
+  - `0.6.11` is live for Windows desktop updater checks

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -1185,7 +1185,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1304,7 +1304,7 @@ dependencies = [
 
 [[package]]
 name = "echo-core-client"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "base64 0.22.1",
  "livekit",
@@ -1323,7 +1323,7 @@ dependencies = [
 
 [[package]]
 name = "echo-core-control"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "argon2",
  "axum",
@@ -1459,7 +1459,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1968,7 +1968,7 @@ dependencies = [
  "gobject-sys 0.21.5",
  "libc",
  "system-deps 7.0.7",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2406,7 +2406,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.58.0",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -3244,7 +3244,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4721,7 +4721,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4789,7 +4789,7 @@ dependencies = [
  "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5831,7 +5831,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6855,7 +6855,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6948,6 +6948,19 @@ dependencies = [
  "windows-link 0.1.3",
  "windows-result 0.3.4",
  "windows-strings 0.4.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
 ]
 
 [[package]]

--- a/core/client/Cargo.toml
+++ b/core/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "echo-core-client"
-version = "0.6.10"
+version = "0.6.11"
 edition = "2021"
 description = "Echo Chamber native desktop client"
 

--- a/core/client/src/audio_output.rs
+++ b/core/client/src/audio_output.rs
@@ -132,10 +132,7 @@ pub fn list_output_devices() -> Vec<OutputDevice> {
             // Get friendly name via raw COM calls (no Win32_UI_Shell_PropertiesSystem feature)
             let name = get_device_friendly_name_raw(&device).unwrap_or_else(|| id_str.clone());
 
-            devices.push(OutputDevice {
-                id: id_str,
-                name,
-            });
+            devices.push(OutputDevice { id: id_str, name });
         }
     }
 
@@ -153,13 +150,17 @@ fn get_device_friendly_name_raw(device: &IMMDevice) -> Option<String> {
 
         // OpenPropertyStore is at vtable slot 4 (IUnknown=3, Activate=3, OpenPropertyStore=4)
         let open_property_store: unsafe extern "system" fn(
-            *mut std::ffi::c_void, // this
-            i32,                   // STGM (STGM_READ = 0)
+            *mut std::ffi::c_void,      // this
+            i32,                        // STGM (STGM_READ = 0)
             *mut *mut std::ffi::c_void, // IPropertyStore**
         ) -> HRESULT = std::mem::transmute(*(vtable.add(4)));
 
         let mut prop_store: *mut std::ffi::c_void = std::ptr::null_mut();
-        let hr = open_property_store(device_ptr as *mut _, 0 /* STGM_READ */, &mut prop_store);
+        let hr = open_property_store(
+            device_ptr as *mut _,
+            0, /* STGM_READ */
+            &mut prop_store,
+        );
         if hr.is_err() || prop_store.is_null() {
             return None;
         }
@@ -173,11 +174,7 @@ fn get_device_friendly_name_raw(device: &IMMDevice) -> Option<String> {
         ) -> HRESULT = std::mem::transmute(*(store_vtable.add(5)));
 
         let mut value = std::mem::zeroed::<PROPVARIANT>();
-        let hr = get_value(
-            prop_store,
-            &PKEY_DEVICE_FRIENDLYNAME,
-            &mut value,
-        );
+        let hr = get_value(prop_store, &PKEY_DEVICE_FRIENDLYNAME, &mut value);
 
         // Release IPropertyStore
         let release: unsafe extern "system" fn(*mut std::ffi::c_void) -> u32 =
@@ -274,10 +271,8 @@ fn set_default_endpoint(device_id: &str, role: ERole) -> std::result::Result<(),
 
         // CoCreateInstance for IPolicyConfig — since it's not a type known to
         // the windows crate, we create it as IUnknown and then QueryInterface.
-        let unknown: IUnknown =
-            CoCreateInstance(&CPOLICYCONFIG_CLSID, None, CLSCTX_ALL).map_err(|e| {
-                format!("CoCreateInstance(CPolicyConfigClient) failed: {}", e)
-            })?;
+        let unknown: IUnknown = CoCreateInstance(&CPOLICYCONFIG_CLSID, None, CLSCTX_ALL)
+            .map_err(|e| format!("CoCreateInstance(CPolicyConfigClient) failed: {}", e))?;
 
         // QueryInterface for IPolicyConfig
         let mut raw_ptr: *mut std::ffi::c_void = std::ptr::null_mut();
@@ -308,10 +303,7 @@ fn set_default_endpoint(device_id: &str, role: ERole) -> std::result::Result<(),
         ) -> HRESULT = std::mem::transmute(*(vtable.add(13)));
 
         // Convert device_id to wide string
-        let wide: Vec<u16> = device_id
-            .encode_utf16()
-            .chain(std::iter::once(0))
-            .collect();
+        let wide: Vec<u16> = device_id.encode_utf16().chain(std::iter::once(0)).collect();
 
         let hr = set_default_endpoint_fn(raw_ptr, PCWSTR(wide.as_ptr()), role.0 as u32);
 
@@ -321,10 +313,7 @@ fn set_default_endpoint(device_id: &str, role: ERole) -> std::result::Result<(),
         release_fn(raw_ptr);
 
         if hr.is_err() {
-            return Err(format!(
-                "SetDefaultEndpoint failed: 0x{:08X}",
-                hr.0 as u32
-            ));
+            return Err(format!("SetDefaultEndpoint failed: 0x{:08X}", hr.0 as u32));
         }
 
         Ok(())

--- a/core/client/src/capture_health.rs
+++ b/core/client/src/capture_health.rs
@@ -48,23 +48,33 @@ pub enum HealthLevel {
 
 impl HealthLevel {
     fn rank(self) -> u8 {
-        match self { HealthLevel::Green => 0, HealthLevel::Yellow => 1, HealthLevel::Red => 2 }
+        match self {
+            HealthLevel::Green => 0,
+            HealthLevel::Yellow => 1,
+            HealthLevel::Red => 2,
+        }
     }
     fn max(self, other: HealthLevel) -> HealthLevel {
-        if self.rank() >= other.rank() { self } else { other }
+        if self.rank() >= other.rank() {
+            self
+        } else {
+            other
+        }
     }
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub enum CaptureMode {
-    #[default] None,
+    #[default]
+    None,
     Wgc,
     DxgiDd,
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub enum EncoderType {
-    #[default] None,
+    #[default]
+    None,
     Nvenc,
     OpenH264,
 }
@@ -74,8 +84,8 @@ pub struct CaptureHealthSnapshot {
     pub level: HealthLevel,
     pub reasons: Vec<String>,
     pub capture_active: bool,
-    pub capture_mode: String,        // "WGC" | "DXGI-DD" | "None"
-    pub encoder_type: String,        // "NVENC" | "OpenH264" | "None"
+    pub capture_mode: String, // "WGC" | "DXGI-DD" | "None"
+    pub encoder_type: String, // "NVENC" | "OpenH264" | "None"
     pub current_fps: u32,
     pub target_fps: u32,
     pub reinit_count_5m: u32,
@@ -156,7 +166,8 @@ impl CaptureHealthState {
         Self::prune_pairs(&mut e, now);
         e.push((now, current));
         let max = e.iter().map(|(_, n)| *n).max().unwrap_or(0);
-        self.consecutive_timeouts_max_5m.store(max, Ordering::Relaxed);
+        self.consecutive_timeouts_max_5m
+            .store(max, Ordering::Relaxed);
     }
 
     pub fn reset_consecutive_timeouts(&self) {
@@ -164,7 +175,8 @@ impl CaptureHealthState {
     }
 
     pub fn record_encoder_status(&self, skipped_total: u64, sent_total: u64) {
-        self.encoder_skipped_total.store(skipped_total, Ordering::Relaxed);
+        self.encoder_skipped_total
+            .store(skipped_total, Ordering::Relaxed);
         self.encoder_sent_total.store(sent_total, Ordering::Relaxed);
     }
 
@@ -221,22 +233,20 @@ impl CaptureHealthState {
     /// viewer correct us if WebRTC picked OpenH264 or anything else.
     pub fn set_encoder_type_from_string(&self, raw: &str) {
         let lower = raw.to_lowercase();
-        let new_type = if lower.contains("openh264")
-            || lower == "open h264"
-            || lower.contains("software")
-        {
-            EncoderType::OpenH264
-        } else if lower.contains("nvenc")
-            || lower.contains("nvidia")
-            || lower.contains("nvcodec")
-            || lower.contains("external")
-            || lower.contains("hardware")
-        {
-            EncoderType::Nvenc
-        } else {
-            // Unknown encoder string — leave whatever set_active put there.
-            return;
-        };
+        let new_type =
+            if lower.contains("openh264") || lower == "open h264" || lower.contains("software") {
+                EncoderType::OpenH264
+            } else if lower.contains("nvenc")
+                || lower.contains("nvidia")
+                || lower.contains("nvcodec")
+                || lower.contains("external")
+                || lower.contains("hardware")
+            {
+                EncoderType::Nvenc
+            } else {
+                // Unknown encoder string — leave whatever set_active put there.
+                return;
+            };
         *self.encoder_type.write() = new_type;
     }
 
@@ -263,7 +273,9 @@ impl CaptureHealthState {
         let total = skipped + sent;
         let encoder_skip_rate_pct = if total > 0 {
             (skipped as f32 / total as f32) * 100.0
-        } else { 0.0 };
+        } else {
+            0.0
+        };
 
         let mode = self.capture_mode.read().clone();
         let encoder = self.encoder_type.read().clone();
@@ -315,7 +327,10 @@ pub fn classify(snap: &CaptureHealthSnapshot) -> (HealthLevel, Vec<String>) {
     // Reinits
     if snap.reinit_count_5m >= RED_REINITS_5M {
         level = level.max(HealthLevel::Red);
-        reasons.push(format!("{} reinits in 5min (>= {})", snap.reinit_count_5m, RED_REINITS_5M));
+        reasons.push(format!(
+            "{} reinits in 5min (>= {})",
+            snap.reinit_count_5m, RED_REINITS_5M
+        ));
     } else if snap.reinit_count_5m >= YELLOW_REINITS_5M {
         level = level.max(HealthLevel::Yellow);
         reasons.push(format!("{} reinit in 5min", snap.reinit_count_5m));
@@ -324,10 +339,16 @@ pub fn classify(snap: &CaptureHealthSnapshot) -> (HealthLevel, Vec<String>) {
     // Consecutive timeouts (current run)
     if snap.consecutive_timeouts >= RED_CONSECUTIVE_TIMEOUTS {
         level = level.max(HealthLevel::Red);
-        reasons.push(format!("{} consecutive capture timeouts", snap.consecutive_timeouts));
+        reasons.push(format!(
+            "{} consecutive capture timeouts",
+            snap.consecutive_timeouts
+        ));
     } else if snap.consecutive_timeouts >= YELLOW_CONSECUTIVE_TIMEOUTS {
         level = level.max(HealthLevel::Yellow);
-        reasons.push(format!("{} consecutive capture timeouts", snap.consecutive_timeouts));
+        reasons.push(format!(
+            "{} consecutive capture timeouts",
+            snap.consecutive_timeouts
+        ));
     }
 
     // FPS vs target — ONLY meaningful for polling capture modes (DXGI DD).
@@ -363,13 +384,18 @@ pub fn classify(snap: &CaptureHealthSnapshot) -> (HealthLevel, Vec<String>) {
             level = level.max(HealthLevel::Red);
             reasons.push(format!(
                 "capture fps {}/{} ({:.0}%, < {:.0}%)",
-                snap.current_fps, snap.target_fps, frac * 100.0, RED_FPS_FRACTION * 100.0
+                snap.current_fps,
+                snap.target_fps,
+                frac * 100.0,
+                RED_FPS_FRACTION * 100.0
             ));
         } else if frac < YELLOW_FPS_FRACTION {
             level = level.max(HealthLevel::Yellow);
             reasons.push(format!(
                 "capture fps {}/{} ({:.0}%)",
-                snap.current_fps, snap.target_fps, frac * 100.0
+                snap.current_fps,
+                snap.target_fps,
+                frac * 100.0
             ));
         }
     }
@@ -377,10 +403,16 @@ pub fn classify(snap: &CaptureHealthSnapshot) -> (HealthLevel, Vec<String>) {
     // Encoder skip rate
     if snap.encoder_skip_rate_pct >= RED_SKIP_RATE_PCT {
         level = level.max(HealthLevel::Red);
-        reasons.push(format!("encoder skip rate {:.1}%", snap.encoder_skip_rate_pct));
+        reasons.push(format!(
+            "encoder skip rate {:.1}%",
+            snap.encoder_skip_rate_pct
+        ));
     } else if snap.encoder_skip_rate_pct >= YELLOW_SKIP_RATE_PCT {
         level = level.max(HealthLevel::Yellow);
-        reasons.push(format!("encoder skip rate {:.1}%", snap.encoder_skip_rate_pct));
+        reasons.push(format!(
+            "encoder skip rate {:.1}%",
+            snap.encoder_skip_rate_pct
+        ));
     }
 
     // Encoder fallback to OpenH264 — automatic Red
@@ -500,7 +532,11 @@ mod tests {
         s.seconds_since_capture_started = 3; // mid cold-start
         let (lvl, reasons) = classify(&s);
         assert_eq!(lvl, HealthLevel::Green);
-        assert!(reasons.is_empty(), "cold-start fps suppression should produce no reasons, got {:?}", reasons);
+        assert!(
+            reasons.is_empty(),
+            "cold-start fps suppression should produce no reasons, got {:?}",
+            reasons
+        );
     }
 
     #[test]
@@ -537,7 +573,11 @@ mod tests {
         s.target_fps = 30;
         let (lvl, reasons) = classify(&s);
         assert_eq!(lvl, HealthLevel::Green);
-        assert!(reasons.is_empty(), "WGC low fps should not produce reasons, got {:?}", reasons);
+        assert!(
+            reasons.is_empty(),
+            "WGC low fps should not produce reasons, got {:?}",
+            reasons
+        );
     }
 
     #[test]
@@ -587,9 +627,9 @@ mod tests {
     #[test]
     fn multiple_signals_take_max_level_and_list_all_reasons() {
         let mut s = nominal();
-        s.reinit_count_5m = 1;             // yellow
-        s.consecutive_timeouts = 10;       // red
-        s.encoder_skip_rate_pct = 3.0;     // yellow
+        s.reinit_count_5m = 1; // yellow
+        s.consecutive_timeouts = 10; // red
+        s.encoder_skip_rate_pct = 3.0; // yellow
         let (lvl, reasons) = classify(&s);
         assert_eq!(lvl, HealthLevel::Red);
         assert!(reasons.len() >= 3);

--- a/core/client/src/capture_pipeline.rs
+++ b/core/client/src/capture_pipeline.rs
@@ -6,17 +6,20 @@
 //! DXGI OutputDuplication, GPU shaders, anti-MPO) stays in its own module.
 
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex};
-use std::time::{Duration, Instant};
+use std::sync::Arc;
+use std::time::Instant;
 
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use tauri::{AppHandle, Emitter};
+use tokio::sync::mpsc::UnboundedReceiver;
 
-use livekit::prelude::*;
-use livekit::webrtc::prelude::*;
-use livekit::webrtc::native::yuv_helper;
-use livekit::webrtc::video_source::native::NativeVideoSource;
+use crate::file_debug_log;
 use livekit::options::{TrackPublishOptions, VideoCodec, VideoEncoding};
+use livekit::prelude::*;
+use livekit::webrtc::native::yuv_helper;
+use livekit::webrtc::prelude::*;
+use livekit::webrtc::stats::RtcStats;
+use livekit::webrtc::video_source::native::NativeVideoSource;
 
 // ── Stats ──
 
@@ -31,6 +34,13 @@ pub struct CaptureStats {
 
 // ── CapturePublisher ──
 
+/// Hard cap for the capture push rate when NVENC hardware encode is active.
+/// Keep the desktop/full-screen diagnostic path aligned with the 30fps wire
+/// target while we isolate the Win10 SAM-PC no-RTP regression.
+const TARGET_ENCODE_FPS_HARDWARE: f64 = PUBLISH_TARGET_FPS as f64;
+const MIN_FRAME_INTERVAL_HARDWARE: std::time::Duration =
+    std::time::Duration::from_nanos((1_000_000_000.0 / TARGET_ENCODE_FPS_HARDWARE) as u64);
+
 /// Soft cap for the capture push rate when OpenH264 software encode is active.
 /// Software H264 at 1080p at 60+ fps pins the CPU at ~90-100% and caused
 /// Jeff's v0.6.6 crash after ~54 min of sustained load (28K NACKs, CPU
@@ -40,8 +50,8 @@ pub struct CaptureStats {
 /// The WGC/DXGI capture loops still run at native refresh for responsive
 /// frame delivery; this cap just drops excess frames before conversion.
 const TARGET_ENCODE_FPS_SOFTWARE: f64 = 20.0;
-const MIN_FRAME_INTERVAL_SOFTWARE: Duration =
-    Duration::from_nanos((1_000_000_000.0 / TARGET_ENCODE_FPS_SOFTWARE) as u64);
+const MIN_FRAME_INTERVAL_SOFTWARE: std::time::Duration =
+    std::time::Duration::from_nanos((1_000_000_000.0 / TARGET_ENCODE_FPS_SOFTWARE) as u64);
 
 /// Global flag: true if nvcuda.dll loaded successfully at client startup.
 /// When false, the capture pipeline uses MIN_FRAME_INTERVAL_SOFTWARE to
@@ -49,191 +59,158 @@ const MIN_FRAME_INTERVAL_SOFTWARE: Duration =
 /// main.rs's startup probe and never changes after that.
 pub static HAS_NVCUDA: AtomicBool = AtomicBool::new(false);
 
-/// Wire-level publish framerate cap for native screen share.
-/// Keep the capture-side pacing aligned with this number so native publishers
-/// don't push 100+ fps into WebRTC while the rest of the stack thinks the
-/// target is 30fps.
+/// Wire-level publish framerate cap. The capture loop runs at native display
+/// refresh rate (often 144+ Hz) but NVENC's frame_drop=1 throttles the wire
+/// output to this rate. This is the "target" the capture-health classifier
+/// compares current capture FPS against — if capture drops far below this
+/// number something upstream is starving the pipeline.
 pub const PUBLISH_TARGET_FPS: u32 = 30;
-pub const GAME_PUBLISH_TARGET_FPS: u32 = 60;
-
-/// Heartbeat interval for WGC/static-content frame duplication.
-/// If the real capture path has not pushed a new frame in this long, re-push
-/// the most recent BGRA frame so the wire stream stays alive at ~30fps.
-const HEARTBEAT_INTERVAL: Duration = Duration::from_millis(33);
-
-/// Shared heartbeat state.
-///
-/// WGC window capture is event-driven: `on_frame_arrived` only fires when the
-/// captured window repaints. Some windows can go effectively wire-silent when
-/// their redraw pattern changes even though the user still expects a live
-/// stream. The heartbeat thread re-pushes the most recent BGRA frame whenever
-/// the real capture path has been idle for longer than HEARTBEAT_INTERVAL.
-struct HeartbeatState {
-    last_frame: Option<LastFrameBuffer>,
-    last_real_push: Instant,
-}
-
-struct LastFrameBuffer {
-    bgra: Vec<u8>,
-    stride: u32,
-    width: u32,
-    height: u32,
-}
-
-struct HeartbeatHandle {
-    running: Arc<AtomicBool>,
-    thread: Option<std::thread::JoinHandle<()>>,
-}
-
-impl Drop for HeartbeatHandle {
-    fn drop(&mut self) {
-        self.running.store(false, Ordering::Relaxed);
-        if let Some(thread) = self.thread.take() {
-            let _ = thread.join();
-        }
-    }
-}
-
-#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "lowercase")]
-pub enum PublishProfile {
-    Desktop,
-    Game,
-}
-
-impl Default for PublishProfile {
-    fn default() -> Self {
-        Self::Desktop
-    }
-}
-
-impl PublishProfile {
-    pub fn target_fps(self) -> u32 {
-        match self {
-            Self::Desktop => PUBLISH_TARGET_FPS,
-            Self::Game => GAME_PUBLISH_TARGET_FPS,
-        }
-    }
-
-    fn max_bitrate(self) -> u64 {
-        match self {
-            Self::Desktop => 4_000_000,
-            Self::Game => 8_000_000,
-        }
-    }
-
-    fn min_bitrate(self) -> u64 {
-        match self {
-            Self::Desktop => 2_500_000,
-            Self::Game => 3_000_000,
-        }
-    }
-
-    fn hardware_min_frame_interval(self) -> Duration {
-        Duration::from_nanos((1_000_000_000.0 / self.target_fps() as f64) as u64)
-    }
-
-    fn heartbeat_interval(self) -> Option<Duration> {
-        match self {
-            Self::Desktop => Some(HEARTBEAT_INTERVAL),
-            Self::Game => None,
-        }
-    }
-}
 
 /// Shared publisher that connects to the LiveKit SFU, creates a NativeVideoSource,
-/// publishes a Camera track, and provides helpers to push BGRA frames and emit stats.
+/// publishes a caller-selected video track, and provides helpers to push BGRA frames
+/// and emit stats.
 pub struct CapturePublisher {
     room: Room,
     source: NativeVideoSource,
+    track: LocalVideoTrack,
     start_time: Instant,
     frame_count: u64,
     last_pushed: Option<Instant>,
-    hardware_min_frame_interval: Duration,
-    heartbeat_state: Arc<Mutex<HeartbeatState>>,
-    heartbeat_handle: Option<HeartbeatHandle>,
+}
+
+async fn log_room_events(log_prefix: String, mut events: UnboundedReceiver<RoomEvent>) {
+    while let Some(event) = events.recv().await {
+        match event {
+            RoomEvent::LocalTrackPublished { publication, .. } => {
+                let line = format!(
+                    "[{}] room-event local-track-published sid={} source={:?}",
+                    log_prefix,
+                    publication.sid(),
+                    publication.source(),
+                );
+                eprintln!("{}", line);
+                file_debug_log::append(&line);
+            }
+            RoomEvent::LocalTrackSubscribed { track } => {
+                let line = format!(
+                    "[{}] room-event local-track-subscribed sid={} kind={:?}",
+                    log_prefix,
+                    track.sid(),
+                    track.kind(),
+                );
+                eprintln!("{}", line);
+                file_debug_log::append(&line);
+            }
+            _ => {}
+        }
+    }
 }
 
 impl CapturePublisher {
-    /// Connect to the SFU and publish a Camera video track.
+    /// Connect to the SFU and publish a caller-selected video track.
     ///
-    /// Creates a 1080p (or custom resolution) NativeVideoSource, publishes as
-    /// Camera with H264 @ 20Mbps/60fps, and waits 3 seconds for SDP negotiation.
+    /// Creates a 1080p (or custom resolution) NativeVideoSource, publishes with
+    /// H264, and waits 3 seconds for SDP negotiation.
     pub async fn connect_and_publish(
         sfu_url: &str,
         token: &str,
         enc_w: u32,
         enc_h: u32,
-        publish_profile: PublishProfile,
         log_prefix: &str,
+        track_source: TrackSource,
+        is_screencast: bool,
     ) -> Result<Self, String> {
         eprintln!("[{}] connecting to SFU: {}", log_prefix, sfu_url);
+        file_debug_log::append(&format!(
+            "[{}] connect_and_publish start sfu_url={} enc={}x{}",
+            log_prefix, sfu_url, enc_w, enc_h
+        ));
 
-        let (room, _events) = Room::connect(sfu_url, token, RoomOptions::default())
+        let (room, events) = Room::connect(sfu_url, token, RoomOptions::default())
             .await
             .map_err(|e| format!("SFU connect failed: {}", e))?;
+        tokio::spawn(log_room_events(log_prefix.to_string(), events));
 
         eprintln!(
             "[{}] connected as {}",
             log_prefix,
             room.local_participant().identity().as_str(),
         );
+        file_debug_log::append(&format!(
+            "[{}] connected as {}",
+            log_prefix,
+            room.local_participant().identity().as_str()
+        ));
 
-        // Video source at encode resolution — NOT screencast (game streaming prioritizes FPS)
+        // Source profile is caller-controlled so DXGI/WGC screen shares can use
+        // screencast semantics while legacy motion/game paths keep Fluid behavior.
         let source = NativeVideoSource::new(
             VideoResolution {
                 width: enc_w,
                 height: enc_h,
             },
-            false,
+            is_screencast,
         );
-        let track = LocalVideoTrack::create_video_track(
-            "screen",
-            RtcVideoSource::Native(source.clone()),
-        );
+        let track =
+            LocalVideoTrack::create_video_track("screen", RtcVideoSource::Native(source.clone()));
 
         let publish_options = TrackPublishOptions {
-            source: TrackSource::Camera,
+            source: track_source,
             video_codec: VideoCodec::H264,
             simulcast: false,
             video_encoding: Some(VideoEncoding {
-                max_bitrate: publish_profile.max_bitrate(),
-                min_bitrate: publish_profile.min_bitrate(),
-                max_framerate: publish_profile.target_fps() as f64,
+                // Capped at 4 Mbps for multi-publisher rooms. Validated 2026-04-07
+                // with 3 simultaneous 1080p shares and a residential-WAN viewer
+                // (David) who saw 0fps at 8Mbps. 4Mbps × 3 publishers = 12Mbps
+                // aggregate, comfortably under most residential downloads. Per-stream
+                // quality at 1080p30 H264 is still excellent for screen content.
+                // Twitch source quality reference: 6 Mbps at 1080p60 gameplay.
+                max_bitrate: 4_000_000,
+                // 2.5 Mbps hard floor — prevents libwebrtc GoogCC from throttling
+                // to zero under packet loss / RTT spikes, so the stream stays
+                // visible instead of dropping to 0fps and slowly probing back up.
+                min_bitrate: 2_500_000,
+                // 60fps for safe stable testing with David (remote friend).
+                // The level=AUTOSELECT fix is still in h264_encoder_impl.cpp
+                // for later 144fps retest on SAM-PC — harmless at 60fps.
+                // Capped at 30fps for multi-publisher rooms. With 3 simultaneous
+                // 1920x1080 H264 publishers, the cumulative NVDEC decode load
+                // and SFU forwarding pressure makes 60fps unsustainable —
+                // receivers see 10fps after pacing kicks in. 30fps gives
+                // headroom for all parties and is plenty for screen content.
+                // Spencer's recommendation, validated 2026-04-07 with 3 sharers.
+                max_framerate: PUBLISH_TARGET_FPS as f64,
             }),
             ..Default::default()
         };
 
-        room.local_participant()
-            .publish_track(LocalTrack::Video(track), publish_options)
+        let publication = room
+            .local_participant()
+            .publish_track(LocalTrack::Video(track.clone()), publish_options)
             .await
             .map_err(|e| format!("publish failed: {}", e))?;
 
-        eprintln!("[{}] track published, waiting for negotiation...", log_prefix);
-        tokio::time::sleep(Duration::from_secs(3)).await;
-
-        let start_time = Instant::now();
-        let heartbeat_state = Arc::new(Mutex::new(HeartbeatState {
-            last_frame: None,
-            last_real_push: start_time,
-        }));
-        let heartbeat_handle = Self::spawn_heartbeat(
-            heartbeat_state.clone(),
-            source.clone(),
-            start_time,
-            publish_profile.heartbeat_interval(),
+        eprintln!(
+            "[{}] track published sid={} source={:?}, waiting for negotiation...",
             log_prefix,
+            publication.sid(),
+            publication.source(),
         );
+        file_debug_log::append(&format!(
+            "[{}] track published sid={} source={:?}",
+            log_prefix,
+            publication.sid(),
+            publication.source(),
+        ));
+        tokio::time::sleep(std::time::Duration::from_secs(3)).await;
 
         Ok(Self {
             room,
             source,
-            start_time,
+            track,
+            start_time: Instant::now(),
             frame_count: 0,
             last_pushed: None,
-            hardware_min_frame_interval: publish_profile.hardware_min_frame_interval(),
-            heartbeat_state,
-            heartbeat_handle,
         })
     }
 
@@ -247,165 +224,100 @@ impl CapturePublisher {
         token: &str,
         enc_w: u32,
         enc_h: u32,
-        publish_profile: PublishProfile,
         log_prefix: &str,
+        track_source: TrackSource,
+        is_screencast: bool,
     ) -> Result<Self, String> {
         eprintln!("[{}] connecting to SFU: {}", log_prefix, sfu_url);
+        file_debug_log::append(&format!(
+            "[{}] connect_and_publish_blocking start sfu_url={} enc={}x{}",
+            log_prefix, sfu_url, enc_w, enc_h
+        ));
 
-        let (room, _events) = rt
+        let (room, events) = rt
             .block_on(Room::connect(sfu_url, token, RoomOptions::default()))
             .map_err(|e| format!("SFU connect failed: {}", e))?;
+        rt.spawn(log_room_events(log_prefix.to_string(), events));
 
         eprintln!(
             "[{}] connected as {}",
             log_prefix,
             room.local_participant().identity().as_str(),
         );
+        file_debug_log::append(&format!(
+            "[{}] connected as {}",
+            log_prefix,
+            room.local_participant().identity().as_str()
+        ));
 
         let source = NativeVideoSource::new(
             VideoResolution {
                 width: enc_w,
                 height: enc_h,
             },
-            false,
+            is_screencast,
         );
-        let track = LocalVideoTrack::create_video_track(
-            "screen",
-            RtcVideoSource::Native(source.clone()),
-        );
+        let track =
+            LocalVideoTrack::create_video_track("screen", RtcVideoSource::Native(source.clone()));
 
         let publish_options = TrackPublishOptions {
-            source: TrackSource::Camera,
+            source: track_source,
             video_codec: VideoCodec::H264,
             simulcast: false,
             video_encoding: Some(VideoEncoding {
-                max_bitrate: publish_profile.max_bitrate(),
-                min_bitrate: publish_profile.min_bitrate(),
-                max_framerate: publish_profile.target_fps() as f64,
+                // Capped at 4 Mbps for multi-publisher rooms. Validated 2026-04-07
+                // with 3 simultaneous 1080p shares and a residential-WAN viewer
+                // (David) who saw 0fps at 8Mbps. 4Mbps × 3 publishers = 12Mbps
+                // aggregate, comfortably under most residential downloads. Per-stream
+                // quality at 1080p30 H264 is still excellent for screen content.
+                // Twitch source quality reference: 6 Mbps at 1080p60 gameplay.
+                max_bitrate: 4_000_000,
+                // 2.5 Mbps hard floor — prevents libwebrtc GoogCC from throttling
+                // to zero under packet loss / RTT spikes, so the stream stays
+                // visible instead of dropping to 0fps and slowly probing back up.
+                min_bitrate: 2_500_000,
+                // 60fps for safe stable testing with David (remote friend).
+                // The level=AUTOSELECT fix is still in h264_encoder_impl.cpp
+                // for later 144fps retest on SAM-PC — harmless at 60fps.
+                // Capped at 30fps for multi-publisher rooms. With 3 simultaneous
+                // 1920x1080 H264 publishers, the cumulative NVDEC decode load
+                // and SFU forwarding pressure makes 60fps unsustainable —
+                // receivers see 10fps after pacing kicks in. 30fps gives
+                // headroom for all parties and is plenty for screen content.
+                // Spencer's recommendation, validated 2026-04-07 with 3 sharers.
+                max_framerate: PUBLISH_TARGET_FPS as f64,
             }),
             ..Default::default()
         };
 
-        rt.block_on(
-            room.local_participant()
-                .publish_track(LocalTrack::Video(track), publish_options),
-        )
-        .map_err(|e| format!("publish failed: {}", e))?;
+        let publication = rt
+            .block_on(
+                room.local_participant()
+                    .publish_track(LocalTrack::Video(track.clone()), publish_options),
+            )
+            .map_err(|e| format!("publish failed: {}", e))?;
 
-        eprintln!("[{}] track published, waiting for negotiation...", log_prefix);
-        std::thread::sleep(Duration::from_secs(3));
-
-        let start_time = Instant::now();
-        let heartbeat_state = Arc::new(Mutex::new(HeartbeatState {
-            last_frame: None,
-            last_real_push: start_time,
-        }));
-        let heartbeat_handle = Self::spawn_heartbeat(
-            heartbeat_state.clone(),
-            source.clone(),
-            start_time,
-            publish_profile.heartbeat_interval(),
+        eprintln!(
+            "[{}] track published sid={} source={:?}, waiting for negotiation...",
             log_prefix,
+            publication.sid(),
+            publication.source(),
         );
+        file_debug_log::append(&format!(
+            "[{}] track published sid={} source={:?}",
+            log_prefix,
+            publication.sid(),
+            publication.source(),
+        ));
+        std::thread::sleep(std::time::Duration::from_secs(3));
 
         Ok(Self {
             room,
             source,
-            start_time,
+            track,
+            start_time: Instant::now(),
             frame_count: 0,
             last_pushed: None,
-            hardware_min_frame_interval: publish_profile.hardware_min_frame_interval(),
-            heartbeat_state,
-            heartbeat_handle,
-        })
-    }
-
-    fn spawn_heartbeat(
-        state: Arc<Mutex<HeartbeatState>>,
-        source: NativeVideoSource,
-        start_time: Instant,
-        heartbeat_interval: Option<Duration>,
-        log_prefix: &str,
-    ) -> Option<HeartbeatHandle> {
-        let Some(heartbeat_interval) = heartbeat_interval else {
-            return None;
-        };
-        let running = Arc::new(AtomicBool::new(true));
-        let running_clone = running.clone();
-        let log_prefix = log_prefix.to_string();
-        let thread = std::thread::Builder::new()
-            .name(format!("heartbeat-{}", log_prefix))
-            .spawn(move || {
-                eprintln!("[{}] heartbeat watchdog started", log_prefix);
-                let mut heartbeat_pushes: u64 = 0;
-                let mut last_log = Instant::now();
-
-                while running_clone.load(Ordering::Relaxed) {
-                    std::thread::sleep(heartbeat_interval);
-                    if !running_clone.load(Ordering::Relaxed) {
-                        break;
-                    }
-
-                    let snapshot = {
-                        let state = match state.lock() {
-                            Ok(guard) => guard,
-                            Err(poisoned) => poisoned.into_inner(),
-                        };
-                        if state.last_real_push.elapsed() < heartbeat_interval {
-                            None
-                        } else {
-                            state.last_frame.as_ref().map(|frame| LastFrameBuffer {
-                                bgra: frame.bgra.clone(),
-                                stride: frame.stride,
-                                width: frame.width,
-                                height: frame.height,
-                            })
-                        }
-                    };
-
-                    let Some(frame) = snapshot else { continue };
-
-                    let mut i420 = I420Buffer::new(frame.width, frame.height);
-                    let (sy, su, sv) = i420.strides();
-                    let (y, u, v) = i420.data_mut();
-                    yuv_helper::argb_to_i420(
-                        &frame.bgra,
-                        frame.stride,
-                        y,
-                        sy,
-                        u,
-                        su,
-                        v,
-                        sv,
-                        frame.width as i32,
-                        frame.height as i32,
-                    );
-
-                    let vf = VideoFrame {
-                        rotation: VideoRotation::VideoRotation0,
-                        buffer: i420,
-                        timestamp_us: start_time.elapsed().as_micros() as i64,
-                    };
-                    source.capture_frame(&vf);
-                    heartbeat_pushes += 1;
-
-                    if last_log.elapsed() >= Duration::from_secs(10) {
-                        eprintln!(
-                            "[{}] heartbeat: {} duplicate frames pushed in last 10s",
-                            log_prefix, heartbeat_pushes
-                        );
-                        heartbeat_pushes = 0;
-                        last_log = Instant::now();
-                    }
-                }
-
-                eprintln!("[{}] heartbeat watchdog stopped", log_prefix);
-            })
-            .expect("spawn heartbeat thread");
-
-        Some(HeartbeatHandle {
-            running,
-            thread: Some(thread),
         })
     }
 
@@ -419,10 +331,14 @@ impl CapturePublisher {
 
     /// Convert a BGRA frame with explicit stride to I420 and push to the video source.
     pub fn push_frame_strided(&mut self, bgra: &[u8], stride: u32, width: u32, height: u32) {
-        // Pace native capture to the real publish target. Without this, WGC/DXGI
-        // can still push well above 30fps on NVENC systems and drag local FPS down.
+        // Frame rate limiter — choose the interval based on whether we have
+        // hardware (NVENC) or software (OpenH264) encoding. NVENC can handle
+        // 240fps input because it's a dedicated ASIC. OpenH264 runs on CPU
+        // and pins ~90-100% at 60+ fps 1080p — which crashed Jeff's AMD
+        // machine after ~54 min of sustained load. Cap software encode at
+        // 20fps to keep CPU at a sustainable ~30%.
         let min_interval = if HAS_NVCUDA.load(Ordering::Relaxed) {
-            self.hardware_min_frame_interval
+            MIN_FRAME_INTERVAL_HARDWARE
         } else {
             MIN_FRAME_INTERVAL_SOFTWARE
         };
@@ -439,8 +355,16 @@ impl CapturePublisher {
         let (y, u, v) = i420.data_mut();
 
         yuv_helper::argb_to_i420(
-            bgra, stride, y, sy, u, su, v, sv,
-            width as i32, height as i32,
+            bgra,
+            stride,
+            y,
+            sy,
+            u,
+            su,
+            v,
+            sv,
+            width as i32,
+            height as i32,
         );
 
         let vf = VideoFrame {
@@ -450,16 +374,6 @@ impl CapturePublisher {
         };
         self.source.capture_frame(&vf);
         self.frame_count += 1;
-
-        if let Ok(mut state) = self.heartbeat_state.lock() {
-            state.last_real_push = now;
-            state.last_frame = Some(LastFrameBuffer {
-                bgra: bgra.to_vec(),
-                stride,
-                width,
-                height,
-            });
-        }
     }
 
     /// Emit stats via Tauri event every `every_n` frames. Returns current FPS.
@@ -502,50 +416,222 @@ impl CapturePublisher {
     }
 
     /// Elapsed time since the publisher was created.
-    pub fn elapsed(&self) -> Duration {
+    pub fn elapsed(&self) -> std::time::Duration {
         self.start_time.elapsed()
+    }
+
+    pub async fn log_sender_stats(&self, log_prefix: &str) {
+        match self.track.get_stats().await {
+            Ok(stats) => {
+                let transport = stats.iter().find_map(|stat| match stat {
+                    RtcStats::Transport(transport) => Some(transport),
+                    _ => None,
+                });
+                let codec_by_id: std::collections::HashMap<_, _> = stats
+                    .iter()
+                    .filter_map(|stat| match stat {
+                        RtcStats::Codec(codec) => Some((codec.rtc.id.as_str(), codec)),
+                        _ => None,
+                    })
+                    .collect();
+                let candidate_pair_by_id: std::collections::HashMap<_, _> = stats
+                    .iter()
+                    .filter_map(|stat| match stat {
+                        RtcStats::CandidatePair(pair) => Some((pair.rtc.id.as_str(), pair)),
+                        _ => None,
+                    })
+                    .collect();
+                let local_candidate_by_id: std::collections::HashMap<_, _> = stats
+                    .iter()
+                    .filter_map(|stat| match stat {
+                        RtcStats::LocalCandidate(candidate) => {
+                            Some((candidate.rtc.id.as_str(), candidate))
+                        }
+                        _ => None,
+                    })
+                    .collect();
+                let remote_candidate_by_id: std::collections::HashMap<_, _> = stats
+                    .iter()
+                    .filter_map(|stat| match stat {
+                        RtcStats::RemoteCandidate(candidate) => {
+                            Some((candidate.rtc.id.as_str(), candidate))
+                        }
+                        _ => None,
+                    })
+                    .collect();
+                let outbound = stats.iter().find_map(|stat| match stat {
+                    RtcStats::OutboundRtp(outbound) => Some(outbound),
+                    _ => None,
+                });
+                if let Some(outbound) = outbound {
+                    let codec = codec_by_id.get(outbound.stream.codec_id.as_str()).copied();
+                    let remote_inbound = if outbound.outbound.remote_id.is_empty() {
+                        None
+                    } else {
+                        stats.iter().find_map(|stat| match stat {
+                            RtcStats::RemoteInboundRtp(remote)
+                                if remote.rtc.id == outbound.outbound.remote_id =>
+                            {
+                                Some(remote)
+                            }
+                            _ => None,
+                        })
+                    };
+                    let codec_name = codec
+                        .map(|codec| codec.codec.mime_type.as_str())
+                        .filter(|mime| !mime.is_empty())
+                        .unwrap_or("<unknown>");
+                    let codec_fmtp = codec
+                        .map(|codec| codec.codec.sdp_fmtp_line.as_str())
+                        .filter(|fmtp| !fmtp.is_empty())
+                        .unwrap_or("<none>");
+                    let remote_fraction_lost = remote_inbound
+                        .map(|remote| format!("{:.3}", remote.remote_inbound.fraction_lost))
+                        .unwrap_or_else(|| "<none>".to_string());
+                    let remote_rtt = remote_inbound
+                        .map(|remote| format!("{:.3}", remote.remote_inbound.round_trip_time))
+                        .unwrap_or_else(|| "<none>".to_string());
+                    let sender_line = format!(
+                        "[{}] sender-stats bytes={} packets={} frames_sent={} frames_encoded={} key_frames={} fps={:.1} active={} size={}x{} target_bitrate={:.0} encoder={} codec={} fmtp={} quality={:?} nack={} fir={} pli={} remote_fraction_lost={} remote_rtt={}",
+                        log_prefix,
+                        outbound.sent.bytes_sent,
+                        outbound.sent.packets_sent,
+                        outbound.outbound.frames_sent,
+                        outbound.outbound.frames_encoded,
+                        outbound.outbound.key_frames_encoded,
+                        outbound.outbound.frames_per_second,
+                        outbound.outbound.active,
+                        outbound.outbound.frame_width,
+                        outbound.outbound.frame_height,
+                        outbound.outbound.target_bitrate,
+                        outbound.outbound.encoder_implementation,
+                        codec_name,
+                        codec_fmtp,
+                        outbound.outbound.quality_limitation_reason,
+                        outbound.outbound.nack_count,
+                        outbound.outbound.fir_count,
+                        outbound.outbound.pli_count,
+                        remote_fraction_lost,
+                        remote_rtt,
+                    );
+                    eprintln!("{}", sender_line);
+                    file_debug_log::append(&sender_line);
+                } else {
+                    eprintln!("[{}] sender-stats no outbound RTP report", log_prefix);
+                    file_debug_log::append(&format!(
+                        "[{}] sender-stats no outbound RTP report",
+                        log_prefix
+                    ));
+                }
+
+                if let Some(transport) = transport {
+                    let selected_pair_id = transport.transport.selected_candidate_pair_id.as_str();
+                    let selected_pair = candidate_pair_by_id.get(selected_pair_id).copied();
+                    let local_candidate = selected_pair.and_then(|pair| {
+                        local_candidate_by_id
+                            .get(pair.candidate_pair.local_candidate_id.as_str())
+                            .copied()
+                    });
+                    let remote_candidate = selected_pair.and_then(|pair| {
+                        remote_candidate_by_id
+                            .get(pair.candidate_pair.remote_candidate_id.as_str())
+                            .copied()
+                    });
+
+                    eprintln!(
+                        "[{}] transport ice={:?} dtls={:?} bytes_sent={} bytes_recv={} selected_pair={}",
+                        log_prefix,
+                        transport.transport.ice_state,
+                        transport.transport.dtls_state,
+                        transport.transport.bytes_sent,
+                        transport.transport.bytes_received,
+                        if selected_pair_id.is_empty() { "<none>" } else { selected_pair_id },
+                    );
+                    file_debug_log::append(&format!(
+                        "[{}] transport ice={:?} dtls={:?} bytes_sent={} bytes_recv={} selected_pair={}",
+                        log_prefix,
+                        transport.transport.ice_state,
+                        transport.transport.dtls_state,
+                        transport.transport.bytes_sent,
+                        transport.transport.bytes_received,
+                        if selected_pair_id.is_empty() { "<none>" } else { selected_pair_id },
+                    ));
+
+                    if let Some(pair) = selected_pair {
+                        eprintln!(
+                            "[{}] candidate-pair state={:?} nominated={} bytes_sent={} bytes_recv={} current_rtt={:.3} out_bitrate={:.0}",
+                            log_prefix,
+                            pair.candidate_pair.state,
+                            pair.candidate_pair.nominated,
+                            pair.candidate_pair.bytes_sent,
+                            pair.candidate_pair.bytes_received,
+                            pair.candidate_pair.current_round_trip_time,
+                            pair.candidate_pair.available_outgoing_bitrate,
+                        );
+                        file_debug_log::append(&format!(
+                            "[{}] candidate-pair state={:?} nominated={} bytes_sent={} bytes_recv={} current_rtt={:.3} out_bitrate={:.0}",
+                            log_prefix,
+                            pair.candidate_pair.state,
+                            pair.candidate_pair.nominated,
+                            pair.candidate_pair.bytes_sent,
+                            pair.candidate_pair.bytes_received,
+                            pair.candidate_pair.current_round_trip_time,
+                            pair.candidate_pair.available_outgoing_bitrate,
+                        ));
+                    } else {
+                        eprintln!(
+                            "[{}] candidate-pair missing for selected transport pair",
+                            log_prefix
+                        );
+                        file_debug_log::append(&format!(
+                            "[{}] candidate-pair missing for selected transport pair",
+                            log_prefix
+                        ));
+                    }
+
+                    if let Some(local) = local_candidate {
+                        eprintln!(
+                            "[{}] local-candidate type={:?} protocol={} addr={}:{}",
+                            log_prefix,
+                            local.local_candidate.candidate_type,
+                            local.local_candidate.protocol,
+                            local.local_candidate.address,
+                            local.local_candidate.port,
+                        );
+                    }
+                    if let Some(remote) = remote_candidate {
+                        eprintln!(
+                            "[{}] remote-candidate type={:?} protocol={} addr={}:{}",
+                            log_prefix,
+                            remote.remote_candidate.candidate_type,
+                            remote.remote_candidate.protocol,
+                            remote.remote_candidate.address,
+                            remote.remote_candidate.port,
+                        );
+                    }
+                } else {
+                    eprintln!("[{}] transport stats missing", log_prefix);
+                    file_debug_log::append(&format!("[{}] transport stats missing", log_prefix));
+                }
+            }
+            Err(e) => {
+                eprintln!("[{}] sender-stats error: {}", log_prefix, e);
+                file_debug_log::append(&format!("[{}] sender-stats error: {}", log_prefix, e));
+            }
+        }
+    }
+
+    pub fn log_sender_stats_blocking(&self, rt: &tokio::runtime::Handle, log_prefix: &str) {
+        rt.block_on(self.log_sender_stats(log_prefix));
     }
 
     /// Close the SFU room connection.
     pub async fn shutdown(self) {
-        let Self {
-            room,
-            heartbeat_handle,
-            ..
-        } = self;
-        drop(heartbeat_handle);
-        room.close().await.ok();
+        self.room.close().await.ok();
     }
 
     /// Blocking variant of shutdown for use inside `spawn_blocking`.
     pub fn shutdown_blocking(self, rt: &tokio::runtime::Handle) {
-        let Self {
-            room,
-            heartbeat_handle,
-            ..
-        } = self;
-        drop(heartbeat_handle);
-        rt.block_on(room.close()).ok();
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn desktop_profile_stays_conservative() {
-        assert_eq!(PublishProfile::Desktop.target_fps(), PUBLISH_TARGET_FPS);
-        assert_eq!(PublishProfile::Desktop.max_bitrate(), 4_000_000);
-        assert_eq!(PublishProfile::Desktop.min_bitrate(), 2_500_000);
-        assert!(PublishProfile::Desktop.heartbeat_interval().is_some());
-    }
-
-    #[test]
-    fn game_profile_is_high_motion() {
-        assert_eq!(PublishProfile::Game.target_fps(), GAME_PUBLISH_TARGET_FPS);
-        assert_eq!(PublishProfile::Game.max_bitrate(), 8_000_000);
-        assert_eq!(PublishProfile::Game.min_bitrate(), 3_000_000);
-        assert!(PublishProfile::Game.heartbeat_interval().is_none());
+        rt.block_on(self.room.close()).ok();
     }
 }

--- a/core/client/src/desktop_capture.rs
+++ b/core/client/src/desktop_capture.rs
@@ -14,7 +14,8 @@
 //!               → libwebrtc H264 encoder (NVENC on RTX 4090)
 //!                 → RTP → SFU
 
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use livekit::track::TrackSource;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{Duration, Instant};
 use tauri::AppHandle;
@@ -51,7 +52,8 @@ use windows::Win32::UI::WindowsAndMessaging::{
 };
 
 use crate::capture_health::{CaptureHealthState, CaptureMode, EncoderType};
-use crate::capture_pipeline::{CapturePublisher, PublishProfile};
+use crate::capture_pipeline::CapturePublisher;
+use crate::file_debug_log;
 
 // ── GPU HDR→SDR Conversion Pipeline (shared module) ──
 
@@ -60,9 +62,7 @@ use crate::gpu_converter::GpuConverter;
 // ── Global State ──
 
 struct DesktopShareHandle {
-    task_id: u64,
     running: Arc<AtomicBool>,
-    task: tokio::task::JoinHandle<()>,
 }
 
 fn global_state() -> &'static Mutex<Option<DesktopShareHandle>> {
@@ -70,16 +70,42 @@ fn global_state() -> &'static Mutex<Option<DesktopShareHandle>> {
     STATE.get_or_init(|| Mutex::new(None))
 }
 
-fn next_task_id() -> u64 {
-    static NEXT_TASK_ID: AtomicU64 = AtomicU64::new(1);
-    NEXT_TASK_ID.fetch_add(1, Ordering::Relaxed)
-}
-
-fn clear_task_if_current(task_id: u64) {
-    let mut state = global_state().lock().unwrap();
-    if state.as_ref().map(|handle| handle.task_id) == Some(task_id) {
-        *state = None;
+fn windows_build_number() -> u32 {
+    #[repr(C)]
+    struct OsVersionInfoExW {
+        dw_os_version_info_size: u32,
+        dw_major_version: u32,
+        dw_minor_version: u32,
+        dw_build_number: u32,
+        dw_platform_id: u32,
+        sz_csd_version: [u16; 128],
+        w_service_pack_major: u16,
+        w_service_pack_minor: u16,
+        w_suite_mask: u16,
+        w_product_type: u8,
+        w_reserved: u8,
     }
+
+    unsafe {
+        let lib =
+            windows::Win32::System::LibraryLoader::LoadLibraryW(windows::core::w!("ntdll.dll"));
+        if let Ok(h) = lib {
+            let proc = windows::Win32::System::LibraryLoader::GetProcAddress(
+                h,
+                windows::core::s!("RtlGetVersion"),
+            );
+            if let Some(rtl_get_version) = proc {
+                let func: extern "system" fn(*mut OsVersionInfoExW) -> i32 =
+                    std::mem::transmute(rtl_get_version);
+                let mut info: OsVersionInfoExW = std::mem::zeroed();
+                info.dw_os_version_info_size = std::mem::size_of::<OsVersionInfoExW>() as u32;
+                func(&mut info);
+                return info.dw_build_number;
+            }
+        }
+    }
+
+    0
 }
 
 // ── Public API ──
@@ -136,14 +162,19 @@ pub async fn start(
     fullscreen: bool,
     sfu_url: String,
     token: String,
-    publish_profile: PublishProfile,
     app: AppHandle,
     health: Arc<CaptureHealthState>,
 ) -> Result<(), String> {
-    stop().await?;
+    stop();
 
     let running = Arc::new(AtomicBool::new(true));
-    let task_id = next_task_id();
+
+    {
+        let mut state = global_state().lock().unwrap();
+        *state = Some(DesktopShareHandle {
+            running: running.clone(),
+        });
+    }
 
     // Get game PID for audio capture
     let target_pid = unsafe {
@@ -155,74 +186,36 @@ pub async fn start(
 
     let _ = app.emit("desktop-capture-started", target_pid);
 
-    let app_for_capture = app.clone();
     let r2 = running.clone();
     let health_clone = Arc::clone(&health);
-    let task = tokio::spawn(async move {
+    tokio::spawn(async move {
         // Run DXGI capture on a blocking thread — it uses COM and blocking waits
         let result = tokio::task::spawn_blocking(move || {
-            capture_loop_blocking(
-                &sfu_url,
-                &token,
-                publish_profile,
-                &app_for_capture,
-                &r2,
-                hwnd,
-                fullscreen,
-                health_clone,
-            )
+            capture_loop_blocking(&sfu_url, &token, &app, &r2, hwnd, fullscreen, health_clone)
         })
-        .await;
+        .await
+        .map_err(|e| format!("spawn_blocking: {e}"))?;
 
-        if let Err(e) = match result {
-            Ok(inner) => inner,
-            Err(e) => Err(format!("spawn_blocking: {e}")),
-        } {
+        if let Err(e) = result {
             eprintln!("[desktop-capture] error: {e}");
-            let _ = app.emit("desktop-capture-error", e);
+            file_debug_log::append(&format!("[desktop-capture] task error: {}", e));
         }
 
-        let _ = app.emit("desktop-capture-stopped", ());
-        eprintln!("[desktop-capture] task exited");
-        clear_task_if_current(task_id);
-    });
-
-    {
         let mut state = global_state().lock().unwrap();
-        *state = Some(DesktopShareHandle {
-            task_id,
-            running,
-            task,
-        });
-        if state
-            .as_ref()
-            .map(|handle| handle.task.is_finished())
-            .unwrap_or(false)
-        {
-            *state = None;
-        }
-    }
+        *state = None;
+        Ok::<(), String>(())
+    });
 
     Ok(())
 }
 
 /// Stop the current desktop capture.
-pub async fn stop() -> Result<(), String> {
-    let handle = {
-        let mut state = global_state().lock().unwrap();
-        state.take()
-    };
-
-    if let Some(handle) = handle {
+pub fn stop() {
+    let mut state = global_state().lock().unwrap();
+    if let Some(handle) = state.take() {
         handle.running.store(false, Ordering::SeqCst);
         eprintln!("[desktop-capture] stop requested");
-        handle
-            .task
-            .await
-            .map_err(|e| format!("desktop capture task join failed: {e}"))?;
     }
-
-    Ok(())
 }
 
 /// Returns true if a desktop capture is currently running.
@@ -631,7 +624,6 @@ fn composite_cursor(
 fn capture_loop_blocking(
     sfu_url: &str,
     token: &str,
-    publish_profile: PublishProfile,
     app: &AppHandle,
     running: &Arc<AtomicBool>,
     hwnd: u64,
@@ -639,6 +631,10 @@ fn capture_loop_blocking(
     health: Arc<CaptureHealthState>,
 ) -> Result<(), String> {
     eprintln!("[desktop-capture] initializing DXGI Desktop Duplication...");
+    file_debug_log::append(&format!(
+        "[desktop-capture] start hwnd={} fullscreen={}",
+        hwnd, fullscreen
+    ));
 
     // 1. Find the monitor containing the game window
     let factory: IDXGIFactory1 =
@@ -699,28 +695,65 @@ fn capture_loop_blocking(
     // loop entirely on 50 consecutive timeouts, which crashed the share.
     // Try IDXGIOutput5::DuplicateOutput1 first — supports HDR formats and
     // captures DirectFlip content that DuplicateOutput misses (black frames).
+    let os_build = windows_build_number();
+    let use_duplicate_output1 = os_build >= 22000;
+    if !use_duplicate_output1 {
+        eprintln!(
+            "[desktop-capture] Windows build {} detected — forcing legacy DuplicateOutput",
+            os_build
+        );
+        file_debug_log::append(&format!(
+            "[desktop-capture] windows build {} forcing DuplicateOutput",
+            os_build
+        ));
+    }
+
     let create_duplication = || -> Result<IDXGIOutputDuplication, String> {
         unsafe {
             let output5: Result<windows::Win32::Graphics::Dxgi::IDXGIOutput5, _> = output1.cast();
-            if let Ok(out5) = output5 {
-                // Request both formats — prefer BGRA (SDR, no conversion needed),
-                // accept float16 (HDR) if SDR not available.
-                let formats = [
-                    DXGI_FORMAT_B8G8R8A8_UNORM,
-                    windows::Win32::Graphics::Dxgi::Common::DXGI_FORMAT_R16G16B16A16_FLOAT,
-                    windows::Win32::Graphics::Dxgi::Common::DXGI_FORMAT_R10G10B10A2_UNORM,
-                ];
-                match out5.DuplicateOutput1(&device, 0, &formats) {
-                    Ok(dup) => {
-                        eprintln!("[desktop-capture] using DuplicateOutput1 (HDR-capable)");
-                        return Ok(dup);
+            if use_duplicate_output1 {
+                if let Ok(out5) = output5 {
+                    // Request both formats — prefer BGRA (SDR, no conversion needed),
+                    // accept float16 (HDR) if SDR not available.
+                    let formats = [
+                        DXGI_FORMAT_B8G8R8A8_UNORM,
+                        windows::Win32::Graphics::Dxgi::Common::DXGI_FORMAT_R16G16B16A16_FLOAT,
+                        windows::Win32::Graphics::Dxgi::Common::DXGI_FORMAT_R10G10B10A2_UNORM,
+                    ];
+                    match out5.DuplicateOutput1(&device, 0, &formats) {
+                        Ok(dup) => {
+                            eprintln!("[desktop-capture] using DuplicateOutput1 (HDR-capable)");
+                            file_debug_log::append("[desktop-capture] using DuplicateOutput1");
+                            return Ok(dup);
+                        }
+                        Err(e) => {
+                            eprintln!(
+                                "[desktop-capture] DuplicateOutput1 failed: {e}, falling back"
+                            );
+                            file_debug_log::append(&format!(
+                                "[desktop-capture] DuplicateOutput1 failed: {}",
+                                e
+                            ));
+                        }
                     }
-                    Err(e) => {
-                        eprintln!("[desktop-capture] DuplicateOutput1 failed: {e}, falling back");
-                    }
+                } else {
+                    eprintln!(
+                        "[desktop-capture] IDXGIOutput5 not available, using DuplicateOutput"
+                    );
+                    file_debug_log::append(
+                        "[desktop-capture] IDXGIOutput5 unavailable, using DuplicateOutput",
+                    );
                 }
+            } else if output5.is_ok() {
+                eprintln!("[desktop-capture] skipping DuplicateOutput1 on this Windows build");
+                file_debug_log::append(
+                    "[desktop-capture] skipping DuplicateOutput1 on this Windows build",
+                );
             } else {
                 eprintln!("[desktop-capture] IDXGIOutput5 not available, using DuplicateOutput");
+                file_debug_log::append(
+                    "[desktop-capture] IDXGIOutput5 unavailable, using DuplicateOutput",
+                );
             }
             output1
                 .DuplicateOutput(&device)
@@ -759,6 +792,10 @@ fn capture_loop_blocking(
         "[desktop-capture] capture: {}x{} → encode: {}x{} (fullscreen={}, crop={:?})",
         cap_w, cap_h, enc_w, enc_h, fullscreen, crop,
     );
+    file_debug_log::append(&format!(
+        "[desktop-capture] capture {}x{} encode {}x{} fullscreen={} crop={:?}",
+        cap_w, cap_h, enc_w, enc_h, fullscreen, crop
+    ));
 
     // 4. Connect to LiveKit and publish track via shared pipeline
     let rt = tokio::runtime::Handle::current();
@@ -768,15 +805,16 @@ fn capture_loop_blocking(
         token,
         enc_w,
         enc_h,
-        publish_profile,
         "desktop-capture",
+        TrackSource::Screenshare,
+        true,
     )?;
 
     health.set_active(
         true,
         CaptureMode::DxgiDd,
         EncoderType::Nvenc,
-        publish_profile.target_fps(),
+        crate::capture_pipeline::PUBLISH_TARGET_FPS,
     );
 
     // 6. Prepare GPU converter (shader pipeline) or CPU fallback
@@ -830,6 +868,7 @@ fn capture_loop_blocking(
     let _ = composite_cursor; // silence unused-fn warning
 
     eprintln!("[desktop-capture] starting frame loop");
+    file_debug_log::append("[desktop-capture] frame loop starting");
 
     // ── Capture-loop frame rate limiter ──────────────────────────────
     //
@@ -894,6 +933,9 @@ fn capture_loop_blocking(
                             "[desktop-capture] 50 consecutive timeouts (~5s stall) \
                              — reinitializing DXGI Desktop Duplication"
                         );
+                        file_debug_log::append(
+                            "[desktop-capture] 50 consecutive timeouts, reinitializing",
+                        );
                         // Drop the old duplication interface before creating a
                         // new one (the old one may be holding a locked frame
                         // we never released due to the error path).
@@ -932,6 +974,10 @@ fn capture_loop_blocking(
                          desktop switch/UAC/mode change) — reinitializing",
                         code
                     );
+                    file_debug_log::append(&format!(
+                        "[desktop-capture] capture interface invalidated code=0x{:08X}",
+                        code
+                    ));
                     drop(duplication);
                     match reinit_with_backoff(&create_duplication, "access-lost") {
                         Some(new_dup) => {
@@ -945,6 +991,10 @@ fn capture_loop_blocking(
                     }
                 } else {
                     eprintln!("[desktop-capture] AcquireNextFrame error: {e}");
+                    file_debug_log::append(&format!(
+                        "[desktop-capture] AcquireNextFrame error: {}",
+                        e
+                    ));
                     consecutive_timeouts += 1;
                     health.record_consecutive_timeout(consecutive_timeouts);
                     if consecutive_timeouts >= 10 {
@@ -1238,8 +1288,13 @@ fn capture_loop_blocking(
                 60,
             ) {
                 eprintln!("[desktop-capture] {enc_w}x{enc_h} @ {fps}fps ({frame_count} frames)");
+                file_debug_log::append(&format!(
+                    "[desktop-capture] stats {}x{} fps={} frames={}",
+                    enc_w, enc_h, fps, frame_count
+                ));
                 health.record_capture_fps(fps);
             }
+            publisher.log_sender_stats_blocking(&rt, "desktop-capture");
         }
     }
 
@@ -1250,6 +1305,10 @@ fn capture_loop_blocking(
         "[desktop-capture] shutting down, {} frames captured",
         publisher.frame_count()
     );
+    file_debug_log::append(&format!(
+        "[desktop-capture] shutting down frames={}",
+        publisher.frame_count()
+    ));
 
     // Destroy anti-MPO overlay -- restore normal DWM flip behavior
     if let Some(h) = anti_mpo_hwnd {

--- a/core/client/src/file_debug_log.rs
+++ b/core/client/src/file_debug_log.rs
@@ -1,0 +1,41 @@
+use std::fs::{create_dir_all, OpenOptions};
+use std::io::Write;
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn log_path() -> Option<PathBuf> {
+    std::env::current_exe()
+        .ok()
+        .and_then(|path| path.parent().map(|dir| dir.join("capture-debug.log")))
+}
+
+pub fn append(message: &str) {
+    let Some(path) = log_path() else {
+        return;
+    };
+
+    if let Some(parent) = path.parent() {
+        let _ = create_dir_all(parent);
+    }
+
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+
+    if let Ok(mut file) = OpenOptions::new().create(true).append(true).open(path) {
+        let _ = writeln!(file, "[{}] {}", now, message);
+    }
+}
+
+pub fn reset() {
+    let Some(path) = log_path() else {
+        return;
+    };
+
+    if let Some(parent) = path.parent() {
+        let _ = create_dir_all(parent);
+    }
+
+    let _ = std::fs::write(path, b"");
+}

--- a/core/client/src/gpu_converter.rs
+++ b/core/client/src/gpu_converter.rs
@@ -7,22 +7,17 @@
 
 use crate::capture_health::CaptureHealthState;
 use windows::core::PCSTR;
-use windows::Win32::Graphics::Direct3D::ID3DBlob;
 use windows::Win32::Graphics::Direct3D::Fxc::D3DCompile;
+use windows::Win32::Graphics::Direct3D::ID3DBlob;
 use windows::Win32::Graphics::Direct3D11::{
-    D3D11_MAPPED_SUBRESOURCE, D3D11_MAP_READ,
-    D3D11_TEXTURE2D_DESC, D3D11_USAGE_STAGING, D3D11_USAGE_DEFAULT,
-    D3D11_BIND_SHADER_RESOURCE, D3D11_BIND_UNORDERED_ACCESS,
-    D3D11_CPU_ACCESS_READ,
-    ID3D11Device, ID3D11Texture2D, ID3D11ComputeShader,
-    ID3D11ShaderResourceView, ID3D11UnorderedAccessView,
-    D3D11_SHADER_RESOURCE_VIEW_DESC, D3D11_SHADER_RESOURCE_VIEW_DESC_0,
-    D3D11_TEX2D_SRV, D3D11_UNORDERED_ACCESS_VIEW_DESC,
-    D3D11_UNORDERED_ACCESS_VIEW_DESC_0, D3D11_TEX2D_UAV,
+    ID3D11ComputeShader, ID3D11Device, ID3D11ShaderResourceView, ID3D11Texture2D,
+    ID3D11UnorderedAccessView, D3D11_BIND_SHADER_RESOURCE, D3D11_BIND_UNORDERED_ACCESS,
+    D3D11_CPU_ACCESS_READ, D3D11_MAPPED_SUBRESOURCE, D3D11_MAP_READ,
+    D3D11_SHADER_RESOURCE_VIEW_DESC, D3D11_SHADER_RESOURCE_VIEW_DESC_0, D3D11_TEX2D_SRV,
+    D3D11_TEX2D_UAV, D3D11_TEXTURE2D_DESC, D3D11_UNORDERED_ACCESS_VIEW_DESC,
+    D3D11_UNORDERED_ACCESS_VIEW_DESC_0, D3D11_USAGE_DEFAULT, D3D11_USAGE_STAGING,
 };
-use windows::Win32::Graphics::Dxgi::Common::{
-    DXGI_FORMAT_R8G8B8A8_UNORM, DXGI_SAMPLE_DESC,
-};
+use windows::Win32::Graphics::Dxgi::Common::{DXGI_FORMAT_R8G8B8A8_UNORM, DXGI_SAMPLE_DESC};
 
 /// HLSL compute shader: reads source texture (HDR scRGB or SDR BGRA8),
 /// downscales, and writes SDR sRGB BGRA8 at encode resolution.
@@ -100,7 +95,9 @@ pub struct GpuConverter {
 /// For 1920x1080 → max 1920x1080, returns 1920x1080. Always rounds to even
 /// numbers (NVENC requires it).
 fn fit_aspect(src_w: u32, src_h: u32, max_w: u32, max_h: u32) -> (u32, u32) {
-    if src_w == 0 || src_h == 0 { return (max_w, max_h); }
+    if src_w == 0 || src_h == 0 {
+        return (max_w, max_h);
+    }
     let src_aspect = src_w as f64 / src_h as f64;
     let max_aspect = max_w as f64 / max_h as f64;
     let (mut w, mut h) = if src_aspect > max_aspect {
@@ -113,8 +110,12 @@ fn fit_aspect(src_w: u32, src_h: u32, max_w: u32, max_h: u32) -> (u32, u32) {
         (w, max_h)
     };
     // Round to even (NVENC requirement for H.264)
-    if w % 2 != 0 { w -= 1; }
-    if h % 2 != 0 { h -= 1; }
+    if w % 2 != 0 {
+        w -= 1;
+    }
+    if h % 2 != 0 {
+        h -= 1;
+    }
     (w, h)
 }
 
@@ -124,9 +125,11 @@ impl GpuConverter {
     /// after creation to get the actual output size.
     pub fn new(
         device: &ID3D11Device,
-        src_w: u32, src_h: u32,
+        src_w: u32,
+        src_h: u32,
         src_fmt: windows::Win32::Graphics::Dxgi::Common::DXGI_FORMAT,
-        dst_max_w: u32, dst_max_h: u32,
+        dst_max_w: u32,
+        dst_max_h: u32,
     ) -> Result<Self, String> {
         // Preserve aspect ratio — fixes ultrawide (3440x1440) being squished
         // to 1920x1080. We now produce 1920x804 (or whatever fits) instead.
@@ -143,15 +146,20 @@ impl GpuConverter {
                 None,
                 PCSTR(b"main\0".as_ptr()),
                 PCSTR(b"cs_5_0\0".as_ptr()),
-                0, 0,
+                0,
+                0,
                 &mut blob,
                 Some(&mut err_blob),
-            ).map_err(|e| {
-                let msg = err_blob.as_ref().map(|b| {
-                    let ptr = b.GetBufferPointer() as *const u8;
-                    let len = b.GetBufferSize();
-                    String::from_utf8_lossy(std::slice::from_raw_parts(ptr, len)).to_string()
-                }).unwrap_or_default();
+            )
+            .map_err(|e| {
+                let msg = err_blob
+                    .as_ref()
+                    .map(|b| {
+                        let ptr = b.GetBufferPointer() as *const u8;
+                        let len = b.GetBufferSize();
+                        String::from_utf8_lossy(std::slice::from_raw_parts(ptr, len)).to_string()
+                    })
+                    .unwrap_or_default();
                 format!("shader compile failed: {e} — {msg}")
             })?;
         }
@@ -161,7 +169,8 @@ impl GpuConverter {
             let len = blob.GetBufferSize();
             let bytecode = std::slice::from_raw_parts(ptr as *const u8, len);
             let mut cs: Option<ID3D11ComputeShader> = None;
-            device.CreateComputeShader(bytecode, None, Some(&mut cs))
+            device
+                .CreateComputeShader(bytecode, None, Some(&mut cs))
                 .map_err(|e| format!("CreateComputeShader: {e}"))?;
             cs.ok_or("CreateComputeShader returned null")?
         };
@@ -174,13 +183,17 @@ impl GpuConverter {
                 MipLevels: 1,
                 ArraySize: 1,
                 Format: src_fmt,
-                SampleDesc: DXGI_SAMPLE_DESC { Count: 1, Quality: 0 },
+                SampleDesc: DXGI_SAMPLE_DESC {
+                    Count: 1,
+                    Quality: 0,
+                },
                 Usage: D3D11_USAGE_DEFAULT,
                 BindFlags: D3D11_BIND_SHADER_RESOURCE.0 as u32,
                 ..Default::default()
             };
             let mut tex: Option<ID3D11Texture2D> = None;
-            device.CreateTexture2D(&desc, None, Some(&mut tex))
+            device
+                .CreateTexture2D(&desc, None, Some(&mut tex))
                 .map_err(|e| format!("gpu_src: {e}"))?;
             tex.ok_or("gpu_src null")?
         };
@@ -189,11 +202,15 @@ impl GpuConverter {
                 Format: src_fmt,
                 ViewDimension: windows::Win32::Graphics::Direct3D::D3D_SRV_DIMENSION_TEXTURE2D,
                 Anonymous: D3D11_SHADER_RESOURCE_VIEW_DESC_0 {
-                    Texture2D: D3D11_TEX2D_SRV { MostDetailedMip: 0, MipLevels: 1 },
+                    Texture2D: D3D11_TEX2D_SRV {
+                        MostDetailedMip: 0,
+                        MipLevels: 1,
+                    },
                 },
             };
             let mut srv: Option<ID3D11ShaderResourceView> = None;
-            device.CreateShaderResourceView(&gpu_src, Some(&desc), Some(&mut srv))
+            device
+                .CreateShaderResourceView(&gpu_src, Some(&desc), Some(&mut srv))
                 .map_err(|e| format!("gpu_src SRV: {e}"))?;
             srv.ok_or("SRV null")?
         };
@@ -206,13 +223,17 @@ impl GpuConverter {
                 MipLevels: 1,
                 ArraySize: 1,
                 Format: DXGI_FORMAT_R8G8B8A8_UNORM,
-                SampleDesc: DXGI_SAMPLE_DESC { Count: 1, Quality: 0 },
+                SampleDesc: DXGI_SAMPLE_DESC {
+                    Count: 1,
+                    Quality: 0,
+                },
                 Usage: D3D11_USAGE_DEFAULT,
                 BindFlags: D3D11_BIND_UNORDERED_ACCESS.0 as u32,
                 ..Default::default()
             };
             let mut tex: Option<ID3D11Texture2D> = None;
-            device.CreateTexture2D(&desc, None, Some(&mut tex))
+            device
+                .CreateTexture2D(&desc, None, Some(&mut tex))
                 .map_err(|e| format!("gpu_dst: {e}"))?;
             tex.ok_or("gpu_dst null")?
         };
@@ -225,7 +246,8 @@ impl GpuConverter {
                 },
             };
             let mut uav: Option<ID3D11UnorderedAccessView> = None;
-            device.CreateUnorderedAccessView(&gpu_dst, Some(&desc), Some(&mut uav))
+            device
+                .CreateUnorderedAccessView(&gpu_dst, Some(&desc), Some(&mut uav))
                 .map_err(|e| format!("gpu_dst UAV: {e}"))?;
             uav.ok_or("UAV null")?
         };
@@ -238,13 +260,17 @@ impl GpuConverter {
                 MipLevels: 1,
                 ArraySize: 1,
                 Format: DXGI_FORMAT_R8G8B8A8_UNORM,
-                SampleDesc: DXGI_SAMPLE_DESC { Count: 1, Quality: 0 },
+                SampleDesc: DXGI_SAMPLE_DESC {
+                    Count: 1,
+                    Quality: 0,
+                },
                 Usage: D3D11_USAGE_STAGING,
                 CPUAccessFlags: D3D11_CPU_ACCESS_READ.0 as u32,
                 ..Default::default()
             };
             let mut tex: Option<ID3D11Texture2D> = None;
-            device.CreateTexture2D(&desc, None, Some(&mut tex))
+            device
+                .CreateTexture2D(&desc, None, Some(&mut tex))
                 .map_err(|e| format!("staging: {e}"))?;
             tex.ok_or("staging null")?
         };
@@ -258,22 +284,37 @@ impl GpuConverter {
             let desc = windows::Win32::Graphics::Direct3D11::D3D11_BUFFER_DESC {
                 ByteWidth: 48,
                 Usage: D3D11_USAGE_DEFAULT,
-                BindFlags: windows::Win32::Graphics::Direct3D11::D3D11_BIND_CONSTANT_BUFFER.0 as u32,
+                BindFlags: windows::Win32::Graphics::Direct3D11::D3D11_BIND_CONSTANT_BUFFER.0
+                    as u32,
                 ..Default::default()
             };
             let mut buf: Option<windows::Win32::Graphics::Direct3D11::ID3D11Buffer> = None;
-            device.CreateBuffer(&desc, None, Some(&mut buf))
+            device
+                .CreateBuffer(&desc, None, Some(&mut buf))
                 .map_err(|e| format!("cbuffer: {e}"))?;
             buf.ok_or("cbuffer null")?
         };
 
-        let is_hdr = src_fmt == windows::Win32::Graphics::Dxgi::Common::DXGI_FORMAT_R16G16B16A16_FLOAT;
-        eprintln!("[gpu-converter] initialized: {}x{} {:?} → {}x{} BGRA8 (hdr={})",
-            src_w, src_h, src_fmt, dst_w, dst_h, is_hdr);
+        let is_hdr =
+            src_fmt == windows::Win32::Graphics::Dxgi::Common::DXGI_FORMAT_R16G16B16A16_FLOAT;
+        eprintln!(
+            "[gpu-converter] initialized: {}x{} {:?} → {}x{} BGRA8 (hdr={})",
+            src_w, src_h, src_fmt, dst_w, dst_h, is_hdr
+        );
 
         Ok(Self {
-            shader, gpu_src, gpu_src_srv, gpu_dst, gpu_dst_uav, staging, cb_buf,
-            src_w, src_h, dst_w, dst_h, is_hdr,
+            shader,
+            gpu_src,
+            gpu_src_srv,
+            gpu_dst,
+            gpu_dst_uav,
+            staging,
+            cb_buf,
+            src_w,
+            src_h,
+            dst_w,
+            dst_h,
+            is_hdr,
         })
     }
 
@@ -283,7 +324,10 @@ impl GpuConverter {
         &self,
         context: &windows::Win32::Graphics::Direct3D11::ID3D11DeviceContext,
         frame_texture: &ID3D11Texture2D,
-        crop_x: u32, crop_y: u32, crop_w: u32, crop_h: u32,
+        crop_x: u32,
+        crop_y: u32,
+        crop_w: u32,
+        crop_h: u32,
         health: Option<&CaptureHealthState>,
     ) -> Result<(*const u8, u32, u32, u32), String> {
         // 1. Copy captured frame → gpu_src (GPU→GPU, preserves format)
@@ -291,16 +335,20 @@ impl GpuConverter {
 
         // 2. Update constant buffer with crop/scale params + HDR flag
         let params: [u32; 12] = [
-            self.src_w, self.src_h, self.dst_w, self.dst_h,
-            crop_x, crop_y, crop_w, crop_h,
-            if self.is_hdr { 1 } else { 0 }, 0, 0, 0,
+            self.src_w,
+            self.src_h,
+            self.dst_w,
+            self.dst_h,
+            crop_x,
+            crop_y,
+            crop_w,
+            crop_h,
+            if self.is_hdr { 1 } else { 0 },
+            0,
+            0,
+            0,
         ];
-        context.UpdateSubresource(
-            &self.cb_buf,
-            0, None,
-            params.as_ptr() as *const _,
-            0, 0,
-        );
+        context.UpdateSubresource(&self.cb_buf, 0, None, params.as_ptr() as *const _, 0, 0);
 
         // 3. Dispatch compute shader
         context.CSSetShader(&self.shader, None);
@@ -310,7 +358,8 @@ impl GpuConverter {
         let uav_arr: [Option<ID3D11UnorderedAccessView>; 1] = [uav_clone];
         let initial_counts: [u32; 1] = [0];
         context.CSSetUnorderedAccessViews(
-            0, 1,
+            0,
+            1,
             Some(uav_arr.as_ptr() as *const _),
             Some(initial_counts.as_ptr()),
         );
@@ -325,27 +374,34 @@ impl GpuConverter {
         let empty_srv: [Option<ID3D11ShaderResourceView>; 1] = [None];
         context.CSSetShaderResources(0, Some(&empty_srv));
         let empty_uav: [Option<ID3D11UnorderedAccessView>; 1] = [None];
-        context.CSSetUnorderedAccessViews(
-            0, 1,
-            Some(empty_uav.as_ptr() as *const _),
-            None,
-        );
+        context.CSSetUnorderedAccessViews(0, 1, Some(empty_uav.as_ptr() as *const _), None);
 
         // 4. Copy result → staging (GPU→CPU, only ~8MB)
         context.CopyResource(&self.staging, &self.gpu_dst);
 
         // 5. Map staging for CPU read
         let mut mapped = D3D11_MAPPED_SUBRESOURCE::default();
-        context.Map(&self.staging, 0, D3D11_MAP_READ, 0, Some(&mut mapped))
+        context
+            .Map(&self.staging, 0, D3D11_MAP_READ, 0, Some(&mut mapped))
             .map_err(|e| {
-                if let Some(h) = health { h.record_shader_error(); }
+                if let Some(h) = health {
+                    h.record_shader_error();
+                }
                 format!("map staging: {e}")
             })?;
 
-        Ok((mapped.pData as *const u8, mapped.RowPitch, self.dst_w, self.dst_h))
+        Ok((
+            mapped.pData as *const u8,
+            mapped.RowPitch,
+            self.dst_w,
+            self.dst_h,
+        ))
     }
 
-    pub unsafe fn unmap(&self, context: &windows::Win32::Graphics::Direct3D11::ID3D11DeviceContext) {
+    pub unsafe fn unmap(
+        &self,
+        context: &windows::Win32::Graphics::Direct3D11::ID3D11DeviceContext,
+    ) {
         context.Unmap(&self.staging, 0);
     }
 }

--- a/core/client/src/main.rs
+++ b/core/client/src/main.rs
@@ -22,6 +22,8 @@ mod capture_pipeline;
 #[cfg(target_os = "windows")]
 mod desktop_capture;
 #[cfg(target_os = "windows")]
+mod file_debug_log;
+#[cfg(target_os = "windows")]
 mod gpu_converter;
 #[cfg(not(target_os = "windows"))]
 use audio_output_stub as audio_output;
@@ -40,6 +42,7 @@ const DEFAULT_SERVER: &str = "https://echo.fellowshipoftheboatrace.party:9443";
 #[derive(Deserialize)]
 struct Config {
     server: Option<String>,
+    force_software_encoder: Option<bool>,
 }
 
 #[derive(Serialize)]
@@ -50,25 +53,64 @@ struct AppInfo {
     server: String,
 }
 
-fn updater_enabled() -> bool {
-    let version = env!("CARGO_PKG_VERSION");
-    if version.contains('-') {
-        eprintln!(
-            "[updater] disabled for prerelease/test build v{}",
-            version
-        );
+fn is_local_test_build_version(version: &str) -> bool {
+    let lower = version.trim().to_ascii_lowercase();
+    let Some((_, prerelease)) = lower.split_once('-') else {
         return false;
+    };
+    prerelease
+        .split('.')
+        .any(|part| matches!(part, "local" | "dev" | "test" | "lab" | "dirty"))
+}
+
+#[cfg(target_os = "windows")]
+fn detect_windows_build_number() -> u32 {
+    // Use RtlGetVersion (ntdll) — GetVersionEx lies on Win8.1+
+    #[repr(C)]
+    struct OsVersionInfoExW {
+        dw_os_version_info_size: u32,
+        dw_major_version: u32,
+        dw_minor_version: u32,
+        dw_build_number: u32,
+        dw_platform_id: u32,
+        sz_csd_version: [u16; 128],
+        w_service_pack_major: u16,
+        w_service_pack_minor: u16,
+        w_suite_mask: u16,
+        w_product_type: u8,
+        w_reserved: u8,
     }
-    if std::env::var_os("ECHO_DISABLE_AUTO_UPDATER").is_some() {
-        eprintln!("[updater] disabled by ECHO_DISABLE_AUTO_UPDATER");
-        return false;
+
+    unsafe {
+        let lib =
+            windows::Win32::System::LibraryLoader::LoadLibraryW(windows::core::w!("ntdll.dll"));
+        if let Ok(h) = lib {
+            let proc = windows::Win32::System::LibraryLoader::GetProcAddress(
+                h,
+                windows::core::s!("RtlGetVersion"),
+            );
+            if let Some(rtl_get_version) = proc {
+                let func: extern "system" fn(*mut OsVersionInfoExW) -> i32 =
+                    std::mem::transmute(rtl_get_version);
+                let mut info: OsVersionInfoExW = std::mem::zeroed();
+                info.dw_os_version_info_size = std::mem::size_of::<OsVersionInfoExW>() as u32;
+                func(&mut info);
+                return info.dw_build_number;
+            }
+        }
     }
-    true
+
+    0
+}
+
+#[cfg(not(target_os = "windows"))]
+fn detect_windows_build_number() -> u32 {
+    0
 }
 
 /// Load config.json from next to the executable.
 /// Falls back to defaults if missing or invalid.
-fn load_config() -> String {
+fn load_config() -> Config {
     let config_path = std::env::current_exe()
         .ok()
         .and_then(|p| p.parent().map(|d| d.join("config.json")))
@@ -78,11 +120,28 @@ fn load_config() -> String {
         if let Ok(contents) = std::fs::read_to_string(&config_path) {
             let contents = contents.trim_start_matches('\u{FEFF}');
             if let Ok(cfg) = serde_json::from_str::<Config>(contents) {
-                if let Some(server) = cfg.server {
-                    let server = server.trim_end_matches('/').to_string();
-                    eprintln!("[config] server = {}", server);
-                    return server;
+                let server = cfg
+                    .server
+                    .as_deref()
+                    .unwrap_or(DEFAULT_SERVER)
+                    .trim_end_matches('/')
+                    .to_string();
+                eprintln!("[config] server = {}", server);
+                match cfg.force_software_encoder {
+                    Some(force_software_encoder) => {
+                        eprintln!(
+                            "[config] force_software_encoder = {}",
+                            force_software_encoder
+                        );
+                    }
+                    None => {
+                        eprintln!("[config] force_software_encoder = <auto>");
+                    }
                 }
+                return Config {
+                    server: Some(server),
+                    force_software_encoder: cfg.force_software_encoder,
+                };
             }
         }
     }
@@ -91,7 +150,10 @@ fn load_config() -> String {
         "[config] no config.json found, using default: {}",
         DEFAULT_SERVER
     );
-    DEFAULT_SERVER.to_string()
+    Config {
+        server: Some(DEFAULT_SERVER.to_string()),
+        force_software_encoder: None,
+    }
 }
 
 /// Clear webview cache when the app version changes (prevents stale content after update)
@@ -155,9 +217,15 @@ fn get_control_url(server: tauri::State<'_, String>) -> String {
 
 #[tauri::command]
 async fn check_for_updates(app: tauri::AppHandle) -> Result<String, String> {
-    if !updater_enabled() {
-        return Ok("disabled".to_string());
+    let current_version = env!("CARGO_PKG_VERSION");
+    if is_local_test_build_version(current_version) {
+        eprintln!(
+            "[updater] manual check skipped for local test build v{}",
+            current_version
+        );
+        return Ok("local_test_build".to_string());
     }
+
     let updater = app.updater_builder().build().map_err(|e| e.to_string())?;
     match updater.check().await {
         Ok(Some(update)) => {
@@ -284,52 +352,10 @@ fn open_external_url(url: String) -> Result<(), String> {
 
 #[tauri::command]
 fn get_os_build_number() -> u32 {
+    let build = detect_windows_build_number();
     #[cfg(target_os = "windows")]
-    {
-        // Use RtlGetVersion (ntdll) — GetVersionEx lies on Win8.1+
-        #[repr(C)]
-        struct OsVersionInfoExW {
-            dw_os_version_info_size: u32,
-            dw_major_version: u32,
-            dw_minor_version: u32,
-            dw_build_number: u32,
-            dw_platform_id: u32,
-            sz_csd_version: [u16; 128],
-            w_service_pack_major: u16,
-            w_service_pack_minor: u16,
-            w_suite_mask: u16,
-            w_product_type: u8,
-            w_reserved: u8,
-        }
-
-        unsafe {
-            let lib =
-                windows::Win32::System::LibraryLoader::LoadLibraryW(windows::core::w!("ntdll.dll"));
-            if let Ok(h) = lib {
-                let proc = windows::Win32::System::LibraryLoader::GetProcAddress(
-                    h,
-                    windows::core::s!("RtlGetVersion"),
-                );
-                if let Some(rtl_get_version) = proc {
-                    let func: extern "system" fn(*mut OsVersionInfoExW) -> i32 =
-                        std::mem::transmute(rtl_get_version);
-                    let mut info: OsVersionInfoExW = std::mem::zeroed();
-                    info.dw_os_version_info_size = std::mem::size_of::<OsVersionInfoExW>() as u32;
-                    func(&mut info);
-                    eprintln!(
-                        "[os] Windows {}.{} build {}",
-                        info.dw_major_version, info.dw_minor_version, info.dw_build_number
-                    );
-                    return info.dw_build_number;
-                }
-            }
-        }
-        0
-    }
-    #[cfg(not(target_os = "windows"))]
-    {
-        0
-    }
+    eprintln!("[os] Windows build {}", build);
+    build
 }
 
 // ── Native Screen Capture IPC Commands ──
@@ -346,25 +372,17 @@ async fn start_screen_share(
     source_id: u64,
     sfu_url: String,
     token: String,
-    publish_profile: Option<capture_pipeline::PublishProfile>,
     app: tauri::AppHandle,
     health: tauri::State<'_, std::sync::Arc<CaptureHealthState>>,
 ) -> Result<(), String> {
     let health_arc = std::sync::Arc::clone(&*health);
-    screen_capture::start_share(
-        source_id,
-        sfu_url,
-        token,
-        publish_profile.unwrap_or_default(),
-        app,
-        health_arc,
-    ).await
+    screen_capture::start_share(source_id, sfu_url, token, app, health_arc).await
 }
 
 #[cfg(target_os = "windows")]
 #[tauri::command]
-async fn stop_screen_share() -> Result<(), String> {
-    screen_capture::stop_share().await
+fn stop_screen_share() {
+    screen_capture::stop_share();
 }
 
 #[cfg(target_os = "windows")]
@@ -388,20 +406,11 @@ async fn start_desktop_capture(
     fullscreen: bool,
     sfu_url: String,
     token: String,
-    publish_profile: Option<capture_pipeline::PublishProfile>,
     app: tauri::AppHandle,
     health: tauri::State<'_, std::sync::Arc<CaptureHealthState>>,
 ) -> Result<(), String> {
     let health_arc = std::sync::Arc::clone(&*health);
-    desktop_capture::start(
-        hwnd,
-        fullscreen,
-        sfu_url,
-        token,
-        publish_profile.unwrap_or_default(),
-        app,
-        health_arc,
-    ).await
+    desktop_capture::start(hwnd, fullscreen, sfu_url, token, app, health_arc).await
 }
 
 /// Start WGC monitor capture (entire screen). Includes the cursor automatically
@@ -422,8 +431,8 @@ async fn start_screen_share_monitor(
 
 #[cfg(target_os = "windows")]
 #[tauri::command]
-async fn stop_desktop_capture() -> Result<(), String> {
-    desktop_capture::stop().await
+fn stop_desktop_capture() {
+    desktop_capture::stop();
 }
 
 #[cfg(target_os = "windows")]
@@ -455,7 +464,45 @@ fn main() {
         );
     }
 
-    let server = load_config();
+    let config = load_config();
+    let server = config
+        .server
+        .clone()
+        .unwrap_or_else(|| DEFAULT_SERVER.to_string());
+    #[cfg(target_os = "windows")]
+    let windows_build = detect_windows_build_number();
+    #[cfg(not(target_os = "windows"))]
+    let windows_build = 0u32;
+    let auto_force_software_encoder =
+        config.force_software_encoder.is_none() && windows_build > 0 && windows_build < 22000;
+    let force_software_encoder = config
+        .force_software_encoder
+        .unwrap_or(auto_force_software_encoder);
+
+    #[cfg(target_os = "windows")]
+    if auto_force_software_encoder {
+        eprintln!(
+            "[config] Windows build {} detected — forcing software H264 on Win10 native capture",
+            windows_build
+        );
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        file_debug_log::reset();
+        file_debug_log::append(&format!(
+            "[startup] echo-core-client boot server={} force_software_encoder={} auto_force_software_encoder={} windows_build={}",
+            server, force_software_encoder, auto_force_software_encoder, windows_build
+        ));
+    }
+
+    #[cfg(target_os = "windows")]
+    unsafe {
+        if force_software_encoder {
+            std::env::set_var("ECHO_FORCE_SOFTWARE_ENCODER", "1");
+            eprintln!("[init] ECHO_FORCE_SOFTWARE_ENCODER=1");
+        }
+    }
 
     let builder = tauri::Builder::default()
         .plugin(tauri_plugin_updater::Builder::new().build())
@@ -510,32 +557,41 @@ fn main() {
             #[cfg(target_os = "windows")]
             {
                 std::thread::spawn(|| {
+                    let force_software =
+                        std::env::var("ECHO_FORCE_SOFTWARE_ENCODER").ok().as_deref() == Some("1");
+                    if force_software {
+                        eprintln!(
+                            "[init] force_software_encoder active — skipping CUDA probe and preferring OpenH264"
+                        );
+                    }
                     // Direct CUDA probe to diagnose NVENC availability
                     unsafe {
-                        let lib = windows::Win32::System::LibraryLoader::LoadLibraryW(
-                            windows::core::w!("nvcuda.dll"),
-                        );
-                        match lib {
-                            Ok(h) => {
-                                // nvcuda.dll loaded — NVIDIA driver is present.
-                                // Set the global flag so capture_pipeline uses the
-                                // hardware (240fps) frame interval instead of the
-                                // software (20fps) cap. Also used by capture_health
-                                // to default EncoderType correctly for the chip.
-                                crate::capture_pipeline::HAS_NVCUDA.store(true, std::sync::atomic::Ordering::Relaxed);
-                                let cu_init = windows::Win32::System::LibraryLoader::GetProcAddress(
-                                    h, windows::core::s!("cuInit"),
-                                );
-                                if let Some(init_fn) = cu_init {
-                                    let init: extern "system" fn(u32) -> i32 = std::mem::transmute(init_fn);
-                                    let result = init(0);
-                                    eprintln!("[init] CUDA cuInit(0) = {} (0=success)", result);
-                                } else {
-                                    eprintln!("[init] CUDA cuInit not found in nvcuda.dll");
+                        if !force_software {
+                            let lib = windows::Win32::System::LibraryLoader::LoadLibraryW(
+                                windows::core::w!("nvcuda.dll"),
+                            );
+                            match lib {
+                                Ok(h) => {
+                                    // nvcuda.dll loaded — NVIDIA driver is present.
+                                    // Set the global flag so capture_pipeline uses the
+                                    // hardware (240fps) frame interval instead of the
+                                    // software (20fps) cap. Also used by capture_health
+                                    // to default EncoderType correctly for the chip.
+                                    crate::capture_pipeline::HAS_NVCUDA.store(true, std::sync::atomic::Ordering::Relaxed);
+                                    let cu_init = windows::Win32::System::LibraryLoader::GetProcAddress(
+                                        h, windows::core::s!("cuInit"),
+                                    );
+                                    if let Some(init_fn) = cu_init {
+                                        let init: extern "system" fn(u32) -> i32 = std::mem::transmute(init_fn);
+                                        let result = init(0);
+                                        eprintln!("[init] CUDA cuInit(0) = {} (0=success)", result);
+                                    } else {
+                                        eprintln!("[init] CUDA cuInit not found in nvcuda.dll");
+                                    }
                                 }
-                            }
-                            Err(e) => {
-                                eprintln!("[init] nvcuda.dll load failed: {e} — software OpenH264 fallback, capture capped at 20fps");
+                                Err(e) => {
+                                    eprintln!("[init] nvcuda.dll load failed: {e} — software OpenH264 fallback, capture capped at 20fps");
+                                }
                             }
                         }
                     }
@@ -561,48 +617,54 @@ fn main() {
             .build()?;
 
             // Check for updates in the background
-            if updater_enabled() {
-                let handle = app.handle().clone();
-                tauri::async_runtime::spawn(async move {
-                    // Small delay so the window is visible before any update dialog
-                    tokio::time::sleep(std::time::Duration::from_secs(3)).await;
-                    let updater = match handle.updater_builder().build() {
-                        Ok(u) => u,
-                        Err(e) => {
-                            eprintln!("[updater] build failed: {}", e);
-                            return;
-                        }
-                    };
-                    match updater.check().await {
-                        Ok(Some(update)) => {
-                            eprintln!(
-                                "[updater] update available: v{} -> v{}",
-                                env!("CARGO_PKG_VERSION"),
-                                update.version
-                            );
-                            match update
-                                .download_and_install(
-                                    |ev, _| {
-                                        eprintln!("[updater] download progress: {:?}", ev);
-                                    },
-                                    || {
-                                        eprintln!("[updater] ready to install, app will restart...");
-                                    },
-                                )
-                                .await
-                            {
-                                Ok(_) => {
-                                    eprintln!("[updater] install complete, restarting...");
-                                    handle.restart();
-                                }
-                                Err(e) => eprintln!("[updater] install failed: {}", e),
-                            }
-                        }
-                        Ok(None) => eprintln!("[updater] up to date (v{})", env!("CARGO_PKG_VERSION")),
-                        Err(e) => eprintln!("[updater] check failed: {}", e),
+            let handle = app.handle().clone();
+            tauri::async_runtime::spawn(async move {
+                // Small delay so the window is visible before any update dialog
+                tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+                let current_version = env!("CARGO_PKG_VERSION");
+                if is_local_test_build_version(current_version) {
+                    eprintln!(
+                        "[updater] background check disabled for local test build v{}",
+                        current_version
+                    );
+                    return;
+                }
+                let updater = match handle.updater_builder().build() {
+                    Ok(u) => u,
+                    Err(e) => {
+                        eprintln!("[updater] build failed: {}", e);
+                        return;
                     }
-                });
-            }
+                };
+                match updater.check().await {
+                    Ok(Some(update)) => {
+                        eprintln!(
+                            "[updater] update available: v{} -> v{}",
+                            env!("CARGO_PKG_VERSION"),
+                            update.version
+                        );
+                        match update
+                            .download_and_install(
+                                |ev, _| {
+                                    eprintln!("[updater] download progress: {:?}", ev);
+                                },
+                                || {
+                                    eprintln!("[updater] ready to install, app will restart...");
+                                },
+                            )
+                            .await
+                        {
+                            Ok(_) => {
+                                eprintln!("[updater] install complete, restarting...");
+                                handle.restart();
+                            }
+                            Err(e) => eprintln!("[updater] install failed: {}", e),
+                        }
+                    }
+                    Ok(None) => eprintln!("[updater] up to date (v{})", env!("CARGO_PKG_VERSION")),
+                    Err(e) => eprintln!("[updater] check failed: {}", e),
+                }
+            });
 
             Ok(())
         })

--- a/core/client/src/screen_capture.rs
+++ b/core/client/src/screen_capture.rs
@@ -12,12 +12,13 @@
 //!         → libwebrtc H264 encoder (MFT → NVENC)
 //!           → RTP → SFU
 
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use livekit::track::TrackSource;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 use tauri::{AppHandle, Emitter};
 
 use crate::capture_health::{CaptureHealthState, CaptureMode, EncoderType};
-use crate::capture_pipeline::{CapturePublisher, PublishProfile};
+use crate::capture_pipeline::CapturePublisher;
 
 // ── Types ──
 
@@ -35,9 +36,7 @@ pub struct CaptureSource {
 // ── Global State ──
 
 struct ShareHandle {
-    task_id: u64,
     running: Arc<AtomicBool>,
-    task: tokio::task::JoinHandle<()>,
 }
 
 fn global_state() -> &'static Mutex<Option<ShareHandle>> {
@@ -45,15 +44,27 @@ fn global_state() -> &'static Mutex<Option<ShareHandle>> {
     STATE.get_or_init(|| Mutex::new(None))
 }
 
-fn next_task_id() -> u64 {
-    static NEXT_TASK_ID: AtomicU64 = AtomicU64::new(1);
-    NEXT_TASK_ID.fetch_add(1, Ordering::Relaxed)
-}
+#[cfg(target_os = "windows")]
+fn wgc_draw_border_setting(scope: &str) -> windows_capture::settings::DrawBorderSettings {
+    use windows_capture::graphics_capture_api::GraphicsCaptureApi;
+    use windows_capture::settings::DrawBorderSettings;
 
-fn clear_task_if_current(task_id: u64) {
-    let mut state = global_state().lock().unwrap();
-    if state.as_ref().map(|handle| handle.task_id) == Some(task_id) {
-        *state = None;
+    match GraphicsCaptureApi::is_border_settings_supported() {
+        Ok(true) => DrawBorderSettings::WithoutBorder,
+        Ok(false) => {
+            eprintln!(
+                "[{}] WGC border toggle unsupported on this Windows build; using default border settings",
+                scope
+            );
+            DrawBorderSettings::Default
+        }
+        Err(err) => {
+            eprintln!(
+                "[{}] failed to query WGC border support ({:?}); using default border settings",
+                scope, err
+            );
+            DrawBorderSettings::Default
+        }
     }
 }
 
@@ -255,63 +266,43 @@ pub async fn start_share(
     source_id: u64,
     sfu_url: String,
     token: String,
-    publish_profile: PublishProfile,
     app: AppHandle,
     health: Arc<CaptureHealthState>,
 ) -> Result<(), String> {
-    stop_share().await?;
+    stop_share();
 
     let running = Arc::new(AtomicBool::new(true));
-    let task_id = next_task_id();
+
+    {
+        let mut state = global_state().lock().unwrap();
+        *state = Some(ShareHandle {
+            running: running.clone(),
+        });
+    }
 
     let app2 = app.clone();
     let r2 = running.clone();
-    let task = tokio::spawn(async move {
-        if let Err(e) = share_loop(source_id, &sfu_url, &token, publish_profile, &app2, &r2, health).await {
+    tokio::spawn(async move {
+        if let Err(e) = share_loop(source_id, &sfu_url, &token, &app2, &r2, health).await {
             eprintln!("[screen-capture] error: {}", e);
             let _ = app2.emit("screen-capture-error", format!("{}", e));
         }
         let _ = app2.emit("screen-capture-stopped", ());
         eprintln!("[screen-capture] task exited");
-        clear_task_if_current(task_id);
-    });
-
-    {
         let mut state = global_state().lock().unwrap();
-        *state = Some(ShareHandle {
-            task_id,
-            running,
-            task,
-        });
-        if state
-            .as_ref()
-            .map(|handle| handle.task.is_finished())
-            .unwrap_or(false)
-        {
-            *state = None;
-        }
-    }
+        *state = None;
+    });
 
     Ok(())
 }
 
 /// Stop the current screen share.
-pub async fn stop_share() -> Result<(), String> {
-    let handle = {
-        let mut state = global_state().lock().unwrap();
-        state.take()
-    };
-
-    if let Some(handle) = handle {
+pub fn stop_share() {
+    let mut state = global_state().lock().unwrap();
+    if let Some(handle) = state.take() {
         handle.running.store(false, Ordering::SeqCst);
         eprintln!("[screen-capture] stop requested");
-        handle
-            .task
-            .await
-            .map_err(|e| format!("screen capture task join failed: {e}"))?;
     }
-
-    Ok(())
 }
 
 // ── Thumbnail Generation ──
@@ -522,7 +513,6 @@ async fn share_loop(
     source_id: u64,
     sfu_url: &str,
     token: &str,
-    publish_profile: PublishProfile,
     app: &AppHandle,
     running: &Arc<AtomicBool>,
     health: Arc<CaptureHealthState>,
@@ -533,9 +523,11 @@ async fn share_loop(
         token,
         1920,
         1080,
-        publish_profile,
         "screen-capture",
-    ).await?;
+        TrackSource::Camera,
+        false,
+    )
+    .await?;
 
     // Resolve HWND -> PID for WASAPI audio auto-start
     let target_pid = unsafe {
@@ -554,7 +546,7 @@ async fn share_loop(
         true,
         CaptureMode::Wgc,
         EncoderType::Nvenc,
-        publish_profile.target_fps(),
+        crate::capture_pipeline::PUBLISH_TARGET_FPS,
     );
 
     // 2. Start WGC capture -- callback sends BGRA frames via channel
@@ -702,7 +694,7 @@ async fn share_loop(
         let settings = Settings::new(
             window,
             CursorCaptureSettings::Default,
-            DrawBorderSettings::WithoutBorder,
+            wgc_draw_border_setting("screen-capture"),
             SecondaryWindowSettings::Default,
             MinimumUpdateIntervalSettings::Custom(std::time::Duration::from_millis(1)),
             DirtyRegionSettings::Default,
@@ -797,38 +789,29 @@ pub async fn start_share_monitor(
     app: AppHandle,
     health: Arc<CaptureHealthState>,
 ) -> Result<(), String> {
-    stop_share().await?;
+    stop_share();
 
     let running = Arc::new(AtomicBool::new(true));
-    let task_id = next_task_id();
+
+    {
+        let mut state = global_state().lock().unwrap();
+        *state = Some(ShareHandle {
+            running: running.clone(),
+        });
+    }
 
     let app2 = app.clone();
     let r2 = running.clone();
-    let task = tokio::spawn(async move {
+    tokio::spawn(async move {
         if let Err(e) = share_loop_monitor(hmonitor, &sfu_url, &token, &app2, &r2, health).await {
             eprintln!("[screen-capture-monitor] error: {}", e);
             let _ = app2.emit("screen-capture-error", format!("{}", e));
         }
         let _ = app2.emit("screen-capture-stopped", ());
         eprintln!("[screen-capture-monitor] task exited");
-        clear_task_if_current(task_id);
-    });
-
-    {
         let mut state = global_state().lock().unwrap();
-        *state = Some(ShareHandle {
-            task_id,
-            running,
-            task,
-        });
-        if state
-            .as_ref()
-            .map(|handle| handle.task.is_finished())
-            .unwrap_or(false)
-        {
-            *state = None;
-        }
-    }
+        *state = None;
+    });
 
     Ok(())
 }
@@ -847,9 +830,11 @@ async fn share_loop_monitor(
         token,
         1920,
         1080,
-        PublishProfile::Desktop,
         "screen-capture-monitor",
-    ).await?;
+        TrackSource::Camera,
+        false,
+    )
+    .await?;
 
     eprintln!(
         "[screen-capture-monitor] starting WGC monitor capture for HMONITOR {}",
@@ -861,7 +846,7 @@ async fn share_loop_monitor(
         true,
         CaptureMode::Wgc,
         EncoderType::Nvenc,
-        PublishProfile::Desktop.target_fps(),
+        crate::capture_pipeline::PUBLISH_TARGET_FPS,
     );
 
     let (frame_tx, frame_rx) = std::sync::mpsc::sync_channel::<(Vec<u8>, u32, u32)>(4);
@@ -1005,7 +990,7 @@ async fn share_loop_monitor(
         let settings = Settings::new(
             monitor,
             CursorCaptureSettings::Default, // cursor INCLUDED — this is the win
-            DrawBorderSettings::WithoutBorder,
+            wgc_draw_border_setting("screen-capture-monitor"),
             SecondaryWindowSettings::Default,
             MinimumUpdateIntervalSettings::Custom(std::time::Duration::from_millis(1)),
             DirtyRegionSettings::Default,

--- a/core/client/tauri.conf.json
+++ b/core/client/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "Echo Chamber",
-  "version": "0.6.10",
+  "version": "0.6.11",
   "identifier": "com.echochamber.app",
   "build": {
     "frontendDist": "../viewer"
@@ -15,7 +15,7 @@
   },
   "bundle": {
     "active": true,
-    "targets": ["nsis", "dmg"],
+    "targets": ["nsis"],
     "createUpdaterArtifacts": true,
     "icon": [
       "icons/32x32.png",

--- a/core/control/Cargo.toml
+++ b/core/control/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "echo-core-control"
-version = "0.6.10"
+version = "0.6.11"
 edition = "2021"
 
 [dependencies]

--- a/core/control/src/admin.rs
+++ b/core/control/src/admin.rs
@@ -64,6 +64,8 @@ pub(crate) struct ClientStats {
     pub(crate) inbound: Option<Vec<SubscriptionStats>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) capture_health: Option<CaptureHealth>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) watch_debug: Option<String>,
 }
 
 #[derive(Clone, Serialize, Deserialize, Default)]
@@ -576,6 +578,9 @@ pub(crate) async fn client_stats_report(
             }
             if payload.capture_health.is_some() {
                 existing.capture_health = payload.capture_health;
+            }
+            if payload.watch_debug.is_some() {
+                existing.watch_debug = payload.watch_debug;
             }
             if payload.screen_fps.is_some() { existing.screen_fps = payload.screen_fps; }
             if payload.screen_width.is_some() { existing.screen_width = payload.screen_width; }

--- a/core/deploy/agent.ps1
+++ b/core/deploy/agent.ps1
@@ -28,6 +28,23 @@ $stdoutLog = Join-Path $InstallDir "client-stdout.log"
 $stderrLog = Join-Path $InstallDir "client-stderr.log"
 $agentLog = Join-Path $InstallDir "agent.log"
 $pidFile = Join-Path $InstallDir "client.pid"
+$clientTaskName = "EchoChamberClient"
+
+function Get-InstalledClientPath {
+    $candidates = @()
+    if ($env:LOCALAPPDATA) {
+        $candidates += (Join-Path $env:LOCALAPPDATA "Echo Chamber\echo-core-client.exe")
+    }
+    if ($env:USERPROFILE) {
+        $candidates += (Join-Path $env:USERPROFILE "AppData\Local\Echo Chamber\echo-core-client.exe")
+    }
+    foreach ($candidate in $candidates | Select-Object -Unique) {
+        if ($candidate -and (Test-Path $candidate)) {
+            return $candidate
+        }
+    }
+    return $null
+}
 
 function Write-Log([string]$msg) {
     $ts = (Get-Date).ToString("yyyy-MM-dd HH:mm:ss")
@@ -46,7 +63,24 @@ function Get-ClientProcess {
             }
         }
     }
+
+    $proc = Get-Process -Name "echo-core-client" -ErrorAction SilentlyContinue |
+        Sort-Object StartTime -Descending |
+        Select-Object -First 1
+    if ($proc) {
+        return $proc
+    }
+
     return $null
+}
+
+function Get-ClientProcessPath($proc) {
+    if (-not $proc) { return $null }
+    try {
+        return $proc.Path
+    } catch {
+        return $null
+    }
 }
 
 function Stop-Client {
@@ -71,9 +105,45 @@ function Start-Client {
     if (Test-Path $stdoutLog) { "" | Set-Content $stdoutLog }
     if (Test-Path $stderrLog) { "" | Set-Content $stderrLog }
 
+    $clientTask = Get-ScheduledTask -TaskName $clientTaskName -ErrorAction SilentlyContinue
+    if ($clientTask) {
+        try {
+            Start-ScheduledTask -TaskName $clientTaskName
+            Start-Sleep -Seconds 2
+            $proc = Get-Process -Name "echo-core-client" -ErrorAction SilentlyContinue |
+                Sort-Object StartTime -Descending |
+                Select-Object -First 1
+            if ($proc) {
+                Set-Content -Path $pidFile -Value $proc.Id
+                Write-Log "Client started via scheduled task (PID $($proc.Id))."
+                return $true
+            }
+
+            Write-Log "Scheduled task launched but client process was not found."
+            return $false
+        } catch {
+            Write-Log "Scheduled task launch failed, falling back to direct start: $_"
+        }
+    }
+
     $proc = Start-Process -FilePath $exePath -WorkingDirectory $InstallDir -PassThru -RedirectStandardOutput $stdoutLog -RedirectStandardError $stderrLog
     Set-Content -Path $pidFile -Value $proc.Id
-    Write-Log "Client started (PID $($proc.Id))."
+    Write-Log "Client started directly (PID $($proc.Id))."
+    return $true
+}
+
+function Start-InstalledClient {
+    $installedPath = Get-InstalledClientPath
+    if (-not $installedPath) {
+        Write-Log "No installed client exe found under LocalAppData"
+        return $false
+    }
+
+    Stop-Client
+    $workingDir = Split-Path $installedPath -Parent
+    $proc = Start-Process -FilePath $installedPath -WorkingDirectory $workingDir -PassThru
+    Set-Content -Path $pidFile -Value $proc.Id
+    Write-Log "Installed client started directly (PID $($proc.Id)) from $installedPath."
     return $true
 }
 
@@ -128,11 +198,16 @@ while ($listener.IsListening) {
                 $proc = Get-ClientProcess
                 $running = $proc -ne $null
                 $hasExe = Test-Path $exePath
+                $installedPath = Get-InstalledClientPath
                 $body = @{
                     agent = "ok"
                     client_running = $running
                     client_pid = if ($running) { $proc.Id } else { $null }
+                    client_path = if ($running) { Get-ClientProcessPath $proc } else { $null }
                     has_exe = $hasExe
+                    sandbox_exe_path = $exePath
+                    installed_exe_path = $installedPath
+                    installed_exe_exists = [bool]$installedPath
                 } | ConvertTo-Json
                 Send-Response $context 200 $body
             }
@@ -199,6 +274,19 @@ while ($listener.IsListening) {
                     Send-Response $context 200 '{"status":"restarted"}'
                 } else {
                     Send-Response $context 500 '{"error":"no exe found"}'
+                }
+            }
+
+            "/launch-installed" {
+                if ($method -ne "POST") {
+                    Send-Response $context 405 '{"error":"POST required"}'
+                    continue
+                }
+                $ok = Start-InstalledClient
+                if ($ok) {
+                    Send-Response $context 200 '{"status":"installed-client-started"}'
+                } else {
+                    Send-Response $context 500 '{"error":"installed client not found"}'
                 }
             }
 

--- a/core/deploy/build-release.ps1
+++ b/core/deploy/build-release.ps1
@@ -102,6 +102,13 @@ if ($setupExe -and $setupSig) {
     Write-Status "  Looked for: *_${version}_*-setup.exe" Yellow
 }
 
+$manifestPath = Join-Path $bundleDir "latest.json"
+$releaseFiles = @()
+if ($setupExe) { $releaseFiles += $setupExe.FullName }
+if ($setupSig) { $releaseFiles += $setupSig.FullName }
+if (Test-Path $manifestPath) { $releaseFiles += $manifestPath }
+$releaseFilesArg = ($releaseFiles | ForEach-Object { '"' + $_ + '"' }) -join ' '
+
 Write-Status ""
 Write-Status "=== RELEASE READY ===" Green
 Write-Status ""
@@ -114,4 +121,8 @@ Write-Status "     - The .exe.sig (signature for auto-updates)"
 Write-Status "     - latest.json (update manifest)"
 Write-Status ""
 Write-Status "Or use gh CLI:"
-Write-Status "  gh release create v$version --title 'Echo Chamber v$version' $bundleDir\*"
+Write-Status "  gh release create v$version --title 'Echo Chamber v$version' $releaseFilesArg"
+Write-Status ""
+Write-Status "After publishing the Windows release:" Yellow
+Write-Status "  Download latest.json from the GitHub Release and copy to core\deploy\" Yellow
+Write-Status "  Or run: gh release download v$version -p latest.json -D core\deploy\ --clobber" Yellow

--- a/core/deploy/latest.json
+++ b/core/deploy/latest.json
@@ -1,11 +1,11 @@
 {
-  "version": "0.6.8",
-  "notes": "Update to v0.6.8",
-  "pub_date": "2026-04-11T17:17:48Z",
-  "platforms": {
-    "windows-x86_64": {
-      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVSQ3ByNFJuZlpjMEMwWTZHSDdmalNtVkhSbm5SMEliZUV5Wk5GY215K1hiSjRNdTZrVjJ6VEZDcHRzL0pVbG5lQTd4YW5VUkZWalFpOHNOSjF1VEM2a2MvR1g4V1M0QndvPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzc1OTI3ODAyCWZpbGU6RWNobyBDaGFtYmVyXzAuNi44X3g2NC1zZXR1cC5leGUKOFMwWS9ZbVc4ZDJnWUIwejY4N1o2VFpWclIvS3ZMRjdLUFB5NzlsYWdxeVFHdEpRa2hyb2ZUMTJuNkRqV3lpdkpBVU8rYnQzbm15TmlkZFNodkF2Q1E9PQo=",
-      "url": "https://github.com/SamWatson86/echo-chamber/releases/download/v0.6.8/Echo.Chamber_0.6.8_x64-setup.exe"
-    }
-  }
+    "platforms":  {
+                      "windows-x86_64":  {
+                                             "signature":  "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVSQ3ByNFJuZlpjME9rN0huMUV4RmlvRTFBcE95OVVDbmF4di9lcXNRQ0dBVERaNEFYZ1JCODNKOHkwdkpZQWVWM0NvNGVaeVRzRzBTSUNwczJ1ZnNhSHB2b2J2R1duMlFzPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzc2MTMxNDg5CWZpbGU6RWNobyBDaGFtYmVyXzAuNi4xMV94NjQtc2V0dXAuZXhlCmJubnlTVklRUzJhY2lSSDRJRzRveUNRUTNJcEpqdUtMaUE2K0VRcGJoLzZTSXFHUkRBdjdPQ1kvcEdTc2JYV1E4NVBlZUprT0w1WENibU45QVo3Y0JRPT0K",
+                                             "url":  "https://github.com/SamWatson86/echo-chamber/releases/download/v0.6.11/Echo.Chamber_0.6.11_x64-setup.exe"
+                                         }
+                  },
+    "pub_date":  "2026-04-14T01:51:30Z",
+    "version":  "0.6.11",
+    "notes":  "Echo Chamber v0.6.11"
 }

--- a/core/deploy/setup-agent.ps1
+++ b/core/deploy/setup-agent.ps1
@@ -14,6 +14,8 @@ param(
 )
 
 $ErrorActionPreference = "Stop"
+$clientTaskName = "EchoChamberClient"
+$exePath = Join-Path $InstallDir "echo-core-client.exe"
 
 Write-Host "Echo Chamber Deploy Agent Setup" -ForegroundColor Cyan
 Write-Host "================================" -ForegroundColor Cyan
@@ -47,7 +49,10 @@ if ($existing -match "Rule Name") {
     Write-Host "[OK] Firewall rule added (port $Port)" -ForegroundColor Green
 }
 
-# 4. Scheduled task
+# 4. Scheduled task for the deploy agent
+# The live agent should support both the sandbox binary under C:\EchoChamber
+# and the normal installed app under LocalAppData. The HTTP endpoints are used
+# by the dev PC to launch the correct path explicitly instead of guessing.
 $taskName = "EchoChamberDeployAgent"
 $existingTask = Get-ScheduledTask -TaskName $taskName -ErrorAction SilentlyContinue
 if ($existingTask) {
@@ -55,15 +60,32 @@ if ($existingTask) {
     Write-Host "[OK] Removed old scheduled task" -ForegroundColor Yellow
 }
 
-$action = New-ScheduledTaskAction -Execute "powershell.exe" -Argument "-ExecutionPolicy Bypass -WindowStyle Hidden -File `"$agentDst`" -Port $Port -InstallDir `"$InstallDir`""
-$trigger = New-ScheduledTaskTrigger -AtStartup
-$settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -StartWhenAvailable -RestartCount 3 -RestartInterval (New-TimeSpan -Minutes 1)
+$action = New-ScheduledTaskAction -Execute "powershell.exe" -Argument "-NoProfile -NonInteractive -ExecutionPolicy Bypass -WindowStyle Hidden -File `"$agentDst`" -Port $Port -InstallDir `"$InstallDir`""
+$triggers = @(
+    New-ScheduledTaskTrigger -AtStartup
+    New-ScheduledTaskTrigger -AtLogOn
+)
+$settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -StartWhenAvailable -RestartCount 3 -RestartInterval (New-TimeSpan -Minutes 1) -MultipleInstances IgnoreNew
 $principal = New-ScheduledTaskPrincipal -UserId "SYSTEM" -LogonType ServiceAccount -RunLevel Highest
 
-Register-ScheduledTask -TaskName $taskName -Action $action -Trigger $trigger -Settings $settings -Principal $principal -Description "Echo Chamber deploy agent - receives builds from dev PC" | Out-Null
-Write-Host "[OK] Scheduled task installed (runs at startup as SYSTEM)" -ForegroundColor Green
+Register-ScheduledTask -TaskName $taskName -Action $action -Trigger $triggers -Settings $settings -Principal $principal -Description "Echo Chamber deploy agent - receives builds from dev PC" | Out-Null
+Write-Host "[OK] Scheduled task installed (runs at startup + logon as SYSTEM)" -ForegroundColor Green
 
-# 5. Start it now
+# 5. Scheduled task for the actual Echo client in the interactive user session
+$existingClientTask = Get-ScheduledTask -TaskName $clientTaskName -ErrorAction SilentlyContinue
+if ($existingClientTask) {
+    Unregister-ScheduledTask -TaskName $clientTaskName -Confirm:$false
+    Write-Host "[OK] Removed old client launch task" -ForegroundColor Yellow
+}
+
+$clientAction = New-ScheduledTaskAction -Execute $exePath -WorkingDirectory $InstallDir
+$clientSettings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -StartWhenAvailable -MultipleInstances IgnoreNew
+$clientPrincipal = New-ScheduledTaskPrincipal -UserId $env:USERNAME -LogonType Interactive -RunLevel Highest
+$clientTask = New-ScheduledTask -Action $clientAction -Principal $clientPrincipal -Settings $clientSettings
+Register-ScheduledTask -TaskName $clientTaskName -InputObject $clientTask -Description "Echo Chamber desktop client - launched on demand in the interactive user session" | Out-Null
+Write-Host "[OK] Client launch task installed for user $env:USERNAME" -ForegroundColor Green
+
+# 6. Start it now
 Start-ScheduledTask -TaskName $taskName
 Write-Host "[OK] Agent started!" -ForegroundColor Green
 

--- a/core/viewer/audio-routing.js
+++ b/core/viewer/audio-routing.js
@@ -404,6 +404,7 @@ function handleTrackSubscribed(track, publication, participant) {
       return;
     }
     const identity = effectiveParticipant.identity;
+    var _isRemoteScreen = room && room.localParticipant && effectiveParticipant.identity !== room.localParticipant.identity;
     const screenTrackSid = publication?.trackSid || track?.sid || null;
     const existingTile = screenTileByIdentity.get(identity) || (screenTrackSid ? screenTileBySid.get(screenTrackSid) : null);
     if (existingTile && existingTile.isConnected) {
@@ -453,11 +454,10 @@ function handleTrackSubscribed(track, publication, participant) {
     }
     clearScreenTracksForIdentity(effectiveParticipant.identity, screenTrackSid);
     const label = `${participant.name || "Guest"} (Screen)`;
-    const element = createLockedVideoElement(track);
+    const element = createAttachedVideoElement(track);
     configureVideoElement(element, true);
     // Add playout delay buffer for remote screen shares to absorb WiFi jitter.
     // Trades ~150ms latency for smooth playback instead of stuttering.
-    var _isRemoteScreen = room && room.localParticipant && effectiveParticipant.identity !== room.localParticipant.identity;
     if (_isRemoteScreen && track?.mediaStreamTrack) {
       try {
         const pc = room?.engine?.pcManager?.subscriber?.pc;

--- a/core/viewer/changelog.js
+++ b/core/viewer/changelog.js
@@ -8,6 +8,86 @@
 
 var ECHO_CHANGELOG = [
   {
+    version: "2026-04-13l",
+    title: "Win10 Entire Screen Fix",
+    notes: [
+      "Windows 10 native Entire Screen sharing now auto-falls back to software H264 when no explicit encoder override is set. This fixes the blank `0fps` viewer tile on older Win10 full-screen publishers while keeping the native `DXGI Desktop Duplication` path.",
+      "The fallback is scoped to the Win10 native capture path. Newer Windows builds and working hardware-backed paths keep their existing encoder behavior, while Win10 trades peak frame rate for a stream that is actually visible."
+    ]
+  },
+  {
+    version: "2026-04-13k",
+    title: "Auto-Watch New Screen Shares",
+    notes: [
+      "New remote screen shares now auto-watch on first publish instead of waiting behind Start Watching by default. Explicit Stop Watching opt-outs still stick, but first-time viewers no longer miss the startup keyframes from software H264 screen senders.",
+      "This aligns already-connected viewers with the existing late-join behavior so remote screen shares start the same way whether you were already in the room or joined after the share began."
+    ]
+  },
+  {
+    version: "2026-04-13j",
+    title: "SDK Screen Tile Attach",
+    notes: [
+      "Remote screen tiles now prefer the SDK-managed `track.attach()` video path instead of hand-building a `MediaStream` for first attach. This specifically targets the case where a publisher is sending real RTP but already-connected viewers still get a blank `0fps` tile with a `live/muted` screen track.",
+      "The change is scoped to remote screen video elements. Camera and audio flows keep their existing behavior while the Win10 DXGI watch path is hardened."
+    ]
+  },
+  {
+    version: "2026-04-13i",
+    title: "H26x Screen-Share Encoder Path",
+    notes: [
+      "Native H26x screen-share publishing now bypasses the simulcast adapter path again. This restores the sender path that previously turned the Win10 DXGI publisher from zero-byte dead air into a real outgoing stream.",
+      "The rollback decision from earlier live testing was based on a canary that was later clarified to have used the wrong machine direction, so the effective native publish fix is back in while the known-good cross-machine canary is being rechecked explicitly."
+    ]
+  },
+  {
+    version: "2026-04-13h",
+    title: "Software H264 Screen-Share Fallback",
+    notes: [
+      "Native H264 screen-share publishers that fall back to software encoding no longer get forced through the simulcast adapter path. This targets the Win10 DXGI sender case that connected to the room but never emitted RTP.",
+      "NVENC-backed H264 publishing stays on the existing encoder path so known-good hardware screen-share flows keep their current behavior while the Win10 fallback case is isolated."
+    ]
+  },
+  {
+    version: "2026-04-13g",
+    title: "Publishing Stability Rollback",
+    notes: [
+      "A risky encoder-path experiment was rolled back after it regressed a previously working full-screen share path during live canary testing.",
+      "This build is back on the safer publish baseline while Win10-specific native screen-share failures continue to be isolated without widening the blast radius."
+    ]
+  },
+  {
+    version: "2026-04-13d",
+    title: "Local Build Update Guardrails",
+    notes: [
+      "Local prerelease desktop builds now stop advertising the public updater banner and stop auto-updating themselves over the top of an active test session.",
+      "This keeps private DXGI/Win10 test clients coherent while the live public updater manifest still points at the official v0.6.10 release."
+    ]
+  },
+  {
+    version: "2026-04-13c",
+    title: "Win10 DXGI Screen Share Signal",
+    notes: [
+      "Native Win10 DXGI full-screen sharing now publishes with actual screen-share semantics instead of the motion/game camera profile. This targets the subscribed-but-zero-RTP stall on older Windows publishers.",
+      "The working WGC capture paths stay on their existing behavior. This change is scoped to the DXGI Desktop Duplication monitor/full-screen path."
+    ]
+  },
+  {
+    version: "2026-04-13b",
+    title: "Screen Watch Sync",
+    notes: [
+      "Already-connected viewers now use the same screen-subscribe path as late joiners when they click Start Watching. Remote screen shares no longer rely on a separate opt-in branch that could leave a blank 0fps tile behind.",
+      "This specifically hardens the viewer-side watch flow for native Win10 full-screen publishers whose DXGI Desktop Duplication stream is already live in the room."
+    ]
+  },
+  {
+    version: "2026-04-13",
+    title: "Win10 Native Full-Screen Path",
+    notes: [
+      "Windows 10 full-screen shares stay on the native desktop-capture path again. The installed client no longer bounces Entire Screen through the browser/WebView picker.",
+      "Win10 window capture still stays blocked on unsupported WGC builds, but monitor capture remains the intended native DXGI Desktop Duplication path."
+    ]
+  },
+  {
     version: "2026-04-12b",
     title: "Post-Reboot Connect Hotfix (v0.6.10)",
     notes: [

--- a/core/viewer/connect.js
+++ b/core/viewer/connect.js
@@ -650,15 +650,16 @@ async function connectToRoom({ controlUrl, sfuUrl, roomId, identity, name, reuse
       }
     }
 
-    // Opt-in: if a remote screen share arrives but identity isn't in hiddenScreens yet
-    // (TrackSubscribed fired before TrackPublished race), add to hiddenScreens now
-    // But skip if user explicitly opted in via watchedScreens
+    // First-time remote screen shares should auto-watch so the viewer catches
+    // the startup keyframes. Only keep a screen hidden here if the user
+    // explicitly opted out earlier (identity already lives in hiddenScreens).
     var _subSource = getTrackSource(publication, track);
     var _subIsRemoteScreen = _effectiveParticipant && room && room.localParticipant &&
       _effectiveParticipant.identity !== room.localParticipant.identity &&
       (_subSource === LK.Track.Source.ScreenShare || _subSource === LK.Track.Source.ScreenShareAudio);
     if (_subIsRemoteScreen && !hiddenScreens.has(_effectiveParticipant.identity) && !watchedScreens.has(_effectiveParticipant.identity)) {
-      hiddenScreens.add(_effectiveParticipant.identity);
+      watchedScreens.add(_effectiveParticipant.identity);
+      debugLog("[opt-in] auto-watch on track subscribed " + _effectiveParticipant.identity);
     }
     handleTrackSubscribed(track, publication, _effectiveParticipant);
     scheduleReconcileWaves("track-subscribed");
@@ -710,24 +711,27 @@ async function connectToRoom({ controlUrl, sfuUrl, roomId, identity, name, reuse
         (pubSource === LK.Track.Source.ScreenShare || pubSource === LK.Track.Source.ScreenShareAudio);
 
       if (isRemoteScreen) {
-        // Opt-in: don't subscribe to remote screen shares by default
-        if (!hiddenScreens.has(_pubIdentity)) {
-          hiddenScreens.add(_pubIdentity);
-        }
         // Play screen share chime for video track only (not audio), and not during room switches
         if (!_isRoomSwitch && pubSource === LK.Track.Source.ScreenShare) {
           var ssState = participantState.get(_pubIdentity);
           var ssVol = (ssState && ssState.chimeVolume != null) ? ssState.chimeVolume : 0.5;
           playScreenShareChime(ssVol);
         }
-        var cardRef = participantCards.get(_pubIdentity);
-        if (cardRef && cardRef.watchToggleBtn) {
-          cardRef.watchToggleBtn.style.display = "";
-          cardRef.watchToggleBtn.textContent = "Start Watching";
-          if (cardRef.ovWatchClone) { cardRef.ovWatchClone.style.display = ""; cardRef.ovWatchClone.textContent = "Start Watching"; }
+        if (hiddenScreens.has(_pubIdentity)) {
+          var cardRef = participantCards.get(_pubIdentity);
+          if (cardRef && cardRef.watchToggleBtn) {
+            cardRef.watchToggleBtn.style.display = "";
+            cardRef.watchToggleBtn.textContent = "Start Watching";
+            if (cardRef.ovWatchClone) { cardRef.ovWatchClone.style.display = ""; cardRef.ovWatchClone.textContent = "Start Watching"; }
+          }
+          debugLog(`[opt-in] track published (screen, user-hidden) ${_pubIdentity} src=${pubSource}`);
+          // Still hook so we can subscribe later when user opts in
+          if (participant) hookPublication(publication, participant);
+          return;
         }
-        debugLog(`[opt-in] track published (screen, unwatched) ${_pubIdentity} src=${pubSource}`);
-        // Still hook so we can subscribe later when user opts in
+        watchedScreens.add(_pubIdentity);
+        debugLog(`[opt-in] track published (screen, auto-watch) ${_pubIdentity} src=${pubSource}`);
+        startWatchingScreenIdentity(_pubIdentity, "track-published");
         if (participant) hookPublication(publication, participant);
         return;
       }
@@ -1349,6 +1353,8 @@ async function connectToRoom({ controlUrl, sfuUrl, roomId, identity, name, reuse
         : participant.identity;
       // Auto-subscribe to existing screen shares — don't force opt-in for late joiners.
       // The "Stop Watching" button is available if they want to unsubscribe later.
+      startWatchingScreenIdentity(effectiveIdentity, "late-join");
+      return;
       hiddenScreens.delete(effectiveIdentity);
       watchedScreens.add(effectiveIdentity);
       resubscribeParticipantTracks(participant);

--- a/core/viewer/debug.js
+++ b/core/viewer/debug.js
@@ -45,6 +45,25 @@ function logEvent(eventName, detail) {
   } catch (e) {}
 }
 
+function reportWatchDebug(message) {
+  try {
+    if (!message || !currentAccessToken || !room?.localParticipant?.identity) return;
+    fetch(apiUrl("/api/client-stats-report"), {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer " + currentAccessToken,
+      },
+      body: JSON.stringify({
+        identity: room.localParticipant.identity,
+        name: room.localParticipant.name || "",
+        room: currentRoomName || "",
+        watch_debug: message,
+      }),
+    }).catch(function() {});
+  } catch (e) {}
+}
+
 // ── General toast notification ──
 function showToast(message, durationMs) {
   var existing = document.querySelector(".jam-toast");

--- a/core/viewer/index.html
+++ b/core/viewer/index.html
@@ -4,9 +4,9 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Echo Chamber</title>
-    <link rel="stylesheet" href="style.css?v=0.6.2.1775659895" />
-    <link rel="stylesheet" href="jam.css?v=0.6.2.1775659895" />
-    <link rel="stylesheet" href="capture-picker.css?v=0.6.2.1775659895" />
+    <link rel="stylesheet" href="style.css?v=0.6.10-local.1.1776128211" />
+    <link rel="stylesheet" href="jam.css?v=0.6.10-local.1.1776128211" />
+    <link rel="stylesheet" href="capture-picker.css?v=0.6.10-local.1.1776128211" />
   </head>
   <body>
     <main class="app">
@@ -420,40 +420,40 @@
       <pre id="debug-log"></pre>
     </div>
 
-    <script src="livekit-client.umd.js?v=0.6.2.1775659895"></script>
-    <script src="room-switch-state.js?v=0.6.2.1775659895"></script>
-    <script src="jam-session-state.js?v=0.6.2.1775659895"></script>
-    <script src="publish-state-reconcile.js?v=0.6.2.1775659895"></script>
-    <script src="state.js?v=0.6.2.1775659895"></script>
-    <script src="debug.js?v=0.6.2.1775659895"></script>
-    <script src="urls.js?v=0.6.2.1775659895"></script>
-    <script src="settings.js?v=0.6.2.1775659895"></script>
-    <script src="identity.js?v=0.6.2.1775659895"></script>
-    <script src="rnnoise.js?v=0.6.2.1775659895"></script>
-    <script src="chimes.js?v=0.6.2.1775659895"></script>
-    <script src="room-status.js?v=0.6.2.1775659895"></script>
-    <script src="auth.js?v=0.6.2.1775659895"></script>
+    <script src="livekit-client.umd.js?v=0.6.10-local.1.1776128211"></script>
+    <script src="room-switch-state.js?v=0.6.10-local.1.1776128211"></script>
+    <script src="jam-session-state.js?v=0.6.10-local.1.1776128211"></script>
+    <script src="publish-state-reconcile.js?v=0.6.10-local.1.1776128211"></script>
+    <script src="state.js?v=0.6.10-local.1.1776128211"></script>
+    <script src="debug.js?v=0.6.10-local.1.1776128211"></script>
+    <script src="urls.js?v=0.6.10-local.1.1776128211"></script>
+    <script src="settings.js?v=0.6.10-local.1.1776128211"></script>
+    <script src="identity.js?v=0.6.10-local.1.1776128211"></script>
+    <script src="rnnoise.js?v=0.6.10-local.1.1776128211"></script>
+    <script src="chimes.js?v=0.6.10-local.1.1776128211"></script>
+    <script src="room-status.js?v=0.6.10-local.1.1776128211"></script>
+    <script src="auth.js?v=0.6.10-local.1.1776128211"></script>
     <script src="admin-panel.js?v=0.6.2.1775659895"></script>
-    <script src="theme.js?v=0.6.2.1775659895"></script>
-    <script src="chat.js?v=0.6.2.1775659895"></script>
-    <script src="soundboard.js?v=0.6.2.1775659895"></script>
-    <script src="screen-share-state.js?v=0.6.2.1775659895"></script>
-    <script src="screen-share-config.js?v=0.6.2.1775659895"></script>
-    <script src="screen-share-quality.js?v=0.6.2.1775659895"></script>
-    <script src="screen-share-adaptive.js?v=0.6.2.1775659895"></script>
-    <script src="screen-share-native.js?v=0.6.2.1775659895"></script>
-    <script src="participants-grid.js?v=0.6.2.1775659895"></script>
-    <script src="participants-avatar.js?v=0.6.2.1775659895"></script>
-    <script src="participants-fullscreen.js?v=0.6.2.1775659895"></script>
-    <script src="participants.js?v=0.6.2.1775659895"></script>
-    <script src="audio-routing.js?v=0.6.2.1775659895"></script>
-    <script src="media-controls.js?v=0.6.2.1775659895"></script>
-    <script src="admin.js?v=0.6.2.1775659895"></script>
-    <script src="connect.js?v=0.6.2.1775659895"></script>
-    <script src="app.js?v=0.6.2.1775659895"></script>
-    <script src="capture-picker.js?v=0.6.2.1775659895"></script>
-    <script src="jam.js?v=0.6.2.1775659895"></script>
-    <script src="changelog.js?v=0.6.2.1775659895"></script>
+    <script src="theme.js?v=0.6.10-local.1.1776128211"></script>
+    <script src="chat.js?v=0.6.10-local.1.1776128211"></script>
+    <script src="soundboard.js?v=0.6.10-local.1.1776128211"></script>
+    <script src="screen-share-state.js?v=0.6.10-local.1.1776128211"></script>
+    <script src="screen-share-config.js?v=0.6.10-local.1.1776128211"></script>
+    <script src="screen-share-quality.js?v=0.6.10-local.1.1776128211"></script>
+    <script src="screen-share-adaptive.js?v=0.6.10-local.1.1776128211"></script>
+    <script src="screen-share-native.js?v=0.6.10-local.1.1776128211"></script>
+    <script src="participants-grid.js?v=0.6.10-local.1.1776128211"></script>
+    <script src="participants-avatar.js?v=0.6.10-local.1.1776128211"></script>
+    <script src="participants-fullscreen.js?v=0.6.10-local.1.1776128211"></script>
+    <script src="participants.js?v=0.6.10-local.1.1776128211"></script>
+    <script src="audio-routing.js?v=0.6.10-local.1.1776128211"></script>
+    <script src="media-controls.js?v=0.6.10-local.1.1776128211"></script>
+    <script src="admin.js?v=0.6.10-local.1.1776128211"></script>
+    <script src="connect.js?v=0.6.10-local.1.1776128211"></script>
+    <script src="app.js?v=0.6.10-local.1.1776128211"></script>
+    <script src="capture-picker.js?v=0.6.10-local.1.1776128211"></script>
+    <script src="jam.js?v=0.6.10-local.1.1776128211"></script>
+    <script src="changelog.js?v=0.6.10-local.1.1776128211"></script>
 
     <!-- Admin login modal (hidden by default; toggled by adminLoginBtn) -->
     <div id="adminLoginModal" class="modal-overlay" hidden>

--- a/core/viewer/participants-avatar.js
+++ b/core/viewer/participants-avatar.js
@@ -54,6 +54,117 @@ function getRemoteParticipantsForScreenIdentity(identity) {
   return matches;
 }
 
+function startWatchingScreenIdentity(identity, reason) {
+  if (!identity) return;
+
+  hiddenScreens.delete(identity);
+  watchedScreens.add(identity);
+
+  var cardRef = participantCards.get(identity);
+  if (cardRef && cardRef.watchToggleBtn) {
+    cardRef.watchToggleBtn.style.display = "";
+    cardRef.watchToggleBtn.textContent = "Stop Watching";
+    if (cardRef.ovWatchClone) {
+      cardRef.ovWatchClone.style.display = "";
+      cardRef.ovWatchClone.textContent = "Stop Watching";
+    }
+  }
+
+  var tile = screenTileByIdentity.get(identity);
+  if (tile) tile.style.display = "";
+
+  var pState = participantState.get(identity);
+  if (pState && pState.screenAudioEls) {
+    pState.screenAudioEls.forEach(function(el) {
+      el.muted = false;
+      var gn = pState.screenGainNodes?.get(el);
+      if (gn) gn.gain.gain.value = pState.screenVolume || 1;
+    });
+  }
+
+  function formatPubState(pub, remote) {
+    patchScreenCompanionSource(pub, pub?.track, remote);
+    var src = pub ? (pub.source || (pub.track ? pub.track.source : null) || "?") : "?";
+    var kind = pub?.kind || pub?.track?.kind || "?";
+    var mst = pub?.track?.mediaStreamTrack || null;
+    var recv = "?";
+    try {
+      var subPc = room?.engine?.pcManager?.subscriber?.pc;
+      if (mst && subPc?.getReceivers) {
+        recv = subPc.getReceivers().some(function(r) {
+          return r && r.track === mst;
+        }) ? "true" : "false";
+      }
+    } catch (_) {}
+    return remote.identity + ":" + src + ":" + kind +
+      ":sub=" + (pub?.isSubscribed ?? "?") +
+      ":track=" + (!!pub?.track) +
+      ":recv=" + recv +
+      ":mst=" + (mst ? (mst.readyState + "/" + (mst.muted ? "muted" : "live")) : "none");
+  }
+
+  function formatTileState() {
+    var tile = screenTileByIdentity.get(identity);
+    if (!tile) return "tile=none";
+    var video = tile.querySelector("video");
+    if (!video) {
+      return "tile=present:no-video" +
+        ":display=" + (tile.style.display || "auto") +
+        ":client=" + tile.clientWidth + "x" + tile.clientHeight;
+    }
+    return "tile=present" +
+      ":display=" + (tile.style.display || "auto") +
+      ":client=" + tile.clientWidth + "x" + tile.clientHeight +
+      ":video=" + video.videoWidth + "x" + video.videoHeight +
+      ":paused=" + video.paused +
+      ":rs=" + video.readyState;
+  }
+
+  function runStage(stageLabel) {
+    var remotes = getRemoteParticipantsForScreenIdentity(identity);
+    if (remotes.length === 0) {
+      debugLog("[opt-in] " + stageLabel + ": no remote screen participant yet for " + identity);
+      reportWatchDebug("identity=" + identity + " stage=" + stageLabel + " remotes=none hidden=" + hiddenScreens.has(identity) + " watched=" + watchedScreens.has(identity));
+      return;
+    }
+    var summaries = [];
+    remotes.forEach(function(remote) {
+      var pubs = getParticipantPublications(remote);
+      summaries.push(
+        pubs.length > 0
+          ? pubs.map(function(pub) { return formatPubState(pub, remote); }).join(",")
+          : (remote.identity + ":no-pubs")
+      );
+      debugLog("[opt-in] " + stageLabel + ": resubscribe/reconcile " + remote.identity + " -> " + identity);
+      if (typeof resubscribeParticipantTracks === "function") {
+        resubscribeParticipantTracks(remote);
+      } else {
+        pubs.forEach(function(pub) {
+          if (pub?.setSubscribed) pub.setSubscribed(true);
+          hookPublication(pub, remote);
+        });
+      }
+      if (typeof reconcileParticipantMedia === "function") {
+        reconcileParticipantMedia(remote);
+      }
+    });
+    reportWatchDebug(
+      "identity=" + identity +
+      " stage=" + stageLabel +
+      " hidden=" + hiddenScreens.has(identity) +
+      " watched=" + watchedScreens.has(identity) +
+      " " + formatTileState() +
+      " remotes=" + summaries.join(";")
+    );
+  }
+
+  debugLog("[opt-in] start watching " + identity + " reason=" + (reason || "manual"));
+  runStage("immediate");
+  setTimeout(function() { runStage("fallback@500ms"); }, 500);
+  setTimeout(function() { runStage("fallback@1500ms"); }, 1500);
+  scheduleReconcileWaves("opt-in-watch");
+}
+
 function ensureParticipantCard(participant, isLocal = false) {
   const key = participant.identity;
   // Hide ghost subscriber from UI
@@ -179,6 +290,8 @@ function ensureParticipantCard(participant, isLocal = false) {
 
       if (hiddenScreens.has(identity)) {
         // === START WATCHING: subscribe to screen share tracks ===
+        startWatchingScreenIdentity(identity, "manual-click");
+        return;
         hiddenScreens.delete(identity);
         watchedScreens.add(identity);
         watchToggleBtn.textContent = "Stop Watching";

--- a/core/viewer/participants-fullscreen.js
+++ b/core/viewer/participants-fullscreen.js
@@ -246,7 +246,7 @@ function replaceScreenVideoElement(tile, track, publication) {
   if (oldVideo && overlay) {
     cleanupVideoDiagnostics(overlay);
   }
-  const newEl = createLockedVideoElement(track);
+  const newEl = createAttachedVideoElement(track);
   if (!newEl) return;
   configureVideoElement(newEl, true);
   if (oldVideo && oldVideo.parentElement) {

--- a/core/viewer/participants.js
+++ b/core/viewer/participants.js
@@ -110,6 +110,43 @@ function createLockedVideoElement(track) {
   return element;
 }
 
+function createAttachedVideoElement(track) {
+  if (!track) return null;
+  let element = null;
+  try {
+    element = track.attach();
+  } catch (err) {
+    debugLog(`track.attach() failed for ${track.sid || "unknown"}: ${err.message}`);
+  }
+  if (!element) {
+    element = document.createElement("video");
+    try {
+      track.attach(element);
+    } catch (err) {
+      debugLog(`track.attach(video) failed for ${track.sid || "unknown"}: ${err.message}`);
+    }
+  }
+  if (!element) {
+    return createLockedVideoElement(track);
+  }
+  element._lkTrack = track;
+  if (!element.srcObject && track.mediaStreamTrack) {
+    element.srcObject = new MediaStream([track.mediaStreamTrack]);
+  }
+  element.autoplay = true;
+  element.playsInline = true;
+  try {
+    element.defaultMuted = true;
+  } catch (_) {}
+  element.muted = true;
+  Object.defineProperty(element, 'muted', {
+    get: () => true,
+    set: () => {},
+    configurable: true
+  });
+  return element;
+}
+
 function configureVideoElement(element, muted = true) {
   if (!element) return;
   element.autoplay = true;

--- a/core/viewer/room-status.js
+++ b/core/viewer/room-status.js
@@ -214,6 +214,19 @@ function compareVersionTags(left, right) {
 function isNewerVersion(latest, current) {
   return compareVersionTags(latest, current) > 0;
 }
+
+function isLocalTestBuildVersion(version) {
+  var prerelease = parseVersionTag(version).prerelease || [];
+  return prerelease.some(function(part) {
+    return !part.numeric && /^(local|dev|test|lab|dirty)$/.test(part.value);
+  });
+}
+
+function hideUpdateBanner() {
+  var banner = document.getElementById("update-banner");
+  if (banner) banner.remove();
+}
+
 async function checkForUpdateNotification() {
   if (_updateDismissed) return;
   try {
@@ -225,6 +238,10 @@ async function checkForUpdateNotification() {
       } catch (e) { /* ignore */ }
     }
     if (!currentVer) return; // browser viewer doesn't have a version to compare
+    if (isLocalTestBuildVersion(currentVer)) {
+      hideUpdateBanner();
+      return;
+    }
     var cUrl = controlUrlInput ? controlUrlInput.value.trim() : "";
     if (!cUrl) return;
     var resp = await fetch(cUrl + "/api/version");

--- a/core/viewer/screen-share-native.js
+++ b/core/viewer/screen-share-native.js
@@ -66,11 +66,27 @@ async function startScreenShareManual() {
 
   // ── Native client path: custom picker → Tauri IPC ──
   var isNativeClient = !!window.__ECHO_NATIVE__;
+  var source = null;
+  var osBuild = 99999;
+  var wgcSupported = true;
 
   if (isNativeClient) {
-    var source = await showCapturePicker();
+    source = await showCapturePicker();
     if (!source) return;
 
+    // Detect OS build number for WGC availability (24H2+ = build 26100+)
+    // If the IPC command doesn't exist (older client binary), assume WGC is supported
+    // and let it fail naturally in the fallback chain rather than skipping it.
+    try {
+      osBuild = await tauriInvoke('get_os_build_number');
+      debugLog('[os] Windows build: ' + osBuild);
+    } catch (e) {
+      debugLog('[os] build detection unavailable (older client), assuming WGC supported');
+    }
+    wgcSupported = osBuild >= 26100;
+  }
+
+  if (isNativeClient) {
     // Step 1: get control URL
     var controlUrl = _echoServerUrl;
     if (!controlUrl) { showToast('No server URL configured', 8000); return; }
@@ -97,18 +113,6 @@ async function startScreenShareManual() {
     }
 
     if (!screenToken) { showToast('No token received from server', 8000); return; }
-
-    // Detect OS build number for WGC availability (24H2+ = build 26100+)
-    // If the IPC command doesn't exist (older client binary), assume WGC is supported
-    // and let it fail naturally in the fallback chain rather than skipping it.
-    var osBuild = 99999;
-    try {
-      osBuild = await tauriInvoke('get_os_build_number');
-      debugLog('[os] Windows build: ' + osBuild);
-    } catch (e) {
-      debugLog('[os] build detection unavailable (older client), assuming WGC supported');
-    }
-    var wgcSupported = osBuild >= 26100;
 
     try {
       await _startNativeCaptureStopListeners();

--- a/core/viewer/theme.js
+++ b/core/viewer/theme.js
@@ -51,6 +51,11 @@ function buildVersionSection() {
     try {
       var cUrl = controlUrlInput ? controlUrlInput.value.trim() : "";
       var currentVer = versionLabel.textContent.replace(/^Version:\s*v?/, "").split(" ")[0];
+      if (typeof isLocalTestBuildVersion === "function" && isLocalTestBuildVersion(currentVer)) {
+        updateStatus.textContent = "Local test build — auto-update disabled.";
+        updateBtn.disabled = false;
+        return;
+      }
       var latestClient = "";
       if (cUrl) {
         var verResp = await fetch(cUrl + "/api/version");
@@ -65,7 +70,9 @@ function buildVersionSection() {
         if (window.__ECHO_NATIVE__ && hasTauriIPC()) {
           try {
             var result = await tauriInvoke("check_for_updates");
-            if (result !== "up_to_date") {
+            if (result === "local_test_build") {
+              updateStatus.textContent = "Local test build — auto-update disabled.";
+            } else if (result !== "up_to_date") {
               updateStatus.textContent = "Installing v" + latestClient + "... app will restart.";
             }
           } catch (e2) { /* auto-update unavailable */ }
@@ -76,7 +83,11 @@ function buildVersionSection() {
         // Fallback for browser viewer or unknown version
         if (window.__ECHO_NATIVE__ && hasTauriIPC()) {
           var result = await tauriInvoke("check_for_updates");
-          updateStatus.textContent = result === "up_to_date" ? "You're on the latest version!" : "Installing... app will restart.";
+          if (result === "local_test_build") {
+            updateStatus.textContent = "Local test build — auto-update disabled.";
+          } else {
+            updateStatus.textContent = result === "up_to_date" ? "You're on the latest version!" : "Installing... app will restart.";
+          }
         } else {
           updateStatus.textContent = "Version check not available in browser.";
         }

--- a/core/webrtc-sys-local/src/nvidia/cuda_context.cpp
+++ b/core/webrtc-sys-local/src/nvidia/cuda_context.cpp
@@ -3,13 +3,19 @@
 #include "rtc_base/checks.h"
 #include "rtc_base/logging.h"
 
+#include <fstream>
+
 #if defined(WIN32)
 #include <windows.h>
 #else
 #include <dlfcn.h>
 #endif
 
+#include <cstdlib>
 #include <iostream>
+#include <iterator>
+#include <optional>
+#include <string>
 
 #if defined(WIN32)
 static const char CUDA_DYNAMIC_LIBRARY[] = "nvcuda.dll";
@@ -17,7 +23,184 @@ static const char CUDA_DYNAMIC_LIBRARY[] = "nvcuda.dll";
 static const char CUDA_DYNAMIC_LIBRARY[] = "libcuda.so.1";
 #endif
 
+static bool ReadForceSoftwareEncoderFlagFromConfig(
+    const std::string& config_path) {
+  std::ifstream in(config_path, std::ios::binary);
+  if (!in.is_open()) {
+    return false;
+  }
+
+  std::string contents((std::istreambuf_iterator<char>(in)),
+                       std::istreambuf_iterator<char>());
+  const auto key_pos = contents.find("\"force_software_encoder\"");
+  if (key_pos == std::string::npos) {
+    return false;
+  }
+
+  const auto colon_pos = contents.find(':', key_pos);
+  if (colon_pos == std::string::npos) {
+    return false;
+  }
+
+  const auto true_pos = contents.find("true", colon_pos);
+  const auto false_pos = contents.find("false", colon_pos);
+  return true_pos != std::string::npos &&
+         (false_pos == std::string::npos || true_pos < false_pos);
+}
+
+static std::optional<bool> ReadForceSoftwareEncoderOverrideFromConfig(
+    const std::string& config_path) {
+  std::ifstream in(config_path, std::ios::binary);
+  if (!in.is_open()) {
+    return std::nullopt;
+  }
+
+  std::string contents((std::istreambuf_iterator<char>(in)),
+                       std::istreambuf_iterator<char>());
+  const auto key_pos = contents.find("\"force_software_encoder\"");
+  if (key_pos == std::string::npos) {
+    return std::nullopt;
+  }
+
+  const auto colon_pos = contents.find(':', key_pos);
+  if (colon_pos == std::string::npos) {
+    return std::nullopt;
+  }
+
+  const auto true_pos = contents.find("true", colon_pos);
+  const auto false_pos = contents.find("false", colon_pos);
+  if (true_pos != std::string::npos &&
+      (false_pos == std::string::npos || true_pos < false_pos)) {
+    return true;
+  }
+  if (false_pos != std::string::npos &&
+      (true_pos == std::string::npos || false_pos < true_pos)) {
+    return false;
+  }
+
+  return std::nullopt;
+}
+
+static bool ReadForceSoftwareEncoderFlagFromInstalledConfig() {
+#if defined(WIN32)
+  char exe_path[MAX_PATH] = {0};
+  const DWORD len = GetModuleFileNameA(nullptr, exe_path, MAX_PATH);
+  if (len > 0 && len < MAX_PATH) {
+    std::string config_path(exe_path, len);
+    const auto slash_pos = config_path.find_last_of("\\/");
+    if (slash_pos != std::string::npos) {
+      config_path.resize(slash_pos + 1);
+      config_path += "config.json";
+      if (ReadForceSoftwareEncoderFlagFromConfig(config_path)) {
+        return true;
+      }
+    }
+  }
+
+  const char* local_appdata = std::getenv("LOCALAPPDATA");
+  if (local_appdata && *local_appdata) {
+    const std::string local_config =
+        std::string(local_appdata) + "\\Echo Chamber\\config.json";
+    if (ReadForceSoftwareEncoderFlagFromConfig(local_config)) {
+      return true;
+    }
+  }
+#endif
+
+  return false;
+}
+
+static std::optional<bool> ReadForceSoftwareEncoderOverrideFromInstalledConfig() {
+#if defined(WIN32)
+  char exe_path[MAX_PATH] = {0};
+  const DWORD len = GetModuleFileNameA(nullptr, exe_path, MAX_PATH);
+  if (len > 0 && len < MAX_PATH) {
+    std::string config_path(exe_path, len);
+    const auto slash_pos = config_path.find_last_of("\\/");
+    if (slash_pos != std::string::npos) {
+      config_path.resize(slash_pos + 1);
+      config_path += "config.json";
+      if (auto override_value =
+              ReadForceSoftwareEncoderOverrideFromConfig(config_path)) {
+        return override_value;
+      }
+    }
+  }
+
+  const char* local_appdata = std::getenv("LOCALAPPDATA");
+  if (local_appdata && *local_appdata) {
+    const std::string local_config =
+        std::string(local_appdata) + "\\Echo Chamber\\config.json";
+    if (auto override_value =
+            ReadForceSoftwareEncoderOverrideFromConfig(local_config)) {
+      return override_value;
+    }
+  }
+#endif
+
+  return std::nullopt;
+}
+
+static uint32_t DetectWindowsBuildNumber() {
+#if defined(WIN32)
+  typedef struct _OSVERSIONINFOEXW_FFI {
+    uint32_t dwOSVersionInfoSize;
+    uint32_t dwMajorVersion;
+    uint32_t dwMinorVersion;
+    uint32_t dwBuildNumber;
+    uint32_t dwPlatformId;
+    wchar_t szCSDVersion[128];
+    uint16_t wServicePackMajor;
+    uint16_t wServicePackMinor;
+    uint16_t wSuiteMask;
+    uint8_t wProductType;
+    uint8_t wReserved;
+  } OSVERSIONINFOEXW_FFI;
+
+  HMODULE ntdll = LoadLibraryW(L"ntdll.dll");
+  if (!ntdll) {
+    return 0;
+  }
+
+  using RtlGetVersionFn = LONG(WINAPI*)(OSVERSIONINFOEXW_FFI*);
+  auto rtl_get_version =
+      reinterpret_cast<RtlGetVersionFn>(GetProcAddress(ntdll, "RtlGetVersion"));
+  if (!rtl_get_version) {
+    return 0;
+  }
+
+  OSVERSIONINFOEXW_FFI info = {};
+  info.dwOSVersionInfoSize = sizeof(info);
+  if (rtl_get_version(&info) != 0) {
+    return 0;
+  }
+  return info.dwBuildNumber;
+#else
+  return 0;
+#endif
+}
+
 namespace livekit_ffi {
+
+bool IsSoftwareEncoderForced() {
+  const char* raw = std::getenv("ECHO_FORCE_SOFTWARE_ENCODER");
+  if (raw && std::string(raw) == "1") {
+    return true;
+  }
+
+  if (auto override_value = ReadForceSoftwareEncoderOverrideFromInstalledConfig()) {
+    return *override_value;
+  }
+
+#if defined(WIN32)
+  const uint32_t build = DetectWindowsBuildNumber();
+  if (build > 0 && build < 22000) {
+    return true;
+  }
+#endif
+
+  return ReadForceSoftwareEncoderFlagFromInstalledConfig();
+}
 
 #define __CUCTX_CUDA_CALL(call, ret)                        \
   CUresult err__ = call;                                    \
@@ -99,10 +282,19 @@ CudaContext* CudaContext::GetInstance() {
 }
 
 bool CudaContext::IsAvailable() {
+  if (IsSoftwareEncoderForced()) {
+    RTC_LOG(LS_INFO) << "ECHO_FORCE_SOFTWARE_ENCODER=1 — treating CUDA as unavailable";
+    return false;
+  }
   return load_cuda_modules() && check_cuda_device();
 }
 
 bool CudaContext::Initialize() {
+  if (IsSoftwareEncoderForced()) {
+    RTC_LOG(LS_INFO) << "ECHO_FORCE_SOFTWARE_ENCODER=1 — skipping CUDA context initialization";
+    return false;
+  }
+
   // Initialize CUDA context
 
   bool success = load_cuda_modules();

--- a/core/webrtc-sys-local/src/nvidia/cuda_context.h
+++ b/core/webrtc-sys-local/src/nvidia/cuda_context.h
@@ -5,6 +5,8 @@
 
 namespace livekit_ffi {
 
+bool IsSoftwareEncoderForced();
+
 class CudaContext {
  public:
   CudaContext() = default;

--- a/core/webrtc-sys-local/src/nvidia/nvidia_encoder_factory.cpp
+++ b/core/webrtc-sys-local/src/nvidia/nvidia_encoder_factory.cpp
@@ -1,5 +1,6 @@
 #include "nvidia_encoder_factory.h"
 
+#include <cstdlib>
 #include <memory>
 
 #include "cuda_context.h"
@@ -51,6 +52,11 @@ NvidiaVideoEncoderFactory::NvidiaVideoEncoderFactory() {
 NvidiaVideoEncoderFactory::~NvidiaVideoEncoderFactory() {}
 
 bool NvidiaVideoEncoderFactory::IsSupported() {
+  if (livekit_ffi::IsSoftwareEncoderForced()) {
+    std::cout << "[NVENC-factory] force_software_encoder enabled — skipping NVENC registration" << std::endl;
+    return false;
+  }
+
   if (!livekit_ffi::CudaContext::IsAvailable()) {
     RTC_LOG(LS_WARNING) << "Cuda Context is not available.";
     return false;

--- a/core/webrtc-sys-local/src/video_encoder_factory.cpp
+++ b/core/webrtc-sys-local/src/video_encoder_factory.cpp
@@ -16,7 +16,13 @@
 
 #include "livekit/video_encoder_factory.h"
 
+#include <algorithm>
+#include <cstdlib>
+#include <fstream>
 #include <iostream>
+#include <mutex>
+#include <sstream>
+#include <string>
 #include "api/environment/environment_factory.h"
 #include "api/video_codecs/sdp_video_format.h"
 #include "api/video_codecs/video_encoder.h"
@@ -48,6 +54,64 @@
 
 namespace livekit_ffi {
 
+namespace {
+
+std::string FormatVideoFormat(const webrtc::SdpVideoFormat& format) {
+  std::ostringstream out;
+  out << format.name;
+  for (const auto& param : format.parameters) {
+    out << " " << param.first << "=" << param.second;
+  }
+  return out.str();
+}
+
+void AppendEncoderFactoryDebug(const std::string& line) {
+#if defined(WIN32)
+  static std::mutex debug_mutex;
+  std::lock_guard<std::mutex> lock(debug_mutex);
+  const char* local_appdata = std::getenv("LOCALAPPDATA");
+  if (!local_appdata || !*local_appdata) {
+    return;
+  }
+  std::ofstream out(
+      std::string(local_appdata) + "\\Echo Chamber\\encoder-factory-debug.log",
+      std::ios::app);
+  if (!out.is_open()) {
+    return;
+  }
+  out << line << std::endl;
+#else
+  (void)line;
+#endif
+}
+
+int H264PacketizationPreference(const webrtc::SdpVideoFormat& format) {
+  if (format.name != webrtc::kH264CodecName) {
+    return 0;
+  }
+
+  auto it = format.parameters.find("packetization-mode");
+  return (it != format.parameters.end() && it->second == "1") ? 0 : 1;
+}
+
+void AppendPreferredFormats(
+    std::vector<webrtc::SdpVideoFormat>* target,
+    std::vector<webrtc::SdpVideoFormat> formats) {
+  // Browser subscribers are happiest on packetization-mode=1, and our direct
+  // H26x path should prefer hardware/browser-friendly H264 variants before the
+  // raw OpenH264 mode=0 fallback formats.
+  std::stable_sort(
+      formats.begin(), formats.end(),
+      [](const webrtc::SdpVideoFormat& lhs,
+         const webrtc::SdpVideoFormat& rhs) {
+        return H264PacketizationPreference(lhs) <
+               H264PacketizationPreference(rhs);
+      });
+  target->insert(target->end(), formats.begin(), formats.end());
+}
+
+}  // namespace
+
 using Factory = webrtc::VideoEncoderFactoryTemplate<
     webrtc::LibvpxVp8EncoderTemplateAdapter,
 #if defined(WEBRTC_USE_H264)
@@ -57,6 +121,25 @@ using Factory = webrtc::VideoEncoderFactoryTemplate<
     webrtc::LibaomAv1EncoderTemplateAdapter,
 #endif
     webrtc::LibvpxVp9EncoderTemplateAdapter>;
+
+webrtc::SdpVideoFormat NormalizeSoftwareH264Format(
+    webrtc::SdpVideoFormat format) {
+  if (format.name == webrtc::kH264CodecName) {
+    // The working NVENC/VAAPI paths negotiate packetization-mode=1. Keep the
+    // software OpenH264 fallback on that same wire contract so subscribers do
+    // not get stuck on a mode=0-only stream after the direct H26x bypass.
+    format.parameters["packetization-mode"] = "1";
+  }
+  return format;
+}
+
+std::vector<webrtc::SdpVideoFormat> GetSoftwareSupportedFormats() {
+  auto formats = Factory().GetSupportedFormats();
+  for (auto& format : formats) {
+    format = NormalizeSoftwareH264Format(std::move(format));
+  }
+  return formats;
+}
 
 VideoEncoderFactory::InternalFactory::InternalFactory() {
 #ifdef __APPLE__
@@ -82,17 +165,21 @@ VideoEncoderFactory::InternalFactory::InternalFactory() {
 #if defined(USE_NVIDIA_VIDEO_CODEC)
   }
 #endif
+
+  std::ostringstream line;
+  line << "[encoder-factory] ctor hw_factories=" << factories_.size();
+  line << " force_software="
+       << (livekit_ffi::IsSoftwareEncoderForced() ? "1" : "0");
+  AppendEncoderFactoryDebug(line.str());
 }
 
 std::vector<webrtc::SdpVideoFormat>
 VideoEncoderFactory::InternalFactory::GetSupportedFormats() const {
-  std::vector<webrtc::SdpVideoFormat> formats = Factory().GetSupportedFormats();
-
+  std::vector<webrtc::SdpVideoFormat> formats;
   for (const auto& factory : factories_) {
-    auto supported_formats = factory->GetSupportedFormats();
-    formats.insert(formats.end(), supported_formats.begin(),
-                   supported_formats.end());
+    AppendPreferredFormats(&formats, factory->GetSupportedFormats());
   }
+  AppendPreferredFormats(&formats, GetSoftwareSupportedFormats());
   return formats;
 }
 
@@ -100,8 +187,18 @@ VideoEncoderFactory::CodecSupport
 VideoEncoderFactory::InternalFactory::QueryCodecSupport(
     const webrtc::SdpVideoFormat& format,
     std::optional<std::string> scalability_mode) const {
+  for (const auto& factory : factories_) {
+    auto codec_support =
+        factory->QueryCodecSupport(format, scalability_mode);
+    if (codec_support.is_supported) {
+      return codec_support;
+    }
+  }
+
+  auto software_format = NormalizeSoftwareH264Format(format);
   auto original_format =
-      webrtc::FuzzyMatchSdpVideoFormat(Factory().GetSupportedFormats(), format);
+      webrtc::FuzzyMatchSdpVideoFormat(GetSoftwareSupportedFormats(),
+                                       software_format);
   return original_format
              ? Factory().QueryCodecSupport(*original_format, scalability_mode)
              : webrtc::VideoEncoderFactory::CodecSupport{.is_supported = false};
@@ -116,19 +213,29 @@ VideoEncoderFactory::InternalFactory::Create(
     std::cout << " " << p.first << "=" << p.second;
   }
   std::cout << " (hw_factories=" << factories_.size() << ")" << std::endl;
+  AppendEncoderFactoryDebug(
+      "[encoder-factory] internal-create request=" + FormatVideoFormat(format) +
+      " hw_factories=" + std::to_string(factories_.size()));
 
   for (const auto& factory : factories_) {
     for (const auto& supported_format : factory->GetSupportedFormats()) {
       if (supported_format.IsSameCodec(format)) {
         std::cout << "[encoder-factory] HW factory matched! Delegating." << std::endl;
+        AppendEncoderFactoryDebug(
+            "[encoder-factory] hw-match request=" + FormatVideoFormat(format) +
+            " matched=" + FormatVideoFormat(supported_format));
         return factory->Create(env, format);
       }
     }
   }
 
   std::cout << "[encoder-factory] No HW match, falling back to SOFTWARE" << std::endl;
+  AppendEncoderFactoryDebug(
+      "[encoder-factory] no-hw-match request=" + FormatVideoFormat(format));
+  auto software_format = NormalizeSoftwareH264Format(format);
   auto original_format =
-      webrtc::FuzzyMatchSdpVideoFormat(Factory().GetSupportedFormats(), format);
+      webrtc::FuzzyMatchSdpVideoFormat(GetSoftwareSupportedFormats(),
+                                       software_format);
 
   if (original_format) {
     std::cout << "[encoder-factory] Software match: " << original_format->name;
@@ -136,10 +243,16 @@ VideoEncoderFactory::InternalFactory::Create(
       std::cout << " " << p.first << "=" << p.second;
     }
     std::cout << std::endl;
+    AppendEncoderFactoryDebug(
+        "[encoder-factory] software-match request=" + FormatVideoFormat(format) +
+        " normalized=" + FormatVideoFormat(software_format) +
+        " matched=" + FormatVideoFormat(*original_format));
     return Factory().Create(env, *original_format);
   }
 
   std::cout << "[encoder-factory] ERROR: No encoder found at all!" << std::endl;
+  AppendEncoderFactoryDebug(
+      "[encoder-factory] no-encoder request=" + FormatVideoFormat(format));
   return nullptr;
 }
 
@@ -162,7 +275,19 @@ std::unique_ptr<webrtc::VideoEncoder> VideoEncoderFactory::Create(
     const webrtc::Environment& env,
     const webrtc::SdpVideoFormat& format) {
   std::unique_ptr<webrtc::VideoEncoder> encoder;
-  if (format.IsCodecInList(internal_factory_->GetSupportedFormats())) {
+  const bool is_h26x =
+      format.name == "H264" || format.name == "H265" || format.name == "HEVC";
+
+  if (is_h26x) {
+    std::cout
+        << "[encoder-factory] bypassing SimulcastEncoderAdapter for H26x path"
+        << std::endl;
+    AppendEncoderFactoryDebug(
+        "[encoder-factory] direct-h26x request=" + FormatVideoFormat(format));
+    encoder = internal_factory_->Create(env, format);
+  } else if (format.IsCodecInList(internal_factory_->GetSupportedFormats())) {
+    AppendEncoderFactoryDebug(
+        "[encoder-factory] simulcast-adapter request=" + FormatVideoFormat(format));
     encoder = std::make_unique<webrtc::SimulcastEncoderAdapter>(
         env, internal_factory_.get(), nullptr, format);
   }


### PR DESCRIPTION
## Summary
- fix Win10 native Entire Screen by auto-forcing software H264 on older Windows builds
- keep Windows release packaging NSIS-only and bump desktop/control versions to 0.6.11
- publish the 0.6.11 updater manifest and record final live smoke verification

## Verification
- cargo build -p echo-core-client --release
- cargo build -p echo-core-control --release
- powershell -ExecutionPolicy Bypass -File core/deploy/build-release.ps1
- live smoke: SAM-PC Win10 Entire Screen, local Entire Screen, Jeff Entire Screen all worked
- verified https://echo.fellowshipoftheboatrace.party:9443/api/update/latest.json serves 0.6.11