### PR TITLE
[codex] Prevent duplicate bugfix PRs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,10 @@ Echo Chamber is a self-hosted real-time communication app. In this repo, active 
 - Prefer small, focused diffs over broad rewrites.
 - Keep release impact explicit: server-only vs desktop-binary vs both.
 - Avoid one-off patterns; prefer conventional, maintainable approaches.
+- Before creating a new bugfix branch or PR, check existing open PRs, issues,
+  branches, and `CURRENT_SESSION.md` for the same symptom or fix area. If
+  matching work exists, validate, rebase/port, close, or explicitly supersede
+  that work instead of opening a duplicate PR.
 
 ## Quality expectations
 - Any user-facing behavior change should include verification evidence.

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -11,15 +11,21 @@
 2. Use pull requests for all changes.
 3. Required verification checks must pass before merge.
 4. Prefer small, focused PRs unless intentionally batching foundational work.
+5. Before starting a bugfix PR, check open PRs, issues, branches, and
+   `CURRENT_SESSION.md` for the same symptom or fix area. Reuse, update,
+   rebase/port, close, or explicitly supersede existing work instead of
+   opening duplicate PRs.
 
 ## Typical flow
 
 1. Branch from `main`.
-2. Implement change.
-3. Run quick verification locally.
-4. Push branch and open PR.
-5. Ensure CI checks pass.
-6. Merge.
+2. For bugfixes, confirm there is no matching open PR, issue, branch, or
+   deferred note in `CURRENT_SESSION.md`.
+3. Implement change.
+4. Run quick verification locally.
+5. Push branch and open PR.
+6. Ensure CI checks pass.
+7. Merge.
 
 ## PR description minimum
 


### PR DESCRIPTION
## Summary
- Add a duplicate-PR prevention rule to `AGENTS.md` for future agent sessions.
- Update `docs/WORKFLOW.md` so bugfix work checks open PRs, issues, branches, and `CURRENT_SESSION.md` before starting a new PR.

## Release impact
- Server-only: no
- Desktop binary required: no
- Both: no
- Docs/process only

## Verification
- `git diff --check HEAD~1..HEAD`
- Confirmed `F:\EC-worktrees\main` stayed clean on `main`