### PR TITLE
[codex] Harden screen share reliability for v0.6.12

### DIFF
--- a/START_HERE.md
+++ b/START_HERE.md
@@ -1,0 +1,14 @@
+# Start Here
+
+If Sam starts a new Codex thread in this worktree and says `continue`, read:
+
+1. `AGENTS.md`
+2. `docs/handovers/2026-05-02-screen-sources-command.md`
+
+Then continue from the handover's **Exact Prompt to Continue With** section.
+
+This worktree is for the screen sharing source-list bug:
+
+- Path: `F:\EC-worktrees\screen-sources-command`
+- Branch: `codex/screen-sources-command-investigation`
+- Official `main` worktree should remain clean.

--- a/START_HERE.md
+++ b/START_HERE.md
@@ -11,4 +11,15 @@ This worktree is for the screen sharing source-list bug:
 
 - Path: `F:\EC-worktrees\screen-sources-command`
 - Branch: `codex/screen-sources-command-investigation`
+- Local commit: `e4c25e0 Add fallback for missing native screen source command`
+- Status: parked local compatibility fix; not pushed; no PR opened.
 - Official `main` worktree should remain clean.
+
+Important context:
+
+- Sam reported Zane later became able to share his screen, so this is not an active live emergency.
+- The branch still contains a real server/client compatibility fallback for older desktop shells missing `list_screen_sources`.
+- Zane's separate missing-avatar issue was fixed live without a server restart by registering the existing `zane` avatar under the current `z` identity. That avatar fix is server state only; it is not part of this branch's code diff.
+- In Codex Desktop, do not try to switch the `Echo Chamber - Main` project to this branch. Open this folder as its own Project instead, because this branch is already checked out by this worktree.
+
+If Sam asks to "start the work", confirm the worktree and branch, review the handover, and wait for a specific instruction before pushing, opening a PR, deploying, or deleting the branch.

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -1307,6 +1307,8 @@ name = "echo-core-client"
 version = "0.6.11"
 dependencies = [
  "base64 0.22.1",
+ "futures-util",
+ "libwebrtc",
  "livekit",
  "parking_lot",
  "reqwest 0.12.28",

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -1304,7 +1304,7 @@ dependencies = [
 
 [[package]]
 name = "echo-core-client"
-version = "0.6.11"
+version = "0.6.12"
 dependencies = [
  "base64 0.22.1",
  "futures-util",

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -1325,7 +1325,7 @@ dependencies = [
 
 [[package]]
 name = "echo-core-control"
-version = "0.6.11"
+version = "0.6.12"
 dependencies = [
  "argon2",
  "axum",

--- a/core/client/Cargo.toml
+++ b/core/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "echo-core-client"
-version = "0.6.11"
+version = "0.6.12"
 edition = "2021"
 description = "Echo Chamber native desktop client"
 

--- a/core/client/Cargo.toml
+++ b/core/client/Cargo.toml
@@ -13,11 +13,13 @@ tauri-plugin-updater = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 reqwest = { version = "0.12", features = ["json"] }
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "time", "sync"] }
 base64 = "0.22"
 parking_lot = "0.12"
 
 [target.'cfg(windows)'.dependencies]
+futures-util = "0.3"
+libwebrtc = "0.3.29"
 livekit = { version = "0.7", features = ["native-tls"] }
 windows-capture = "1.5"
 windows-core = "0.58"

--- a/core/client/src/capture_pipeline.rs
+++ b/core/client/src/capture_pipeline.rs
@@ -6,10 +6,9 @@
 //! DXGI OutputDuplication, GPU shaders, anti-MPO) stays in its own module.
 
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Emitter};
 use tokio::sync::mpsc::UnboundedReceiver;
 
@@ -34,13 +33,6 @@ pub struct CaptureStats {
 
 // ── CapturePublisher ──
 
-/// Hard cap for the capture push rate when NVENC hardware encode is active.
-/// Keep the desktop/full-screen diagnostic path aligned with the 30fps wire
-/// target while we isolate the Win10 SAM-PC no-RTP regression.
-const TARGET_ENCODE_FPS_HARDWARE: f64 = PUBLISH_TARGET_FPS as f64;
-const MIN_FRAME_INTERVAL_HARDWARE: std::time::Duration =
-    std::time::Duration::from_nanos((1_000_000_000.0 / TARGET_ENCODE_FPS_HARDWARE) as u64);
-
 /// Soft cap for the capture push rate when OpenH264 software encode is active.
 /// Software H264 at 1080p at 60+ fps pins the CPU at ~90-100% and caused
 /// Jeff's v0.6.6 crash after ~54 min of sustained load (28K NACKs, CPU
@@ -59,12 +51,53 @@ const MIN_FRAME_INTERVAL_SOFTWARE: std::time::Duration =
 /// main.rs's startup probe and never changes after that.
 pub static HAS_NVCUDA: AtomicBool = AtomicBool::new(false);
 
-/// Wire-level publish framerate cap. The capture loop runs at native display
-/// refresh rate (often 144+ Hz) but NVENC's frame_drop=1 throttles the wire
-/// output to this rate. This is the "target" the capture-health classifier
-/// compares current capture FPS against — if capture drops far below this
-/// number something upstream is starving the pipeline.
+/// Desktop wire-level publish framerate cap. Game/window capture can opt into
+/// the high-motion profile below. The capture loop runs at native display
+/// refresh rate (often 144+ Hz), but the publisher paces frames to the selected
+/// profile's wire target.
 pub const PUBLISH_TARGET_FPS: u32 = 30;
+pub const GAME_PUBLISH_TARGET_FPS: u32 = 60;
+pub const STATIC_FRAME_HEARTBEAT_INTERVAL: Duration = Duration::from_millis(200);
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum PublishProfile {
+    Desktop,
+    Game,
+}
+
+impl Default for PublishProfile {
+    fn default() -> Self {
+        Self::Desktop
+    }
+}
+
+impl PublishProfile {
+    pub fn target_fps(self) -> u32 {
+        match self {
+            Self::Desktop => PUBLISH_TARGET_FPS,
+            Self::Game => GAME_PUBLISH_TARGET_FPS,
+        }
+    }
+
+    fn max_bitrate(self) -> u64 {
+        match self {
+            Self::Desktop => 4_000_000,
+            Self::Game => 8_000_000,
+        }
+    }
+
+    fn min_bitrate(self) -> u64 {
+        match self {
+            Self::Desktop => 2_500_000,
+            Self::Game => 3_000_000,
+        }
+    }
+
+    fn hardware_min_frame_interval(self) -> Duration {
+        Duration::from_nanos((1_000_000_000.0 / self.target_fps() as f64) as u64)
+    }
+}
 
 /// Shared publisher that connects to the LiveKit SFU, creates a NativeVideoSource,
 /// publishes a caller-selected video track, and provides helpers to push BGRA frames
@@ -75,7 +108,61 @@ pub struct CapturePublisher {
     track: LocalVideoTrack,
     start_time: Instant,
     frame_count: u64,
-    last_pushed: Option<Instant>,
+    next_push_at: Option<Instant>,
+    hardware_min_frame_interval: Duration,
+}
+
+fn should_push_frame_at_deadline(
+    now: Instant,
+    next_push_at: &mut Option<Instant>,
+    min_interval: Duration,
+) -> bool {
+    let Some(next) = next_push_at else {
+        *next_push_at = Some(now + min_interval);
+        return true;
+    };
+
+    if now < *next {
+        return false;
+    }
+
+    while *next <= now {
+        *next += min_interval;
+    }
+    true
+}
+
+pub(crate) struct StaticFrameHeartbeat {
+    interval: Duration,
+    last_fresh_frame_at: Option<Instant>,
+    last_heartbeat_at: Option<Instant>,
+}
+
+impl StaticFrameHeartbeat {
+    pub(crate) fn new(interval: Duration) -> Self {
+        Self {
+            interval,
+            last_fresh_frame_at: None,
+            last_heartbeat_at: None,
+        }
+    }
+
+    pub(crate) fn record_fresh_frame(&mut self, now: Instant) {
+        self.last_fresh_frame_at = Some(now);
+        self.last_heartbeat_at = None;
+    }
+
+    pub(crate) fn should_publish(&mut self, now: Instant) -> bool {
+        let Some(last_fresh_frame_at) = self.last_fresh_frame_at else {
+            return false;
+        };
+        let last_publish_at = self.last_heartbeat_at.unwrap_or(last_fresh_frame_at);
+        if now.duration_since(last_publish_at) < self.interval {
+            return false;
+        }
+        self.last_heartbeat_at = Some(now);
+        true
+    }
 }
 
 async fn log_room_events(log_prefix: String, mut events: UnboundedReceiver<RoomEvent>) {
@@ -116,14 +203,22 @@ impl CapturePublisher {
         token: &str,
         enc_w: u32,
         enc_h: u32,
+        publish_profile: PublishProfile,
         log_prefix: &str,
         track_source: TrackSource,
         is_screencast: bool,
     ) -> Result<Self, String> {
         eprintln!("[{}] connecting to SFU: {}", log_prefix, sfu_url);
         file_debug_log::append(&format!(
-            "[{}] connect_and_publish start sfu_url={} enc={}x{}",
-            log_prefix, sfu_url, enc_w, enc_h
+            "[{}] connect_and_publish start sfu_url={} enc={}x{} profile={:?} target_fps={} max_bitrate={} min_bitrate={}",
+            log_prefix,
+            sfu_url,
+            enc_w,
+            enc_h,
+            publish_profile,
+            publish_profile.target_fps(),
+            publish_profile.max_bitrate(),
+            publish_profile.min_bitrate()
         ));
 
         let (room, events) = Room::connect(sfu_url, token, RoomOptions::default())
@@ -159,27 +254,16 @@ impl CapturePublisher {
             video_codec: VideoCodec::H264,
             simulcast: false,
             video_encoding: Some(VideoEncoding {
-                // Capped at 4 Mbps for multi-publisher rooms. Validated 2026-04-07
-                // with 3 simultaneous 1080p shares and a residential-WAN viewer
-                // (David) who saw 0fps at 8Mbps. 4Mbps × 3 publishers = 12Mbps
-                // aggregate, comfortably under most residential downloads. Per-stream
-                // quality at 1080p30 H264 is still excellent for screen content.
-                // Twitch source quality reference: 6 Mbps at 1080p60 gameplay.
-                max_bitrate: 4_000_000,
+                // Desktop uses the conservative multi-publisher budget validated
+                // 2026-04-07. Game shares opt into a higher-motion bitrate budget.
+                max_bitrate: publish_profile.max_bitrate(),
                 // 2.5 Mbps hard floor — prevents libwebrtc GoogCC from throttling
                 // to zero under packet loss / RTT spikes, so the stream stays
                 // visible instead of dropping to 0fps and slowly probing back up.
-                min_bitrate: 2_500_000,
-                // 60fps for safe stable testing with David (remote friend).
-                // The level=AUTOSELECT fix is still in h264_encoder_impl.cpp
-                // for later 144fps retest on SAM-PC — harmless at 60fps.
-                // Capped at 30fps for multi-publisher rooms. With 3 simultaneous
-                // 1920x1080 H264 publishers, the cumulative NVDEC decode load
-                // and SFU forwarding pressure makes 60fps unsustainable —
-                // receivers see 10fps after pacing kicks in. 30fps gives
-                // headroom for all parties and is plenty for screen content.
-                // Spencer's recommendation, validated 2026-04-07 with 3 sharers.
-                max_framerate: PUBLISH_TARGET_FPS as f64,
+                min_bitrate: publish_profile.min_bitrate(),
+                // Profile-selected wire target: desktop stays conservative;
+                // game/window capture gets the high-motion 60fps path.
+                max_framerate: publish_profile.target_fps() as f64,
             }),
             ..Default::default()
         };
@@ -210,7 +294,8 @@ impl CapturePublisher {
             track,
             start_time: Instant::now(),
             frame_count: 0,
-            last_pushed: None,
+            next_push_at: None,
+            hardware_min_frame_interval: publish_profile.hardware_min_frame_interval(),
         })
     }
 
@@ -224,14 +309,22 @@ impl CapturePublisher {
         token: &str,
         enc_w: u32,
         enc_h: u32,
+        publish_profile: PublishProfile,
         log_prefix: &str,
         track_source: TrackSource,
         is_screencast: bool,
     ) -> Result<Self, String> {
         eprintln!("[{}] connecting to SFU: {}", log_prefix, sfu_url);
         file_debug_log::append(&format!(
-            "[{}] connect_and_publish_blocking start sfu_url={} enc={}x{}",
-            log_prefix, sfu_url, enc_w, enc_h
+            "[{}] connect_and_publish_blocking start sfu_url={} enc={}x{} profile={:?} target_fps={} max_bitrate={} min_bitrate={}",
+            log_prefix,
+            sfu_url,
+            enc_w,
+            enc_h,
+            publish_profile,
+            publish_profile.target_fps(),
+            publish_profile.max_bitrate(),
+            publish_profile.min_bitrate()
         ));
 
         let (room, events) = rt
@@ -265,27 +358,16 @@ impl CapturePublisher {
             video_codec: VideoCodec::H264,
             simulcast: false,
             video_encoding: Some(VideoEncoding {
-                // Capped at 4 Mbps for multi-publisher rooms. Validated 2026-04-07
-                // with 3 simultaneous 1080p shares and a residential-WAN viewer
-                // (David) who saw 0fps at 8Mbps. 4Mbps × 3 publishers = 12Mbps
-                // aggregate, comfortably under most residential downloads. Per-stream
-                // quality at 1080p30 H264 is still excellent for screen content.
-                // Twitch source quality reference: 6 Mbps at 1080p60 gameplay.
-                max_bitrate: 4_000_000,
+                // Desktop uses the conservative multi-publisher budget validated
+                // 2026-04-07. Game shares opt into a higher-motion bitrate budget.
+                max_bitrate: publish_profile.max_bitrate(),
                 // 2.5 Mbps hard floor — prevents libwebrtc GoogCC from throttling
                 // to zero under packet loss / RTT spikes, so the stream stays
                 // visible instead of dropping to 0fps and slowly probing back up.
-                min_bitrate: 2_500_000,
-                // 60fps for safe stable testing with David (remote friend).
-                // The level=AUTOSELECT fix is still in h264_encoder_impl.cpp
-                // for later 144fps retest on SAM-PC — harmless at 60fps.
-                // Capped at 30fps for multi-publisher rooms. With 3 simultaneous
-                // 1920x1080 H264 publishers, the cumulative NVDEC decode load
-                // and SFU forwarding pressure makes 60fps unsustainable —
-                // receivers see 10fps after pacing kicks in. 30fps gives
-                // headroom for all parties and is plenty for screen content.
-                // Spencer's recommendation, validated 2026-04-07 with 3 sharers.
-                max_framerate: PUBLISH_TARGET_FPS as f64,
+                min_bitrate: publish_profile.min_bitrate(),
+                // Profile-selected wire target: desktop stays conservative;
+                // game/window capture gets the high-motion 60fps path.
+                max_framerate: publish_profile.target_fps() as f64,
             }),
             ..Default::default()
         };
@@ -317,7 +399,8 @@ impl CapturePublisher {
             track,
             start_time: Instant::now(),
             frame_count: 0,
-            last_pushed: None,
+            next_push_at: None,
+            hardware_min_frame_interval: publish_profile.hardware_min_frame_interval(),
         })
     }
 
@@ -325,12 +408,18 @@ impl CapturePublisher {
     ///
     /// `bgra` must be tightly packed (stride = width * 4). For pitched data,
     /// use `push_frame_strided`.
-    pub fn push_frame(&mut self, bgra: &[u8], width: u32, height: u32) {
-        self.push_frame_strided(bgra, width * 4, width, height);
+    pub fn push_frame(&mut self, bgra: &[u8], width: u32, height: u32) -> bool {
+        self.push_frame_strided(bgra, width * 4, width, height)
     }
 
     /// Convert a BGRA frame with explicit stride to I420 and push to the video source.
-    pub fn push_frame_strided(&mut self, bgra: &[u8], stride: u32, width: u32, height: u32) {
+    pub fn push_frame_strided(
+        &mut self,
+        bgra: &[u8],
+        stride: u32,
+        width: u32,
+        height: u32,
+    ) -> bool {
         // Frame rate limiter — choose the interval based on whether we have
         // hardware (NVENC) or software (OpenH264) encoding. NVENC can handle
         // 240fps input because it's a dedicated ASIC. OpenH264 runs on CPU
@@ -338,17 +427,13 @@ impl CapturePublisher {
         // machine after ~54 min of sustained load. Cap software encode at
         // 20fps to keep CPU at a sustainable ~30%.
         let min_interval = if HAS_NVCUDA.load(Ordering::Relaxed) {
-            MIN_FRAME_INTERVAL_HARDWARE
+            self.hardware_min_frame_interval
         } else {
             MIN_FRAME_INTERVAL_SOFTWARE
         };
-        let now = Instant::now();
-        if let Some(last) = self.last_pushed {
-            if now.duration_since(last) < min_interval {
-                return; // drop this frame
-            }
+        if !should_push_frame_at_deadline(Instant::now(), &mut self.next_push_at, min_interval) {
+            return false; // drop this frame
         }
-        self.last_pushed = Some(now);
 
         let mut i420 = I420Buffer::new(width, height);
         let (sy, su, sv) = i420.strides();
@@ -374,6 +459,7 @@ impl CapturePublisher {
         };
         self.source.capture_frame(&vf);
         self.frame_count += 1;
+        true
     }
 
     /// Emit stats via Tauri event every `every_n` frames. Returns current FPS.
@@ -633,5 +719,86 @@ impl CapturePublisher {
     /// Blocking variant of shutdown for use inside `spawn_blocking`.
     pub fn shutdown_blocking(self, rt: &tokio::runtime::Handle) {
         rt.block_on(self.room.close()).ok();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn desktop_profile_stays_conservative() {
+        assert_eq!(PublishProfile::Desktop.target_fps(), PUBLISH_TARGET_FPS);
+        assert_eq!(PublishProfile::Desktop.max_bitrate(), 4_000_000);
+        assert_eq!(PublishProfile::Desktop.min_bitrate(), 2_500_000);
+    }
+
+    #[test]
+    fn game_profile_is_high_motion() {
+        let profile: PublishProfile = serde_json::from_str("\"game\"").expect("game profile");
+
+        assert_eq!(profile, PublishProfile::Game);
+        assert_eq!(profile.target_fps(), 60);
+        assert_eq!(profile.max_bitrate(), 8_000_000);
+        assert_eq!(profile.min_bitrate(), 3_000_000);
+    }
+
+    fn pushed_frame_count(source_hz: u32, target_hz: u32, seconds: u32) -> usize {
+        let start = Instant::now();
+        let source_interval_ns = (1_000_000_000.0 / source_hz as f64) as u64;
+        let target_interval = Duration::from_nanos((1_000_000_000.0 / target_hz as f64) as u64);
+        let mut next_push_at = None;
+
+        (0..source_hz * seconds)
+            .filter(|frame| {
+                let now = start + Duration::from_nanos(source_interval_ns * *frame as u64);
+                should_push_frame_at_deadline(now, &mut next_push_at, target_interval)
+            })
+            .count()
+    }
+
+    #[test]
+    fn frame_deadline_pacer_preserves_60fps_from_144hz_capture() {
+        assert_eq!(pushed_frame_count(144, 60, 1), 60);
+    }
+
+    #[test]
+    fn frame_deadline_pacer_preserves_30fps_from_120hz_capture() {
+        assert_eq!(pushed_frame_count(120, 30, 1), 30);
+    }
+
+    #[test]
+    fn static_frame_heartbeat_waits_until_a_frame_exists() {
+        let start = Instant::now();
+        let mut heartbeat = StaticFrameHeartbeat::new(Duration::from_millis(200));
+
+        assert!(!heartbeat.should_publish(start + Duration::from_secs(1)));
+    }
+
+    #[test]
+    fn static_frame_heartbeat_republishes_after_static_interval() {
+        let start = Instant::now();
+        let mut heartbeat = StaticFrameHeartbeat::new(Duration::from_millis(200));
+
+        heartbeat.record_fresh_frame(start);
+
+        assert!(!heartbeat.should_publish(start + Duration::from_millis(199)));
+        assert!(heartbeat.should_publish(start + Duration::from_millis(200)));
+        assert!(!heartbeat.should_publish(start + Duration::from_millis(399)));
+        assert!(heartbeat.should_publish(start + Duration::from_millis(400)));
+    }
+
+    #[test]
+    fn static_frame_heartbeat_fresh_frame_resets_deadline() {
+        let start = Instant::now();
+        let mut heartbeat = StaticFrameHeartbeat::new(Duration::from_millis(200));
+
+        heartbeat.record_fresh_frame(start);
+        assert!(heartbeat.should_publish(start + Duration::from_millis(250)));
+
+        heartbeat.record_fresh_frame(start + Duration::from_millis(300));
+
+        assert!(!heartbeat.should_publish(start + Duration::from_millis(499)));
+        assert!(heartbeat.should_publish(start + Duration::from_millis(500)));
     }
 }

--- a/core/client/src/desktop_capture.rs
+++ b/core/client/src/desktop_capture.rs
@@ -52,7 +52,7 @@ use windows::Win32::UI::WindowsAndMessaging::{
 };
 
 use crate::capture_health::{CaptureHealthState, CaptureMode, EncoderType};
-use crate::capture_pipeline::CapturePublisher;
+use crate::capture_pipeline::{CapturePublisher, PublishProfile};
 use crate::file_debug_log;
 
 // ── GPU HDR→SDR Conversion Pipeline (shared module) ──
@@ -162,6 +162,7 @@ pub async fn start(
     fullscreen: bool,
     sfu_url: String,
     token: String,
+    publish_profile: PublishProfile,
     app: AppHandle,
     health: Arc<CaptureHealthState>,
 ) -> Result<(), String> {
@@ -191,7 +192,16 @@ pub async fn start(
     tokio::spawn(async move {
         // Run DXGI capture on a blocking thread — it uses COM and blocking waits
         let result = tokio::task::spawn_blocking(move || {
-            capture_loop_blocking(&sfu_url, &token, &app, &r2, hwnd, fullscreen, health_clone)
+            capture_loop_blocking(
+                &sfu_url,
+                &token,
+                publish_profile,
+                &app,
+                &r2,
+                hwnd,
+                fullscreen,
+                health_clone,
+            )
         })
         .await
         .map_err(|e| format!("spawn_blocking: {e}"))?;
@@ -624,6 +634,7 @@ fn composite_cursor(
 fn capture_loop_blocking(
     sfu_url: &str,
     token: &str,
+    publish_profile: PublishProfile,
     app: &AppHandle,
     running: &Arc<AtomicBool>,
     hwnd: u64,
@@ -805,6 +816,7 @@ fn capture_loop_blocking(
         token,
         enc_w,
         enc_h,
+        publish_profile,
         "desktop-capture",
         TrackSource::Screenshare,
         true,
@@ -814,7 +826,7 @@ fn capture_loop_blocking(
         true,
         CaptureMode::DxgiDd,
         EncoderType::Nvenc,
-        crate::capture_pipeline::PUBLISH_TARGET_FPS,
+        publish_profile.target_fps(),
     );
 
     // 6. Prepare GPU converter (shader pipeline) or CPU fallback

--- a/core/client/src/display_placement.rs
+++ b/core/client/src/display_placement.rs
@@ -1,6 +1,9 @@
 use serde::{Deserialize, Serialize};
 use tauri::{Manager, PhysicalPosition, PhysicalSize, Position, Size, WebviewWindow};
 
+const DISPLAY_SPAN_MIN_SECONDARY_EDGE_PX: u32 = 32;
+const DISPLAY_SPAN_MIN_SECONDARY_AREA_RATIO: f64 = 0.01;
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct DisplayRect {
     pub(crate) x: i32,
@@ -36,6 +39,10 @@ pub(crate) struct EchoDisplayStatus {
 }
 
 impl DisplayRect {
+    fn area(&self) -> u64 {
+        self.width as u64 * self.height as u64
+    }
+
     fn right(&self) -> i32 {
         self.x + self.width as i32
     }
@@ -44,20 +51,29 @@ impl DisplayRect {
         self.y + self.height as i32
     }
 
-    fn intersection_area(&self, other: &DisplayRect) -> u64 {
+    fn intersection_dimensions(&self, other: &DisplayRect) -> Option<(u32, u32)> {
         let left = self.x.max(other.x);
         let top = self.y.max(other.y);
         let right = self.right().min(other.right());
         let bottom = self.bottom().min(other.bottom());
         if right <= left || bottom <= top {
-            return 0;
+            return None;
         }
-        (right - left) as u64 * (bottom - top) as u64
+        Some(((right - left) as u32, (bottom - top) as u32))
+    }
+
+    fn intersection_area(&self, other: &DisplayRect) -> u64 {
+        self.intersection_dimensions(other)
+            .map(|(width, height)| width as u64 * height as u64)
+            .unwrap_or(0)
     }
 }
 
 pub(crate) fn make_display_id(name: &str, rect: &DisplayRect) -> String {
-    format!("{}:{}:{}:{}:{}", name, rect.x, rect.y, rect.width, rect.height)
+    format!(
+        "{}:{}:{}:{}:{}",
+        name, rect.x, rect.y, rect.width, rect.height
+    )
 }
 
 pub(crate) fn select_preferred_display<'a>(
@@ -84,12 +100,47 @@ pub(crate) fn display_with_largest_overlap<'a>(
         .max_by_key(|display| window_rect.intersection_area(&display.rect))
 }
 
-pub(crate) fn window_spans_displays(window_rect: &DisplayRect, displays: &[EchoDisplayInfo]) -> bool {
-    let overlap_count = displays
+pub(crate) fn window_spans_displays(
+    window_rect: &DisplayRect,
+    displays: &[EchoDisplayInfo],
+) -> bool {
+    let overlaps: Vec<_> = displays
         .iter()
-        .filter(|display| window_rect.intersection_area(&display.rect) > 0)
+        .filter_map(|display| {
+            let area = window_rect.intersection_area(&display.rect);
+            (area > 0).then_some((display, area))
+        })
+        .collect();
+    if overlaps.len() <= 1 {
+        return false;
+    }
+
+    let largest_overlap = overlaps.iter().map(|(_, area)| *area).max().unwrap_or(0);
+    let window_area = window_rect.area();
+    let overlap_count = overlaps
+        .iter()
+        .filter(|(display, area)| {
+            *area == largest_overlap
+                || is_meaningful_secondary_display_overlap(window_rect, &display.rect, window_area)
+        })
         .count();
     overlap_count > 1
+}
+
+fn is_meaningful_secondary_display_overlap(
+    window_rect: &DisplayRect,
+    display_rect: &DisplayRect,
+    window_area: u64,
+) -> bool {
+    let Some((width, height)) = window_rect.intersection_dimensions(display_rect) else {
+        return false;
+    };
+    if width < DISPLAY_SPAN_MIN_SECONDARY_EDGE_PX || height < DISPLAY_SPAN_MIN_SECONDARY_EDGE_PX {
+        return false;
+    }
+    let area = width as u64 * height as u64;
+    let min_area = (window_area as f64 * DISPLAY_SPAN_MIN_SECONDARY_AREA_RATIO).ceil() as u64;
+    area >= min_area
 }
 
 fn centered_window_rect(display: &EchoDisplayInfo, width: u32, height: u32) -> DisplayRect {
@@ -126,7 +177,10 @@ pub(crate) fn list_echo_displays(
         .primary_monitor()
         .map_err(|e| e.to_string())?
         .map(|monitor| {
-            let name = monitor.name().cloned().unwrap_or_else(|| "Display".to_string());
+            let name = monitor
+                .name()
+                .cloned()
+                .unwrap_or_else(|| "Display".to_string());
             let pos = monitor.position();
             let size = monitor.size();
             let rect = DisplayRect {
@@ -142,7 +196,10 @@ pub(crate) fn list_echo_displays(
     let displays = monitors
         .into_iter()
         .map(|monitor| {
-            let name = monitor.name().cloned().unwrap_or_else(|| "Display".to_string());
+            let name = monitor
+                .name()
+                .cloned()
+                .unwrap_or_else(|| "Display".to_string());
             let pos = monitor.position();
             let size = monitor.size();
             let rect = DisplayRect {
@@ -186,7 +243,11 @@ pub(crate) fn build_display_status(
     let spans = window_spans_displays(&window_rect, &displays);
     let on_preferred = preferred_id
         .filter(|value| !value.trim().is_empty())
-        .and_then(|id| current_display_id.as_ref().map(|current_id| current_id == id))
+        .and_then(|id| {
+            current_display_id
+                .as_ref()
+                .map(|current_id| current_id == id)
+        })
         .unwrap_or(true);
 
     Ok(EchoDisplayStatus {
@@ -216,10 +277,15 @@ pub(crate) fn move_window_to_display(
 
     let _ = window.unmaximize();
     window
-        .set_position(Position::Physical(PhysicalPosition::new(target.x, target.y)))
+        .set_position(Position::Physical(PhysicalPosition::new(
+            target.x, target.y,
+        )))
         .map_err(|e| e.to_string())?;
     window
-        .set_size(Size::Physical(PhysicalSize::new(target.width, target.height)))
+        .set_size(Size::Physical(PhysicalSize::new(
+            target.width,
+            target.height,
+        )))
         .map_err(|e| e.to_string())?;
     let _ = window.maximize();
 
@@ -240,11 +306,23 @@ pub(crate) fn move_window_to_saved_preferred_display(
 mod tests {
     use super::*;
 
-    fn display(id: &str, x: i32, y: i32, width: u32, height: u32, primary: bool) -> EchoDisplayInfo {
+    fn display(
+        id: &str,
+        x: i32,
+        y: i32,
+        width: u32,
+        height: u32,
+        primary: bool,
+    ) -> EchoDisplayInfo {
         EchoDisplayInfo {
             id: id.to_string(),
             name: id.to_string(),
-            rect: DisplayRect { x, y, width, height },
+            rect: DisplayRect {
+                x,
+                y,
+                width,
+                height,
+            },
             scale_factor: 1.0,
             primary,
             preferred: false,
@@ -259,7 +337,9 @@ mod tests {
         ];
 
         assert_eq!(
-            select_preferred_display(&displays, Some("intel")).unwrap().id,
+            select_preferred_display(&displays, Some("intel"))
+                .unwrap()
+                .id,
             "intel"
         );
     }
@@ -283,9 +363,30 @@ mod tests {
             display("left", -2560, 0, 2560, 1440, false),
             display("right", 0, 0, 2560, 1440, true),
         ];
-        let window = DisplayRect { x: -100, y: 10, width: 400, height: 400 };
+        let window = DisplayRect {
+            x: -100,
+            y: 10,
+            width: 400,
+            height: 400,
+        };
 
         assert!(window_spans_displays(&window, &displays));
+    }
+
+    #[test]
+    fn ignores_maximized_window_invisible_border_overlap() {
+        let displays = vec![
+            display("left", -2560, 0, 2560, 1440, false),
+            display("right", 0, 0, 2560, 1440, true),
+        ];
+        let window = DisplayRect {
+            x: -2568,
+            y: -8,
+            width: 2576,
+            height: 1456,
+        };
+
+        assert!(!window_spans_displays(&window, &displays));
     }
 
     #[test]
@@ -294,7 +395,12 @@ mod tests {
             display("left", -2560, 0, 2560, 1440, false),
             display("right", 0, 0, 2560, 1440, true),
         ];
-        let window = DisplayRect { x: 100, y: 10, width: 400, height: 400 };
+        let window = DisplayRect {
+            x: 100,
+            y: 10,
+            width: 400,
+            height: 400,
+        };
 
         assert!(!window_spans_displays(&window, &displays));
     }

--- a/core/client/src/display_placement.rs
+++ b/core/client/src/display_placement.rs
@@ -1,0 +1,301 @@
+use serde::{Deserialize, Serialize};
+use tauri::{Manager, PhysicalPosition, PhysicalSize, Position, Size, WebviewWindow};
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct DisplayRect {
+    pub(crate) x: i32,
+    pub(crate) y: i32,
+    pub(crate) width: u32,
+    pub(crate) height: u32,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub(crate) struct EchoDisplayInfo {
+    pub(crate) id: String,
+    pub(crate) name: String,
+    pub(crate) rect: DisplayRect,
+    pub(crate) scale_factor: f64,
+    pub(crate) primary: bool,
+    pub(crate) preferred: bool,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub(crate) struct EchoDisplayStatus {
+    pub(crate) available: bool,
+    pub(crate) displays: Vec<EchoDisplayInfo>,
+    pub(crate) current_display_id: Option<String>,
+    pub(crate) current_display_name: Option<String>,
+    pub(crate) preferred_display_id: Option<String>,
+    pub(crate) on_preferred_display: bool,
+    pub(crate) window_spans_displays: bool,
+    pub(crate) window_x: i32,
+    pub(crate) window_y: i32,
+    pub(crate) window_width: u32,
+    pub(crate) window_height: u32,
+    pub(crate) scale_factor: Option<f64>,
+}
+
+impl DisplayRect {
+    fn right(&self) -> i32 {
+        self.x + self.width as i32
+    }
+
+    fn bottom(&self) -> i32 {
+        self.y + self.height as i32
+    }
+
+    fn intersection_area(&self, other: &DisplayRect) -> u64 {
+        let left = self.x.max(other.x);
+        let top = self.y.max(other.y);
+        let right = self.right().min(other.right());
+        let bottom = self.bottom().min(other.bottom());
+        if right <= left || bottom <= top {
+            return 0;
+        }
+        (right - left) as u64 * (bottom - top) as u64
+    }
+}
+
+pub(crate) fn make_display_id(name: &str, rect: &DisplayRect) -> String {
+    format!("{}:{}:{}:{}:{}", name, rect.x, rect.y, rect.width, rect.height)
+}
+
+pub(crate) fn select_preferred_display<'a>(
+    displays: &'a [EchoDisplayInfo],
+    preferred_id: Option<&str>,
+) -> Option<&'a EchoDisplayInfo> {
+    if let Some(id) = preferred_id.filter(|s| !s.trim().is_empty()) {
+        if let Some(display) = displays.iter().find(|display| display.id == id) {
+            return Some(display);
+        }
+    }
+    displays
+        .iter()
+        .find(|display| display.primary)
+        .or_else(|| displays.first())
+}
+
+pub(crate) fn display_with_largest_overlap<'a>(
+    window_rect: &DisplayRect,
+    displays: &'a [EchoDisplayInfo],
+) -> Option<&'a EchoDisplayInfo> {
+    displays
+        .iter()
+        .max_by_key(|display| window_rect.intersection_area(&display.rect))
+}
+
+pub(crate) fn window_spans_displays(window_rect: &DisplayRect, displays: &[EchoDisplayInfo]) -> bool {
+    let overlap_count = displays
+        .iter()
+        .filter(|display| window_rect.intersection_area(&display.rect) > 0)
+        .count();
+    overlap_count > 1
+}
+
+fn centered_window_rect(display: &EchoDisplayInfo, width: u32, height: u32) -> DisplayRect {
+    let clamped_width = width.min(display.rect.width);
+    let clamped_height = height.min(display.rect.height);
+    DisplayRect {
+        x: display.rect.x + ((display.rect.width - clamped_width) / 2) as i32,
+        y: display.rect.y + ((display.rect.height - clamped_height) / 2) as i32,
+        width: clamped_width,
+        height: clamped_height,
+    }
+}
+
+fn preferred_display_from_settings(app: &tauri::AppHandle) -> Option<String> {
+    let settings_path = app.path().app_data_dir().ok()?.join("settings.json");
+    let settings = std::fs::read_to_string(settings_path).ok()?;
+    let json: serde_json::Value = serde_json::from_str(&settings).ok()?;
+    json.get("echo-preferred-display-id")
+        .and_then(|value| value.as_str())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+pub(crate) fn load_preferred_display_id(app: &tauri::AppHandle) -> Option<String> {
+    preferred_display_from_settings(app)
+}
+
+pub(crate) fn list_echo_displays(
+    window: &WebviewWindow,
+    preferred_id: Option<&str>,
+) -> Result<Vec<EchoDisplayInfo>, String> {
+    let primary_id = window
+        .primary_monitor()
+        .map_err(|e| e.to_string())?
+        .map(|monitor| {
+            let name = monitor.name().cloned().unwrap_or_else(|| "Display".to_string());
+            let pos = monitor.position();
+            let size = monitor.size();
+            let rect = DisplayRect {
+                x: pos.x,
+                y: pos.y,
+                width: size.width,
+                height: size.height,
+            };
+            make_display_id(&name, &rect)
+        });
+
+    let monitors = window.available_monitors().map_err(|e| e.to_string())?;
+    let displays = monitors
+        .into_iter()
+        .map(|monitor| {
+            let name = monitor.name().cloned().unwrap_or_else(|| "Display".to_string());
+            let pos = monitor.position();
+            let size = monitor.size();
+            let rect = DisplayRect {
+                x: pos.x,
+                y: pos.y,
+                width: size.width,
+                height: size.height,
+            };
+            let id = make_display_id(&name, &rect);
+            EchoDisplayInfo {
+                primary: primary_id.as_deref() == Some(id.as_str()),
+                preferred: preferred_id == Some(id.as_str()),
+                id,
+                name,
+                rect,
+                scale_factor: monitor.scale_factor(),
+            }
+        })
+        .collect();
+
+    Ok(displays)
+}
+
+pub(crate) fn build_display_status(
+    window: &WebviewWindow,
+    preferred_id: Option<&str>,
+) -> Result<EchoDisplayStatus, String> {
+    let displays = list_echo_displays(window, preferred_id)?;
+    let pos = window.outer_position().map_err(|e| e.to_string())?;
+    let size = window.outer_size().map_err(|e| e.to_string())?;
+    let window_rect = DisplayRect {
+        x: pos.x,
+        y: pos.y,
+        width: size.width,
+        height: size.height,
+    };
+    let current = display_with_largest_overlap(&window_rect, &displays);
+    let current_display_id = current.map(|display| display.id.clone());
+    let current_display_name = current.map(|display| display.name.clone());
+    let scale_factor = current.map(|display| display.scale_factor);
+    let spans = window_spans_displays(&window_rect, &displays);
+    let on_preferred = preferred_id
+        .filter(|value| !value.trim().is_empty())
+        .and_then(|id| current_display_id.as_ref().map(|current_id| current_id == id))
+        .unwrap_or(true);
+
+    Ok(EchoDisplayStatus {
+        available: !displays.is_empty(),
+        displays,
+        current_display_id,
+        current_display_name,
+        preferred_display_id: preferred_id.map(ToOwned::to_owned),
+        on_preferred_display: on_preferred,
+        window_spans_displays: spans,
+        window_x: window_rect.x,
+        window_y: window_rect.y,
+        window_width: window_rect.width,
+        window_height: window_rect.height,
+        scale_factor,
+    })
+}
+
+pub(crate) fn move_window_to_display(
+    window: &WebviewWindow,
+    display_id: &str,
+) -> Result<EchoDisplayStatus, String> {
+    let displays = list_echo_displays(window, Some(display_id))?;
+    let display = select_preferred_display(&displays, Some(display_id))
+        .ok_or_else(|| "No displays available".to_string())?;
+    let target = centered_window_rect(display, 1280, 800);
+
+    let _ = window.unmaximize();
+    window
+        .set_position(Position::Physical(PhysicalPosition::new(target.x, target.y)))
+        .map_err(|e| e.to_string())?;
+    window
+        .set_size(Size::Physical(PhysicalSize::new(target.width, target.height)))
+        .map_err(|e| e.to_string())?;
+    let _ = window.maximize();
+
+    build_display_status(window, Some(display_id))
+}
+
+pub(crate) fn move_window_to_saved_preferred_display(
+    app: &tauri::AppHandle,
+    window: &WebviewWindow,
+) -> Result<Option<EchoDisplayStatus>, String> {
+    let Some(display_id) = load_preferred_display_id(app) else {
+        return Ok(None);
+    };
+    move_window_to_display(window, &display_id).map(Some)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn display(id: &str, x: i32, y: i32, width: u32, height: u32, primary: bool) -> EchoDisplayInfo {
+        EchoDisplayInfo {
+            id: id.to_string(),
+            name: id.to_string(),
+            rect: DisplayRect { x, y, width, height },
+            scale_factor: 1.0,
+            primary,
+            preferred: false,
+        }
+    }
+
+    #[test]
+    fn selects_saved_preferred_display_first() {
+        let displays = vec![
+            display("intel", -2560, 0, 2560, 1440, false),
+            display("rtx", 0, 0, 2560, 1440, true),
+        ];
+
+        assert_eq!(
+            select_preferred_display(&displays, Some("intel")).unwrap().id,
+            "intel"
+        );
+    }
+
+    #[test]
+    fn falls_back_to_primary_without_saved_preference() {
+        let displays = vec![
+            display("left", -2560, 0, 2560, 1440, false),
+            display("primary", 0, 0, 2560, 1440, true),
+        ];
+
+        assert_eq!(
+            select_preferred_display(&displays, None).unwrap().id,
+            "primary"
+        );
+    }
+
+    #[test]
+    fn detects_window_spanning_two_displays() {
+        let displays = vec![
+            display("left", -2560, 0, 2560, 1440, false),
+            display("right", 0, 0, 2560, 1440, true),
+        ];
+        let window = DisplayRect { x: -100, y: 10, width: 400, height: 400 };
+
+        assert!(window_spans_displays(&window, &displays));
+    }
+
+    #[test]
+    fn does_not_flag_window_inside_one_display_as_spanning() {
+        let displays = vec![
+            display("left", -2560, 0, 2560, 1440, false),
+            display("right", 0, 0, 2560, 1440, true),
+        ];
+        let window = DisplayRect { x: 100, y: 10, width: 400, height: 400 };
+
+        assert!(!window_spans_displays(&window, &displays));
+    }
+}

--- a/core/client/src/gpu_preference.rs
+++ b/core/client/src/gpu_preference.rs
@@ -1,0 +1,239 @@
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+use windows::core::PCWSTR;
+use windows::Win32::System::Registry::{
+    RegCloseKey, RegCreateKeyExW, RegSetValueExW, HKEY, HKEY_CURRENT_USER, KEY_SET_VALUE,
+    REG_OPTION_NON_VOLATILE, REG_SZ,
+};
+
+pub(crate) const HIGH_PERFORMANCE_GPU_PREFERENCE: &str = "GpuPreference=2;";
+
+const GPU_PREFERENCE_REGISTRY_KEY: &str = r"Software\Microsoft\DirectX\UserGpuPreferences";
+const WEBVIEW2_EXE_NAME: &str = "msedgewebview2.exe";
+
+const WEBVIEW2_BROWSER_ARGUMENTS: &str = "--ignore-certificate-errors --enable-features=AcceleratedVideoEncoder,MediaFoundationVideoEncoding --ignore-gpu-blocklist --force_high_performance_gpu --webrtc-max-cpu-consumption-percentage=100 --force-fieldtrials=WebRTC-Bwe-AllocationProbing/Enabled/";
+
+#[derive(Debug, Default)]
+pub(crate) struct GpuPreferenceStartupReport {
+    pub(crate) applied: Vec<PathBuf>,
+    pub(crate) failed: Vec<(PathBuf, String)>,
+}
+
+impl GpuPreferenceStartupReport {
+    pub(crate) fn summary(&self) -> String {
+        format!(
+            "applied={} failed={}",
+            self.applied.len(),
+            self.failed.len()
+        )
+    }
+}
+
+pub(crate) fn webview2_additional_browser_arguments() -> &'static str {
+    WEBVIEW2_BROWSER_ARGUMENTS
+}
+
+pub(crate) fn ensure_startup_gpu_preferences() -> GpuPreferenceStartupReport {
+    let mut report = GpuPreferenceStartupReport::default();
+    let current_exe = match std::env::current_exe() {
+        Ok(path) => path,
+        Err(e) => {
+            report
+                .failed
+                .push((PathBuf::from("<current_exe>"), e.to_string()));
+            return report;
+        }
+    };
+
+    let targets = collect_gpu_preference_targets(&current_exe, discover_webview2_runtime_dirs());
+    for target in targets {
+        match set_high_performance_gpu_preference(&target) {
+            Ok(()) => report.applied.push(target),
+            Err(e) => report.failed.push((target, e)),
+        }
+    }
+
+    report
+}
+
+fn collect_gpu_preference_targets<I, P>(current_exe: &Path, webview2_roots: I) -> Vec<PathBuf>
+where
+    I: IntoIterator<Item = P>,
+    P: AsRef<Path>,
+{
+    let mut seen = HashSet::new();
+    let mut targets = Vec::new();
+
+    push_unique_target(&mut targets, &mut seen, current_exe.to_path_buf());
+    for root in webview2_roots {
+        let candidate = root.as_ref().join(WEBVIEW2_EXE_NAME);
+        push_unique_target(&mut targets, &mut seen, candidate);
+    }
+
+    targets
+}
+
+fn push_unique_target(targets: &mut Vec<PathBuf>, seen: &mut HashSet<String>, path: PathBuf) {
+    let key = path.to_string_lossy().to_ascii_lowercase();
+    if seen.insert(key) {
+        targets.push(path);
+    }
+}
+
+fn discover_webview2_runtime_dirs() -> Vec<PathBuf> {
+    let mut dirs = Vec::new();
+    let mut roots = Vec::new();
+
+    for var in ["ProgramFiles(x86)", "ProgramFiles"] {
+        if let Some(base) = std::env::var_os(var) {
+            roots.push(PathBuf::from(base).join(r"Microsoft\EdgeWebView\Application"));
+        }
+    }
+    roots.push(PathBuf::from(
+        r"C:\Program Files (x86)\Microsoft\EdgeWebView\Application",
+    ));
+    roots.push(PathBuf::from(
+        r"C:\Program Files\Microsoft\EdgeWebView\Application",
+    ));
+
+    let mut seen = HashSet::new();
+    for root in roots {
+        let Ok(entries) = std::fs::read_dir(root) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.join(WEBVIEW2_EXE_NAME).is_file() {
+                let key = path.to_string_lossy().to_ascii_lowercase();
+                if seen.insert(key) {
+                    dirs.push(path);
+                }
+            }
+        }
+    }
+
+    dirs.sort();
+    dirs
+}
+
+fn set_high_performance_gpu_preference(path: &Path) -> Result<(), String> {
+    let subkey = wide_null(GPU_PREFERENCE_REGISTRY_KEY);
+    let value_name = wide_null_os(path.as_os_str());
+    let data = wide_null(HIGH_PERFORMANCE_GPU_PREFERENCE);
+    let data_bytes =
+        unsafe { std::slice::from_raw_parts(data.as_ptr() as *const u8, data.len() * 2) };
+
+    let mut hkey = HKEY::default();
+    let status = unsafe {
+        RegCreateKeyExW(
+            HKEY_CURRENT_USER,
+            PCWSTR(subkey.as_ptr()),
+            0,
+            PCWSTR::null(),
+            REG_OPTION_NON_VOLATILE,
+            KEY_SET_VALUE,
+            None,
+            &mut hkey,
+            None,
+        )
+    };
+    if status.is_err() {
+        return Err(format!("RegCreateKeyExW failed: {:?}", status));
+    }
+
+    let status = unsafe {
+        RegSetValueExW(
+            hkey,
+            PCWSTR(value_name.as_ptr()),
+            0,
+            REG_SZ,
+            Some(data_bytes),
+        )
+    };
+    let _ = unsafe { RegCloseKey(hkey) };
+
+    if status.is_err() {
+        return Err(format!("RegSetValueExW failed: {:?}", status));
+    }
+
+    Ok(())
+}
+
+fn wide_null(value: &str) -> Vec<u16> {
+    value.encode_utf16().chain(std::iter::once(0)).collect()
+}
+
+fn wide_null_os(value: &std::ffi::OsStr) -> Vec<u16> {
+    use std::os::windows::ffi::OsStrExt;
+    value.encode_wide().chain(std::iter::once(0)).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn high_performance_value_matches_windows_gpu_preference_format() {
+        assert_eq!(HIGH_PERFORMANCE_GPU_PREFERENCE, "GpuPreference=2;");
+    }
+
+    #[test]
+    fn startup_targets_include_current_exe_and_all_webview2_runtimes() {
+        let current_exe = Path::new(r"F:\Echo\echo-core-client.exe");
+        let roots = vec![
+            PathBuf::from(
+                r"C:\Program Files (x86)\Microsoft\EdgeWebView\Application\147.0.3912.72",
+            ),
+            PathBuf::from(
+                r"C:\Program Files (x86)\Microsoft\EdgeWebView\Application\147.0.3912.98",
+            ),
+        ];
+
+        let targets = collect_gpu_preference_targets(current_exe, roots.iter());
+
+        assert_eq!(
+            targets,
+            vec![
+                PathBuf::from(r"F:\Echo\echo-core-client.exe"),
+                PathBuf::from(
+                    r"C:\Program Files (x86)\Microsoft\EdgeWebView\Application\147.0.3912.72\msedgewebview2.exe"
+                ),
+                PathBuf::from(
+                    r"C:\Program Files (x86)\Microsoft\EdgeWebView\Application\147.0.3912.98\msedgewebview2.exe"
+                ),
+            ]
+        );
+    }
+
+    #[test]
+    fn startup_targets_are_deduplicated_without_losing_order() {
+        let current_exe = Path::new(r"F:\Echo\echo-core-client.exe");
+        let roots = vec![
+            PathBuf::from(r"C:\Runtime"),
+            PathBuf::from(r"C:\Runtime"),
+            PathBuf::from(r"C:\Runtime"),
+        ];
+
+        let targets = collect_gpu_preference_targets(current_exe, roots.iter());
+
+        assert_eq!(
+            targets,
+            vec![
+                PathBuf::from(r"F:\Echo\echo-core-client.exe"),
+                PathBuf::from(r"C:\Runtime\msedgewebview2.exe"),
+            ]
+        );
+    }
+
+    #[test]
+    fn webview2_arguments_request_high_performance_gpu_once() {
+        let args = webview2_additional_browser_arguments();
+
+        assert!(args.contains("--force_high_performance_gpu"));
+        assert_eq!(args.matches("--force_high_performance_gpu").count(), 1);
+        assert!(args.contains("--ignore-gpu-blocklist"));
+        assert!(args.contains("AcceleratedVideoEncoder"));
+    }
+}

--- a/core/client/src/main.rs
+++ b/core/client/src/main.rs
@@ -22,6 +22,8 @@ mod capture_pipeline;
 #[cfg(target_os = "windows")]
 mod desktop_capture;
 #[cfg(target_os = "windows")]
+mod display_placement;
+#[cfg(target_os = "windows")]
 mod file_debug_log;
 #[cfg(target_os = "windows")]
 mod gpu_converter;

--- a/core/client/src/main.rs
+++ b/core/client/src/main.rs
@@ -263,6 +263,36 @@ fn set_always_on_top(app: tauri::AppHandle, on_top: bool) -> Result<(), String> 
     window.set_always_on_top(on_top).map_err(|e| e.to_string())
 }
 
+#[cfg(target_os = "windows")]
+#[tauri::command]
+fn list_echo_displays(
+    app: tauri::AppHandle,
+    preferred_display_id: Option<String>,
+) -> Result<Vec<display_placement::EchoDisplayInfo>, String> {
+    let window = app.get_webview_window("main").ok_or("window not found")?;
+    display_placement::list_echo_displays(&window, preferred_display_id.as_deref())
+}
+
+#[cfg(target_os = "windows")]
+#[tauri::command]
+fn get_echo_display_status(
+    app: tauri::AppHandle,
+    preferred_display_id: Option<String>,
+) -> Result<display_placement::EchoDisplayStatus, String> {
+    let window = app.get_webview_window("main").ok_or("window not found")?;
+    display_placement::build_display_status(&window, preferred_display_id.as_deref())
+}
+
+#[cfg(target_os = "windows")]
+#[tauri::command]
+fn move_echo_to_display(
+    app: tauri::AppHandle,
+    display_id: String,
+) -> Result<display_placement::EchoDisplayStatus, String> {
+    let window = app.get_webview_window("main").ok_or("window not found")?;
+    display_placement::move_window_to_display(&window, &display_id)
+}
+
 #[tauri::command]
 fn list_capturable_windows() -> Vec<audio_capture::WindowInfo> {
     audio_capture::list_capturable_windows()
@@ -550,6 +580,12 @@ fn main() {
             get_capture_health,
             #[cfg(target_os = "windows")]
             report_encoder_implementation,
+            #[cfg(target_os = "windows")]
+            list_echo_displays,
+            #[cfg(target_os = "windows")]
+            get_echo_display_status,
+            #[cfg(target_os = "windows")]
+            move_echo_to_display,
         ])
         .setup(move |app| {
             // Pre-initialize LiveKit runtime so NVENC hardware encoder is detected
@@ -607,7 +643,7 @@ fn main() {
 
             // Load viewer from the server so JS/CSS updates are live without reinstalling
             let viewer_url = format!("{}/viewer/", app.state::<String>().inner());
-            WebviewWindowBuilder::new(
+            let main_window = WebviewWindowBuilder::new(
                 app,
                 "main",
                 WebviewUrl::External(viewer_url.parse().unwrap()),
@@ -617,6 +653,30 @@ fn main() {
             .min_inner_size(800.0, 600.0)
             .initialization_script("window.__ECHO_NATIVE__ = true;")
             .build()?;
+
+            #[cfg(target_os = "windows")]
+            {
+                let app_handle = app.handle().clone();
+                match display_placement::move_window_to_saved_preferred_display(
+                    &app_handle,
+                    &main_window,
+                ) {
+                    Ok(Some(status)) => {
+                        eprintln!(
+                            "[display] moved Echo to preferred display {:?} current={:?} spans={}",
+                            status.preferred_display_id,
+                            status.current_display_name,
+                            status.window_spans_displays
+                        );
+                    }
+                    Ok(None) => {
+                        eprintln!("[display] no preferred Echo display saved");
+                    }
+                    Err(e) => {
+                        eprintln!("[display] preferred display move failed: {}", e);
+                    }
+                }
+            }
 
             // Check for updates in the background
             let handle = app.handle().clone();

--- a/core/client/src/main.rs
+++ b/core/client/src/main.rs
@@ -40,6 +40,10 @@ use tauri_plugin_updater::UpdaterExt;
 
 #[cfg(target_os = "windows")]
 use crate::capture_health::{CaptureHealthSnapshot, CaptureHealthState};
+#[cfg(target_os = "windows")]
+use crate::native_presenter::{
+    NativePresenterManager, NativePresenterStartRequest, NativePresenterStatus,
+};
 
 const DEFAULT_SERVER: &str = "https://echo.fellowshipoftheboatrace.party:9443";
 
@@ -295,6 +299,32 @@ fn move_echo_to_display(
     display_placement::move_window_to_display(&window, &display_id)
 }
 
+#[cfg(target_os = "windows")]
+#[tauri::command]
+async fn start_native_presenter(
+    presenter: tauri::State<'_, Arc<NativePresenterManager>>,
+    request: NativePresenterStartRequest,
+) -> Result<NativePresenterStatus, String> {
+    presenter.start_receive_probe(request).await
+}
+
+#[cfg(target_os = "windows")]
+#[tauri::command]
+fn stop_native_presenter(
+    presenter: tauri::State<'_, Arc<NativePresenterManager>>,
+    reason: Option<String>,
+) -> Result<NativePresenterStatus, String> {
+    Ok(presenter.stop(reason.as_deref().unwrap_or("stopped by viewer")))
+}
+
+#[cfg(target_os = "windows")]
+#[tauri::command]
+fn get_native_presenter_status(
+    presenter: tauri::State<'_, Arc<NativePresenterManager>>,
+) -> Result<NativePresenterStatus, String> {
+    Ok(presenter.status())
+}
+
 #[tauri::command]
 fn list_capturable_windows() -> Vec<audio_capture::WindowInfo> {
     audio_capture::list_capturable_windows()
@@ -546,6 +576,8 @@ fn main() {
     // Gate the state management so macOS builds compile.
     #[cfg(target_os = "windows")]
     let builder = builder.manage(Arc::new(CaptureHealthState::new()));
+    #[cfg(target_os = "windows")]
+    let builder = builder.manage(NativePresenterManager::new());
 
     builder
         .invoke_handler(tauri::generate_handler![
@@ -588,6 +620,12 @@ fn main() {
             get_echo_display_status,
             #[cfg(target_os = "windows")]
             move_echo_to_display,
+            #[cfg(target_os = "windows")]
+            start_native_presenter,
+            #[cfg(target_os = "windows")]
+            stop_native_presenter,
+            #[cfg(target_os = "windows")]
+            get_native_presenter_status,
         ])
         .setup(move |app| {
             // Pre-initialize LiveKit runtime so NVENC hardware encoder is detected

--- a/core/client/src/main.rs
+++ b/core/client/src/main.rs
@@ -27,6 +27,8 @@ mod display_placement;
 mod file_debug_log;
 #[cfg(target_os = "windows")]
 mod gpu_converter;
+#[cfg(target_os = "windows")]
+mod native_presenter;
 #[cfg(not(target_os = "windows"))]
 use audio_output_stub as audio_output;
 

--- a/core/client/src/main.rs
+++ b/core/client/src/main.rs
@@ -28,6 +28,8 @@ mod file_debug_log;
 #[cfg(target_os = "windows")]
 mod gpu_converter;
 #[cfg(target_os = "windows")]
+mod gpu_preference;
+#[cfg(target_os = "windows")]
 mod native_presenter;
 #[cfg(not(target_os = "windows"))]
 use audio_output_stub as audio_output;
@@ -436,11 +438,20 @@ async fn start_screen_share(
     source_id: u64,
     sfu_url: String,
     token: String,
+    publish_profile: Option<capture_pipeline::PublishProfile>,
     app: tauri::AppHandle,
     health: tauri::State<'_, std::sync::Arc<CaptureHealthState>>,
 ) -> Result<(), String> {
     let health_arc = std::sync::Arc::clone(&*health);
-    screen_capture::start_share(source_id, sfu_url, token, app, health_arc).await
+    screen_capture::start_share(
+        source_id,
+        sfu_url,
+        token,
+        publish_profile.unwrap_or_default(),
+        app,
+        health_arc,
+    )
+    .await
 }
 
 #[cfg(target_os = "windows")]
@@ -453,6 +464,12 @@ fn stop_screen_share() {
 #[tauri::command]
 fn get_source_thumbnail(source_id: u64, is_monitor: bool) -> Option<String> {
     screen_capture::get_thumbnail(source_id, is_monitor)
+}
+
+#[cfg(target_os = "windows")]
+#[tauri::command]
+fn get_capture_window_status(source_id: u64) -> screen_capture::CaptureWindowStatus {
+    screen_capture::get_capture_window_status(source_id)
 }
 
 // ── Desktop Capture (DXGI Desktop Duplication) IPC Commands ──
@@ -470,11 +487,21 @@ async fn start_desktop_capture(
     fullscreen: bool,
     sfu_url: String,
     token: String,
+    publish_profile: Option<capture_pipeline::PublishProfile>,
     app: tauri::AppHandle,
     health: tauri::State<'_, std::sync::Arc<CaptureHealthState>>,
 ) -> Result<(), String> {
     let health_arc = std::sync::Arc::clone(&*health);
-    desktop_capture::start(hwnd, fullscreen, sfu_url, token, app, health_arc).await
+    desktop_capture::start(
+        hwnd,
+        fullscreen,
+        sfu_url,
+        token,
+        publish_profile.unwrap_or_default(),
+        app,
+        health_arc,
+    )
+    .await
 }
 
 /// Start WGC monitor capture (entire screen). Includes the cursor automatically
@@ -519,12 +546,43 @@ fn report_encoder_implementation(state: tauri::State<Arc<CaptureHealthState>>, e
 }
 
 fn main() {
+    #[cfg(target_os = "windows")]
+    {
+        file_debug_log::reset();
+        let report = gpu_preference::ensure_startup_gpu_preferences();
+        let summary = report.summary();
+        eprintln!("[gpu-preference] startup {}", summary);
+        file_debug_log::append(&format!("[gpu-preference] startup {}", summary));
+        for path in &report.applied {
+            eprintln!(
+                "[gpu-preference] high-performance GPU preference set for {}",
+                path.display()
+            );
+            file_debug_log::append(&format!(
+                "[gpu-preference] high-performance GPU preference set for {}",
+                path.display()
+            ));
+        }
+        for (path, error) in &report.failed {
+            eprintln!(
+                "[gpu-preference] failed to set high-performance GPU preference for {}: {}",
+                path.display(),
+                error
+            );
+            file_debug_log::append(&format!(
+                "[gpu-preference] failed to set high-performance GPU preference for {}: {}",
+                path.display(),
+                error
+            ));
+        }
+    }
+
     // Windows: WebView2 browser arguments for GPU encoding + self-signed TLS
     #[cfg(target_os = "windows")]
     unsafe {
         std::env::set_var(
             "WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS",
-            "--ignore-certificate-errors --enable-features=AcceleratedVideoEncoder,MediaFoundationVideoEncoding --ignore-gpu-blocklist --webrtc-max-cpu-consumption-percentage=100 --force-fieldtrials=WebRTC-Bwe-AllocationProbing/Enabled/",
+            gpu_preference::webview2_additional_browser_arguments(),
         );
     }
 
@@ -553,7 +611,6 @@ fn main() {
 
     #[cfg(target_os = "windows")]
     {
-        file_debug_log::reset();
         file_debug_log::append(&format!(
             "[startup] echo-core-client boot server={} force_software_encoder={} auto_force_software_encoder={} windows_build={}",
             server, force_software_encoder, auto_force_software_encoder, windows_build
@@ -602,6 +659,8 @@ fn main() {
             stop_screen_share,
             #[cfg(target_os = "windows")]
             get_source_thumbnail,
+            #[cfg(target_os = "windows")]
+            get_capture_window_status,
             #[cfg(target_os = "windows")]
             check_desktop_capture_available,
             #[cfg(target_os = "windows")]

--- a/core/client/src/native_presenter.rs
+++ b/core/client/src/native_presenter.rs
@@ -1,0 +1,282 @@
+use parking_lot::Mutex;
+use serde::{Deserialize, Serialize};
+use std::sync::{
+    atomic::{AtomicU64, Ordering},
+    Arc,
+};
+use std::time::Instant;
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum NativePresenterMode {
+    Off,
+    On,
+    Auto,
+}
+
+impl NativePresenterMode {
+    pub(crate) fn from_setting(value: &str) -> Self {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "on" => Self::On,
+            "auto" => Self::Auto,
+            _ => Self::Off,
+        }
+    }
+}
+
+impl Default for NativePresenterMode {
+    fn default() -> Self {
+        Self::Off
+    }
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
+pub(crate) struct NativePresenterTileRect {
+    pub(crate) x: i32,
+    pub(crate) y: i32,
+    pub(crate) width: u32,
+    pub(crate) height: u32,
+    pub(crate) scale_factor: f64,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub(crate) struct NativePresenterStartRequest {
+    pub(crate) mode: NativePresenterMode,
+    pub(crate) room: String,
+    pub(crate) sfu_url: String,
+    pub(crate) token: String,
+    pub(crate) viewer_identity: String,
+    pub(crate) participant_identity: String,
+    pub(crate) track_sid: String,
+    pub(crate) tile: NativePresenterTileRect,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum NativePresenterState {
+    Disabled,
+    Starting,
+    Receiving,
+    Fallback,
+    Stopped,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub(crate) struct NativePresenterStatus {
+    pub(crate) state: NativePresenterState,
+    pub(crate) render_path: String,
+    pub(crate) target_identity: Option<String>,
+    pub(crate) target_track_sid: Option<String>,
+    pub(crate) native_receive_fps: Option<f64>,
+    pub(crate) native_presented_fps: Option<f64>,
+    pub(crate) native_frames_received: u64,
+    pub(crate) native_frames_dropped: u64,
+    pub(crate) queue_depth: u32,
+    pub(crate) tile_width: Option<u32>,
+    pub(crate) tile_height: Option<u32>,
+    pub(crate) fallback_reason: Option<String>,
+    pub(crate) updated_at_ms: u64,
+}
+
+impl Default for NativePresenterStatus {
+    fn default() -> Self {
+        Self {
+            state: NativePresenterState::Disabled,
+            render_path: "webview2".to_string(),
+            target_identity: None,
+            target_track_sid: None,
+            native_receive_fps: None,
+            native_presented_fps: None,
+            native_frames_received: 0,
+            native_frames_dropped: 0,
+            queue_depth: 0,
+            tile_width: None,
+            tile_height: None,
+            fallback_reason: None,
+            updated_at_ms: 0,
+        }
+    }
+}
+
+pub(crate) fn native_presenter_identity(viewer_identity: &str) -> String {
+    let trimmed = viewer_identity.trim();
+    if trimmed.ends_with("$native-presenter") {
+        trimmed.to_string()
+    } else {
+        format!("{trimmed}$native-presenter")
+    }
+}
+
+pub(crate) struct NativePresenterManager {
+    generation: AtomicU64,
+    status: Mutex<NativePresenterStatus>,
+    started_at: Instant,
+}
+
+impl NativePresenterManager {
+    pub(crate) fn new() -> Arc<Self> {
+        Arc::new(Self {
+            generation: AtomicU64::new(0),
+            status: Mutex::new(NativePresenterStatus::default()),
+            started_at: Instant::now(),
+        })
+    }
+
+    pub(crate) fn status(&self) -> NativePresenterStatus {
+        self.status.lock().clone()
+    }
+
+    pub(crate) fn validate_start_request(
+        &self,
+        request: &NativePresenterStartRequest,
+    ) -> Result<(), String> {
+        if request.mode == NativePresenterMode::Off {
+            self.set_fallback("native presenter mode is off");
+            return Err("native presenter mode is off".to_string());
+        }
+        if request.room.trim().is_empty() {
+            self.set_fallback("room is empty");
+            return Err("room is empty".to_string());
+        }
+        if request.sfu_url.trim().is_empty() {
+            self.set_fallback("sfu_url is empty");
+            return Err("sfu_url is empty".to_string());
+        }
+        if request.token.trim().is_empty() {
+            self.set_fallback("token is empty");
+            return Err("token is empty".to_string());
+        }
+        if request.viewer_identity.trim().is_empty() {
+            self.set_fallback("viewer_identity is empty");
+            return Err("viewer_identity is empty".to_string());
+        }
+        if request.participant_identity.trim().is_empty() {
+            self.set_fallback("participant_identity is empty");
+            return Err("participant_identity is empty".to_string());
+        }
+        if request.track_sid.trim().is_empty() {
+            self.set_fallback("track_sid is empty");
+            return Err("track_sid is empty".to_string());
+        }
+        if request.tile.width == 0 || request.tile.height == 0 {
+            self.set_fallback("tile has zero size");
+            return Err("tile has zero size".to_string());
+        }
+        Ok(())
+    }
+
+    pub(crate) fn mark_starting(&self, request: &NativePresenterStartRequest) -> u64 {
+        let generation = self.generation.fetch_add(1, Ordering::SeqCst) + 1;
+        let mut status = self.status.lock();
+        *status = NativePresenterStatus {
+            state: NativePresenterState::Starting,
+            render_path: "native_receive_probe".to_string(),
+            target_identity: Some(request.participant_identity.clone()),
+            target_track_sid: Some(request.track_sid.clone()),
+            native_receive_fps: None,
+            native_presented_fps: None,
+            native_frames_received: 0,
+            native_frames_dropped: 0,
+            queue_depth: 0,
+            tile_width: Some(request.tile.width),
+            tile_height: Some(request.tile.height),
+            fallback_reason: None,
+            updated_at_ms: self.elapsed_ms(),
+        };
+        generation
+    }
+
+    pub(crate) fn stop(&self, reason: &str) -> NativePresenterStatus {
+        self.generation.fetch_add(1, Ordering::SeqCst);
+        let mut status = self.status.lock();
+        status.state = NativePresenterState::Stopped;
+        status.render_path = "webview2".to_string();
+        status.fallback_reason = Some(reason.to_string());
+        status.updated_at_ms = self.elapsed_ms();
+        status.clone()
+    }
+
+    pub(crate) fn generation(&self) -> u64 {
+        self.generation.load(Ordering::SeqCst)
+    }
+
+    fn set_fallback(&self, reason: &str) {
+        let mut status = self.status.lock();
+        status.state = NativePresenterState::Fallback;
+        status.render_path = "webview2".to_string();
+        status.fallback_reason = Some(reason.to_string());
+        status.updated_at_ms = self.elapsed_ms();
+    }
+
+    fn elapsed_ms(&self) -> u64 {
+        self.started_at
+            .elapsed()
+            .as_millis()
+            .min(u128::from(u64::MAX)) as u64
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mode_defaults_to_off_for_unknown_values() {
+        assert_eq!(NativePresenterMode::from_setting("off"), NativePresenterMode::Off);
+        assert_eq!(NativePresenterMode::from_setting("on"), NativePresenterMode::On);
+        assert_eq!(NativePresenterMode::from_setting("auto"), NativePresenterMode::Auto);
+        assert_eq!(NativePresenterMode::from_setting(""), NativePresenterMode::Off);
+        assert_eq!(NativePresenterMode::from_setting("fast"), NativePresenterMode::Off);
+    }
+
+    #[test]
+    fn native_presenter_identity_is_derived_from_viewer_identity() {
+        assert_eq!(
+            native_presenter_identity("Sam-1234"),
+            "Sam-1234$native-presenter"
+        );
+        assert_eq!(
+            native_presenter_identity("Sam-1234$native-presenter"),
+            "Sam-1234$native-presenter"
+        );
+    }
+
+    #[test]
+    fn status_starts_disabled() {
+        let manager = NativePresenterManager::new();
+        let status = manager.status();
+        assert_eq!(status.state, NativePresenterState::Disabled);
+        assert_eq!(status.render_path, "webview2");
+        assert_eq!(status.native_receive_fps, None);
+    }
+
+    #[test]
+    fn rejected_start_records_fallback_reason() {
+        let manager = NativePresenterManager::new();
+        let request = NativePresenterStartRequest {
+            mode: NativePresenterMode::Off,
+            room: "main".to_string(),
+            sfu_url: "wss://example.invalid".to_string(),
+            token: "token".to_string(),
+            viewer_identity: "Sam-1234".to_string(),
+            participant_identity: "Spencer-2222".to_string(),
+            track_sid: "TR_screen".to_string(),
+            tile: NativePresenterTileRect {
+                x: 0,
+                y: 0,
+                width: 1920,
+                height: 1080,
+                scale_factor: 1.0,
+            },
+        };
+
+        let result = manager.validate_start_request(&request);
+
+        assert!(result.is_err());
+        assert_eq!(manager.status().state, NativePresenterState::Fallback);
+        assert_eq!(
+            manager.status().fallback_reason.as_deref(),
+            Some("native presenter mode is off")
+        );
+    }
+}

--- a/core/client/src/native_presenter.rs
+++ b/core/client/src/native_presenter.rs
@@ -107,6 +107,21 @@ pub(crate) fn native_presenter_identity(viewer_identity: &str) -> String {
     }
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum NativeTrackSource {
+    ScreenShare,
+    Camera,
+    Other,
+}
+
+pub(crate) fn is_target_screen_track(
+    target_track_sid: &str,
+    publication_track_sid: &str,
+    source: NativeTrackSource,
+) -> bool {
+    source == NativeTrackSource::ScreenShare && target_track_sid == publication_track_sid
+}
+
 pub(crate) struct NativePresenterManager {
     generation: AtomicU64,
     status: Mutex<NativePresenterStatus>,
@@ -205,8 +220,31 @@ impl NativePresenterManager {
         request: NativePresenterStartRequest,
     ) -> Result<NativePresenterStatus, String> {
         self.validate_start_request(&request)?;
-        self.mark_starting(&request);
+        let generation = self.mark_starting(&request);
+        let manager = Arc::clone(self);
+        tauri::async_runtime::spawn(async move {
+            if let Err(error) = run_receive_probe(manager.clone(), generation, request).await {
+                if manager.generation() == generation {
+                    manager.set_fallback(&error);
+                }
+            }
+        });
         Ok(self.status())
+    }
+
+    pub(crate) fn record_native_frame_sample(&self, frames: u64, elapsed_secs: f64) {
+        let fps = if elapsed_secs > 0.0 {
+            Some(((frames as f64 / elapsed_secs) * 10.0).round() / 10.0)
+        } else {
+            None
+        };
+        let mut status = self.status.lock();
+        status.state = NativePresenterState::Receiving;
+        status.native_frames_received = frames;
+        status.native_receive_fps = fps;
+        status.native_presented_fps = None;
+        status.queue_depth = 0;
+        status.updated_at_ms = self.elapsed_ms();
     }
 
     fn set_fallback(&self, reason: &str) {
@@ -222,6 +260,86 @@ impl NativePresenterManager {
             .elapsed()
             .as_millis()
             .min(u128::from(u64::MAX)) as u64
+    }
+}
+
+#[cfg(target_os = "windows")]
+async fn run_receive_probe(
+    manager: Arc<NativePresenterManager>,
+    generation: u64,
+    request: NativePresenterStartRequest,
+) -> Result<(), String> {
+    use futures_util::StreamExt;
+    use libwebrtc::video_stream::native::{NativeVideoStream, NativeVideoStreamOptions};
+    use livekit::{prelude::*, Room, RoomEvent, RoomOptions};
+    use std::time::{Duration, Instant};
+
+    livekit::ensure_runtime_initialized();
+    let mut options = RoomOptions::default();
+    options.auto_subscribe = true;
+    options.adaptive_stream = false;
+    options.dynacast = false;
+    let (_room, mut events) = Room::connect(&request.sfu_url, &request.token, options)
+        .await
+        .map_err(|error| format!("native presenter connect failed: {error}"))?;
+
+    let startup_deadline = Instant::now() + Duration::from_secs(8);
+    loop {
+        if manager.generation() != generation {
+            return Ok(());
+        }
+        if Instant::now() > startup_deadline {
+            return Err("target screen track was not subscribed within 8 seconds".to_string());
+        }
+        let event = match tokio::time::timeout(Duration::from_millis(500), events.recv()).await {
+            Ok(Some(event)) => event,
+            Ok(None) => return Err("native presenter room event stream closed".to_string()),
+            Err(_) => continue,
+        };
+        let RoomEvent::TrackSubscribed { track, publication, .. } = event else {
+            continue;
+        };
+        let source = match publication.source() {
+            TrackSource::Screenshare => NativeTrackSource::ScreenShare,
+            TrackSource::Camera => NativeTrackSource::Camera,
+            _ => NativeTrackSource::Other,
+        };
+        if !is_target_screen_track(&request.track_sid, &publication.sid().to_string(), source) {
+            continue;
+        }
+        let RemoteTrack::Video(video_track) = track else {
+            continue;
+        };
+        let mut stream = NativeVideoStream::with_options(
+            video_track.rtc_track(),
+            NativeVideoStreamOptions {
+                queue_size_frames: Some(1),
+            },
+        );
+        let started = Instant::now();
+        let mut frames = 0u64;
+        while manager.generation() == generation {
+            let frame = tokio::time::timeout(Duration::from_millis(500), stream.next()).await;
+            match frame {
+                Ok(Some(frame)) => {
+                    let _width = frame.buffer.width();
+                    let _height = frame.buffer.height();
+                    frames += 1;
+                    let elapsed = started.elapsed().as_secs_f64();
+                    if frames == 1 || frames % 30 == 0 {
+                        manager.record_native_frame_sample(frames, elapsed);
+                    }
+                }
+                Ok(None) => return Err("native video stream ended".to_string()),
+                Err(_) => {
+                    if started.elapsed() > Duration::from_secs(2) {
+                        manager.record_native_frame_sample(frames, started.elapsed().as_secs_f64());
+                    }
+                }
+            }
+        }
+        stream.close();
+        return Ok(());
     }
 }
 
@@ -324,5 +442,53 @@ mod tests {
             status.fallback_reason.as_deref(),
             Some("user disabled native presenter")
         );
+    }
+
+    #[test]
+    fn track_match_requires_target_sid_and_screen_source() {
+        assert!(is_target_screen_track(
+            "TR_screen",
+            "TR_screen",
+            NativeTrackSource::ScreenShare
+        ));
+        assert!(!is_target_screen_track(
+            "TR_screen",
+            "TR_camera",
+            NativeTrackSource::ScreenShare
+        ));
+        assert!(!is_target_screen_track(
+            "TR_screen",
+            "TR_screen",
+            NativeTrackSource::Camera
+        ));
+    }
+
+    #[test]
+    fn frame_sample_updates_receive_fps() {
+        let manager = NativePresenterManager::new();
+        let request = NativePresenterStartRequest {
+            mode: NativePresenterMode::On,
+            room: "main".to_string(),
+            sfu_url: "wss://echo.example.invalid".to_string(),
+            token: "token".to_string(),
+            viewer_identity: "Sam-1234".to_string(),
+            participant_identity: "Spencer-2222".to_string(),
+            track_sid: "TR_screen".to_string(),
+            tile: NativePresenterTileRect {
+                x: 0,
+                y: 0,
+                width: 1920,
+                height: 1080,
+                scale_factor: 1.0,
+            },
+        };
+        manager.mark_starting(&request);
+
+        manager.record_native_frame_sample(120, 2.0);
+
+        let status = manager.status();
+        assert_eq!(status.state, NativePresenterState::Receiving);
+        assert_eq!(status.native_frames_received, 120);
+        assert_eq!(status.native_receive_fps, Some(60.0));
     }
 }

--- a/core/client/src/native_presenter.rs
+++ b/core/client/src/native_presenter.rs
@@ -200,6 +200,15 @@ impl NativePresenterManager {
         self.generation.load(Ordering::SeqCst)
     }
 
+    pub(crate) async fn start_receive_probe(
+        self: &Arc<Self>,
+        request: NativePresenterStartRequest,
+    ) -> Result<NativePresenterStatus, String> {
+        self.validate_start_request(&request)?;
+        self.mark_starting(&request);
+        Ok(self.status())
+    }
+
     fn set_fallback(&self, reason: &str) {
         let mut status = self.status.lock();
         status.state = NativePresenterState::Fallback;
@@ -277,6 +286,43 @@ mod tests {
         assert_eq!(
             manager.status().fallback_reason.as_deref(),
             Some("native presenter mode is off")
+        );
+    }
+
+    #[test]
+    fn start_validation_accepts_on_mode_with_complete_target() {
+        let manager = NativePresenterManager::new();
+        let request = NativePresenterStartRequest {
+            mode: NativePresenterMode::On,
+            room: "main".to_string(),
+            sfu_url: "wss://echo.example.invalid".to_string(),
+            token: "token".to_string(),
+            viewer_identity: "Sam-1234".to_string(),
+            participant_identity: "Spencer-2222".to_string(),
+            track_sid: "TR_screen".to_string(),
+            tile: NativePresenterTileRect {
+                x: 10,
+                y: 20,
+                width: 1920,
+                height: 1080,
+                scale_factor: 1.0,
+            },
+        };
+
+        assert!(manager.validate_start_request(&request).is_ok());
+    }
+
+    #[test]
+    fn stop_returns_webview2_status() {
+        let manager = NativePresenterManager::new();
+
+        let status = manager.stop("user disabled native presenter");
+
+        assert_eq!(status.state, NativePresenterState::Stopped);
+        assert_eq!(status.render_path, "webview2");
+        assert_eq!(
+            status.fallback_reason.as_deref(),
+            Some("user disabled native presenter")
         );
     }
 }

--- a/core/client/src/native_presenter.rs
+++ b/core/client/src/native_presenter.rs
@@ -1,3 +1,4 @@
+use crate::file_debug_log;
 use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
 use std::sync::{
@@ -45,7 +46,13 @@ pub(crate) struct NativePresenterStartRequest {
     pub(crate) room: String,
     pub(crate) sfu_url: String,
     pub(crate) token: String,
+    #[serde(default)]
+    pub(crate) viewer_token: Option<String>,
     pub(crate) viewer_identity: String,
+    #[serde(default)]
+    pub(crate) viewer_name: Option<String>,
+    #[serde(default)]
+    pub(crate) control_url: Option<String>,
     pub(crate) participant_identity: String,
     pub(crate) track_sid: String,
     pub(crate) tile: NativePresenterTileRect,
@@ -76,6 +83,14 @@ pub(crate) struct NativePresenterStatus {
     pub(crate) tile_height: Option<u32>,
     pub(crate) fallback_reason: Option<String>,
     pub(crate) updated_at_ms: u64,
+}
+
+#[derive(Serialize)]
+struct NativePresenterStatsReportPayload<'a> {
+    identity: &'a str,
+    name: &'a str,
+    room: &'a str,
+    native_presenter: &'a NativePresenterStatus,
 }
 
 impl Default for NativePresenterStatus {
@@ -119,7 +134,217 @@ pub(crate) fn is_target_screen_track(
     publication_track_sid: &str,
     source: NativeTrackSource,
 ) -> bool {
-    source == NativeTrackSource::ScreenShare && target_track_sid == publication_track_sid
+    let _ = source;
+    !target_track_sid.is_empty() && target_track_sid == publication_track_sid
+}
+
+fn native_track_source_label(source: NativeTrackSource) -> &'static str {
+    match source {
+        NativeTrackSource::ScreenShare => "screen_share",
+        NativeTrackSource::Camera => "camera",
+        NativeTrackSource::Other => "other",
+    }
+}
+
+fn native_presenter_start_log_line(
+    generation: u64,
+    request: &NativePresenterStartRequest,
+) -> String {
+    format!(
+        "[native-presenter] start generation={} mode={:?} room={} sfu_url={} viewer={} presenter={} target={} track_sid={} tile={},{} {}x{} scale={}",
+        generation,
+        request.mode,
+        request.room,
+        request.sfu_url,
+        request.viewer_identity,
+        native_presenter_identity(&request.viewer_identity),
+        request.participant_identity,
+        request.track_sid,
+        request.tile.x,
+        request.tile.y,
+        request.tile.width,
+        request.tile.height,
+        request.tile.scale_factor
+    )
+}
+
+fn native_presenter_track_log_line(
+    target_track_sid: &str,
+    publication_track_sid: &str,
+    source: NativeTrackSource,
+    matched: bool,
+) -> String {
+    format!(
+        "[native-presenter] subscribed-track target_sid={} publication_sid={} source={} matched={}",
+        target_track_sid,
+        publication_track_sid,
+        native_track_source_label(source),
+        matched
+    )
+}
+
+fn native_presenter_frame_log_line(
+    frames: u64,
+    elapsed_secs: f64,
+    width: u32,
+    height: u32,
+) -> String {
+    let fps = if elapsed_secs > 0.0 {
+        ((frames as f64 / elapsed_secs) * 10.0).round() / 10.0
+    } else {
+        0.0
+    };
+    format!(
+        "[native-presenter] frames frames={} fps={:.1} frame={}x{}",
+        frames, fps, width, height
+    )
+}
+
+fn native_presenter_receiver_stats_log_line(
+    stats: &[livekit::webrtc::stats::RtcStats],
+) -> Option<String> {
+    use livekit::webrtc::stats::RtcStats;
+
+    let inbound = stats.iter().find_map(|stat| match stat {
+        RtcStats::InboundRtp(inbound)
+            if inbound.stream.kind.eq_ignore_ascii_case("video")
+                || inbound.inbound.frame_width > 0
+                || inbound.inbound.frames_received > 0
+                || inbound.inbound.frames_decoded > 0 =>
+        {
+            Some(inbound)
+        }
+        _ => None,
+    })?;
+    let codec = stats
+        .iter()
+        .find_map(|stat| match stat {
+            RtcStats::Codec(codec) if codec.rtc.id == inbound.stream.codec_id => {
+                Some(codec.codec.mime_type.as_str())
+            }
+            _ => None,
+        })
+        .unwrap_or("?");
+    Some(format!(
+        "[native-presenter] receiver-stats codec={} packets={} lost={} jitter_ms={:.1} bytes={} frames_received={} frames_decoded={} key_frames={} fps={:.1} size={}x{} decoder={} nack={} pli={} fir={}",
+        codec,
+        inbound.received.packets_received,
+        inbound.received.packets_lost,
+        inbound.received.jitter * 1000.0,
+        inbound.inbound.bytes_received,
+        inbound.inbound.frames_received,
+        inbound.inbound.frames_decoded,
+        inbound.inbound.key_frames_decoded,
+        inbound.inbound.frames_per_second,
+        inbound.inbound.frame_width,
+        inbound.inbound.frame_height,
+        if inbound.inbound.decoder_implementation.is_empty() {
+            "?"
+        } else {
+            inbound.inbound.decoder_implementation.as_str()
+        },
+        inbound.inbound.nack_count,
+        inbound.inbound.pli_count,
+        inbound.inbound.fir_count
+    ))
+}
+
+#[cfg(target_os = "windows")]
+async fn log_native_presenter_receiver_stats(video_track: &livekit::prelude::RemoteVideoTrack) {
+    match video_track.get_stats().await {
+        Ok(stats) => {
+            if let Some(line) = native_presenter_receiver_stats_log_line(&stats) {
+                file_debug_log::append(&line);
+            } else {
+                file_debug_log::append("[native-presenter] receiver-stats no inbound video report");
+            }
+        }
+        Err(error) => {
+            file_debug_log::append(&format!(
+                "[native-presenter] receiver-stats error={}",
+                error
+            ));
+        }
+    }
+}
+
+fn native_presenter_stats_report_url(control_url: &str) -> Option<String> {
+    let trimmed = control_url.trim().trim_end_matches('/');
+    if trimmed.is_empty() {
+        return None;
+    }
+    Some(format!("{trimmed}/api/client-stats-report"))
+}
+
+fn native_presenter_stats_report_body(
+    request: &NativePresenterStartRequest,
+    status: &NativePresenterStatus,
+) -> Result<String, serde_json::Error> {
+    let payload = NativePresenterStatsReportPayload {
+        identity: request.viewer_identity.as_str(),
+        name: request.viewer_name.as_deref().unwrap_or(""),
+        room: request.room.as_str(),
+        native_presenter: status,
+    };
+    serde_json::to_string(&payload)
+}
+
+async fn post_native_presenter_stats(
+    request: &NativePresenterStartRequest,
+    status: &NativePresenterStatus,
+) {
+    let Some(token) = request
+        .viewer_token
+        .as_deref()
+        .map(str::trim)
+        .filter(|token| !token.is_empty())
+    else {
+        return;
+    };
+    let Some(url) = request
+        .control_url
+        .as_deref()
+        .and_then(native_presenter_stats_report_url)
+    else {
+        return;
+    };
+    let body = match native_presenter_stats_report_body(request, status) {
+        Ok(body) => body,
+        Err(error) => {
+            file_debug_log::append(&format!(
+                "[native-presenter] stats report skipped serialization error={}",
+                error
+            ));
+            return;
+        }
+    };
+    let result = reqwest::Client::new()
+        .post(&url)
+        .bearer_auth(token)
+        .header(reqwest::header::CONTENT_TYPE, "application/json")
+        .body(body)
+        .send()
+        .await;
+    match result {
+        Ok(response) if response.status().is_success() => {
+            file_debug_log::append(&format!(
+                "[native-presenter] stats report posted state={:?} fps={:?} frames={}",
+                status.state, status.native_receive_fps, status.native_frames_received
+            ));
+        }
+        Ok(response) => {
+            file_debug_log::append(&format!(
+                "[native-presenter] stats report failed status={}",
+                response.status()
+            ));
+        }
+        Err(error) => {
+            file_debug_log::append(&format!(
+                "[native-presenter] stats report failed error={}",
+                error
+            ));
+        }
+    }
 }
 
 pub(crate) struct NativePresenterManager {
@@ -198,6 +423,7 @@ impl NativePresenterManager {
             fallback_reason: None,
             updated_at_ms: self.elapsed_ms(),
         };
+        file_debug_log::append(&native_presenter_start_log_line(generation, request));
         generation
     }
 
@@ -208,6 +434,7 @@ impl NativePresenterManager {
         status.render_path = "webview2".to_string();
         status.fallback_reason = Some(reason.to_string());
         status.updated_at_ms = self.elapsed_ms();
+        file_debug_log::append(&format!("[native-presenter] stop reason={}", reason));
         status.clone()
     }
 
@@ -224,6 +451,10 @@ impl NativePresenterManager {
         let manager = Arc::clone(self);
         tauri::async_runtime::spawn(async move {
             if let Err(error) = run_receive_probe(manager.clone(), generation, request).await {
+                file_debug_log::append(&format!(
+                    "[native-presenter] receive-probe error generation={} error={}",
+                    generation, error
+                ));
                 if manager.generation() == generation {
                     manager.set_fallback(&error);
                 }
@@ -253,6 +484,7 @@ impl NativePresenterManager {
         status.render_path = "webview2".to_string();
         status.fallback_reason = Some(reason.to_string());
         status.updated_at_ms = self.elapsed_ms();
+        file_debug_log::append(&format!("[native-presenter] fallback reason={}", reason));
     }
 
     fn elapsed_ms(&self) -> u64 {
@@ -282,10 +514,22 @@ async fn run_receive_probe(
     let (_room, mut events) = Room::connect(&request.sfu_url, &request.token, options)
         .await
         .map_err(|error| format!("native presenter connect failed: {error}"))?;
+    file_debug_log::append(&format!(
+        "[native-presenter] connected generation={} room={} presenter={} target={} track_sid={}",
+        generation,
+        request.room,
+        native_presenter_identity(&request.viewer_identity),
+        request.participant_identity,
+        request.track_sid
+    ));
 
     let startup_deadline = Instant::now() + Duration::from_secs(8);
     loop {
         if manager.generation() != generation {
+            file_debug_log::append(&format!(
+                "[native-presenter] generation superseded generation={}",
+                generation
+            ));
             return Ok(());
         }
         if Instant::now() > startup_deadline {
@@ -296,7 +540,10 @@ async fn run_receive_probe(
             Ok(None) => return Err("native presenter room event stream closed".to_string()),
             Err(_) => continue,
         };
-        let RoomEvent::TrackSubscribed { track, publication, .. } = event else {
+        let RoomEvent::TrackSubscribed {
+            track, publication, ..
+        } = event
+        else {
             continue;
         };
         let source = match publication.source() {
@@ -304,41 +551,85 @@ async fn run_receive_probe(
             TrackSource::Camera => NativeTrackSource::Camera,
             _ => NativeTrackSource::Other,
         };
-        if !is_target_screen_track(&request.track_sid, &publication.sid().to_string(), source) {
+        let publication_sid = publication.sid().to_string();
+        let matched = is_target_screen_track(&request.track_sid, &publication_sid, source);
+        file_debug_log::append(&native_presenter_track_log_line(
+            &request.track_sid,
+            &publication_sid,
+            source,
+            matched,
+        ));
+        if !matched {
             continue;
         }
         let RemoteTrack::Video(video_track) = track else {
+            file_debug_log::append(&format!(
+                "[native-presenter] matched track was not video track_sid={}",
+                publication_sid
+            ));
             continue;
         };
+        let stats_track = video_track.clone();
         let mut stream = NativeVideoStream::with_options(
             video_track.rtc_track(),
             NativeVideoStreamOptions {
                 queue_size_frames: Some(1),
             },
         );
+        file_debug_log::append(&format!(
+            "[native-presenter] native video stream opened generation={} track_sid={} queue_size_frames=1",
+            generation, publication_sid
+        ));
+        post_native_presenter_stats(&request, &manager.status()).await;
         let started = Instant::now();
         let mut frames = 0u64;
+        let mut logged_waiting_for_frames = false;
+        let mut last_stats_report = Instant::now() - Duration::from_secs(60);
+        let mut last_receiver_stats_report = Instant::now() - Duration::from_secs(60);
         while manager.generation() == generation {
             let frame = tokio::time::timeout(Duration::from_millis(500), stream.next()).await;
             match frame {
                 Ok(Some(frame)) => {
-                    let _width = frame.buffer.width();
-                    let _height = frame.buffer.height();
+                    let width = frame.buffer.width();
+                    let height = frame.buffer.height();
                     frames += 1;
                     let elapsed = started.elapsed().as_secs_f64();
                     if frames == 1 || frames % 30 == 0 {
                         manager.record_native_frame_sample(frames, elapsed);
+                        file_debug_log::append(&native_presenter_frame_log_line(
+                            frames, elapsed, width, height,
+                        ));
+                        if frames == 1 || last_stats_report.elapsed() >= Duration::from_millis(2500)
+                        {
+                            last_stats_report = Instant::now();
+                            post_native_presenter_stats(&request, &manager.status()).await;
+                        }
                     }
                 }
                 Ok(None) => return Err("native video stream ended".to_string()),
                 Err(_) => {
                     if started.elapsed() > Duration::from_secs(2) {
                         manager.record_native_frame_sample(frames, started.elapsed().as_secs_f64());
+                        if !logged_waiting_for_frames {
+                            logged_waiting_for_frames = true;
+                            file_debug_log::append(&format!(
+                                "[native-presenter] waiting for frames generation={} track_sid={} frames={}",
+                                generation, publication_sid, frames
+                            ));
+                        }
                     }
                 }
             }
+            if last_receiver_stats_report.elapsed() >= Duration::from_millis(2500) {
+                last_receiver_stats_report = Instant::now();
+                log_native_presenter_receiver_stats(&stats_track).await;
+            }
         }
         stream.close();
+        file_debug_log::append(&format!(
+            "[native-presenter] native video stream closed generation={} track_sid={} frames={}",
+            generation, publication_sid, frames
+        ));
         return Ok(());
     }
 }
@@ -349,11 +640,26 @@ mod tests {
 
     #[test]
     fn mode_defaults_to_off_for_unknown_values() {
-        assert_eq!(NativePresenterMode::from_setting("off"), NativePresenterMode::Off);
-        assert_eq!(NativePresenterMode::from_setting("on"), NativePresenterMode::On);
-        assert_eq!(NativePresenterMode::from_setting("auto"), NativePresenterMode::Auto);
-        assert_eq!(NativePresenterMode::from_setting(""), NativePresenterMode::Off);
-        assert_eq!(NativePresenterMode::from_setting("fast"), NativePresenterMode::Off);
+        assert_eq!(
+            NativePresenterMode::from_setting("off"),
+            NativePresenterMode::Off
+        );
+        assert_eq!(
+            NativePresenterMode::from_setting("on"),
+            NativePresenterMode::On
+        );
+        assert_eq!(
+            NativePresenterMode::from_setting("auto"),
+            NativePresenterMode::Auto
+        );
+        assert_eq!(
+            NativePresenterMode::from_setting(""),
+            NativePresenterMode::Off
+        );
+        assert_eq!(
+            NativePresenterMode::from_setting("fast"),
+            NativePresenterMode::Off
+        );
     }
 
     #[test]
@@ -385,7 +691,10 @@ mod tests {
             room: "main".to_string(),
             sfu_url: "wss://example.invalid".to_string(),
             token: "token".to_string(),
+            viewer_token: None,
             viewer_identity: "Sam-1234".to_string(),
+            viewer_name: None,
+            control_url: None,
             participant_identity: "Spencer-2222".to_string(),
             track_sid: "TR_screen".to_string(),
             tile: NativePresenterTileRect {
@@ -415,7 +724,10 @@ mod tests {
             room: "main".to_string(),
             sfu_url: "wss://echo.example.invalid".to_string(),
             token: "token".to_string(),
+            viewer_token: None,
             viewer_identity: "Sam-1234".to_string(),
+            viewer_name: None,
+            control_url: None,
             participant_identity: "Spencer-2222".to_string(),
             track_sid: "TR_screen".to_string(),
             tile: NativePresenterTileRect {
@@ -445,7 +757,7 @@ mod tests {
     }
 
     #[test]
-    fn track_match_requires_target_sid_and_screen_source() {
+    fn track_match_requires_target_sid() {
         assert!(is_target_screen_track(
             "TR_screen",
             "TR_screen",
@@ -456,11 +768,74 @@ mod tests {
             "TR_camera",
             NativeTrackSource::ScreenShare
         ));
-        assert!(!is_target_screen_track(
+        assert!(is_target_screen_track(
             "TR_screen",
             "TR_screen",
             NativeTrackSource::Camera
         ));
+    }
+
+    #[test]
+    fn target_sid_match_accepts_camera_labeled_screen_companion_tracks() {
+        assert!(is_target_screen_track(
+            "TR_screen",
+            "TR_screen",
+            NativeTrackSource::Camera
+        ));
+    }
+
+    #[test]
+    fn receiver_stats_log_line_reports_inbound_video_decode_state() {
+        use livekit::webrtc::stats::{dictionaries, CodecStats, InboundRtpStats, RtcStats};
+
+        let stats = vec![
+            RtcStats::Codec(CodecStats {
+                rtc: dictionaries::RtcStats {
+                    id: "codec_1".to_string(),
+                    timestamp: 1,
+                },
+                codec: dictionaries::CodecStats {
+                    mime_type: "video/H264".to_string(),
+                    ..Default::default()
+                },
+            }),
+            RtcStats::InboundRtp(InboundRtpStats {
+                stream: dictionaries::RtpStreamStats {
+                    kind: "video".to_string(),
+                    codec_id: "codec_1".to_string(),
+                    ..Default::default()
+                },
+                received: dictionaries::ReceivedRtpStreamStats {
+                    packets_received: 44,
+                    packets_lost: 2,
+                    jitter: 0.012,
+                },
+                inbound: dictionaries::InboundRtpStreamStats {
+                    bytes_received: 88_000,
+                    frames_received: 30,
+                    frames_decoded: 0,
+                    key_frames_decoded: 0,
+                    frames_per_second: 0.0,
+                    frame_width: 1920,
+                    frame_height: 1080,
+                    decoder_implementation: "unknown".to_string(),
+                    nack_count: 3,
+                    pli_count: 1,
+                    fir_count: 0,
+                    ..Default::default()
+                },
+                ..Default::default()
+            }),
+        ];
+
+        let line = native_presenter_receiver_stats_log_line(&stats).expect("stats log line");
+
+        assert!(line.contains("codec=video/H264"));
+        assert!(line.contains("packets=44"));
+        assert!(line.contains("bytes=88000"));
+        assert!(line.contains("frames_received=30"));
+        assert!(line.contains("frames_decoded=0"));
+        assert!(line.contains("decoder=unknown"));
     }
 
     #[test]
@@ -471,7 +846,10 @@ mod tests {
             room: "main".to_string(),
             sfu_url: "wss://echo.example.invalid".to_string(),
             token: "token".to_string(),
+            viewer_token: None,
             viewer_identity: "Sam-1234".to_string(),
+            viewer_name: None,
+            control_url: None,
             participant_identity: "Spencer-2222".to_string(),
             track_sid: "TR_screen".to_string(),
             tile: NativePresenterTileRect {
@@ -490,5 +868,106 @@ mod tests {
         assert_eq!(status.state, NativePresenterState::Receiving);
         assert_eq!(status.native_frames_received, 120);
         assert_eq!(status.native_receive_fps, Some(60.0));
+    }
+
+    #[test]
+    fn start_log_line_includes_target_context_without_token() {
+        let request = NativePresenterStartRequest {
+            mode: NativePresenterMode::On,
+            room: "main".to_string(),
+            sfu_url: "wss://echo.example.invalid".to_string(),
+            token: "secret-token".to_string(),
+            viewer_token: None,
+            viewer_identity: "Sam-1234".to_string(),
+            viewer_name: None,
+            control_url: None,
+            participant_identity: "Spencer-2222".to_string(),
+            track_sid: "TR_screen".to_string(),
+            tile: NativePresenterTileRect {
+                x: -100,
+                y: 20,
+                width: 1920,
+                height: 1080,
+                scale_factor: 1.5,
+            },
+        };
+
+        let line = native_presenter_start_log_line(4, &request);
+
+        assert!(line.contains("generation=4"));
+        assert!(line.contains("viewer=Sam-1234"));
+        assert!(line.contains("target=Spencer-2222"));
+        assert!(line.contains("track_sid=TR_screen"));
+        assert!(line.contains("tile=-100,20 1920x1080 scale=1.5"));
+        assert!(!line.contains("secret-token"));
+    }
+
+    #[test]
+    fn track_log_line_marks_target_match() {
+        let line = native_presenter_track_log_line(
+            "TR_screen",
+            "TR_screen",
+            NativeTrackSource::ScreenShare,
+            true,
+        );
+
+        assert!(line.contains("publication_sid=TR_screen"));
+        assert!(line.contains("source=screen_share"));
+        assert!(line.contains("matched=true"));
+    }
+
+    #[test]
+    fn stats_report_url_uses_control_url_without_double_slash() {
+        assert_eq!(
+            native_presenter_stats_report_url("https://echo.example.invalid/"),
+            Some("https://echo.example.invalid/api/client-stats-report".to_string())
+        );
+        assert_eq!(native_presenter_stats_report_url("   "), None);
+    }
+
+    #[test]
+    fn stats_report_payload_uses_visible_identity_without_tokens() {
+        let request = NativePresenterStartRequest {
+            mode: NativePresenterMode::On,
+            room: "main".to_string(),
+            sfu_url: "wss://echo.example.invalid".to_string(),
+            token: "hidden-native-token".to_string(),
+            viewer_token: Some("visible-viewer-token".to_string()),
+            viewer_identity: "Sam-1234".to_string(),
+            viewer_name: Some("Sam".to_string()),
+            control_url: Some("https://echo.example.invalid".to_string()),
+            participant_identity: "Spencer-2222".to_string(),
+            track_sid: "TR_screen".to_string(),
+            tile: NativePresenterTileRect {
+                x: 0,
+                y: 0,
+                width: 1920,
+                height: 1080,
+                scale_factor: 1.0,
+            },
+        };
+        let status = NativePresenterStatus {
+            state: NativePresenterState::Receiving,
+            render_path: "native_receive_probe".to_string(),
+            target_identity: Some("Spencer-2222".to_string()),
+            target_track_sid: Some("TR_screen".to_string()),
+            native_receive_fps: Some(58.5),
+            native_presented_fps: None,
+            native_frames_received: 120,
+            native_frames_dropped: 0,
+            queue_depth: 0,
+            tile_width: Some(1920),
+            tile_height: Some(1080),
+            fallback_reason: None,
+            updated_at_ms: 1234,
+        };
+
+        let body = native_presenter_stats_report_body(&request, &status).unwrap();
+
+        assert!(body.contains("\"identity\":\"Sam-1234\""));
+        assert!(body.contains("\"name\":\"Sam\""));
+        assert!(body.contains("\"native_receive_fps\":58.5"));
+        assert!(!body.contains("hidden-native-token"));
+        assert!(!body.contains("visible-viewer-token"));
     }
 }

--- a/core/client/src/screen_capture.rs
+++ b/core/client/src/screen_capture.rs
@@ -18,7 +18,10 @@ use std::sync::{Arc, Mutex, OnceLock};
 use tauri::{AppHandle, Emitter};
 
 use crate::capture_health::{CaptureHealthState, CaptureMode, EncoderType};
-use crate::capture_pipeline::CapturePublisher;
+use crate::capture_pipeline::{
+    CapturePublisher, PublishProfile, StaticFrameHeartbeat, STATIC_FRAME_HEARTBEAT_INTERVAL,
+};
+use crate::file_debug_log;
 
 // ── Types ──
 
@@ -33,10 +36,197 @@ pub struct CaptureSource {
     pub pid: u32,
 }
 
+#[derive(serde::Serialize, Clone, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct CaptureWindowStatus {
+    pub available: bool,
+    pub visible: bool,
+    pub minimized: bool,
+    pub echo_above_source: bool,
+    pub echo_overlap_ratio: f64,
+    pub warning: Option<String>,
+}
+
+impl CaptureWindowStatus {
+    fn unavailable() -> Self {
+        Self {
+            available: false,
+            visible: false,
+            minimized: false,
+            echo_above_source: false,
+            echo_overlap_ratio: 0.0,
+            warning: Some("Shared window is unavailable".to_string()),
+        }
+    }
+}
+
 // ── Global State ──
 
 struct ShareHandle {
     running: Arc<AtomicBool>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct WindowBounds {
+    left: i32,
+    top: i32,
+    right: i32,
+    bottom: i32,
+}
+
+fn window_overlap_ratio(source: WindowBounds, cover: WindowBounds) -> f64 {
+    let left = source.left.max(cover.left);
+    let top = source.top.max(cover.top);
+    let right = source.right.min(cover.right);
+    let bottom = source.bottom.min(cover.bottom);
+    if right <= left || bottom <= top {
+        return 0.0;
+    }
+    let source_width = (source.right - source.left).max(0) as u64;
+    let source_height = (source.bottom - source.top).max(0) as u64;
+    let source_area = source_width * source_height;
+    if source_area == 0 {
+        return 0.0;
+    }
+    let overlap_area = (right - left) as u64 * (bottom - top) as u64;
+    overlap_area as f64 / source_area as f64
+}
+
+fn capture_source_visibility_warning(
+    visible: bool,
+    minimized: bool,
+    echo_above_source: bool,
+    echo_overlap_ratio: f64,
+) -> Option<&'static str> {
+    if minimized {
+        return Some("Shared window is minimized");
+    }
+    if !visible {
+        return Some("Shared window is hidden");
+    }
+    if echo_above_source && echo_overlap_ratio >= 0.80 {
+        return Some("Echo is covering the shared window");
+    }
+    None
+}
+
+fn window_bounds_for_hwnd(hwnd: windows::Win32::Foundation::HWND) -> Option<WindowBounds> {
+    use windows::Win32::Foundation::RECT;
+    use windows::Win32::UI::WindowsAndMessaging::GetWindowRect;
+
+    let mut rect = RECT::default();
+    if unsafe { GetWindowRect(hwnd, &mut rect) }.is_err() {
+        return None;
+    }
+    if rect.right <= rect.left || rect.bottom <= rect.top {
+        return None;
+    }
+    Some(WindowBounds {
+        left: rect.left,
+        top: rect.top,
+        right: rect.right,
+        bottom: rect.bottom,
+    })
+}
+
+fn find_current_process_main_window() -> Option<windows::Win32::Foundation::HWND> {
+    use windows::Win32::Foundation::{BOOL, HWND, LPARAM, TRUE};
+    use windows::Win32::System::Threading::GetCurrentProcessId;
+    use windows::Win32::UI::WindowsAndMessaging::{
+        EnumWindows, GetWindowThreadProcessId, IsWindowVisible,
+    };
+
+    struct Search {
+        current_pid: u32,
+        best_hwnd: HWND,
+        best_area: u64,
+    }
+
+    unsafe extern "system" fn enum_window(hwnd: HWND, lparam: LPARAM) -> BOOL {
+        let search = &mut *(lparam.0 as *mut Search);
+        if !IsWindowVisible(hwnd).as_bool() {
+            return TRUE;
+        }
+
+        let mut pid = 0;
+        GetWindowThreadProcessId(hwnd, Some(&mut pid));
+        if pid != search.current_pid {
+            return TRUE;
+        }
+
+        let Some(bounds) = window_bounds_for_hwnd(hwnd) else {
+            return TRUE;
+        };
+        let area =
+            (bounds.right - bounds.left).max(0) as u64 * (bounds.bottom - bounds.top).max(0) as u64;
+        if area > search.best_area {
+            search.best_hwnd = hwnd;
+            search.best_area = area;
+        }
+        TRUE
+    }
+
+    let mut search = Search {
+        current_pid: unsafe { GetCurrentProcessId() },
+        best_hwnd: HWND::default(),
+        best_area: 0,
+    };
+    let _ = unsafe {
+        EnumWindows(
+            Some(enum_window),
+            LPARAM(&mut search as *mut Search as isize),
+        )
+    };
+
+    if search.best_hwnd.0.is_null() {
+        None
+    } else {
+        Some(search.best_hwnd)
+    }
+}
+
+fn window_is_above(
+    source_hwnd: windows::Win32::Foundation::HWND,
+    candidate_hwnd: windows::Win32::Foundation::HWND,
+) -> bool {
+    use windows::Win32::Foundation::{BOOL, HWND, LPARAM, TRUE};
+    use windows::Win32::UI::WindowsAndMessaging::EnumWindows;
+
+    if source_hwnd == candidate_hwnd {
+        return true;
+    }
+
+    struct Search {
+        source_hwnd: HWND,
+        candidate_hwnd: HWND,
+        candidate_above_source: bool,
+    }
+
+    unsafe extern "system" fn enum_window(hwnd: HWND, lparam: LPARAM) -> BOOL {
+        let search = &mut *(lparam.0 as *mut Search);
+        if hwnd == search.candidate_hwnd {
+            search.candidate_above_source = true;
+            return BOOL(0);
+        }
+        if hwnd == search.source_hwnd {
+            search.candidate_above_source = false;
+            return BOOL(0);
+        }
+        TRUE
+    }
+
+    let mut search = Search {
+        source_hwnd,
+        candidate_hwnd,
+        candidate_above_source: false,
+    };
+    let _ = unsafe {
+        EnumWindows(
+            Some(enum_window),
+            LPARAM(&mut search as *mut Search as isize),
+        )
+    };
+    search.candidate_above_source
 }
 
 fn global_state() -> &'static Mutex<Option<ShareHandle>> {
@@ -266,6 +456,7 @@ pub async fn start_share(
     source_id: u64,
     sfu_url: String,
     token: String,
+    publish_profile: PublishProfile,
     app: AppHandle,
     health: Arc<CaptureHealthState>,
 ) -> Result<(), String> {
@@ -283,7 +474,17 @@ pub async fn start_share(
     let app2 = app.clone();
     let r2 = running.clone();
     tokio::spawn(async move {
-        if let Err(e) = share_loop(source_id, &sfu_url, &token, &app2, &r2, health).await {
+        if let Err(e) = share_loop(
+            source_id,
+            &sfu_url,
+            &token,
+            publish_profile,
+            &app2,
+            &r2,
+            health,
+        )
+        .await
+        {
             eprintln!("[screen-capture] error: {}", e);
             let _ = app2.emit("screen-capture-error", format!("{}", e));
         }
@@ -306,6 +507,49 @@ pub fn stop_share() {
 }
 
 // ── Thumbnail Generation ──
+
+pub fn get_capture_window_status(source_id: u64) -> CaptureWindowStatus {
+    use windows::Win32::Foundation::HWND;
+    use windows::Win32::UI::WindowsAndMessaging::{IsIconic, IsWindow, IsWindowVisible};
+
+    let source_hwnd = HWND(source_id as *mut _);
+    if source_hwnd.0.is_null() || !unsafe { IsWindow(source_hwnd) }.as_bool() {
+        return CaptureWindowStatus::unavailable();
+    }
+
+    let visible = unsafe { IsWindowVisible(source_hwnd) }.as_bool();
+    let minimized = unsafe { IsIconic(source_hwnd) }.as_bool();
+    let source_bounds = window_bounds_for_hwnd(source_hwnd);
+
+    let (echo_above_source, echo_overlap_ratio) = if let (Some(source_bounds), Some(echo_hwnd)) =
+        (source_bounds, find_current_process_main_window())
+    {
+        let echo_above_source = window_is_above(source_hwnd, echo_hwnd);
+        let echo_overlap_ratio = window_bounds_for_hwnd(echo_hwnd)
+            .map(|echo_bounds| window_overlap_ratio(source_bounds, echo_bounds))
+            .unwrap_or(0.0);
+        (echo_above_source, echo_overlap_ratio)
+    } else {
+        (false, 0.0)
+    };
+
+    let warning = capture_source_visibility_warning(
+        visible,
+        minimized,
+        echo_above_source,
+        echo_overlap_ratio,
+    )
+    .map(ToOwned::to_owned);
+
+    CaptureWindowStatus {
+        available: true,
+        visible,
+        minimized,
+        echo_above_source,
+        echo_overlap_ratio,
+        warning,
+    }
+}
 
 /// Generate a 240x135 thumbnail of a capture source as a base64 BMP data URI.
 pub fn get_thumbnail(source_id: u64, is_monitor: bool) -> Option<String> {
@@ -513,6 +757,7 @@ async fn share_loop(
     source_id: u64,
     sfu_url: &str,
     token: &str,
+    publish_profile: PublishProfile,
     app: &AppHandle,
     running: &Arc<AtomicBool>,
     health: Arc<CaptureHealthState>,
@@ -523,6 +768,7 @@ async fn share_loop(
         token,
         1920,
         1080,
+        publish_profile,
         "screen-capture",
         TrackSource::Camera,
         false,
@@ -546,7 +792,7 @@ async fn share_loop(
         true,
         CaptureMode::Wgc,
         EncoderType::Nvenc,
-        crate::capture_pipeline::PUBLISH_TARGET_FPS,
+        publish_profile.target_fps(),
     );
 
     // 2. Start WGC capture -- callback sends BGRA frames via channel
@@ -570,6 +816,9 @@ async fn share_loop(
             running: Arc<AtomicBool>,
             wgc_frame_count: u64,
             wgc_start: std::time::Instant,
+            last_wgc_log_at: std::time::Instant,
+            last_wgc_log_count: u64,
+            channel_drop_count: u64,
             /// GPU pipeline: (device, context, converter) -- lazily created on first frame
             gpu: Option<(ID3D11Device, ID3D11DeviceContext, GpuConverter)>,
         }
@@ -588,6 +837,9 @@ async fn share_loop(
                     running,
                     wgc_frame_count: 0,
                     wgc_start: std::time::Instant::now(),
+                    last_wgc_log_at: std::time::Instant::now(),
+                    last_wgc_log_count: 0,
+                    channel_drop_count: 0,
                     gpu: None,
                 })
             }
@@ -674,7 +926,22 @@ async fn share_loop(
                     converter.unmap(context);
 
                     // Non-blocking: drop frame if receiver is behind
-                    let _ = self.tx.try_send((bgra, out_w, out_h));
+                    if self.tx.try_send((bgra, out_w, out_h)).is_err() {
+                        self.channel_drop_count += 1;
+                    }
+                }
+
+                let now = std::time::Instant::now();
+                let elapsed = now.duration_since(self.last_wgc_log_at).as_secs_f64();
+                if elapsed >= 2.0 {
+                    let frame_delta = self.wgc_frame_count - self.last_wgc_log_count;
+                    let interval_fps = frame_delta as f64 / elapsed;
+                    file_debug_log::append(&format!(
+                        "[wgc-callback] source={}x{} interval_fps={:.1} total_frames={} channel_drops={}",
+                        w, h, interval_fps, self.wgc_frame_count, self.channel_drop_count
+                    ));
+                    self.last_wgc_log_at = now;
+                    self.last_wgc_log_count = self.wgc_frame_count;
                 }
 
                 Ok(())
@@ -716,30 +983,94 @@ async fn share_loop(
     let mut drop_count: u64 = 0;
     let mut yuv_total_us: u64 = 0;
     let mut capture_total_us: u64 = 0;
+    let mut publish_attempt_count: u64 = 0;
+    let mut last_publish_log_at = std::time::Instant::now();
+    let mut last_publish_attempt_count: u64 = 0;
+    let mut last_publish_frame_count: u64 = 0;
+    let mut last_sender_stats_at = std::time::Instant::now();
+    let mut last_frame: Option<(Vec<u8>, u32, u32)> = None;
+    let mut heartbeat = StaticFrameHeartbeat::new(STATIC_FRAME_HEARTBEAT_INTERVAL);
+    let mut heartbeat_attempt_count: u64 = 0;
+    let mut heartbeat_pushed_count: u64 = 0;
 
-    // Drain channel aggressively: if multiple frames queued, skip to latest
+    // Drain channel aggressively: if multiple frames queued, skip to latest.
+    // WGC window capture is repaint-driven, so a static browser window may stop
+    // producing new callbacks. Keep the SFU track alive by republishing the last
+    // good frame at a low heartbeat cadence until fresh frames resume.
     while running.load(Ordering::SeqCst) {
-        let frame = match frame_rx.recv_timeout(std::time::Duration::from_millis(100)) {
-            Ok(f) => f,
-            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => continue,
+        let from_heartbeat = match frame_rx.recv_timeout(std::time::Duration::from_millis(100)) {
+            Ok(frame) => {
+                // Skip to newest frame if channel has backed up
+                let mut latest = frame;
+                while let Ok(newer) = frame_rx.try_recv() {
+                    drop_count += 1;
+                    latest = newer;
+                }
+                heartbeat.record_fresh_frame(std::time::Instant::now());
+                last_frame = Some(latest);
+                false
+            }
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+                let now = std::time::Instant::now();
+                if last_frame.is_none() || !heartbeat.should_publish(now) {
+                    continue;
+                }
+                true
+            }
             Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => break,
         };
 
-        // Skip to newest frame if channel has backed up
-        let mut latest = frame;
-        while let Ok(newer) = frame_rx.try_recv() {
-            drop_count += 1;
-            latest = newer;
-        }
-        let (bgra_data, width, height) = latest;
+        let Some((bgra_data, width, height)) = last_frame.as_ref() else {
+            continue;
+        };
 
         // Data arrives already downscaled to 1080p by GPU shader
         let t0 = std::time::Instant::now();
-        publisher.push_frame(&bgra_data, width, height);
+        publish_attempt_count += 1;
+        if from_heartbeat {
+            heartbeat_attempt_count += 1;
+        }
+        let pushed = publisher.push_frame(bgra_data, *width, *height);
+        if from_heartbeat && pushed {
+            heartbeat_pushed_count += 1;
+        }
         let t1 = std::time::Instant::now();
 
         yuv_total_us += (t1 - t0).as_micros() as u64;
         let fc = publisher.frame_count();
+
+        let now = std::time::Instant::now();
+        let interval = now.duration_since(last_publish_log_at).as_secs_f64();
+        if interval >= 2.0 {
+            let attempt_delta = publish_attempt_count - last_publish_attempt_count;
+            let pushed_delta = fc - last_publish_frame_count;
+            let attempt_fps = attempt_delta as f64 / interval;
+            let pushed_fps = pushed_delta as f64 / interval;
+            let paced_drops = attempt_delta.saturating_sub(pushed_delta);
+            file_debug_log::append(&format!(
+                "[wgc-publish] interval attempts_fps={:.1} pushed_fps={:.1} paced_drops={} total_pushed={} channel_drops={} heartbeat_attempts={} heartbeat_pushed={} last_pushed={} last_heartbeat={}",
+                attempt_fps,
+                pushed_fps,
+                paced_drops,
+                fc,
+                drop_count,
+                heartbeat_attempt_count,
+                heartbeat_pushed_count,
+                pushed,
+                from_heartbeat
+            ));
+            health.record_capture_fps(pushed_fps.round() as u32);
+            last_publish_log_at = now;
+            last_publish_attempt_count = publish_attempt_count;
+            last_publish_frame_count = fc;
+            heartbeat_attempt_count = 0;
+            heartbeat_pushed_count = 0;
+        }
+
+        if now.duration_since(last_sender_stats_at) >= std::time::Duration::from_secs(5) {
+            publisher.log_sender_stats("screen-capture").await;
+            last_sender_stats_at = now;
+        }
 
         if fc % 30 == 0 {
             let elapsed = publisher.elapsed().as_secs_f64();
@@ -758,7 +1089,7 @@ async fn share_loop(
                 width, height, fps, fc, drop_count, avg_yuv_ms
             );
             if let Some(emit_fps) =
-                publisher.maybe_emit_stats(app, "screen-capture-stats", "wgc", width, height, 30)
+                publisher.maybe_emit_stats(app, "screen-capture-stats", "wgc", *width, *height, 30)
             {
                 health.record_capture_fps(emit_fps);
             }
@@ -830,6 +1161,7 @@ async fn share_loop_monitor(
         token,
         1920,
         1080,
+        PublishProfile::Desktop,
         "screen-capture-monitor",
         TrackSource::Camera,
         false,
@@ -846,7 +1178,7 @@ async fn share_loop_monitor(
         true,
         CaptureMode::Wgc,
         EncoderType::Nvenc,
-        crate::capture_pipeline::PUBLISH_TARGET_FPS,
+        PublishProfile::Desktop.target_fps(),
     );
 
     let (frame_tx, frame_rx) = std::sync::mpsc::sync_channel::<(Vec<u8>, u32, u32)>(4);
@@ -1072,4 +1404,51 @@ async fn share_loop_monitor(
     health.set_active(false, CaptureMode::None, EncoderType::None, 0);
     publisher.shutdown().await;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn source_visibility_warning_flags_minimized_window() {
+        assert_eq!(
+            capture_source_visibility_warning(true, true, false, 0.0),
+            Some("Shared window is minimized")
+        );
+    }
+
+    #[test]
+    fn source_visibility_warning_flags_echo_covering_source() {
+        assert_eq!(
+            capture_source_visibility_warning(true, false, true, 0.81),
+            Some("Echo is covering the shared window")
+        );
+    }
+
+    #[test]
+    fn source_visibility_warning_allows_overlap_when_echo_is_behind_source() {
+        assert_eq!(
+            capture_source_visibility_warning(true, false, false, 1.0),
+            None
+        );
+    }
+
+    #[test]
+    fn window_overlap_ratio_uses_source_window_area() {
+        let source = WindowBounds {
+            left: 0,
+            top: 0,
+            right: 100,
+            bottom: 100,
+        };
+        let cover = WindowBounds {
+            left: 50,
+            top: 0,
+            right: 150,
+            bottom: 100,
+        };
+
+        assert_eq!(window_overlap_ratio(source, cover), 0.5);
+    }
 }

--- a/core/client/tauri.conf.json
+++ b/core/client/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "Echo Chamber",
-  "version": "0.6.11",
+  "version": "0.6.12",
   "identifier": "com.echochamber.app",
   "build": {
     "frontendDist": "../viewer"

--- a/core/control/Cargo.toml
+++ b/core/control/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "echo-core-control"
-version = "0.6.11"
+version = "0.6.12"
 edition = "2021"
 
 [dependencies]

--- a/core/control/src/admin.rs
+++ b/core/control/src/admin.rs
@@ -67,6 +67,8 @@ pub(crate) struct ClientStats {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) display_status: Option<ClientDisplayStatus>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) native_presenter: Option<NativePresenterReport>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) watch_debug: Option<String>,
 }
 
@@ -132,6 +134,24 @@ pub(crate) struct ClientDisplayStatus {
     pub(crate) window_width: u32,
     pub(crate) window_height: u32,
     pub(crate) scale_factor: Option<f64>,
+}
+
+#[derive(Clone, Serialize, Deserialize, Default)]
+#[serde(default)]
+pub(crate) struct NativePresenterReport {
+    pub(crate) state: String,
+    pub(crate) render_path: String,
+    pub(crate) target_identity: Option<String>,
+    pub(crate) target_track_sid: Option<String>,
+    pub(crate) native_receive_fps: Option<f64>,
+    pub(crate) native_presented_fps: Option<f64>,
+    pub(crate) native_frames_received: u64,
+    pub(crate) native_frames_dropped: u64,
+    pub(crate) queue_depth: u32,
+    pub(crate) fallback_reason: Option<String>,
+    pub(crate) tile_width: Option<u32>,
+    pub(crate) tile_height: Option<u32>,
+    pub(crate) updated_at_ms: u64,
 }
 
 #[derive(Clone, Serialize, Deserialize, Default)]
@@ -579,6 +599,58 @@ pub(crate) async fn admin_report_stats(
 /// Added 2026-04-08 to instrument the per-receiver mystery (Sam publishes ok,
 /// David sees 4fps, Decker sees 7fps — need to know which inbound numbers
 /// differ between receivers).
+fn merge_client_stats(existing: &mut ClientStats, payload: ClientStats, now: u64) {
+    existing.updated_at = now;
+    if !payload.name.is_empty() {
+        existing.name = payload.name;
+    }
+    if !payload.room.is_empty() {
+        existing.room = payload.room;
+    }
+    if payload.inbound.is_some() {
+        existing.inbound = payload.inbound;
+    }
+    if payload.capture_health.is_some() {
+        existing.capture_health = payload.capture_health;
+    }
+    if payload.display_status.is_some() {
+        existing.display_status = payload.display_status;
+    }
+    if payload.native_presenter.is_some() {
+        existing.native_presenter = payload.native_presenter;
+    }
+    if payload.watch_debug.is_some() {
+        existing.watch_debug = payload.watch_debug;
+    }
+    if payload.screen_fps.is_some() {
+        existing.screen_fps = payload.screen_fps;
+    }
+    if payload.screen_width.is_some() {
+        existing.screen_width = payload.screen_width;
+    }
+    if payload.screen_height.is_some() {
+        existing.screen_height = payload.screen_height;
+    }
+    if payload.screen_bitrate_kbps.is_some() {
+        existing.screen_bitrate_kbps = payload.screen_bitrate_kbps;
+    }
+    if payload.bwe_kbps.is_some() {
+        existing.bwe_kbps = payload.bwe_kbps;
+    }
+    if payload.quality_limitation.is_some() {
+        existing.quality_limitation = payload.quality_limitation;
+    }
+    if payload.encoder.is_some() {
+        existing.encoder = payload.encoder;
+    }
+    if payload.ice_local_type.is_some() {
+        existing.ice_local_type = payload.ice_local_type;
+    }
+    if payload.ice_remote_type.is_some() {
+        existing.ice_remote_type = payload.ice_remote_type;
+    }
+}
+
 pub(crate) async fn client_stats_report(
     State(state): State<AppState>,
     headers: HeaderMap,
@@ -592,36 +664,7 @@ pub(crate) async fn client_stats_report(
     let now = now_ts();
     match stats.get_mut(&identity) {
         Some(existing) => {
-            // Merge: prefer incoming inbound array, name, room; keep publisher
-            // fields if the report doesn't include them.
-            existing.updated_at = now;
-            if !payload.name.is_empty() {
-                existing.name = payload.name;
-            }
-            if !payload.room.is_empty() {
-                existing.room = payload.room;
-            }
-            if payload.inbound.is_some() {
-                existing.inbound = payload.inbound;
-            }
-            if payload.capture_health.is_some() {
-                existing.capture_health = payload.capture_health;
-            }
-            if payload.display_status.is_some() {
-                existing.display_status = payload.display_status;
-            }
-            if payload.watch_debug.is_some() {
-                existing.watch_debug = payload.watch_debug;
-            }
-            if payload.screen_fps.is_some() { existing.screen_fps = payload.screen_fps; }
-            if payload.screen_width.is_some() { existing.screen_width = payload.screen_width; }
-            if payload.screen_height.is_some() { existing.screen_height = payload.screen_height; }
-            if payload.screen_bitrate_kbps.is_some() { existing.screen_bitrate_kbps = payload.screen_bitrate_kbps; }
-            if payload.bwe_kbps.is_some() { existing.bwe_kbps = payload.bwe_kbps; }
-            if payload.quality_limitation.is_some() { existing.quality_limitation = payload.quality_limitation; }
-            if payload.encoder.is_some() { existing.encoder = payload.encoder; }
-            if payload.ice_local_type.is_some() { existing.ice_local_type = payload.ice_local_type; }
-            if payload.ice_remote_type.is_some() { existing.ice_remote_type = payload.ice_remote_type; }
+            merge_client_stats(existing, payload, now);
         }
         None => {
             let mut entry = payload;
@@ -1317,4 +1360,47 @@ pub(crate) async fn admin_force_reload(
         "rooms": rooms_processed,
         "errors": errors,
     })))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn client_stats_merge_preserves_native_presenter_report() {
+        let mut existing = ClientStats {
+            identity: "Sam-1234".to_string(),
+            name: "Sam".to_string(),
+            room: "main".to_string(),
+            updated_at: 1,
+            ..Default::default()
+        };
+        let payload = ClientStats {
+            native_presenter: Some(NativePresenterReport {
+                state: "receiving".to_string(),
+                render_path: "native_receive_probe".to_string(),
+                target_identity: Some("Spencer-2222".to_string()),
+                target_track_sid: Some("TR_screen".to_string()),
+                native_receive_fps: Some(59.7),
+                native_presented_fps: None,
+                native_frames_received: 120,
+                native_frames_dropped: 0,
+                queue_depth: 0,
+                fallback_reason: None,
+                tile_width: Some(1920),
+                tile_height: Some(1080),
+                updated_at_ms: 4567,
+            }),
+            ..Default::default()
+        };
+
+        merge_client_stats(&mut existing, payload, 42);
+
+        let native = existing.native_presenter.expect("native presenter report");
+        assert_eq!(existing.updated_at, 42);
+        assert_eq!(native.state, "receiving");
+        assert_eq!(native.render_path, "native_receive_probe");
+        assert_eq!(native.native_receive_fps, Some(59.7));
+        assert_eq!(native.target_identity.as_deref(), Some("Spencer-2222"));
+    }
 }

--- a/core/control/src/admin.rs
+++ b/core/control/src/admin.rs
@@ -65,6 +65,8 @@ pub(crate) struct ClientStats {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) capture_health: Option<CaptureHealth>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) display_status: Option<ClientDisplayStatus>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) watch_debug: Option<String>,
 }
 
@@ -104,6 +106,32 @@ pub(crate) struct SubscriptionStats {
     pub(crate) ice_local_type: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) ice_remote_type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) presented_fps: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) presented_width: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) presented_height: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) presented_frames: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) presentation_age_ms: Option<u64>,
+}
+
+#[derive(Clone, Serialize, Deserialize, Default)]
+#[serde(default)]
+pub(crate) struct ClientDisplayStatus {
+    pub(crate) available: bool,
+    pub(crate) current_display_id: Option<String>,
+    pub(crate) current_display_name: Option<String>,
+    pub(crate) preferred_display_id: Option<String>,
+    pub(crate) on_preferred_display: bool,
+    pub(crate) window_spans_displays: bool,
+    pub(crate) window_x: i32,
+    pub(crate) window_y: i32,
+    pub(crate) window_width: u32,
+    pub(crate) window_height: u32,
+    pub(crate) scale_factor: Option<f64>,
 }
 
 #[derive(Clone, Serialize, Deserialize, Default)]
@@ -578,6 +606,9 @@ pub(crate) async fn client_stats_report(
             }
             if payload.capture_health.is_some() {
                 existing.capture_health = payload.capture_health;
+            }
+            if payload.display_status.is_some() {
+                existing.display_status = payload.display_status;
             }
             if payload.watch_debug.is_some() {
                 existing.watch_debug = payload.watch_debug;

--- a/core/control/src/auth.rs
+++ b/core/control/src/auth.rs
@@ -72,6 +72,55 @@ pub struct LiveKitVideoGrant {
     pub canPublishData: bool,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum CompanionIdentityKind {
+    ScreenPublisher,
+    NativePresenter,
+}
+
+pub(crate) fn companion_identity_kind(identity: &str) -> Option<CompanionIdentityKind> {
+    if identity.ends_with("$screen") {
+        Some(CompanionIdentityKind::ScreenPublisher)
+    } else if identity.ends_with("$native-presenter") {
+        Some(CompanionIdentityKind::NativePresenter)
+    } else {
+        None
+    }
+}
+
+pub(crate) fn livekit_video_grant(
+    room: String,
+    kind: Option<CompanionIdentityKind>,
+) -> LiveKitVideoGrant {
+    match kind {
+        Some(CompanionIdentityKind::ScreenPublisher) => LiveKitVideoGrant {
+            room,
+            roomJoin: true,
+            canPublish: true,
+            canSubscribe: false,
+            canPublishData: true,
+        },
+        Some(CompanionIdentityKind::NativePresenter) => LiveKitVideoGrant {
+            room,
+            roomJoin: true,
+            canPublish: false,
+            canSubscribe: true,
+            canPublishData: false,
+        },
+        None => LiveKitVideoGrant {
+            room,
+            roomJoin: true,
+            canPublish: true,
+            canSubscribe: true,
+            canPublishData: true,
+        },
+    }
+}
+
+pub(crate) fn skip_participant_tracking(kind: Option<CompanionIdentityKind>) -> bool {
+    kind.is_some()
+}
+
 // ── Handlers ──────────────────────────────────────────────────────────────
 
 pub async fn login(
@@ -153,9 +202,8 @@ pub async fn issue_token(
     let now = now_ts();
     let exp = now + state.config.livekit_token_ttl_secs;
 
-    // $screen identities are companion connections for native screen capture.
-    // They publish video only (no subscribe needed) and skip name conflict checks.
-    let is_screen_identity = payload.identity.ends_with("$screen");
+    // Companion identities are system connections, not visible people.
+    let companion_kind = companion_identity_kind(&payload.identity);
 
     let claims = LiveKitClaims {
         iss: state.config.livekit_api_key.clone(),
@@ -163,13 +211,7 @@ pub async fn issue_token(
         iat: now as usize,
         exp: exp as usize,
         name: payload.name.clone(),
-        video: LiveKitVideoGrant {
-            room: payload.room.clone(),
-            roomJoin: true,
-            canPublish: true,
-            canSubscribe: !is_screen_identity, // screen identity only publishes
-            canPublishData: true,
-        },
+        video: livekit_video_grant(payload.room.clone(), companion_kind),
     };
 
     let token = encode(
@@ -179,9 +221,12 @@ pub async fn issue_token(
     )
     .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
-    // $screen identities skip participant tracking — they're not real users
-    if is_screen_identity {
-        info!("issued $screen token for room={} identity={}", payload.room, payload.identity);
+    // Companion identities skip participant tracking because they are not real users.
+    if skip_participant_tracking(companion_kind) {
+        info!(
+            "issued companion token for room={} identity={} kind={:?}",
+            payload.room, payload.identity, companion_kind
+        );
         return Ok(Json(TokenResponse {
             token,
             expires_in_seconds: state.config.livekit_token_ttl_secs,
@@ -314,4 +359,45 @@ pub fn verify_password(config: &Config, password: &str) -> bool {
     }
     warn!("admin password not configured");
     false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn screen_companion_identity_gets_publish_only_grant() {
+        let kind = companion_identity_kind("Sam-1234$screen");
+        let grant = livekit_video_grant("main".to_string(), kind);
+
+        assert_eq!(kind, Some(CompanionIdentityKind::ScreenPublisher));
+        assert!(grant.canPublish);
+        assert!(!grant.canSubscribe);
+        assert!(grant.canPublishData);
+        assert!(skip_participant_tracking(kind));
+    }
+
+    #[test]
+    fn native_presenter_identity_gets_receive_only_grant() {
+        let kind = companion_identity_kind("Sam-1234$native-presenter");
+        let grant = livekit_video_grant("main".to_string(), kind);
+
+        assert_eq!(kind, Some(CompanionIdentityKind::NativePresenter));
+        assert!(!grant.canPublish);
+        assert!(grant.canSubscribe);
+        assert!(!grant.canPublishData);
+        assert!(skip_participant_tracking(kind));
+    }
+
+    #[test]
+    fn normal_identity_gets_normal_viewer_grant() {
+        let kind = companion_identity_kind("Sam-1234");
+        let grant = livekit_video_grant("main".to_string(), kind);
+
+        assert_eq!(kind, None);
+        assert!(grant.canPublish);
+        assert!(grant.canSubscribe);
+        assert!(grant.canPublishData);
+        assert!(!skip_participant_tracking(kind));
+    }
 }

--- a/core/deploy/latest.json
+++ b/core/deploy/latest.json
@@ -1,11 +1,11 @@
 {
     "platforms":  {
                       "windows-x86_64":  {
-                                             "signature":  "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVSQ3ByNFJuZlpjME9rN0huMUV4RmlvRTFBcE95OVVDbmF4di9lcXNRQ0dBVERaNEFYZ1JCODNKOHkwdkpZQWVWM0NvNGVaeVRzRzBTSUNwczJ1ZnNhSHB2b2J2R1duMlFzPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzc2MTMxNDg5CWZpbGU6RWNobyBDaGFtYmVyXzAuNi4xMV94NjQtc2V0dXAuZXhlCmJubnlTVklRUzJhY2lSSDRJRzRveUNRUTNJcEpqdUtMaUE2K0VRcGJoLzZTSXFHUkRBdjdPQ1kvcEdTc2JYV1E4NVBlZUprT0w1WENibU45QVo3Y0JRPT0K",
-                                             "url":  "https://github.com/SamWatson86/echo-chamber/releases/download/v0.6.11/Echo.Chamber_0.6.11_x64-setup.exe"
+                                             "signature":  "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVSQ3ByNFJuZlpjME5QUDQzblFnaXZvd1BqNVNYK2luTzVQWmxETTBkblltRUl5NWVCRjFGaTVrWlQ4OG1rN1BsNzMyZ2llMkZSZU83cWo0VFBxVlBUNUltbSszN09CZVFvPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzc3OTQxNzQ4CWZpbGU6RWNobyBDaGFtYmVyXzAuNi4xMl94NjQtc2V0dXAuZXhlCjV2MW9vMEE5Y3E5SnhiSXRJZzNhOEtzMmhaQkh6b0hyTnJ5aHZXRkt1VjEzbi9BZzhocHZhT1dsOFdsTnNCNUJuT0p3OHpyMm1acmdKb2pzVDJXN0NBPT0K",
+                                             "url":  "https://github.com/SamWatson86/echo-chamber/releases/download/v0.6.12/Echo.Chamber_0.6.12_x64-setup.exe"
                                          }
                   },
-    "pub_date":  "2026-04-14T01:51:30Z",
-    "version":  "0.6.11",
-    "notes":  "Echo Chamber v0.6.11"
+    "pub_date":  "2026-05-05T00:42:28Z",
+    "version":  "0.6.12",
+    "notes":  "Echo Chamber v0.6.12"
 }

--- a/core/viewer/admin.js
+++ b/core/viewer/admin.js
@@ -345,6 +345,13 @@ async function fetchAdminDashboard() {
           }
           if (s.ice_remote_type) chips += '<span class="adm-badge adm-ice-' + s.ice_remote_type + '">' + s.ice_remote_type + '</span>';
           if (s.screen_fps != null) chips += '<span class="adm-chip">' + s.screen_fps + 'fps ' + s.screen_width + 'x' + s.screen_height + '</span>';
+          if (s.native_presenter && s.native_presenter.state && s.native_presenter.state !== "disabled") {
+            var np = s.native_presenter;
+            var npText = "native " + np.state;
+            if (np.native_receive_fps != null) npText += " " + Math.round(np.native_receive_fps) + "fps";
+            if (np.fallback_reason) npText += " - " + np.fallback_reason;
+            chips += '<span class="adm-chip" title="Native presenter receive probe">' + escAdm(npText) + '</span>';
+          }
           if (s.quality_limitation && s.quality_limitation !== "none") chips += '<span class="adm-badge adm-badge-warn">' + s.quality_limitation + '</span>';
           html += '<div class="adm-participant"><span>' + escAdm(p.name || p.identity) + '</span><span class="adm-time">' + fmtDur(p.online_seconds) + '</span>' + chips + '</div>';
         });

--- a/core/viewer/capture-picker.js
+++ b/core/viewer/capture-picker.js
@@ -7,6 +7,11 @@ var _capturePickerReject = null;
 var _selectedSource = null;
 var _capturePickerSupport = null;
 
+function isTauriCommandMissingError(err, commandName) {
+    var msg = (err && err.message) ? err.message : String(err || '');
+    return msg.indexOf('Command ' + commandName + ' not found') !== -1;
+}
+
 /**
  * Show the capture source picker modal.
  * Returns a Promise that resolves with the selected source or null if cancelled.
@@ -78,6 +83,15 @@ function _cancelPicker() {
         _capturePickerResolve(null);
         _capturePickerResolve = null;
     }
+}
+
+function _rejectPicker(err) {
+    _closePicker();
+    if (_capturePickerReject) {
+        _capturePickerReject(err);
+        _capturePickerReject = null;
+    }
+    _capturePickerResolve = null;
 }
 
 function _confirmPicker() {
@@ -172,6 +186,10 @@ async function _loadSources() {
         _loadThumbnails(sources);
 
     } catch (err) {
+        if (isTauriCommandMissingError(err, 'list_screen_sources')) {
+            _rejectPicker(err);
+            return;
+        }
         body.innerHTML = '<div class="capture-source-empty">Error loading sources: ' +
             (err.message || err) + '</div>';
     }
@@ -270,4 +288,8 @@ function _showThumbFallback(container, source) {
 function _escHtml(s) {
     return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
         .replace(/"/g, '&quot;');
+}
+
+if (typeof module !== "undefined" && module.exports) {
+    module.exports = { isTauriCommandMissingError };
 }

--- a/core/viewer/changelog.js
+++ b/core/viewer/changelog.js
@@ -8,6 +8,16 @@
 
 var ECHO_CHANGELOG = [
   {
+    version: "2026-05-04",
+    title: "Screen Share Reliability Fixes (v0.6.12)",
+    notes: [
+      "Windows desktop clients now force Echo/WebView2 and common browser capture paths onto the high-performance GPU at startup. This targets the mixed-iGPU/NVIDIA setup where streams looked awful even though the PC had plenty of GPU headroom.",
+      "Native window shares now keep static browser/app windows alive with heartbeat frames instead of dropping toward 0fps when the source stops repainting.",
+      "If Echo is covering the shared window, or the source is minimized/hidden, the publisher gets a warning instead of silently sending a frozen or disappearing stream.",
+      "The display placement warning now ignores tiny invisible maximized-window borders crossing onto the next monitor, while still catching real cross-display placement."
+    ]
+  },
+  {
     version: "2026-04-13l",
     title: "Win10 Entire Screen Fix",
     notes: [

--- a/core/viewer/connect.js
+++ b/core/viewer/connect.js
@@ -853,6 +853,8 @@ async function connectToRoom({ controlUrl, sfuUrl, roomId, identity, name, reuse
     if (participant.identity.endsWith('$screen')) {
       debugLog('[screen-merge] $screen companion joined: ' + participant.identity);
       // Don't toast $screen companion joins — they're internal implementation detail
+    } else if (isNativePresenterIdentity(participant.identity)) {
+      debugLog('[native-presenter] companion joined: ' + participant.identity);
     }
     ensureParticipantCard(participant);
     debugLog(`participant connected ${participant.identity} (reconnecting=${_isReconnecting})`);
@@ -883,7 +885,8 @@ async function connectToRoom({ controlUrl, sfuUrl, roomId, identity, name, reuse
     // PERSONAL enter music plays every time anyone starts a screen share.
     // Bug reported by Sam during 2026-04-08 v0.6.4 friend testing.
     if (!_isRoomSwitch && !_isReconnecting && !wasPendingDisconnect &&
-        !participant.identity.endsWith('$screen')) {
+        !participant.identity.endsWith('$screen') &&
+        !isNativePresenterIdentity(participant.identity)) {
       playChimeForParticipant(participant.identity, "enter");
     }
     // Attach tracks — immediate on room switch (tracks already published), delayed on first connect

--- a/core/viewer/debug.js
+++ b/core/viewer/debug.js
@@ -45,21 +45,61 @@ function logEvent(eventName, detail) {
   } catch (e) {}
 }
 
+function buildNativePresenterDebugFallback(reason) {
+  return {
+    state: "fallback",
+    render_path: "webview2",
+    target_identity: null,
+    target_track_sid: null,
+    native_receive_fps: null,
+    native_presented_fps: null,
+    native_frames_received: 0,
+    native_frames_dropped: 0,
+    queue_depth: 0,
+    fallback_reason: reason || "native presenter unavailable",
+    tile_width: null,
+    tile_height: null,
+    updated_at_ms: Date.now(),
+  };
+}
+
+function getNativePresenterDebugReport() {
+  if (typeof getNativePresenterStatusForReport === "function") {
+    return getNativePresenterStatusForReport();
+  }
+  if (typeof getNativePresenterStatusSnapshot === "function") {
+    try {
+      return getNativePresenterStatusSnapshot()
+        || buildNativePresenterDebugFallback("native presenter status unavailable");
+    } catch (e) {
+      return buildNativePresenterDebugFallback(
+        "native presenter status error: " + (e && e.message ? e.message : e)
+      );
+    }
+  }
+  return typeof window !== "undefined" && window.__ECHO_NATIVE__ === true
+    ? buildNativePresenterDebugFallback("native presenter script unavailable")
+    : null;
+}
+
 function reportWatchDebug(message) {
   try {
     if (!message || !currentAccessToken || !room?.localParticipant?.identity) return;
+    var payload = {
+      identity: room.localParticipant.identity,
+      name: room.localParticipant.name || "",
+      room: currentRoomName || "",
+      watch_debug: message,
+    };
+    var nativePresenter = getNativePresenterDebugReport();
+    if (nativePresenter) payload.native_presenter = nativePresenter;
     fetch(apiUrl("/api/client-stats-report"), {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
         Authorization: "Bearer " + currentAccessToken,
       },
-      body: JSON.stringify({
-        identity: room.localParticipant.identity,
-        name: room.localParticipant.name || "",
-        room: currentRoomName || "",
-        watch_debug: message,
-      }),
+      body: JSON.stringify(payload),
     }).catch(function() {});
   } catch (e) {}
 }
@@ -123,4 +163,11 @@ function escAdm(s) {
   var d = document.createElement("div");
   d.textContent = s || "";
   return d.innerHTML;
+}
+
+if (typeof module === "object" && module.exports) {
+  module.exports = {
+    buildNativePresenterDebugFallback,
+    getNativePresenterDebugReport,
+  };
 }

--- a/core/viewer/debug.test.js
+++ b/core/viewer/debug.test.js
@@ -1,0 +1,49 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const {
+  buildNativePresenterDebugFallback,
+  getNativePresenterDebugReport,
+} = require("./debug.js");
+
+test("native presenter debug fallback uses client stats schema", () => {
+  const report = buildNativePresenterDebugFallback("native presenter script unavailable");
+
+  assert.equal(report.state, "fallback");
+  assert.equal(report.render_path, "webview2");
+  assert.equal(report.fallback_reason, "native presenter script unavailable");
+  assert.equal(report.target_identity, null);
+  assert.equal(report.target_track_sid, null);
+});
+
+test("native presenter debug report is null outside native shell", () => {
+  const oldWindow = global.window;
+  const oldSnapshot = global.getNativePresenterStatusSnapshot;
+  const oldStatsHelper = global.getNativePresenterStatusForReport;
+  delete global.getNativePresenterStatusSnapshot;
+  delete global.getNativePresenterStatusForReport;
+  global.window = { __ECHO_NATIVE__: false };
+
+  assert.equal(getNativePresenterDebugReport(), null);
+
+  global.window = oldWindow;
+  if (oldSnapshot) global.getNativePresenterStatusSnapshot = oldSnapshot;
+  if (oldStatsHelper) global.getNativePresenterStatusForReport = oldStatsHelper;
+});
+
+test("native presenter debug report exposes missing script in native shell", () => {
+  const oldWindow = global.window;
+  const oldSnapshot = global.getNativePresenterStatusSnapshot;
+  const oldStatsHelper = global.getNativePresenterStatusForReport;
+  delete global.getNativePresenterStatusSnapshot;
+  delete global.getNativePresenterStatusForReport;
+  global.window = { __ECHO_NATIVE__: true };
+
+  const report = getNativePresenterDebugReport();
+
+  assert.equal(report.state, "fallback");
+  assert.equal(report.fallback_reason, "native presenter script unavailable");
+
+  global.window = oldWindow;
+  if (oldSnapshot) global.getNativePresenterStatusSnapshot = oldSnapshot;
+  if (oldStatsHelper) global.getNativePresenterStatusForReport = oldStatsHelper;
+});

--- a/core/viewer/display-status.js
+++ b/core/viewer/display-status.js
@@ -10,6 +10,35 @@ function isEchoDisplayWarning(status) {
   return status.on_preferred_display === false || status.window_spans_displays === true;
 }
 
+function isRawWindowsDisplayName(name) {
+  return typeof name === "string" && /^\\\\\.\\DISPLAY\d+$/i.test(name.trim());
+}
+
+function describeEchoDisplayName(name) {
+  if (!name || isRawWindowsDisplayName(name)) return "current display";
+  return name;
+}
+
+function getEchoDisplayStatusLabel(status) {
+  return isEchoDisplayWarning(status) ? "Check display path" : "Full-tilt display";
+}
+
+function getEchoDisplayStatusTitle(status) {
+  var current = status && status.current_display_name ? status.current_display_name : "unknown display";
+  var parts = [
+    "Click to save this monitor as Echo's preferred full-performance display.",
+    "Shift-click moves Echo to the saved display.",
+  ];
+  if (status && status.window_spans_displays) {
+    parts.push("Echo appears to overlap more than one display.");
+  }
+  if (status && status.on_preferred_display === false) {
+    parts.push("Echo is not on the saved preferred display.");
+  }
+  parts.push("Detected path: " + current);
+  return parts.join(" ");
+}
+
 function getEchoDisplayStatusSnapshot() {
   return _echoDisplayStatus || null;
 }
@@ -58,7 +87,7 @@ async function saveCurrentEchoDisplayAsPreferred() {
     return;
   }
   echoSet("echo-preferred-display-id", status.current_display_id);
-  showToast("Echo display saved: " + (status.current_display_name || "current display"), 2500);
+  showToast("Echo display saved: " + describeEchoDisplayName(status.current_display_name), 2500);
   await refreshEchoDisplayStatus();
 }
 
@@ -71,10 +100,8 @@ function renderEchoDisplayStatus(status) {
   }
 
   var warning = isEchoDisplayWarning(status);
-  var name = status.current_display_name || "Display";
-  var suffix = warning ? "Check display path" : "Full-tilt display";
-  el.textContent = suffix + ": " + name;
-  el.title = "Click to save this monitor as Echo's preferred full-performance display. Shift-click moves Echo to the saved display.";
+  el.textContent = getEchoDisplayStatusLabel(status);
+  el.title = getEchoDisplayStatusTitle(status);
   el.classList.remove("hidden");
   el.classList.toggle("display-warning", warning);
 }
@@ -99,6 +126,8 @@ if (typeof document !== "undefined") {
 
 if (typeof module === "object" && module.exports) {
   module.exports = {
+    describeEchoDisplayName,
+    getEchoDisplayStatusLabel,
     isEchoDisplayWarning,
   };
 }

--- a/core/viewer/display-status.js
+++ b/core/viewer/display-status.js
@@ -23,6 +23,10 @@ function getEchoDisplayStatusLabel(status) {
   return isEchoDisplayWarning(status) ? "Check display path" : "Full-tilt display";
 }
 
+function shouldShowEchoDisplayStatus(status) {
+  return isEchoDisplayWarning(status);
+}
+
 function getEchoDisplayStatusTitle(status) {
   var current = status && status.current_display_name ? status.current_display_name : "unknown display";
   var parts = [
@@ -94,7 +98,7 @@ async function saveCurrentEchoDisplayAsPreferred() {
 function renderEchoDisplayStatus(status) {
   var el = document.getElementById("echo-display-status");
   if (!el) return;
-  if (!status || status.available === false) {
+  if (!shouldShowEchoDisplayStatus(status)) {
     el.classList.add("hidden");
     return;
   }
@@ -128,6 +132,7 @@ if (typeof module === "object" && module.exports) {
   module.exports = {
     describeEchoDisplayName,
     getEchoDisplayStatusLabel,
+    shouldShowEchoDisplayStatus,
     isEchoDisplayWarning,
   };
 }

--- a/core/viewer/display-status.js
+++ b/core/viewer/display-status.js
@@ -1,0 +1,104 @@
+/* =========================================================
+   DISPLAY STATUS - native Echo display-path badge and stats cache
+   ========================================================= */
+
+var _echoDisplayStatus = null;
+var _echoDisplayStatusTimer = null;
+
+function isEchoDisplayWarning(status) {
+  if (!status || status.available === false) return false;
+  return status.on_preferred_display === false || status.window_spans_displays === true;
+}
+
+function getEchoDisplayStatusSnapshot() {
+  return _echoDisplayStatus || null;
+}
+
+function getPreferredEchoDisplayId() {
+  return echoGet("echo-preferred-display-id") || "";
+}
+
+async function refreshEchoDisplayStatus() {
+  if (!window.__ECHO_NATIVE__ || !hasTauriIPC()) return null;
+  try {
+    var preferredId = getPreferredEchoDisplayId();
+    _echoDisplayStatus = await tauriInvoke("get_echo_display_status", {
+      preferredDisplayId: preferredId || null,
+    });
+    renderEchoDisplayStatus(_echoDisplayStatus);
+    return _echoDisplayStatus;
+  } catch (e) {
+    debugLog("[display] status failed: " + e);
+    return null;
+  }
+}
+
+async function moveEchoToPreferredDisplay() {
+  if (!window.__ECHO_NATIVE__ || !hasTauriIPC()) return null;
+  var preferredId = getPreferredEchoDisplayId();
+  if (!preferredId) {
+    showToast("No Echo display selected yet", 2500);
+    return null;
+  }
+  try {
+    _echoDisplayStatus = await tauriInvoke("move_echo_to_display", { displayId: preferredId });
+    renderEchoDisplayStatus(_echoDisplayStatus);
+    return _echoDisplayStatus;
+  } catch (e) {
+    showToast("Display move failed: " + e, 4000);
+    debugLog("[display] move failed: " + e);
+    return null;
+  }
+}
+
+async function saveCurrentEchoDisplayAsPreferred() {
+  var status = await refreshEchoDisplayStatus();
+  if (!status || !status.current_display_id) {
+    showToast("Could not detect current Echo display", 3000);
+    return;
+  }
+  echoSet("echo-preferred-display-id", status.current_display_id);
+  showToast("Echo display saved: " + (status.current_display_name || "current display"), 2500);
+  await refreshEchoDisplayStatus();
+}
+
+function renderEchoDisplayStatus(status) {
+  var el = document.getElementById("echo-display-status");
+  if (!el) return;
+  if (!status || status.available === false) {
+    el.classList.add("hidden");
+    return;
+  }
+
+  var warning = isEchoDisplayWarning(status);
+  var name = status.current_display_name || "Display";
+  var suffix = warning ? "Check display path" : "Full-tilt display";
+  el.textContent = suffix + ": " + name;
+  el.title = "Click to save this monitor as Echo's preferred full-performance display. Shift-click moves Echo to the saved display.";
+  el.classList.remove("hidden");
+  el.classList.toggle("display-warning", warning);
+}
+
+function startEchoDisplayStatusMonitor() {
+  if (_echoDisplayStatusTimer) return;
+  refreshEchoDisplayStatus();
+  _echoDisplayStatusTimer = setInterval(refreshEchoDisplayStatus, 5000);
+  var el = document.getElementById("echo-display-status");
+  if (el && !el._echoDisplayClickBound) {
+    el._echoDisplayClickBound = true;
+    el.addEventListener("click", function(e) {
+      if (e.shiftKey) moveEchoToPreferredDisplay();
+      else saveCurrentEchoDisplayAsPreferred();
+    });
+  }
+}
+
+if (typeof document !== "undefined") {
+  document.addEventListener("DOMContentLoaded", startEchoDisplayStatusMonitor);
+}
+
+if (typeof module === "object" && module.exports) {
+  module.exports = {
+    isEchoDisplayWarning,
+  };
+}

--- a/core/viewer/display-status.test.js
+++ b/core/viewer/display-status.test.js
@@ -3,6 +3,7 @@ const assert = require("node:assert/strict");
 const {
   describeEchoDisplayName,
   getEchoDisplayStatusLabel,
+  shouldShowEchoDisplayStatus,
   isEchoDisplayWarning,
 } = require("./display-status.js");
 
@@ -54,4 +55,19 @@ test("display warning label stays plain for non-technical users", () => {
 test("raw Windows display device names are described generically in toasts", () => {
   assert.equal(describeEchoDisplayName("\\\\.\\DISPLAY1"), "current display");
   assert.equal(describeEchoDisplayName("Samsung Odyssey"), "Samsung Odyssey");
+});
+
+test("display status is hidden unless there is an actionable warning", () => {
+  assert.equal(shouldShowEchoDisplayStatus(null), false);
+  assert.equal(shouldShowEchoDisplayStatus({ available: false }), false);
+  assert.equal(shouldShowEchoDisplayStatus({
+    available: true,
+    on_preferred_display: true,
+    window_spans_displays: false,
+  }), false);
+  assert.equal(shouldShowEchoDisplayStatus({
+    available: true,
+    on_preferred_display: false,
+    window_spans_displays: false,
+  }), true);
 });

--- a/core/viewer/display-status.test.js
+++ b/core/viewer/display-status.test.js
@@ -1,6 +1,10 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
-const { isEchoDisplayWarning } = require("./display-status.js");
+const {
+  describeEchoDisplayName,
+  getEchoDisplayStatusLabel,
+  isEchoDisplayWarning,
+} = require("./display-status.js");
 
 test("display warning is false when native status is unavailable", () => {
   assert.equal(isEchoDisplayWarning(null), false);
@@ -21,4 +25,33 @@ test("display warning is true when Echo spans displays", () => {
     on_preferred_display: true,
     window_spans_displays: true,
   }), true);
+});
+
+test("display status label does not expose raw Windows display device names", () => {
+  const label = getEchoDisplayStatusLabel({
+    available: true,
+    current_display_name: "\\\\.\\DISPLAY1",
+    on_preferred_display: true,
+    window_spans_displays: false,
+  });
+
+  assert.equal(label, "Full-tilt display");
+  assert.equal(label.includes("\\\\.\\DISPLAY1"), false);
+});
+
+test("display warning label stays plain for non-technical users", () => {
+  const label = getEchoDisplayStatusLabel({
+    available: true,
+    current_display_name: "\\\\.\\DISPLAY1",
+    on_preferred_display: false,
+    window_spans_displays: false,
+  });
+
+  assert.equal(label, "Check display path");
+  assert.equal(label.includes("\\\\.\\DISPLAY1"), false);
+});
+
+test("raw Windows display device names are described generically in toasts", () => {
+  assert.equal(describeEchoDisplayName("\\\\.\\DISPLAY1"), "current display");
+  assert.equal(describeEchoDisplayName("Samsung Odyssey"), "Samsung Odyssey");
 });

--- a/core/viewer/display-status.test.js
+++ b/core/viewer/display-status.test.js
@@ -1,0 +1,24 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { isEchoDisplayWarning } = require("./display-status.js");
+
+test("display warning is false when native status is unavailable", () => {
+  assert.equal(isEchoDisplayWarning(null), false);
+  assert.equal(isEchoDisplayWarning({ available: false }), false);
+});
+
+test("display warning is true when Echo is off the preferred display", () => {
+  assert.equal(isEchoDisplayWarning({
+    available: true,
+    on_preferred_display: false,
+    window_spans_displays: false,
+  }), true);
+});
+
+test("display warning is true when Echo spans displays", () => {
+  assert.equal(isEchoDisplayWarning({
+    available: true,
+    on_preferred_display: true,
+    window_spans_displays: true,
+  }), true);
+});

--- a/core/viewer/index.html
+++ b/core/viewer/index.html
@@ -4,9 +4,9 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Echo Chamber</title>
-    <link rel="stylesheet" href="style.css?v=0.6.10-local.1.1776128211" />
-    <link rel="stylesheet" href="jam.css?v=0.6.10-local.1.1776128211" />
-    <link rel="stylesheet" href="capture-picker.css?v=0.6.10-local.1.1776128211" />
+    <link rel="stylesheet" href="style.css?v=0.6.11.1777930912" />
+    <link rel="stylesheet" href="jam.css?v=0.6.11.1777930912" />
+    <link rel="stylesheet" href="capture-picker.css?v=0.6.11.1777930912" />
   </head>
   <body>
     <main class="app">
@@ -421,42 +421,42 @@
       <pre id="debug-log"></pre>
     </div>
 
-    <script src="livekit-client.umd.js?v=0.6.10-local.1.1776128211"></script>
-    <script src="room-switch-state.js?v=0.6.10-local.1.1776128211"></script>
-    <script src="jam-session-state.js?v=0.6.10-local.1.1776128211"></script>
-    <script src="publish-state-reconcile.js?v=0.6.10-local.1.1776128211"></script>
-    <script src="state.js?v=0.6.10-local.1.1776128211"></script>
-    <script src="debug.js?v=0.6.10-local.1.1776128211"></script>
-    <script src="urls.js?v=0.6.10-local.1.1776128211"></script>
-    <script src="settings.js?v=0.6.10-local.1.1776128211"></script>
+    <script src="livekit-client.umd.js?v=0.6.11.1777930912"></script>
+    <script src="room-switch-state.js?v=0.6.11.1777930912"></script>
+    <script src="jam-session-state.js?v=0.6.11.1777930912"></script>
+    <script src="publish-state-reconcile.js?v=0.6.11.1777930912"></script>
+    <script src="state.js?v=0.6.11.1777930912"></script>
+    <script src="debug.js?v=0.6.11.1777930912"></script>
+    <script src="urls.js?v=0.6.11.1777930912"></script>
+    <script src="settings.js?v=0.6.11.1777930912"></script>
     <script src="display-status.js?v=0.6.10-local.1.1776128211"></script>
-    <script src="native-presenter.js?v=0.6.10-local.1.1776128211"></script>
-    <script src="identity.js?v=0.6.10-local.1.1776128211"></script>
-    <script src="rnnoise.js?v=0.6.10-local.1.1776128211"></script>
-    <script src="chimes.js?v=0.6.10-local.1.1776128211"></script>
-    <script src="room-status.js?v=0.6.10-local.1.1776128211"></script>
-    <script src="auth.js?v=0.6.10-local.1.1776128211"></script>
+    <script src="native-presenter.js?v=0.6.11.1777921630"></script>
+    <script src="identity.js?v=0.6.11.1777930912"></script>
+    <script src="rnnoise.js?v=0.6.11.1777930912"></script>
+    <script src="chimes.js?v=0.6.11.1777930912"></script>
+    <script src="room-status.js?v=0.6.11.1777930912"></script>
+    <script src="auth.js?v=0.6.11.1777930912"></script>
     <script src="admin-panel.js?v=0.6.2.1775659895"></script>
-    <script src="theme.js?v=0.6.10-local.1.1776128211"></script>
-    <script src="chat.js?v=0.6.10-local.1.1776128211"></script>
-    <script src="soundboard.js?v=0.6.10-local.1.1776128211"></script>
-    <script src="screen-share-state.js?v=0.6.10-local.1.1776128211"></script>
-    <script src="screen-share-config.js?v=0.6.10-local.1.1776128211"></script>
-    <script src="screen-share-quality.js?v=0.6.10-local.1.1776128211"></script>
-    <script src="screen-share-adaptive.js?v=0.6.10-local.1.1776128211"></script>
-    <script src="screen-share-native.js?v=0.6.10-local.1.1776128211"></script>
-    <script src="participants-grid.js?v=0.6.10-local.1.1776128211"></script>
-    <script src="participants-avatar.js?v=0.6.10-local.1.1776128211"></script>
-    <script src="participants-fullscreen.js?v=0.6.10-local.1.1776128211"></script>
-    <script src="participants.js?v=0.6.10-local.1.1776128211"></script>
-    <script src="audio-routing.js?v=0.6.10-local.1.1776128211"></script>
-    <script src="media-controls.js?v=0.6.10-local.1.1776128211"></script>
-    <script src="admin.js?v=0.6.10-local.1.1776128211"></script>
-    <script src="connect.js?v=0.6.10-local.1.1776128211"></script>
-    <script src="app.js?v=0.6.10-local.1.1776128211"></script>
-    <script src="capture-picker.js?v=0.6.10-local.1.1776128211"></script>
-    <script src="jam.js?v=0.6.10-local.1.1776128211"></script>
-    <script src="changelog.js?v=0.6.10-local.1.1776128211"></script>
+    <script src="theme.js?v=0.6.11.1777930912"></script>
+    <script src="chat.js?v=0.6.11.1777930912"></script>
+    <script src="soundboard.js?v=0.6.11.1777930912"></script>
+    <script src="screen-share-state.js?v=0.6.11.1777930912"></script>
+    <script src="screen-share-config.js?v=0.6.11.1777930912"></script>
+    <script src="screen-share-quality.js?v=0.6.11.1777930912"></script>
+    <script src="screen-share-adaptive.js?v=0.6.11.1777930912"></script>
+    <script src="screen-share-native.js?v=0.6.11.1777930912"></script>
+    <script src="participants-grid.js?v=0.6.11.1777930912"></script>
+    <script src="participants-avatar.js?v=0.6.11.1777930912"></script>
+    <script src="participants-fullscreen.js?v=0.6.11.1777930912"></script>
+    <script src="participants.js?v=0.6.11.1777930912"></script>
+    <script src="audio-routing.js?v=0.6.11.1777930912"></script>
+    <script src="media-controls.js?v=0.6.11.1777930912"></script>
+    <script src="admin.js?v=0.6.11.1777930912"></script>
+    <script src="connect.js?v=0.6.11.1777930912"></script>
+    <script src="app.js?v=0.6.11.1777930912"></script>
+    <script src="capture-picker.js?v=0.6.11.1777930912"></script>
+    <script src="jam.js?v=0.6.11.1777930912"></script>
+    <script src="changelog.js?v=0.6.11.1777930912"></script>
 
     <!-- Admin login modal (hidden by default; toggled by adminLoginBtn) -->
     <div id="adminLoginModal" class="modal-overlay" hidden>

--- a/core/viewer/index.html
+++ b/core/viewer/index.html
@@ -126,6 +126,7 @@
           <div class="room-main">
             <div class="grid-header">
               <h2>Screens</h2>
+              <button id="echo-display-status" type="button" class="echo-display-status hidden"></button>
             </div>
             <div id="screen-grid" class="media-grid screens-grid"></div>
           </div>
@@ -428,6 +429,7 @@
     <script src="debug.js?v=0.6.10-local.1.1776128211"></script>
     <script src="urls.js?v=0.6.10-local.1.1776128211"></script>
     <script src="settings.js?v=0.6.10-local.1.1776128211"></script>
+    <script src="display-status.js?v=0.6.10-local.1.1776128211"></script>
     <script src="identity.js?v=0.6.10-local.1.1776128211"></script>
     <script src="rnnoise.js?v=0.6.10-local.1.1776128211"></script>
     <script src="chimes.js?v=0.6.10-local.1.1776128211"></script>

--- a/core/viewer/index.html
+++ b/core/viewer/index.html
@@ -430,6 +430,7 @@
     <script src="urls.js?v=0.6.10-local.1.1776128211"></script>
     <script src="settings.js?v=0.6.10-local.1.1776128211"></script>
     <script src="display-status.js?v=0.6.10-local.1.1776128211"></script>
+    <script src="native-presenter.js?v=0.6.10-local.1.1776128211"></script>
     <script src="identity.js?v=0.6.10-local.1.1776128211"></script>
     <script src="rnnoise.js?v=0.6.10-local.1.1776128211"></script>
     <script src="chimes.js?v=0.6.10-local.1.1776128211"></script>

--- a/core/viewer/native-presenter.js
+++ b/core/viewer/native-presenter.js
@@ -5,7 +5,11 @@
 const NATIVE_PRESENTER_MODE_KEY = "echo-native-presenter-mode";
 var _nativePresenterStatus = null;
 var _nativePresenterActiveTrackSid = "";
+var _nativePresenterPendingTrackSid = "";
+var _nativePresenterStartToken = 0;
 var _nativePresenterPollTimer = null;
+var _nativePresenterRetryTimers = [];
+var _nativePresenterLastReportAt = 0;
 
 function normalizeNativePresenterMode(value) {
   var mode = String(value || "off").toLowerCase();
@@ -21,6 +25,10 @@ function nativePresenterIdentity(viewerIdentity) {
   var identity = String(viewerIdentity || "").trim();
   if (!identity) return "";
   return identity.endsWith("$native-presenter") ? identity : identity + "$native-presenter";
+}
+
+function isNativePresenterIdentity(identity) {
+  return String(identity || "").endsWith("$native-presenter");
 }
 
 function buildNativePresenterTileRect(tile, scaleFactor) {
@@ -54,8 +62,158 @@ function buildNativePresenterReport(status) {
   };
 }
 
+function buildNativePresenterStatsPayload(status, context) {
+  var report = buildNativePresenterReport(status);
+  if (!report) return null;
+  var ctx = context || {};
+  return {
+    identity: ctx.identity || "",
+    name: ctx.name || "",
+    room: ctx.room || "",
+    native_presenter: report,
+  };
+}
+
+function buildNativePresenterStartRequest(options) {
+  var opts = options || {};
+  return {
+    mode: opts.mode,
+    room: opts.room,
+    sfu_url: opts.sfuUrl,
+    token: opts.nativeToken,
+    viewer_token: opts.viewerToken || "",
+    viewer_identity: opts.viewerIdentity || "",
+    viewer_name: opts.viewerName || "",
+    control_url: opts.controlUrl || "",
+    participant_identity: opts.participantIdentity || "",
+    track_sid: opts.trackSid || "",
+    tile: buildNativePresenterTileRect(opts.tile, opts.scaleFactor || window.devicePixelRatio || 1),
+  };
+}
+
+function nativePresenterStartBlockReason(trackSid, activeTrackSid, pendingTrackSid) {
+  var sid = String(trackSid || "").trim();
+  var active = String(activeTrackSid || "").trim();
+  var pending = String(pendingTrackSid || "").trim();
+  if (!sid) return "native presenter target unavailable";
+  if (active) {
+    return active === sid ? "already active" : "native presenter already probing another screen";
+  }
+  if (pending) {
+    return pending === sid ? "already pending" : "native presenter start already pending for another screen";
+  }
+  return null;
+}
+
+function skipNativePresenterStart(reason, meta) {
+  try {
+    var target = meta && (meta.trackSid || meta.track_sid || meta?.tile?.dataset?.trackSid);
+    debugLog("[native-presenter] " + reason + (target ? " target=" + target : ""));
+  } catch (e) {}
+  return _nativePresenterStatus;
+}
+
+function postNativePresenterStatus(status, force) {
+  try {
+    if (!status || !currentAccessToken || !room?.localParticipant?.identity) return;
+    var now = Date.now();
+    if (!force && now - _nativePresenterLastReportAt < 2500) return;
+    _nativePresenterLastReportAt = now;
+    var payload = buildNativePresenterStatsPayload(status, {
+      identity: room.localParticipant.identity,
+      name: room.localParticipant.name || "",
+      room: currentRoomName || "",
+    });
+    if (!payload) return;
+    fetch(apiUrl("/api/client-stats-report"), {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer " + currentAccessToken,
+      },
+      body: JSON.stringify(payload),
+    }).catch(function() {});
+  } catch (e) {}
+}
+
+function buildNativePresenterIdleStatus(mode) {
+  var normalizedMode = mode === "loading" ? "loading" : normalizeNativePresenterMode(mode);
+  return {
+    state: "idle",
+    render_path: "webview2",
+    target_identity: null,
+    target_track_sid: null,
+    native_receive_fps: null,
+    native_presented_fps: null,
+    native_frames_received: 0,
+    native_frames_dropped: 0,
+    queue_depth: 0,
+    tile_width: null,
+    tile_height: null,
+    fallback_reason: "native presenter script loaded; waiting for screen track",
+    mode: normalizedMode,
+    updated_at_ms: Date.now(),
+  };
+}
+
+function buildNativePresenterFallbackStatus(reason, meta) {
+  var tile = meta && meta.tile;
+  var rect = null;
+  try {
+    rect = tile && typeof tile.getBoundingClientRect === "function"
+      ? buildNativePresenterTileRect(tile, meta.scaleFactor || window.devicePixelRatio || 1)
+      : null;
+  } catch (e) {
+    rect = null;
+  }
+  return {
+    state: "fallback",
+    render_path: "webview2",
+    target_identity: meta && (meta.identity || meta.participant_identity) || null,
+    target_track_sid: meta && (meta.trackSid || meta.track_sid) || null,
+    native_receive_fps: null,
+    native_presented_fps: null,
+    native_frames_received: 0,
+    native_frames_dropped: 0,
+    queue_depth: 0,
+    tile_width: rect ? rect.width : null,
+    tile_height: rect ? rect.height : null,
+    fallback_reason: reason || "native presenter skipped",
+    updated_at_ms: Date.now(),
+  };
+}
+
+function recordNativePresenterFallback(reason, meta) {
+  _nativePresenterStatus = buildNativePresenterFallbackStatus(reason, meta || {});
+  debugLog("[native-presenter] " + _nativePresenterStatus.fallback_reason);
+  return _nativePresenterStatus;
+}
+
 function getNativePresenterStatusSnapshot() {
+  if (_nativePresenterStatus && _nativePresenterStatus.state === "idle") {
+    _nativePresenterStatus = buildNativePresenterIdleStatus(getNativePresenterMode());
+  }
   return buildNativePresenterReport(_nativePresenterStatus);
+}
+
+async function refreshNativePresenterStatusSnapshot() {
+  if (!window.__ECHO_NATIVE__ || typeof hasTauriIPC !== "function" || !hasTauriIPC()) {
+    return getNativePresenterStatusSnapshot();
+  }
+  if (typeof tauriInvoke !== "function") return getNativePresenterStatusSnapshot();
+  try {
+    _nativePresenterStatus = await tauriInvoke("get_native_presenter_status");
+    postNativePresenterStatus(_nativePresenterStatus, false);
+  } catch (e) {
+    debugLog("[native-presenter] status refresh failed: " + (e && e.message ? e.message : e));
+  }
+  return getNativePresenterStatusSnapshot();
+}
+
+function exposeNativePresenterGlobals(root) {
+  if (!root) return;
+  root.getNativePresenterStatusSnapshot = getNativePresenterStatusSnapshot;
+  root.refreshNativePresenterStatusSnapshot = refreshNativePresenterStatusSnapshot;
 }
 
 function shouldNativePresenterProbeScreen(mode, tile) {
@@ -76,51 +234,101 @@ async function fetchNativePresenterToken(identity) {
   return fetchRoomToken(controlUrl, adminToken, roomId, presenterIdentity, presenterName);
 }
 
+function scheduleNativePresenterProbeRetries(meta) {
+  if (!meta || !meta.trackSid) return;
+  if (nativePresenterStartBlockReason(meta.trackSid, _nativePresenterActiveTrackSid, _nativePresenterPendingTrackSid)) return;
+  [750, 2500].forEach(function(delay) {
+    var timer = setTimeout(function() {
+      if (nativePresenterStartBlockReason(meta.trackSid, _nativePresenterActiveTrackSid, _nativePresenterPendingTrackSid)) return;
+      if (meta.tile && !meta.tile.isConnected) return;
+      maybeStartNativePresenterForScreenTrack(meta).catch(function(e) {
+        debugLog("[native-presenter] retry failed: " + (e && e.message ? e.message : e));
+      });
+    }, delay);
+    _nativePresenterRetryTimers.push(timer);
+  });
+}
+
 async function maybeStartNativePresenterForScreenTrack(meta) {
   try {
     var mode = getNativePresenterMode();
     var tile = meta && meta.tile;
-    if (!shouldNativePresenterProbeScreen(mode, tile)) return null;
+    if (mode === "off") return recordNativePresenterFallback("native presenter mode is off", meta);
+    if (!window.__ECHO_NATIVE__) return recordNativePresenterFallback("native shell unavailable", meta);
+    if (typeof hasTauriIPC !== "function" || !hasTauriIPC()) return recordNativePresenterFallback("tauri ipc unavailable", meta);
+    if (!tile || !tile.dataset) return recordNativePresenterFallback("screen tile metadata unavailable", meta);
+    if (!tile.dataset.trackSid || !tile.dataset.identity) return recordNativePresenterFallback("screen tile target unavailable", meta);
+    if (!shouldNativePresenterProbeScreen(mode, tile)) return recordNativePresenterFallback("native presenter screen probe not eligible", meta);
     var identity = meta.identity || (tile.dataset && tile.dataset.identity) || "";
     var trackSid = meta.trackSid || (tile.dataset && tile.dataset.trackSid) || "";
-    if (!identity || !trackSid) return null;
-    if (_nativePresenterActiveTrackSid === trackSid) return _nativePresenterStatus;
+    if (!identity || !trackSid) return recordNativePresenterFallback("native presenter target unavailable", meta);
+    var blockReason = nativePresenterStartBlockReason(
+      trackSid,
+      _nativePresenterActiveTrackSid,
+      _nativePresenterPendingTrackSid
+    );
+    if (blockReason) return skipNativePresenterStart(blockReason, meta);
 
+    var startToken = ++_nativePresenterStartToken;
+    _nativePresenterPendingTrackSid = trackSid;
     var token = await fetchNativePresenterToken(room?.localParticipant?.identity || identityInput.value || identity);
+    if (_nativePresenterPendingTrackSid !== trackSid || startToken !== _nativePresenterStartToken) {
+      return skipNativePresenterStart("start canceled", meta);
+    }
     var status = await tauriInvoke("start_native_presenter", {
-      request: {
+      request: buildNativePresenterStartRequest({
         mode: mode,
         room: currentRoomName || "main",
-        sfu_url: sfuUrlInput.value.trim(),
-        token: token,
-        viewer_identity: room?.localParticipant?.identity || identityInput.value || "",
-        participant_identity: identity,
-        track_sid: trackSid,
-        tile: buildNativePresenterTileRect(tile, window.devicePixelRatio || 1),
-      },
+        sfuUrl: sfuUrlInput.value.trim(),
+        nativeToken: token,
+        viewerToken: currentAccessToken || "",
+        viewerIdentity: room?.localParticipant?.identity || identityInput.value || "",
+        viewerName: nameInput.value.trim() || "",
+        controlUrl: controlUrlInput.value.trim(),
+        participantIdentity: identity,
+        trackSid: trackSid,
+        tile: tile,
+        scaleFactor: window.devicePixelRatio || 1,
+      }),
     });
+    if (_nativePresenterPendingTrackSid !== trackSid || startToken !== _nativePresenterStartToken) {
+      return skipNativePresenterStart("start canceled", meta);
+    }
     _nativePresenterStatus = status;
     _nativePresenterActiveTrackSid = trackSid;
+    _nativePresenterPendingTrackSid = "";
     startNativePresenterStatusPolling();
+    postNativePresenterStatus(status, true);
     debugLog("[native-presenter] receive probe started for " + identity + " " + trackSid);
     return status;
   } catch (e) {
-    debugLog("[native-presenter] start failed: " + (e && e.message ? e.message : e));
+    _nativePresenterPendingTrackSid = "";
+    recordNativePresenterFallback("start failed: " + (e && e.message ? e.message : e), meta);
     return null;
   }
 }
 
 async function stopNativePresenterForTrack(trackSid) {
+  if (_nativePresenterPendingTrackSid && _nativePresenterPendingTrackSid === trackSid) {
+    _nativePresenterPendingTrackSid = "";
+    _nativePresenterStartToken += 1;
+    return _nativePresenterStatus;
+  }
   if (!_nativePresenterActiveTrackSid || _nativePresenterActiveTrackSid !== trackSid) return null;
   return stopAllNativePresenter("track removed");
 }
 
 async function stopAllNativePresenter(reason) {
   if (!window.__ECHO_NATIVE__ || typeof hasTauriIPC !== "function" || !hasTauriIPC()) return null;
+  _nativePresenterRetryTimers.forEach(function(timer) { clearTimeout(timer); });
+  _nativePresenterRetryTimers = [];
+  _nativePresenterPendingTrackSid = "";
+  _nativePresenterStartToken += 1;
   try {
     var status = await tauriInvoke("stop_native_presenter", { reason: reason || "viewer stopped" });
     _nativePresenterStatus = status;
     _nativePresenterActiveTrackSid = "";
+    postNativePresenterStatus(status, true);
     return status;
   } catch (e) {
     debugLog("[native-presenter] stop failed: " + (e && e.message ? e.message : e));
@@ -131,20 +339,26 @@ async function stopAllNativePresenter(reason) {
 function startNativePresenterStatusPolling() {
   if (_nativePresenterPollTimer) return;
   _nativePresenterPollTimer = setInterval(async function() {
-    try {
-      if (!window.__ECHO_NATIVE__ || typeof hasTauriIPC !== "function" || !hasTauriIPC()) return;
-      _nativePresenterStatus = await tauriInvoke("get_native_presenter_status");
-    } catch (e) {
-      debugLog("[native-presenter] status failed: " + (e && e.message ? e.message : e));
-    }
+    await refreshNativePresenterStatusSnapshot();
   }, 1000);
 }
+
+_nativePresenterStatus = buildNativePresenterIdleStatus("loading");
+exposeNativePresenterGlobals(typeof globalThis === "object" ? globalThis : null);
 
 if (typeof module === "object" && module.exports) {
   module.exports = {
     normalizeNativePresenterMode,
     nativePresenterIdentity,
+    isNativePresenterIdentity,
     buildNativePresenterTileRect,
+    buildNativePresenterIdleStatus,
+    buildNativePresenterFallbackStatus,
     buildNativePresenterReport,
+    buildNativePresenterStatsPayload,
+    buildNativePresenterStartRequest,
+    nativePresenterStartBlockReason,
+    exposeNativePresenterGlobals,
+    refreshNativePresenterStatusSnapshot,
   };
 }

--- a/core/viewer/native-presenter.js
+++ b/core/viewer/native-presenter.js
@@ -1,0 +1,150 @@
+/* =========================================================
+   NATIVE PRESENTER - guarded native receive probe for screen tiles
+   ========================================================= */
+
+const NATIVE_PRESENTER_MODE_KEY = "echo-native-presenter-mode";
+var _nativePresenterStatus = null;
+var _nativePresenterActiveTrackSid = "";
+var _nativePresenterPollTimer = null;
+
+function normalizeNativePresenterMode(value) {
+  var mode = String(value || "off").toLowerCase();
+  return mode === "on" || mode === "auto" ? mode : "off";
+}
+
+function getNativePresenterMode() {
+  if (typeof echoGet !== "function") return "off";
+  return normalizeNativePresenterMode(echoGet(NATIVE_PRESENTER_MODE_KEY));
+}
+
+function nativePresenterIdentity(viewerIdentity) {
+  var identity = String(viewerIdentity || "").trim();
+  if (!identity) return "";
+  return identity.endsWith("$native-presenter") ? identity : identity + "$native-presenter";
+}
+
+function buildNativePresenterTileRect(tile, scaleFactor) {
+  var rect = tile.getBoundingClientRect();
+  var scale = Number(scaleFactor || window.devicePixelRatio || 1) || 1;
+  return {
+    x: Math.round(rect.left * scale),
+    y: Math.round(rect.top * scale),
+    width: Math.max(1, Math.round(rect.width * scale)),
+    height: Math.max(1, Math.round(rect.height * scale)),
+    scale_factor: scale,
+  };
+}
+
+function buildNativePresenterReport(status) {
+  if (!status) return null;
+  return {
+    state: status.state || "disabled",
+    render_path: status.render_path || "webview2",
+    target_identity: status.target_identity || null,
+    target_track_sid: status.target_track_sid || null,
+    native_receive_fps: status.native_receive_fps ?? null,
+    native_presented_fps: status.native_presented_fps ?? null,
+    native_frames_received: status.native_frames_received || 0,
+    native_frames_dropped: status.native_frames_dropped || 0,
+    queue_depth: status.queue_depth || 0,
+    fallback_reason: status.fallback_reason || null,
+    tile_width: status.tile_width || null,
+    tile_height: status.tile_height || null,
+    updated_at_ms: status.updated_at_ms || 0,
+  };
+}
+
+function getNativePresenterStatusSnapshot() {
+  return buildNativePresenterReport(_nativePresenterStatus);
+}
+
+function shouldNativePresenterProbeScreen(mode, tile) {
+  if (!window.__ECHO_NATIVE__ || typeof hasTauriIPC !== "function" || !hasTauriIPC()) return false;
+  if (mode === "off") return false;
+  if (!tile || !tile.dataset || !tile.dataset.trackSid || !tile.dataset.identity) return false;
+  if (mode === "on") return true;
+  var rect = tile.getBoundingClientRect();
+  return rect.width >= 1600 || rect.height >= 900;
+}
+
+async function fetchNativePresenterToken(identity) {
+  if (!adminToken) throw new Error("admin token unavailable");
+  var controlUrl = controlUrlInput.value.trim();
+  var roomId = currentRoomName || "main";
+  var presenterIdentity = nativePresenterIdentity(identity);
+  var presenterName = (nameInput.value.trim() || "Viewer") + " Native Presenter";
+  return fetchRoomToken(controlUrl, adminToken, roomId, presenterIdentity, presenterName);
+}
+
+async function maybeStartNativePresenterForScreenTrack(meta) {
+  try {
+    var mode = getNativePresenterMode();
+    var tile = meta && meta.tile;
+    if (!shouldNativePresenterProbeScreen(mode, tile)) return null;
+    var identity = meta.identity || (tile.dataset && tile.dataset.identity) || "";
+    var trackSid = meta.trackSid || (tile.dataset && tile.dataset.trackSid) || "";
+    if (!identity || !trackSid) return null;
+    if (_nativePresenterActiveTrackSid === trackSid) return _nativePresenterStatus;
+
+    var token = await fetchNativePresenterToken(room?.localParticipant?.identity || identityInput.value || identity);
+    var status = await tauriInvoke("start_native_presenter", {
+      request: {
+        mode: mode,
+        room: currentRoomName || "main",
+        sfu_url: sfuUrlInput.value.trim(),
+        token: token,
+        viewer_identity: room?.localParticipant?.identity || identityInput.value || "",
+        participant_identity: identity,
+        track_sid: trackSid,
+        tile: buildNativePresenterTileRect(tile, window.devicePixelRatio || 1),
+      },
+    });
+    _nativePresenterStatus = status;
+    _nativePresenterActiveTrackSid = trackSid;
+    startNativePresenterStatusPolling();
+    debugLog("[native-presenter] receive probe started for " + identity + " " + trackSid);
+    return status;
+  } catch (e) {
+    debugLog("[native-presenter] start failed: " + (e && e.message ? e.message : e));
+    return null;
+  }
+}
+
+async function stopNativePresenterForTrack(trackSid) {
+  if (!_nativePresenterActiveTrackSid || _nativePresenterActiveTrackSid !== trackSid) return null;
+  return stopAllNativePresenter("track removed");
+}
+
+async function stopAllNativePresenter(reason) {
+  if (!window.__ECHO_NATIVE__ || typeof hasTauriIPC !== "function" || !hasTauriIPC()) return null;
+  try {
+    var status = await tauriInvoke("stop_native_presenter", { reason: reason || "viewer stopped" });
+    _nativePresenterStatus = status;
+    _nativePresenterActiveTrackSid = "";
+    return status;
+  } catch (e) {
+    debugLog("[native-presenter] stop failed: " + (e && e.message ? e.message : e));
+    return null;
+  }
+}
+
+function startNativePresenterStatusPolling() {
+  if (_nativePresenterPollTimer) return;
+  _nativePresenterPollTimer = setInterval(async function() {
+    try {
+      if (!window.__ECHO_NATIVE__ || typeof hasTauriIPC !== "function" || !hasTauriIPC()) return;
+      _nativePresenterStatus = await tauriInvoke("get_native_presenter_status");
+    } catch (e) {
+      debugLog("[native-presenter] status failed: " + (e && e.message ? e.message : e));
+    }
+  }, 1000);
+}
+
+if (typeof module === "object" && module.exports) {
+  module.exports = {
+    normalizeNativePresenterMode,
+    nativePresenterIdentity,
+    buildNativePresenterTileRect,
+    buildNativePresenterReport,
+  };
+}

--- a/core/viewer/native-presenter.test.js
+++ b/core/viewer/native-presenter.test.js
@@ -3,8 +3,16 @@ const assert = require("node:assert/strict");
 const {
   normalizeNativePresenterMode,
   nativePresenterIdentity,
+  isNativePresenterIdentity,
   buildNativePresenterTileRect,
+  buildNativePresenterIdleStatus,
+  buildNativePresenterFallbackStatus,
   buildNativePresenterReport,
+  buildNativePresenterStatsPayload,
+  buildNativePresenterStartRequest,
+  nativePresenterStartBlockReason,
+  exposeNativePresenterGlobals,
+  refreshNativePresenterStatusSnapshot,
 } = require("./native-presenter.js");
 
 test("native presenter mode defaults to off", () => {
@@ -21,6 +29,13 @@ test("native presenter identity is a hidden companion identity", () => {
     nativePresenterIdentity("Sam-1234$native-presenter"),
     "Sam-1234$native-presenter"
   );
+});
+
+test("native presenter companion identities are hidden from participant UI", () => {
+  assert.equal(isNativePresenterIdentity("Sam-1234$native-presenter"), true);
+  assert.equal(isNativePresenterIdentity("Sam-1234"), false);
+  assert.equal(isNativePresenterIdentity("Sam-1234$screen"), false);
+  assert.equal(isNativePresenterIdentity(""), false);
 });
 
 test("tile rect is converted to physical pixels", () => {
@@ -41,6 +56,36 @@ test("tile rect is converted to physical pixels", () => {
 
 test("native presenter report is null when status is missing", () => {
   assert.equal(buildNativePresenterReport(null), null);
+});
+
+test("native presenter idle status proves the script loaded", () => {
+  const status = buildNativePresenterIdleStatus("on");
+
+  assert.equal(status.state, "idle");
+  assert.equal(status.render_path, "webview2");
+  assert.equal(status.fallback_reason, "native presenter script loaded; waiting for screen track");
+  assert.equal(status.mode, "on");
+});
+
+test("native presenter fallback status reports skipped activation reason", () => {
+  const status = buildNativePresenterFallbackStatus("admin token unavailable", {
+    identity: "SAM-PC-1234",
+    trackSid: "TR_screen",
+    tile: {
+      getBoundingClientRect() {
+        return { left: 0, top: 0, width: 1280, height: 720 };
+      },
+    },
+    scaleFactor: 1,
+  });
+
+  assert.equal(status.state, "fallback");
+  assert.equal(status.render_path, "webview2");
+  assert.equal(status.fallback_reason, "admin token unavailable");
+  assert.equal(status.target_identity, "SAM-PC-1234");
+  assert.equal(status.target_track_sid, "TR_screen");
+  assert.equal(status.tile_width, 1280);
+  assert.equal(status.tile_height, 720);
 });
 
 test("native presenter report exposes safe telemetry names", () => {
@@ -65,4 +110,139 @@ test("native presenter report exposes safe telemetry names", () => {
   assert.equal(report.native_receive_fps, 59.7);
   assert.equal(report.native_presented_fps, null);
   assert.equal(report.target_identity, "Spencer-2222");
+});
+
+test("refresh native presenter status asks Tauri for live Rust status", async () => {
+  const oldWindow = global.window;
+  const oldHasTauriIPC = global.hasTauriIPC;
+  const oldTauriInvoke = global.tauriInvoke;
+  const oldDebugLog = global.debugLog;
+  global.window = { __ECHO_NATIVE__: true };
+  global.hasTauriIPC = () => true;
+  global.debugLog = () => {};
+  global.tauriInvoke = async (command) => {
+    assert.equal(command, "get_native_presenter_status");
+    return {
+      state: "receiving",
+      render_path: "native_receive_probe",
+      target_identity: "SAM-PC-1234",
+      target_track_sid: "TR_screen",
+      native_receive_fps: 58.8,
+      native_presented_fps: null,
+      native_frames_received: 240,
+      native_frames_dropped: 0,
+      queue_depth: 0,
+      fallback_reason: null,
+      tile_width: 1920,
+      tile_height: 1080,
+      updated_at_ms: 1234,
+    };
+  };
+
+  const report = await refreshNativePresenterStatusSnapshot();
+
+  assert.equal(report.state, "receiving");
+  assert.equal(report.native_receive_fps, 58.8);
+  assert.equal(report.native_frames_received, 240);
+
+  global.window = oldWindow;
+  global.hasTauriIPC = oldHasTauriIPC;
+  global.tauriInvoke = oldTauriInvoke;
+  global.debugLog = oldDebugLog;
+});
+
+test("native presenter telemetry functions are exposed for other scripts", () => {
+  const root = {};
+
+  exposeNativePresenterGlobals(root);
+
+  assert.equal(typeof root.getNativePresenterStatusSnapshot, "function");
+  assert.equal(typeof root.refreshNativePresenterStatusSnapshot, "function");
+});
+
+test("native presenter stats payload carries native report for dashboard merge", () => {
+  const payload = buildNativePresenterStatsPayload({
+    state: "receiving",
+    render_path: "native_receive_probe",
+    target_identity: "SAM-PC-1234",
+    target_track_sid: "TR_screen",
+    native_receive_fps: 15.1,
+    native_presented_fps: null,
+    native_frames_received: 1200,
+    native_frames_dropped: 0,
+    queue_depth: 0,
+    fallback_reason: null,
+    tile_width: 1920,
+    tile_height: 1080,
+    updated_at_ms: 12345,
+  }, {
+    identity: "Sam-1234",
+    name: "Sam",
+    room: "main",
+  });
+
+  assert.equal(payload.identity, "Sam-1234");
+  assert.equal(payload.name, "Sam");
+  assert.equal(payload.room, "main");
+  assert.equal(payload.native_presenter.state, "receiving");
+  assert.equal(payload.native_presenter.render_path, "native_receive_probe");
+  assert.equal(payload.native_presenter.native_receive_fps, 15.1);
+});
+
+test("native presenter start request carries visible viewer token for native status reporting", () => {
+  const tile = {
+    dataset: {
+      identity: "SAM-PC-1234",
+      trackSid: "TR_screen",
+    },
+    getBoundingClientRect() {
+      return { left: 10, top: 20, width: 1280, height: 720 };
+    },
+  };
+
+  const request = buildNativePresenterStartRequest({
+    mode: "on",
+    room: "main",
+    sfuUrl: "wss://echo.example.invalid",
+    nativeToken: "hidden-native-token",
+    viewerIdentity: "Sam-1234",
+    viewerName: "Sam",
+    viewerToken: "visible-viewer-token",
+    controlUrl: "https://echo.example.invalid/",
+    participantIdentity: "SAM-PC-1234",
+    trackSid: "TR_screen",
+    tile,
+    scaleFactor: 1,
+  });
+
+  assert.equal(request.token, "hidden-native-token");
+  assert.equal(request.viewer_token, "visible-viewer-token");
+  assert.equal(request.viewer_name, "Sam");
+  assert.equal(request.control_url, "https://echo.example.invalid/");
+  assert.equal(request.viewer_identity, "Sam-1234");
+  assert.equal(request.participant_identity, "SAM-PC-1234");
+  assert.deepEqual(request.tile, {
+    x: 10,
+    y: 20,
+    width: 1280,
+    height: 720,
+    scale_factor: 1,
+  });
+});
+
+test("native presenter blocks a second active target", () => {
+  assert.equal(
+    nativePresenterStartBlockReason("TR_brad", "TR_sam", ""),
+    "native presenter already probing another screen"
+  );
+  assert.equal(nativePresenterStartBlockReason("TR_sam", "TR_sam", ""), "already active");
+});
+
+test("native presenter blocks a second pending target", () => {
+  assert.equal(
+    nativePresenterStartBlockReason("TR_brad", "", "TR_sam"),
+    "native presenter start already pending for another screen"
+  );
+  assert.equal(nativePresenterStartBlockReason("TR_sam", "", "TR_sam"), "already pending");
+  assert.equal(nativePresenterStartBlockReason("TR_sam", "", ""), null);
 });

--- a/core/viewer/native-presenter.test.js
+++ b/core/viewer/native-presenter.test.js
@@ -1,0 +1,68 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const {
+  normalizeNativePresenterMode,
+  nativePresenterIdentity,
+  buildNativePresenterTileRect,
+  buildNativePresenterReport,
+} = require("./native-presenter.js");
+
+test("native presenter mode defaults to off", () => {
+  assert.equal(normalizeNativePresenterMode("off"), "off");
+  assert.equal(normalizeNativePresenterMode("on"), "on");
+  assert.equal(normalizeNativePresenterMode("auto"), "auto");
+  assert.equal(normalizeNativePresenterMode(""), "off");
+  assert.equal(normalizeNativePresenterMode("turbo"), "off");
+});
+
+test("native presenter identity is a hidden companion identity", () => {
+  assert.equal(nativePresenterIdentity("Sam-1234"), "Sam-1234$native-presenter");
+  assert.equal(
+    nativePresenterIdentity("Sam-1234$native-presenter"),
+    "Sam-1234$native-presenter"
+  );
+});
+
+test("tile rect is converted to physical pixels", () => {
+  const tile = {
+    getBoundingClientRect() {
+      return { left: 10.25, top: 20.5, width: 640.5, height: 360.25 };
+    },
+  };
+  const rect = buildNativePresenterTileRect(tile, 1.5);
+  assert.deepEqual(rect, {
+    x: 15,
+    y: 31,
+    width: 961,
+    height: 540,
+    scale_factor: 1.5,
+  });
+});
+
+test("native presenter report is null when status is missing", () => {
+  assert.equal(buildNativePresenterReport(null), null);
+});
+
+test("native presenter report exposes safe telemetry names", () => {
+  const report = buildNativePresenterReport({
+    state: "receiving",
+    render_path: "native_receive_probe",
+    target_identity: "Spencer-2222",
+    target_track_sid: "TR_screen",
+    native_receive_fps: 59.7,
+    native_presented_fps: null,
+    native_frames_received: 120,
+    native_frames_dropped: 0,
+    queue_depth: 0,
+    fallback_reason: null,
+    tile_width: 1920,
+    tile_height: 1080,
+    updated_at_ms: 4567,
+  });
+
+  assert.equal(report.state, "receiving");
+  assert.equal(report.render_path, "native_receive_probe");
+  assert.equal(report.native_receive_fps, 59.7);
+  assert.equal(report.native_presented_fps, null);
+  assert.equal(report.target_identity, "Spencer-2222");
+});

--- a/core/viewer/participants-avatar.js
+++ b/core/viewer/participants-avatar.js
@@ -169,8 +169,8 @@ function ensureParticipantCard(participant, isLocal = false) {
   const key = participant.identity;
   // Hide ghost subscriber from UI
   if (key.startsWith("__echo_ghost_")) return null;
-  // Hide $screen companion identities from participant list
-  if (isScreenIdentity(key)) return null;
+  // Hide internal companion identities from participant list.
+  if (isScreenIdentity(key) || isNativePresenterIdentity(key)) return null;
   if (participantCards.has(key)) {
     debugLog(`participant card already exists for ${key}`);
     return participantCards.get(key);

--- a/core/viewer/participants-fullscreen.js
+++ b/core/viewer/participants-fullscreen.js
@@ -97,6 +97,9 @@ function registerScreenTrack(trackSid, publication, tile, identity) {
       debugLog("[native-presenter] register start failed: " + (e && e.message ? e.message : e));
     });
   }
+  if (typeof scheduleNativePresenterProbeRetries === "function") {
+    scheduleNativePresenterProbeRetries({ trackSid, publication, tile, identity });
+  }
   if (ENABLE_SCREEN_WATCHDOG) startScreenWatchdog();
 }
 

--- a/core/viewer/participants-fullscreen.js
+++ b/core/viewer/participants-fullscreen.js
@@ -408,12 +408,59 @@ function getTrackSid(publication, track, fallback) {
 
 // ── Video diagnostics ──
 
+function createVideoFrameRateTracker(nowFn) {
+  const getNow = typeof nowFn === "function" ? nowFn : () => performance.now();
+  let callbackFrames = 0;
+  let lastCallbackFrames = 0;
+  let latestPresentedFrames = null;
+  let lastPresentedFrames = null;
+  let lastSampleTs = getNow();
+
+  function noteFrame(metadata) {
+    callbackFrames += 1;
+    const presented = Number(metadata?.presentedFrames);
+    if (Number.isFinite(presented)) {
+      if (lastPresentedFrames === null) {
+        lastPresentedFrames = presented;
+      }
+      latestPresentedFrames = presented;
+    }
+  }
+
+  function sample(sampleTs) {
+    const now = typeof sampleTs === "number" ? sampleTs : getNow();
+    const elapsed = (now - lastSampleTs) / 1000;
+    let frameDelta = callbackFrames - lastCallbackFrames;
+
+    if (latestPresentedFrames !== null && lastPresentedFrames !== null) {
+      frameDelta = latestPresentedFrames - lastPresentedFrames;
+      lastPresentedFrames = latestPresentedFrames;
+    }
+
+    lastCallbackFrames = callbackFrames;
+    lastSampleTs = now;
+
+    if (!Number.isFinite(frameDelta) || frameDelta < 0) {
+      frameDelta = 0;
+    }
+    return elapsed > 0 ? frameDelta / elapsed : 0;
+  }
+
+  function presentedFrames() {
+    return latestPresentedFrames;
+  }
+
+  return { noteFrame, sample, presentedFrames };
+}
+
+function getVideoPresentationSnapshot(element) {
+  return element?._echoPresentationStats || null;
+}
+
 function attachVideoDiagnostics(track, element, overlay) {
   if (!element || !overlay) return;
   const mediaTrack = track?.mediaStreamTrack;
-  let frames = 0;
-  let lastFrames = 0;
-  let lastTs = performance.now();
+  const frameRate = createVideoFrameRateTracker(() => performance.now());
   element._lastFrameTs = performance.now();
   element._firstFrameTs = element._firstFrameTs || 0;
   let lastMediaTime = element.currentTime || 0;
@@ -460,21 +507,30 @@ function attachVideoDiagnostics(track, element, overlay) {
         element._firstFrameTs = now;
       }
     }
-    const elapsed = (now - lastTs) / 1000;
-    const fps = elapsed > 0 ? (frames - lastFrames) / elapsed : 0;
-    lastFrames = frames;
-    lastTs = now;
+    const fps = frameRate.sample(now);
     const w = element.videoWidth || 0;
     const h = element.videoHeight || 0;
     const ready = element.readyState;
     const muted = mediaTrack?.muted ? "muted" : "live";
     const isBlack = detectBlack();
+    element._echoPresentationStats = {
+      fps,
+      width: w,
+      height: h,
+      readyState: ready,
+      muted: mediaTrack?.muted === true,
+      black: isBlack,
+      firstFrameTs: element._firstFrameTs || 0,
+      lastFrameTs: element._lastFrameTs || 0,
+      presentedFrames: frameRate.presentedFrames(),
+      updatedAt: Date.now(),
+    };
     overlay.textContent = `${w}x${h} | fps ${fps.toFixed(1)} | ${muted} | rs ${ready}${isBlack ? " | black" : ""}`;
   };
 
   if (typeof element.requestVideoFrameCallback === "function") {
-    const onFrame = () => {
-      frames += 1;
+    const onFrame = (_now, metadata) => {
+      frameRate.noteFrame(metadata);
       element._lastFrameTs = performance.now();
       if (!element._firstFrameTs) {
         element._firstFrameTs = element._lastFrameTs;
@@ -498,6 +554,13 @@ function attachVideoDiagnostics(track, element, overlay) {
       overlay.textContent = "track ended";
     };
   }
+}
+
+if (typeof module === "object" && module.exports) {
+  module.exports = {
+    createVideoFrameRateTracker,
+    getVideoPresentationSnapshot,
+  };
 }
 
 function cleanupVideoDiagnostics(overlay) {

--- a/core/viewer/participants-fullscreen.js
+++ b/core/viewer/participants-fullscreen.js
@@ -83,6 +83,7 @@ function openImageLightbox(src) {
 function registerScreenTrack(trackSid, publication, tile, identity) {
   if (!trackSid || !tile) return;
   screenTrackMeta.set(trackSid, {
+    trackSid,
     publication,
     tile,
     lastFix: 0,
@@ -91,11 +92,21 @@ function registerScreenTrack(trackSid, publication, tile, identity) {
     identity: identity || "",
     createdAt: performance.now()
   });
+  if (typeof maybeStartNativePresenterForScreenTrack === "function") {
+    maybeStartNativePresenterForScreenTrack({ trackSid, publication, tile, identity }).catch(function(e) {
+      debugLog("[native-presenter] register start failed: " + (e && e.message ? e.message : e));
+    });
+  }
   if (ENABLE_SCREEN_WATCHDOG) startScreenWatchdog();
 }
 
 function unregisterScreenTrack(trackSid) {
   if (!trackSid) return;
+  if (typeof stopNativePresenterForTrack === "function") {
+    stopNativePresenterForTrack(trackSid).catch(function(e) {
+      debugLog("[native-presenter] unregister stop failed: " + (e && e.message ? e.message : e));
+    });
+  }
   screenTrackMeta.delete(trackSid);
   if (screenTrackMeta.size === 0 && screenWatchdogTimer) {
     clearInterval(screenWatchdogTimer);

--- a/core/viewer/participants-grid.js
+++ b/core/viewer/participants-grid.js
@@ -163,6 +163,11 @@ function removeScreenTile(trackSid) {
 }
 
 function clearMedia() {
+  if (typeof stopAllNativePresenter === "function") {
+    stopAllNativePresenter("media cleared").catch(function(e) {
+      debugLog("[native-presenter] clearMedia stop failed: " + (e && e.message ? e.message : e));
+    });
+  }
   screenGridEl.innerHTML = "";
   screenTileBySid.clear();
   screenTileByIdentity.clear();

--- a/core/viewer/participants-grid.js
+++ b/core/viewer/participants-grid.js
@@ -17,6 +17,7 @@ function addTile(label, element) {
 
 function addScreenTile(label, element, trackSid) {
   configureVideoElement(element, true);
+  element.classList.add("screen-video-surface");
   // Force contain so ultrawides and non-standard ratios are never stretched
   element.style.setProperty("object-fit", "contain", "important");
   element.style.width = "100%";

--- a/core/viewer/reliability-scenarios.test.js
+++ b/core/viewer/reliability-scenarios.test.js
@@ -3,6 +3,7 @@ const assert = require("node:assert/strict");
 const { createRoomSwitchState } = require("./room-switch-state.js");
 const { createJamSessionState } = require("./jam-session-state.js");
 const { reconcilePublishIndicators } = require("./publish-state-reconcile.js");
+const { isTauriCommandMissingError } = require("./capture-picker.js");
 
 test("room transition keeps heartbeat on connected room until switch commit", () => {
   const rooms = createRoomSwitchState({ initialRoomName: "main", cooldownMs: 0 });
@@ -12,6 +13,17 @@ test("room transition keeps heartbeat on connected room until switch commit", ()
 
   rooms.markConnected("gaming");
   assert.equal(rooms.heartbeatRoomName(), "gaming");
+});
+
+test("native picker detects missing Tauri command for compatibility fallback", () => {
+  assert.equal(
+    isTauriCommandMissingError(
+      new Error("Command list_screen_sources not found"),
+      "list_screen_sources"
+    ),
+    true
+  );
+  assert.equal(isTauriCommandMissingError(new Error("permission denied"), "list_screen_sources"), false);
 });
 
 test("switch transition publish drift is reconciled against actual publication", () => {

--- a/core/viewer/screen-share-adaptive.js
+++ b/core/viewer/screen-share-adaptive.js
@@ -11,6 +11,69 @@ function getScreenPresentationStatsForIdentity(identity) {
   return video?._echoPresentationStats || null;
 }
 
+function buildNativePresenterUnavailableReport(reason) {
+  return {
+    state: "fallback",
+    render_path: "webview2",
+    target_identity: null,
+    target_track_sid: null,
+    native_receive_fps: null,
+    native_presented_fps: null,
+    native_frames_received: 0,
+    native_frames_dropped: 0,
+    queue_depth: 0,
+    fallback_reason: reason || "native presenter unavailable",
+    tile_width: null,
+    tile_height: null,
+    updated_at_ms: Date.now(),
+  };
+}
+
+function getNativePresenterStatusForReport() {
+  var root = typeof globalThis === "object" ? globalThis : null;
+  var snapshot = typeof getNativePresenterStatusSnapshot === "function"
+    ? getNativePresenterStatusSnapshot
+    : root && typeof root.getNativePresenterStatusSnapshot === "function"
+    ? root.getNativePresenterStatusSnapshot
+    : null;
+  if (snapshot) {
+    try {
+      return snapshot() || buildNativePresenterUnavailableReport("native presenter status unavailable");
+    } catch (e) {
+      return buildNativePresenterUnavailableReport(
+        "native presenter status error: " + (e && e.message ? e.message : e)
+      );
+    }
+  }
+  var nativeShell = root && root.window && root.window.__ECHO_NATIVE__ === true;
+  return nativeShell ? buildNativePresenterUnavailableReport("native presenter script unavailable") : null;
+}
+
+async function resolveNativePresenterStatusForReport() {
+  var root = typeof globalThis === "object" ? globalThis : null;
+  var refresh = typeof refreshNativePresenterStatusSnapshot === "function"
+    ? refreshNativePresenterStatusSnapshot
+    : root && typeof root.refreshNativePresenterStatusSnapshot === "function"
+    ? root.refreshNativePresenterStatusSnapshot
+    : null;
+  if (refresh) {
+    try {
+      return await refresh() || buildNativePresenterUnavailableReport("native presenter status unavailable");
+    } catch (e) {
+      return buildNativePresenterUnavailableReport(
+        "native presenter status refresh error: " + (e && e.message ? e.message : e)
+      );
+    }
+  }
+  return getNativePresenterStatusForReport();
+}
+
+function exposeNativePresenterReportGlobals(root) {
+  if (!root) return;
+  root.getNativePresenterStatusForReport = getNativePresenterStatusForReport;
+  root.resolveNativePresenterStatusForReport = resolveNativePresenterStatusForReport;
+}
+
 function startInboundScreenStatsMonitor() {
   if (_inboundScreenStatsInterval) return;
   _inboundScreenStatsInterval = setInterval(async () => {
@@ -607,9 +670,7 @@ function startInboundScreenStatsMonitor() {
         var displayStatus = typeof getEchoDisplayStatusSnapshot === "function"
           ? getEchoDisplayStatusSnapshot()
           : null;
-        var nativePresenter = typeof getNativePresenterStatusSnapshot === "function"
-          ? getNativePresenterStatusSnapshot()
-          : null;
+        var nativePresenter = await resolveNativePresenterStatusForReport();
 
         // Fire the POST whenever we have ANYTHING to report — either receive-side
         // inbound stats (other publishers exist) OR local capture health (we are
@@ -637,6 +698,17 @@ function startInboundScreenStatsMonitor() {
       }
     } catch (e) {}
   }, 3000);
+}
+
+exposeNativePresenterReportGlobals(typeof globalThis === "object" ? globalThis : null);
+
+if (typeof module === "object" && module.exports) {
+  module.exports = {
+    buildNativePresenterUnavailableReport,
+    exposeNativePresenterReportGlobals,
+    getNativePresenterStatusForReport,
+    resolveNativePresenterStatusForReport,
+  };
 }
 
 function stopInboundScreenStatsMonitor() {

--- a/core/viewer/screen-share-adaptive.js
+++ b/core/viewer/screen-share-adaptive.js
@@ -607,13 +607,16 @@ function startInboundScreenStatsMonitor() {
         var displayStatus = typeof getEchoDisplayStatusSnapshot === "function"
           ? getEchoDisplayStatusSnapshot()
           : null;
+        var nativePresenter = typeof getNativePresenterStatusSnapshot === "function"
+          ? getNativePresenterStatusSnapshot()
+          : null;
 
         // Fire the POST whenever we have ANYTHING to report — either receive-side
         // inbound stats (other publishers exist) OR local capture health (we are
         // a Tauri publisher). Without this OR, a publisher alone in the room
         // would never report their own capture telemetry. Discovered live
         // 2026-04-08 during Phase 2 smoke test.
-        if (inboundArr2.length > 0 || captureHealth || displayStatus) {
+        if (inboundArr2.length > 0 || captureHealth || displayStatus || nativePresenter) {
           fetch(apiUrl("/api/client-stats-report"), {
             method: "POST",
             headers: {
@@ -627,6 +630,7 @@ function startInboundScreenStatsMonitor() {
               inbound: inboundArr2,
               capture_health: captureHealth,
               display_status: displayStatus,
+              native_presenter: nativePresenter,
             }),
           }).catch(function() {});
         }

--- a/core/viewer/screen-share-adaptive.js
+++ b/core/viewer/screen-share-adaptive.js
@@ -2,6 +2,15 @@
    SCREEN SHARE — AIMD bitrate control + adaptive layer switching + camera adaptation
    ========================================================= */
 
+function getScreenPresentationStatsForIdentity(identity) {
+  var tile = screenTileByIdentity.get(identity);
+  var video = tile ? tile.querySelector("video") : null;
+  if (typeof getVideoPresentationSnapshot === "function") {
+    return getVideoPresentationSnapshot(video);
+  }
+  return video?._echoPresentationStats || null;
+}
+
 function startInboundScreenStatsMonitor() {
   if (_inboundScreenStatsInterval) return;
   _inboundScreenStatsInterval = setInterval(async () => {
@@ -565,6 +574,10 @@ function startInboundScreenStatsMonitor() {
           var fromId = parts.slice(0, parts.length - 1).join("-");
           var avgF = dt.fpsHistory.length > 0
             ? dt.fpsHistory.reduce(function(a, b) { return a + b; }, 0) / dt.fpsHistory.length : 0;
+          var presentation = source === "screen" ? getScreenPresentationStatsForIdentity(fromId) : null;
+          var presentationAge = presentation?.updatedAt
+            ? Math.max(0, Date.now() - presentation.updatedAt)
+            : null;
           inboundArr2.push({
             from: fromId, source: source,
             fps: dt._lastReport.fps, width: dt._lastReport.w, height: dt._lastReport.h,
@@ -575,6 +588,11 @@ function startInboundScreenStatsMonitor() {
             layer: dt.currentQuality, codec: dt._lastReport.codec || null,
             ice_local_type: dt._lastReport.ice_local_type || null,
             ice_remote_type: dt._lastReport.ice_remote_type || null,
+            presented_fps: presentation ? presentation.fps : null,
+            presented_width: presentation ? presentation.width : null,
+            presented_height: presentation ? presentation.height : null,
+            presented_frames: presentation ? presentation.presentedFrames : null,
+            presentation_age_ms: presentationAge,
           });
         });
 
@@ -586,13 +604,16 @@ function startInboundScreenStatsMonitor() {
             captureHealth = await tauriInvoke("get_capture_health");
           }
         } catch (e) { /* IPC unavailable, e.g. browser viewer */ }
+        var displayStatus = typeof getEchoDisplayStatusSnapshot === "function"
+          ? getEchoDisplayStatusSnapshot()
+          : null;
 
         // Fire the POST whenever we have ANYTHING to report — either receive-side
         // inbound stats (other publishers exist) OR local capture health (we are
         // a Tauri publisher). Without this OR, a publisher alone in the room
         // would never report their own capture telemetry. Discovered live
         // 2026-04-08 during Phase 2 smoke test.
-        if (inboundArr2.length > 0 || captureHealth) {
+        if (inboundArr2.length > 0 || captureHealth || displayStatus) {
           fetch(apiUrl("/api/client-stats-report"), {
             method: "POST",
             headers: {
@@ -605,6 +626,7 @@ function startInboundScreenStatsMonitor() {
               room: currentRoomName || "",
               inbound: inboundArr2,
               capture_health: captureHealth,
+              display_status: displayStatus,
             }),
           }).catch(function() {});
         }

--- a/core/viewer/screen-share-adaptive.test.js
+++ b/core/viewer/screen-share-adaptive.test.js
@@ -1,0 +1,88 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const {
+  buildNativePresenterUnavailableReport,
+  exposeNativePresenterReportGlobals,
+  getNativePresenterStatusForReport,
+  resolveNativePresenterStatusForReport,
+} = require("./screen-share-adaptive.js");
+
+test("native presenter unavailable report uses dashboard-safe shape", () => {
+  const report = buildNativePresenterUnavailableReport("native presenter script unavailable");
+
+  assert.equal(report.state, "fallback");
+  assert.equal(report.render_path, "webview2");
+  assert.equal(report.fallback_reason, "native presenter script unavailable");
+  assert.equal(report.target_identity, null);
+  assert.equal(report.target_track_sid, null);
+});
+
+test("native presenter report is null in browser viewer when script is missing", () => {
+  const oldWindow = global.window;
+  const oldSnapshot = global.getNativePresenterStatusSnapshot;
+  delete global.getNativePresenterStatusSnapshot;
+  global.window = { __ECHO_NATIVE__: false };
+
+  assert.equal(getNativePresenterStatusForReport(), null);
+
+  global.window = oldWindow;
+  if (oldSnapshot) global.getNativePresenterStatusSnapshot = oldSnapshot;
+});
+
+test("native presenter report exposes missing script in native shell", () => {
+  const oldWindow = global.window;
+  const oldSnapshot = global.getNativePresenterStatusSnapshot;
+  delete global.getNativePresenterStatusSnapshot;
+  global.window = { __ECHO_NATIVE__: true };
+
+  const report = getNativePresenterStatusForReport();
+
+  assert.equal(report.state, "fallback");
+  assert.equal(report.fallback_reason, "native presenter script unavailable");
+
+  global.window = oldWindow;
+  if (oldSnapshot) global.getNativePresenterStatusSnapshot = oldSnapshot;
+});
+
+test("native presenter dashboard report prefers refreshed Rust status", async () => {
+  const oldWindow = global.window;
+  const oldSnapshot = global.getNativePresenterStatusSnapshot;
+  const oldRefresh = global.refreshNativePresenterStatusSnapshot;
+  global.window = { __ECHO_NATIVE__: true };
+  global.getNativePresenterStatusSnapshot = () => ({
+    state: "fallback",
+    render_path: "webview2",
+    fallback_reason: "stale cached fallback",
+    native_frames_received: 0,
+  });
+  global.refreshNativePresenterStatusSnapshot = async () => ({
+    state: "receiving",
+    render_path: "native_receive_probe",
+    target_identity: "SAM-PC-1234",
+    target_track_sid: "TR_screen",
+    native_receive_fps: 58.8,
+    native_frames_received: 240,
+  });
+
+  const report = await resolveNativePresenterStatusForReport();
+
+  assert.equal(report.state, "receiving");
+  assert.equal(report.render_path, "native_receive_probe");
+  assert.equal(report.native_receive_fps, 58.8);
+  assert.equal(report.fallback_reason, undefined);
+
+  global.window = oldWindow;
+  if (oldSnapshot) global.getNativePresenterStatusSnapshot = oldSnapshot;
+  else delete global.getNativePresenterStatusSnapshot;
+  if (oldRefresh) global.refreshNativePresenterStatusSnapshot = oldRefresh;
+  else delete global.refreshNativePresenterStatusSnapshot;
+});
+
+test("native presenter report functions are exposed for debug reporter", () => {
+  const root = {};
+
+  exposeNativePresenterReportGlobals(root);
+
+  assert.equal(typeof root.getNativePresenterStatusForReport, "function");
+  assert.equal(typeof root.resolveNativePresenterStatusForReport, "function");
+});

--- a/core/viewer/screen-share-native.js
+++ b/core/viewer/screen-share-native.js
@@ -71,7 +71,22 @@ async function startScreenShareManual() {
   var wgcSupported = true;
 
   if (isNativeClient) {
-    source = await showCapturePicker();
+    try {
+      source = await showCapturePicker();
+    } catch (pickerErr) {
+      if (typeof isTauriCommandMissingError === 'function' &&
+          isTauriCommandMissingError(pickerErr, 'list_screen_sources')) {
+        debugLog('[native-capture] list_screen_sources unavailable; using browser screen picker fallback');
+        showToast('Native screen picker unavailable; using browser picker', 5000);
+        isNativeClient = false;
+      } else {
+        showToast('Screen source picker failed: ' + (pickerErr.message || pickerErr), 8000);
+        return;
+      }
+    }
+  }
+
+  if (isNativeClient) {
     if (!source) return;
 
     // Detect OS build number for WGC availability (24H2+ = build 26100+)

--- a/core/viewer/screen-share-native.js
+++ b/core/viewer/screen-share-native.js
@@ -4,6 +4,101 @@
    and per-process audio capture via WASAPI.
    ========================================================= */
 
+function _sourceVisibilityPollIntervalMs() {
+  return typeof SOURCE_VISIBILITY_POLL_MS === 'number' ? SOURCE_VISIBILITY_POLL_MS : 3000;
+}
+
+function _sourceVisibilityToastCooldownMs() {
+  return typeof SOURCE_VISIBILITY_TOAST_COOLDOWN_MS === 'number' ? SOURCE_VISIBILITY_TOAST_COOLDOWN_MS : 10000;
+}
+
+function _shouldMonitorNativeCaptureSource(source, mode) {
+  return !!(
+    source &&
+    source.id &&
+    source.sourceType !== 'monitor' &&
+    (mode === 'wgc' || mode === 'desktop-dd')
+  );
+}
+
+function _captureSourceVisibilityToastMessage(status) {
+  if (!status || !status.warning) return null;
+  return status.warning + '. Keep the shared window visible while sharing.';
+}
+
+function _stopSourceVisibilityMonitor() {
+  if (_sourceVisibilityInterval) {
+    clearInterval(_sourceVisibilityInterval);
+    _sourceVisibilityInterval = null;
+  }
+  _sourceVisibilityLastWarning = null;
+  _sourceVisibilityLastToastAt = 0;
+  if (typeof window !== 'undefined') window._echoNativeCaptureSource = null;
+}
+
+async function _pollNativeCaptureSourceVisibility(source) {
+  if (!source || !source.id || typeof tauriInvoke !== 'function') return;
+  try {
+    var status = await tauriInvoke('get_capture_window_status', { sourceId: source.id });
+    var message = _captureSourceVisibilityToastMessage(status);
+    if (!message) {
+      if (_sourceVisibilityLastWarning && typeof debugLog === 'function') {
+        debugLog('[source-visibility] recovered');
+      }
+      _sourceVisibilityLastWarning = null;
+      return;
+    }
+
+    var now = Date.now();
+    var warning = status.warning || message;
+    var shouldToast =
+      warning !== _sourceVisibilityLastWarning ||
+      now - _sourceVisibilityLastToastAt >= _sourceVisibilityToastCooldownMs();
+
+    if (shouldToast) {
+      if (typeof showToast === 'function') showToast(message, 5000);
+      if (typeof debugLog === 'function') {
+        var overlap = status.echoOverlapRatio;
+        if (typeof overlap !== 'number') overlap = status.echo_overlap_ratio;
+        debugLog('[source-visibility] ' + warning + ' overlap=' + (overlap || 0).toFixed(2));
+      }
+      _sourceVisibilityLastWarning = warning;
+      _sourceVisibilityLastToastAt = now;
+    }
+  } catch (err) {
+    if (typeof isTauriCommandMissingError === 'function' &&
+        isTauriCommandMissingError(err, 'get_capture_window_status')) {
+      if (typeof debugLog === 'function') {
+        debugLog('[source-visibility] get_capture_window_status unavailable; monitor disabled');
+      }
+      _stopSourceVisibilityMonitor();
+      return;
+    }
+    if (typeof debugLog === 'function') {
+      debugLog('[source-visibility] status poll failed: ' + (err.message || err));
+    }
+  }
+}
+
+function _startSourceVisibilityMonitor(source) {
+  _stopSourceVisibilityMonitor();
+  if (!_shouldMonitorNativeCaptureSource(source, window._echoNativeCaptureMode)) return;
+
+  window._echoNativeCaptureSource = {
+    id: source.id,
+    sourceType: source.sourceType,
+  };
+
+  _pollNativeCaptureSourceVisibility(window._echoNativeCaptureSource);
+  _sourceVisibilityInterval = setInterval(function() {
+    if (!window._echoNativeCaptureActive && !window._echoNativeCaptureMode) {
+      _stopSourceVisibilityMonitor();
+      return;
+    }
+    _pollNativeCaptureSourceVisibility(window._echoNativeCaptureSource);
+  }, _sourceVisibilityPollIntervalMs());
+}
+
 function _stopNativeCaptureStopListeners() {
   if (_nativeCaptureStopUnlisten) {
     try { _nativeCaptureStopUnlisten(); } catch (e) {}
@@ -15,8 +110,10 @@ async function _finalizeNativeCaptureStop(stopMessage) {
   var wasActive = !!(window._echoNativeCaptureActive || window._echoNativeCaptureMode || screenEnabled);
   window._echoNativeCaptureActive = false;
   window._echoNativeCaptureMode = null;
+  window._echoNativeCaptureSource = null;
   screenEnabled = false;
   _stopNativeCaptureStopListeners();
+  _stopSourceVisibilityMonitor();
   _stopQualityWarnListener();
   await stopNativeAudioCapture();
   renderPublishButtons();
@@ -222,6 +319,7 @@ async function startScreenShareManual() {
       }
       screenEnabled = true;
       window._echoNativeCaptureActive = true;
+      _startSourceVisibilityMonitor(source);
       _startQualityWarnListener();
       renderPublishButtons();
       var modeLabel = window._echoNativeCaptureMode === 'desktop-dd' ? 'Desktop Duplication' : 'Window Capture';
@@ -251,10 +349,12 @@ async function startScreenShareManual() {
             sourceId: source.id,
             sfuUrl: sfuUrl,
             token: screenToken,
+            publishProfile: 'game',
           });
           window._echoNativeCaptureMode = 'wgc';
           screenEnabled = true;
           window._echoNativeCaptureActive = true;
+          _startSourceVisibilityMonitor(source);
           renderPublishButtons();
           fallbackStarted = true;
           showToast('Using standard capture (game hook unavailable)', 5000);

--- a/core/viewer/screen-share-native.test.js
+++ b/core/viewer/screen-share-native.test.js
@@ -1,0 +1,105 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const vm = require("node:vm");
+
+function loadScreenShareNative() {
+  const calls = [];
+  const context = {
+    window: { __ECHO_NATIVE__: true },
+    _nativeCaptureStopUnlisten: null,
+    screenEnabled: false,
+    _echoServerUrl: "https://echo.example.test:9443",
+    adminToken: "admin-token",
+    currentRoomName: "main",
+    room: {
+      localParticipant: {
+        identity: "Sam",
+        name: "Sam",
+      },
+    },
+    getLiveKitClient() {
+      return {};
+    },
+    showCapturePicker: async () => ({
+      sourceType: "game",
+      id: 4242,
+      pid: 0,
+      isMonitor: false,
+    }),
+    fetchRoomToken: async () => "screen-token",
+    tauriInvoke: async (command, args) => {
+      calls.push({ command, args });
+      if (command === "get_os_build_number") return 26100;
+      if (command === "start_screen_share") {
+        const starts = calls.filter((call) => call.command === "start_screen_share");
+        if (starts.length === 1) throw new Error("first WGC start failed");
+      }
+      if (command === "check_desktop_capture_available") return [false, "unavailable"];
+      return null;
+    },
+    tauriListen: undefined,
+    debugLog() {},
+    showToast() {},
+    renderPublishButtons() {},
+    _startQualityWarnListener() {
+      throw new Error("force outer fallback path");
+    },
+    _stopQualityWarnListener() {},
+    _sourceVisibilityInterval: null,
+    _sourceVisibilityLastWarning: null,
+    _sourceVisibilityLastToastAt: 0,
+    stopNativeAudioCapture: async () => {},
+    startNativeAudioCapture: async () => {},
+    isTauriCommandMissingError: () => false,
+    console,
+    setTimeout,
+    clearTimeout,
+    setInterval: () => 1,
+    clearInterval: () => {},
+  };
+  context.global = context;
+  vm.createContext(context);
+  const code = fs.readFileSync(path.join(__dirname, "screen-share-native.js"), "utf8");
+  vm.runInContext(code, context, { filename: "screen-share-native.js" });
+  return { context, calls };
+}
+
+test("game WGC fallback keeps the high-motion publish profile", async () => {
+  const { context, calls } = loadScreenShareNative();
+
+  await context.startScreenShareManual();
+
+  const screenStarts = calls.filter((call) => call.command === "start_screen_share");
+  assert.equal(screenStarts.length, 2);
+  assert.equal(screenStarts[1].args.publishProfile, "game");
+});
+
+test("source visibility warning tells the publisher to keep the shared window visible", () => {
+  const { context } = loadScreenShareNative();
+
+  assert.equal(
+    context._captureSourceVisibilityToastMessage({
+      warning: "Echo is covering the shared window",
+    }),
+    "Echo is covering the shared window. Keep the shared window visible while sharing."
+  );
+});
+
+test("source visibility monitor is only enabled for native window-like sources", () => {
+  const { context } = loadScreenShareNative();
+
+  assert.equal(
+    context._shouldMonitorNativeCaptureSource({ id: 123, sourceType: "window" }, "wgc"),
+    true
+  );
+  assert.equal(
+    context._shouldMonitorNativeCaptureSource({ id: 456, sourceType: "game" }, "desktop-dd"),
+    true
+  );
+  assert.equal(
+    context._shouldMonitorNativeCaptureSource({ id: 789, sourceType: "monitor" }, "desktop-dd"),
+    false
+  );
+});

--- a/core/viewer/screen-share-state.js
+++ b/core/viewer/screen-share-state.js
@@ -9,11 +9,12 @@ var _qualityWarnLowSince = 0;       // timestamp when FPS first dropped below th
 var _qualityWarnShowing = false;     // whether banner is currently visible
 var _qualityWarnDismissed = false;   // dismissed for this session
 var _qualityWarnBannerEl = null;     // DOM element
-// Capture is intentionally capped at 30fps in capture_pipeline.rs.
-// Under multi-publisher GPU contention, capture floats 22-28fps which is
-// fine — only warn when it drops below 18fps (real degradation).
+// Desktop sharing stays conservative, while game capture can opt into the
+// high-motion publish profile. Only warn here on obvious real degradation.
 const QUALITY_WARN_FPS_THRESHOLD = 18;
 const QUALITY_WARN_DURATION_MS = 5000;
+const SOURCE_VISIBILITY_POLL_MS = 3000;
+const SOURCE_VISIBILITY_TOAST_COOLDOWN_MS = 10000;
 
 // ── Screen share track refs (so we can unpublish on stop) ──
 let _screenShareVideoTrack = null;
@@ -41,6 +42,9 @@ var _nativeAudioTrack = null;       // Published LiveKit track
 var _nativeAudioUnlisten = null;    // Tauri event unlisten function
 var _nativeAudioActive = false;
 var _nativeCaptureStopUnlisten = null; // Tauri stop-event unlisten function
+var _sourceVisibilityInterval = null;
+var _sourceVisibilityLastWarning = null;
+var _sourceVisibilityLastToastAt = 0;
 
 // NOTE: The following state variables are declared in state.js (loaded earlier):
 //   _latestScreenStats, _cameraReducedForScreenShare, _bwLimitedCount,

--- a/core/viewer/screen-video-surface.test.js
+++ b/core/viewer/screen-video-surface.test.js
@@ -1,0 +1,27 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const gridJs = fs.readFileSync(path.join(__dirname, "participants-grid.js"), "utf8");
+const css = fs.readFileSync(path.join(__dirname, "style.css"), "utf8");
+
+test("screen tiles do not apply a render-size cap", () => {
+  assert.equal(gridJs.includes("computeScreenRenderCap"), false);
+  assert.equal(gridJs.includes("applyScreenRenderCap"), false);
+  assert.equal(gridJs.includes("maxWidth ="), false);
+  assert.equal(gridJs.includes("maxHeight ="), false);
+});
+
+test("screen video elements receive the protected surface class", () => {
+  assert.match(gridJs, /element\.classList\.add\("screen-video-surface"\)/);
+});
+
+test("protected video surface rules avoid direct filters and clipping", () => {
+  const match = css.match(/\.screens-grid \.tile video\.screen-video-surface\s*\{([^}]*)\}/);
+  assert.ok(match, "missing .screens-grid .tile video.screen-video-surface rule");
+  assert.equal(/filter\s*:/.test(match[1]), false);
+  assert.equal(/backdrop-filter\s*:/.test(match[1]), false);
+  assert.equal(/border-radius\s*:/.test(match[1]), false);
+  assert.equal(/box-shadow\s*:/.test(match[1]), false);
+});

--- a/core/viewer/settings.js
+++ b/core/viewer/settings.js
@@ -35,7 +35,7 @@ var _SETTINGS_KEYS = [
   "echo-core-remember-name", "echo-core-remember-pass",
   "echo-core-identity-suffix", "echo-core-device-id",
   "echo-avatar-device", "echo-volume-prefs",
-  "echo-performance-mode",
+  "echo-performance-mode", "echo-native-presenter-mode",
   "echo-preferred-display-id", "echo-auto-move-to-preferred-display"
 ];
 

--- a/core/viewer/settings.js
+++ b/core/viewer/settings.js
@@ -35,7 +35,8 @@ var _SETTINGS_KEYS = [
   "echo-core-remember-name", "echo-core-remember-pass",
   "echo-core-identity-suffix", "echo-core-device-id",
   "echo-avatar-device", "echo-volume-prefs",
-  "echo-performance-mode"
+  "echo-performance-mode",
+  "echo-preferred-display-id", "echo-auto-move-to-preferred-display"
 ];
 
 async function loadAllSettings() {

--- a/core/viewer/style.css
+++ b/core/viewer/style.css
@@ -930,6 +930,13 @@ video {
   min-height: 0;
 }
 
+.grid-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
 .grid-header h2 {
   margin: 0;
   font-size: 15px;
@@ -937,6 +944,24 @@ video {
   text-transform: uppercase;
   letter-spacing: 0.03em;
   color: rgba(226, 232, 240, 0.9);
+}
+
+.echo-display-status {
+  border: 1px solid rgba(56, 189, 248, 0.35);
+  background: rgba(8, 47, 73, 0.72);
+  color: rgba(226, 232, 240, 0.96);
+  border-radius: 6px;
+  padding: 4px 8px;
+  font-size: 11px;
+  line-height: 1.2;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.echo-display-status.display-warning {
+  border-color: rgba(245, 158, 11, 0.65);
+  background: rgba(69, 43, 8, 0.82);
+  color: #fde68a;
 }
 
 .screens-grid .tile video {

--- a/core/viewer/style.css
+++ b/core/viewer/style.css
@@ -964,13 +964,19 @@ video {
   color: #fde68a;
 }
 
-.screens-grid .tile video {
+.screens-grid .tile video.screen-video-surface {
+  display: block;
   width: 100%;
   height: 100%;
   object-fit: contain;
   background: transparent;
   flex: 1 1 0;
   min-height: 0;
+  justify-self: center;
+  align-self: center;
+  transform: translateZ(0);
+  backface-visibility: hidden;
+  mix-blend-mode: normal;
 }
 
 .screens-grid {
@@ -986,10 +992,30 @@ video {
   min-width: 0;
   max-height: 100%;
   max-width: 100%;
-  overflow: hidden;
+  overflow: visible;
   aspect-ratio: 16 / 9;
   justify-self: center;
   align-self: center;
+  position: relative;
+  isolation: isolate;
+}
+
+.screens-grid .tile::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  border-radius: var(--radius);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.28), inset 0 1px 0 rgba(255, 255, 255, 0.04);
+  z-index: 3;
+}
+
+.screens-grid .tile .tile-overlay,
+.screens-grid .tile .tile-fullscreen-btn,
+.screens-grid .tile .tile-volume-wrap,
+.screens-grid .tile .tile-poster {
+  z-index: 4;
 }
 
 .screens-grid .tile h3 {

--- a/core/viewer/video-diagnostics.test.js
+++ b/core/viewer/video-diagnostics.test.js
@@ -1,0 +1,39 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const {
+  createVideoFrameRateTracker,
+  getVideoPresentationSnapshot,
+} = require("./participants-fullscreen.js");
+
+test("video diagnostics use presentedFrames when callbacks skip frames", () => {
+  let now = 0;
+  const tracker = createVideoFrameRateTracker(() => now);
+
+  tracker.noteFrame({ presentedFrames: 10 });
+  now = 1000;
+  tracker.noteFrame({ presentedFrames: 55 });
+
+  assert.equal(tracker.sample(), 45);
+  assert.equal(tracker.presentedFrames(), 55);
+});
+
+test("video diagnostics fall back to callback count without presentedFrames", () => {
+  let now = 0;
+  const tracker = createVideoFrameRateTracker(() => now);
+
+  tracker.noteFrame();
+  tracker.noteFrame();
+  now = 1000;
+
+  assert.equal(tracker.sample(), 2);
+  assert.equal(tracker.presentedFrames(), null);
+});
+
+test("video presentation snapshot returns null for missing element", () => {
+  assert.equal(getVideoPresentationSnapshot(null), null);
+});
+
+test("video presentation snapshot returns the element stats object", () => {
+  const stats = { fps: 59.8, width: 1920, height: 1080 };
+  assert.equal(getVideoPresentationSnapshot({ _echoPresentationStats: stats }), stats);
+});

--- a/docs/handovers/2026-05-02-full-quality-display-path-validation.md
+++ b/docs/handovers/2026-05-02-full-quality-display-path-validation.md
@@ -1,0 +1,109 @@
+# Full-Quality Display Path Validation
+
+Date: 2026-05-02
+Branch: `codex/screen-sources-command-investigation`
+
+## Build
+
+- Viewer tests: `node --test core/viewer/*.test.js` passed, 58/58.
+- Focused screen-surface/video diagnostics tests passed, 8/8.
+- Client display-placement tests: `cargo test -p echo-core-client display_placement` passed, 4/4.
+- Rust checks: `cargo check -p echo-core-client -p echo-core-control` passed.
+- Desktop client build: `cargo build -p echo-core-client` passed.
+- Control build: `cargo build -p echo-core-control` passed.
+
+## Test Setup Correction
+
+The first live run only launched the branch desktop client. The running control server was still the installed release control process from:
+
+`F:\Codex AI\The Echo Chamber\core\target\release\echo-core-control.exe`
+
+That served old viewer assets and could not report `presented_fps` or `display_status`. The control process was then swapped to the branch debug control binary while keeping the normal certs/SFU/TURN environment:
+
+`F:\EC-worktrees\screen-sources-command\core\target\debug\echo-core-control.exe`
+
+The branch control log confirmed:
+
+- Viewer dir: `F:\EC-worktrees\screen-sources-command\core\viewer`
+- Admin dir: `F:\EC-worktrees\screen-sources-command\core\admin`
+- Server stamp: `0.6.11.1777694918`
+
+## Display Path
+
+Windows display mapping during validation:
+
+- `\\.\DISPLAY1`: NVIDIA GeForce RTX 4090, 3840x2160 @ 144 Hz, position `(-3840, 0)`.
+- `\\.\DISPLAY5`: Intel UHD Graphics 770, 3840x2160 @ 60 Hz, position `(0, 0)`.
+
+Echo was on `\\.\DISPLAY1`, the RTX 4090 display.
+
+## Maximized Result
+
+When maximized on the RTX display, Windows reported the Echo outer window as:
+
+- `window_x=-3851`
+- `window_y=-11`
+- `window_width=3862`
+- `window_height=2110`
+- `window_spans_displays=true`
+
+This appears to be the normal invisible maximized frame crossing the display boundary by about 11 physical pixels.
+
+Observed Sam receive/presentation samples while maximized:
+
+- 1920x1080 stream: WebRTC receive roughly 26-35 FPS, presented roughly 20-27 FPS.
+- 1920x804 stream: WebRTC receive roughly 19-40 FPS, presented roughly 9-31 FPS.
+
+GPU counters during the maximized bad state:
+
+- Echo WebView2 GPU process: about 65% 3D engine.
+- Echo WebView2 video decode: about 2-5%.
+- DWM was active on both GPU paths.
+- MyRadar and Codex also had measurable GPU/CPU activity, but Echo's own WebView2 GPU process remained the dominant Echo-side cost.
+
+## Non-Maximized Result
+
+At an almost-full RTX display placement with no display spanning:
+
+- `window_x=-3840`
+- `window_y=60`
+- `window_width=3600`
+- `window_height=1980`
+- `window_spans_displays=false`
+
+Presented FPS was still unstable:
+
+- 1920x1080 stream: receive roughly 26-32 FPS, presented roughly 13-28 FPS.
+- 1920x804 stream: receive roughly 27-49 FPS, presented roughly 16-29 FPS.
+
+At a smaller 1920x1080 physical Echo window on the same RTX display:
+
+- `window_x=-3840`
+- `window_y=60`
+- `window_width=1920`
+- `window_height=1080`
+- `window_spans_displays=false`
+
+Presented FPS recovered:
+
+- 1920x1080 stream: receive roughly 28-31 FPS, presented roughly 28-30 FPS.
+- 1920x804 stream: receive roughly 87-90 FPS, presented roughly 59-60 FPS.
+
+## CSS Probe
+
+A temporary probe removed direct video compositor hints and over-video decorative paint:
+
+- Removed `transform: translateZ(0)` from `.screen-video-surface`.
+- Removed `backface-visibility`.
+- Removed the `.screens-grid .tile::after` decorative overlay.
+- Disabled blur on the screen tile FPS overlay.
+
+Focused tests passed after the probe, but maximized presentation still collapsed. The probe was reverted because it did not solve the issue and removed visual polish.
+
+## Decision
+
+Result: WebView2 large-window screen-grid presentation is the wall.
+
+The receive path is not the primary bottleneck. The same remote streams present smoothly in Sam's viewer at a smaller window size and present much better for other viewers. The failure appears when the WebView2 screen grid has to compose a large 4K-class surface on Sam's mixed Intel/NVIDIA display setup.
+
+Next step: start a separate native presenter design/spike. Target a minimal Direct3D/DirectComposition proof of concept for one received screen tile while keeping WebView2 as the surrounding UI shell. This is the path that removes the bottleneck instead of lowering stream quality or trimming visual effects.

--- a/docs/handovers/2026-05-02-native-presenter-gate-1.md
+++ b/docs/handovers/2026-05-02-native-presenter-gate-1.md
@@ -1,0 +1,82 @@
+# Native Presenter Gate 1 Handoff
+
+Date: 2026-05-02
+Branch: codex/screen-sources-command-investigation
+Worktree: F:\EC-worktrees\screen-sources-command
+
+## What Changed
+
+- Added a guarded Windows native presenter receive probe in the desktop client.
+- Added hidden receive-only `$native-presenter` LiveKit token support.
+- Added viewer opt-in setting plumbing with normal default `off`.
+- Added native receive FPS/status telemetry to client stats and the admin dashboard.
+- Kept WebView2 as the visible rendering path.
+
+## Why This Exists
+
+Sam's low-FPS symptom tracks with the maximized viewer/grid presentation path, not with the remote stream quality itself. Gate 1 tests the next important question: can the Windows client receive the same screen track through native LiveKit/WebRTC code at healthy FPS while WebView2 remains visibly rendering the current UI?
+
+## What This Proves
+
+Gate 1 proves whether the desktop client can safely join as a hidden receive-only companion and receive the selected screen track natively without disturbing the normal viewer.
+
+## What This Does Not Do
+
+- It does not draw native video.
+- It does not hide or replace the WebView2 video element.
+- It does not reduce stream quality.
+- It does not deploy to friends.
+- It does not change the normal default for users; the native presenter setting remains `off`.
+
+## Implementation Commits
+
+- `74cfda2 feat(client): add native presenter state model`
+- `a928c02 feat(control): issue receive-only native presenter tokens`
+- `618a984 feat(client): expose native presenter ipc`
+- `7a8ac3a feat(viewer): add guarded native presenter bridge`
+- `7784f36 feat(control): report native presenter telemetry`
+- `66506eb feat(client): receive native screen frames`
+
+## Verification
+
+Fresh verification run on 2026-05-02:
+
+- `node --test core/viewer/*.test.js` - 63 passed, 0 failed.
+- `cargo test -p echo-core-client native_presenter` - 8 passed, 0 failed.
+- `cargo test -p echo-core-control auth::tests` - 3 passed, 0 failed.
+- `cargo test -p echo-core-control admin::tests` - 1 passed, 0 failed.
+- `cargo check -p echo-core-client -p echo-core-control` - passed.
+- `cargo build -p echo-core-client` - passed.
+
+The Rust commands still emit existing warnings from the local LiveKit/libwebrtc/client/control code, but the commands exited successfully.
+
+## Local Test Protocol
+
+Do not silently monitor or relaunch Echo. Tell Sam first.
+
+1. Close Echo before testing a new desktop build.
+2. Open the branch debug client from `F:\EC-worktrees\screen-sources-command\core\target\debug\echo-core-client.exe`.
+3. Confirm the running client path before monitoring.
+4. Enable the native presenter setting only for Sam's local test.
+5. Join a room with one remote screen share.
+6. Confirm the dashboard native presenter status shows `starting` then `receiving`.
+7. Compare WebView receive FPS, WebView presented FPS, and native receive FPS.
+8. Turn the setting off and confirm status returns to WebView2/stopped without restarting.
+
+## Manual Pass Criteria
+
+- The native presenter remains hidden from normal participants.
+- The dashboard shows native presenter `receiving` for the selected screen track.
+- Native receive FPS is plausible for the stream.
+- Turning the setting off stops the native probe without restarting Echo.
+- WebView2 remains the visible fallback at all times.
+
+## Next Decision
+
+If native receive FPS is healthy while WebView presented FPS remains low in maximized 4K mode, proceed to the Gate 2 one-tile native presentation plan.
+
+If native receive FPS is also low, stop Gate 2 and investigate the receive/network/SFU path instead.
+
+## Known Local State
+
+`core/viewer/index.html` has generated cache-busting stamp churn from local server/test activity. Do not stage that churn unless the script tag itself is intentionally being changed.

--- a/docs/handovers/2026-05-02-screen-sources-command.md
+++ b/docs/handovers/2026-05-02-screen-sources-command.md
@@ -1,0 +1,85 @@
+# Screen Sources Command Investigation Handover
+
+Date: 2026-05-02
+Worktree: `F:\EC-worktrees\screen-sources-command`
+Branch: `codex/screen-sources-command-investigation`
+Base: `origin/main` at `55e0a72`
+
+## How to Resume
+
+If Sam starts a new Codex thread in this worktree and says only `continue`, treat that as:
+
+1. Read `AGENTS.md`.
+2. Read this handover.
+3. Run `git status --porcelain=v1 -b`.
+4. Continue the screen-source command investigation from the current decision point.
+
+Do not ask Sam to re-explain the issue unless the local evidence has gone missing or contradicts this file.
+
+## User Goal
+
+Z tried to share his screen and saw:
+
+`Error loading sources: Command list_screen_sources not found`
+
+Sam reported this as a new bug. This worktree was created to keep the official `main` worktree clean while investigating.
+
+## Current Status
+
+- Worktree created and aligned with `origin/main`.
+- Viewer compatibility patch has been implemented.
+- Sam reported Zane was later able to share his screen, so this is no longer an active live incident.
+- Keep this branch as a parked compatibility hardening patch unless Sam explicitly asks to discard it.
+- Official `main` worktree stayed clean.
+- No push or PR has been created.
+
+## Evidence
+
+- `core/viewer/capture-picker.js` calls `tauriInvoke('list_screen_sources')`.
+- Current `origin/main` has `core/client/src/main.rs` defining and registering `list_screen_sources`.
+- Tag `v0.4.3` does not register `list_screen_sources`.
+- Live admin dashboard showed Z online as `z-6826` on the current server-served viewer stamp `0.6.11.1777212663`.
+- The live viewer stamp does not prove the installed desktop shell version, because the viewer is served by the server.
+
+## Root Cause
+
+This is a compatibility boundary bug.
+
+The server-served viewer can be newer than a user's installed desktop shell. If that older shell exposes Tauri IPC but does not register `list_screen_sources`, the native picker displays:
+
+`Error loading sources: Command list_screen_sources not found`
+
+Before this patch, the picker only rendered that error inside the modal and never rejected/resolved the picker promise, so the screen-share flow stalled instead of falling back.
+
+## Patch Implemented
+
+- Added `isTauriCommandMissingError` in `core/viewer/capture-picker.js`.
+- When `list_screen_sources` is missing, the picker now rejects instead of trapping the user in the modal.
+- `core/viewer/screen-share-native.js` catches that compatibility failure and falls back to the browser `getDisplayMedia` screen picker.
+- Added regression coverage in `core/viewer/reliability-scenarios.test.js`.
+
+## Verification
+
+Passed:
+
+```powershell
+node --test core/viewer/reliability-scenarios.test.js
+node --test core/viewer/*.test.js
+node --check core/viewer/capture-picker.js
+node --check core/viewer/screen-share-native.js
+git diff --check
+```
+
+`node --test core/viewer/*.test.js` reported 48 passing tests.
+
+## Release Impact
+
+Server-served viewer update. This patch does not require a new desktop binary for the fallback behavior. Users on old desktop shells should receive the viewer behavior from the server after deploy.
+
+Users still need a newer desktop shell for native capture quality, but this patch avoids the hard failure by falling back to browser capture.
+
+Do not treat this as an emergency deploy. The practical live issue self-resolved, likely because the desktop shell updated/restarted or the user moved onto a compatible path. This branch is useful as a low-risk future-proofing fix for server/client version skew.
+
+## Exact Prompt to Continue With
+
+Continue from the parked screen-source compatibility fix. Confirm clean status in `F:\EC-worktrees\screen-sources-command`, review the diff in `core/viewer/capture-picker.js`, `core/viewer/screen-share-native.js`, and `core/viewer/reliability-scenarios.test.js`, then prepare the branch for PR/server-served viewer deploy only if Sam asks. Preserve the official main worktree and do not push or open a PR without Sam asking.

--- a/docs/handovers/2026-05-02-screen-sources-command.md
+++ b/docs/handovers/2026-05-02-screen-sources-command.md
@@ -4,6 +4,7 @@ Date: 2026-05-02
 Worktree: `F:\EC-worktrees\screen-sources-command`
 Branch: `codex/screen-sources-command-investigation`
 Base: `origin/main` at `55e0a72`
+Local commit: `e4c25e0 Add fallback for missing native screen source command`
 
 ## How to Resume
 
@@ -12,9 +13,12 @@ If Sam starts a new Codex thread in this worktree and says only `continue`, trea
 1. Read `AGENTS.md`.
 2. Read this handover.
 3. Run `git status --porcelain=v1 -b`.
-4. Continue the screen-source command investigation from the current decision point.
+4. Confirm the current folder is `F:\EC-worktrees\screen-sources-command`, not `F:\EC-worktrees\main`.
+5. Continue the screen-source command investigation from the current decision point.
 
 Do not ask Sam to re-explain the issue unless the local evidence has gone missing or contradicts this file.
+
+In Codex Desktop, this work should be opened as its own Project pointed at `F:\EC-worktrees\screen-sources-command`. Do not try to switch the `Echo Chamber - Main` project to this branch; Git will block that because this branch is already checked out by this worktree.
 
 ## User Goal
 
@@ -30,6 +34,7 @@ Sam reported this as a new bug. This worktree was created to keep the official `
 - Viewer compatibility patch has been implemented.
 - Sam reported Zane was later able to share his screen, so this is no longer an active live incident.
 - Keep this branch as a parked compatibility hardening patch unless Sam explicitly asks to discard it.
+- The patch has been committed locally as `e4c25e0`.
 - Official `main` worktree stayed clean.
 - No push or PR has been created.
 
@@ -40,6 +45,8 @@ Sam reported this as a new bug. This worktree was created to keep the official `
 - Tag `v0.4.3` does not register `list_screen_sources`.
 - Live admin dashboard showed Z online as `z-6826` on the current server-served viewer stamp `0.6.11.1777212663`.
 - The live viewer stamp does not prove the installed desktop shell version, because the viewer is served by the server.
+- After the initial report, Sam said Zane was suddenly able to share his screen. That suggests the live symptom resolved through a client restart/update or compatible path, but the fallback remains valid hardening for future version skew.
+- A separate Zane avatar issue was investigated during the same live session. `/api/avatar/zane` returned 200 while `/api/avatar/z` and `/api/avatar/z-6826` returned 404, showing an identity-key mismatch. The existing avatar was re-registered under `z` through the app's avatar API; afterward `zane`, `z`, and `z-6826` all returned 200. No server restart was needed, and this branch does not include avatar code changes.
 
 ## Root Cause
 
@@ -60,7 +67,7 @@ Before this patch, the picker only rendered that error inside the modal and neve
 
 ## Verification
 
-Passed:
+Passed before local commit:
 
 ```powershell
 node --test core/viewer/reliability-scenarios.test.js
@@ -72,6 +79,17 @@ git diff --check
 
 `node --test core/viewer/*.test.js` reported 48 passing tests.
 
+Fresh verification after the branch was parked:
+
+```powershell
+node --test core/viewer/*.test.js
+node --check core/viewer/capture-picker.js
+node --check core/viewer/screen-share-native.js
+git diff --check
+```
+
+Result: 48 passing viewer tests, both touched JS files parsed successfully, and `git diff --check` only reported normal CRLF warnings.
+
 ## Release Impact
 
 Server-served viewer update. This patch does not require a new desktop binary for the fallback behavior. Users on old desktop shells should receive the viewer behavior from the server after deploy.
@@ -80,6 +98,16 @@ Users still need a newer desktop shell for native capture quality, but this patc
 
 Do not treat this as an emergency deploy. The practical live issue self-resolved, likely because the desktop shell updated/restarted or the user moved onto a compatible path. This branch is useful as a low-risk future-proofing fix for server/client version skew.
 
+## Current Decision Point
+
+Sam needs to choose one of these paths:
+
+1. Leave the branch parked locally as a known compatibility fix.
+2. Push it and open a PR when he wants the fallback reviewed.
+3. Delete/discard it only if he explicitly decides the compatibility fallback is not worth keeping.
+
+Do not push, deploy, open a PR, or delete the worktree unless Sam asks.
+
 ## Exact Prompt to Continue With
 
-Continue from the parked screen-source compatibility fix. Confirm clean status in `F:\EC-worktrees\screen-sources-command`, review the diff in `core/viewer/capture-picker.js`, `core/viewer/screen-share-native.js`, and `core/viewer/reliability-scenarios.test.js`, then prepare the branch for PR/server-served viewer deploy only if Sam asks. Preserve the official main worktree and do not push or open a PR without Sam asking.
+Continue from the parked screen-source compatibility fix in `F:\EC-worktrees\screen-sources-command` on branch `codex/screen-sources-command-investigation`. Confirm status, review commit `e4c25e0`, and summarize the current decision point: leave parked, prepare PR, or discard only if Sam explicitly asks. Preserve the official main worktree and do not push, deploy, open a PR, or delete the worktree without Sam asking.

--- a/docs/superpowers/plans/2026-05-02-full-quality-screen-viewer-display-path.md
+++ b/docs/superpowers/plans/2026-05-02-full-quality-screen-viewer-display-path.md
@@ -1,0 +1,1332 @@
+# Full-Quality Screen Viewer Display Path Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Keep remote screen streams full quality while making Echo prefer Sam's RTX 4090 display path and exposing enough diagnostics to prove whether WebView2 presentation is the remaining bottleneck.
+
+**Architecture:** First fix the measurement layer so the tile badge reports presented frames instead of callback scheduling artifacts. Then add native display authority in the Tauri client, post display/presentation status through the existing stats pipeline, and preserve the polished UI by moving expensive visual work off the hot `<video>` surface instead of reducing stream quality. The native presenter is a decision gate after evidence, not part of this implementation batch.
+
+**Tech Stack:** Rust/Tauri v2 client, Windows WebView2, existing viewer JavaScript modules, existing Axum control-plane stats API, Node built-in test runner, Cargo tests/checks.
+
+---
+
+## File Structure
+
+- `core/viewer/participants-fullscreen.js` owns per-video presentation diagnostics.
+- `core/viewer/video-diagnostics.test.js` verifies the presented-frame FPS tracker.
+- `core/viewer/participants-grid.js` owns screen tile construction and must not apply stream/render caps as product behavior.
+- `core/viewer/screen-video-surface.test.js` verifies the viewer does not reintroduce the render cap or direct video-surface effects.
+- `core/control/src/admin.rs` owns the stats schema accepted by `/api/client-stats-report` and returned by `/admin/api/dashboard`.
+- `core/client/src/display_placement.rs` will own display enumeration, preferred-display selection, window placement, and pure geometry tests.
+- `core/client/src/main.rs` wires display-placement commands into Tauri and applies launch placement after creating the main window.
+- `core/viewer/display-status.js` polls native display status, renders the display-path badge, and exposes cached status to the stats reporter.
+- `core/viewer/display-status.test.js` verifies warning-state logic without requiring a browser DOM.
+- `core/viewer/screen-share-adaptive.js` adds presentation and display-path fields to the existing receive-side stats POST.
+- `core/viewer/settings.js` adds display preference keys to the existing settings persistence allowlist.
+- `core/viewer/index.html` loads `display-status.js` and adds the display-path badge host.
+- `core/viewer/style.css` styles the display-path badge and moves screen-tile polish off the video element.
+
+---
+
+### Task 1: Keep the Correct Presented-Frame Diagnostic, Drop the Render-Cap Experiment
+
+**Files:**
+- Modify: `core/viewer/participants-fullscreen.js`
+- Modify: `core/viewer/participants-grid.js`
+- Create: `core/viewer/video-diagnostics.test.js`
+- Delete: `core/viewer/screen-render-cap.test.js`
+
+- [ ] **Step 1: Write the presented-frame tracker test**
+
+Create `core/viewer/video-diagnostics.test.js` with this complete content:
+
+```js
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const {
+  createVideoFrameRateTracker,
+  getVideoPresentationSnapshot,
+} = require("./participants-fullscreen.js");
+
+test("video diagnostics use presentedFrames when callbacks skip frames", () => {
+  let now = 0;
+  const tracker = createVideoFrameRateTracker(() => now);
+
+  tracker.noteFrame({ presentedFrames: 10 });
+  now = 1000;
+  tracker.noteFrame({ presentedFrames: 55 });
+
+  assert.equal(tracker.sample(), 45);
+  assert.equal(tracker.presentedFrames(), 55);
+});
+
+test("video diagnostics fall back to callback count without presentedFrames", () => {
+  let now = 0;
+  const tracker = createVideoFrameRateTracker(() => now);
+
+  tracker.noteFrame();
+  tracker.noteFrame();
+  now = 1000;
+
+  assert.equal(tracker.sample(), 2);
+  assert.equal(tracker.presentedFrames(), null);
+});
+
+test("video presentation snapshot returns null for missing element", () => {
+  assert.equal(getVideoPresentationSnapshot(null), null);
+});
+
+test("video presentation snapshot returns the element stats object", () => {
+  const stats = { fps: 59.8, width: 1920, height: 1080 };
+  assert.equal(getVideoPresentationSnapshot({ _echoPresentationStats: stats }), stats);
+});
+```
+
+- [ ] **Step 2: Run the test to verify the current baseline**
+
+Run:
+
+```powershell
+node --test 'F:\EC-worktrees\screen-sources-command\core\viewer\video-diagnostics.test.js'
+```
+
+Expected before implementation: fail if `getVideoPresentationSnapshot` or `presentedFrames()` is missing.
+
+- [ ] **Step 3: Implement the diagnostic tracker**
+
+In `core/viewer/participants-fullscreen.js`, keep the existing `createVideoFrameRateTracker()` shape but replace it with this implementation:
+
+```js
+function createVideoFrameRateTracker(nowFn) {
+  const getNow = typeof nowFn === "function" ? nowFn : () => performance.now();
+  let callbackFrames = 0;
+  let lastCallbackFrames = 0;
+  let latestPresentedFrames = null;
+  let lastPresentedFrames = null;
+  let lastSampleTs = getNow();
+
+  function noteFrame(metadata) {
+    callbackFrames += 1;
+    const presented = Number(metadata?.presentedFrames);
+    if (Number.isFinite(presented)) {
+      if (lastPresentedFrames === null) {
+        lastPresentedFrames = presented;
+      }
+      latestPresentedFrames = presented;
+    }
+  }
+
+  function sample(sampleTs) {
+    const now = typeof sampleTs === "number" ? sampleTs : getNow();
+    const elapsed = (now - lastSampleTs) / 1000;
+    let frameDelta = callbackFrames - lastCallbackFrames;
+
+    if (latestPresentedFrames !== null && lastPresentedFrames !== null) {
+      frameDelta = latestPresentedFrames - lastPresentedFrames;
+      lastPresentedFrames = latestPresentedFrames;
+    }
+
+    lastCallbackFrames = callbackFrames;
+    lastSampleTs = now;
+
+    if (!Number.isFinite(frameDelta) || frameDelta < 0) {
+      frameDelta = 0;
+    }
+    return elapsed > 0 ? frameDelta / elapsed : 0;
+  }
+
+  function presentedFrames() {
+    return latestPresentedFrames;
+  }
+
+  return { noteFrame, sample, presentedFrames };
+}
+
+function getVideoPresentationSnapshot(element) {
+  return element?._echoPresentationStats || null;
+}
+```
+
+- [ ] **Step 4: Store presentation stats on each video element**
+
+In `attachVideoDiagnostics()`, after `const fps = frameRate.sample(now);` and after computing `w`, `h`, `ready`, `muted`, and `isBlack`, store the stats:
+
+```js
+    element._echoPresentationStats = {
+      fps,
+      width: w,
+      height: h,
+      readyState: ready,
+      muted: mediaTrack?.muted === true,
+      black: isBlack,
+      firstFrameTs: element._firstFrameTs || 0,
+      lastFrameTs: element._lastFrameTs || 0,
+      presentedFrames: frameRate.presentedFrames(),
+      updatedAt: Date.now(),
+    };
+```
+
+Keep the overlay line as:
+
+```js
+    overlay.textContent = `${w}x${h} | fps ${fps.toFixed(1)} | ${muted} | rs ${ready}${isBlack ? " | black" : ""}`;
+```
+
+- [ ] **Step 5: Export the diagnostic helpers for Node tests**
+
+At the bottom of `core/viewer/participants-fullscreen.js`, use this export block:
+
+```js
+if (typeof module === "object" && module.exports) {
+  module.exports = {
+    createVideoFrameRateTracker,
+    getVideoPresentationSnapshot,
+  };
+}
+```
+
+- [ ] **Step 6: Remove the render cap from the grid module**
+
+In `core/viewer/participants-grid.js`, delete `computeScreenRenderCap()` and `applyScreenRenderCap()`. In `tagAspect()`, remove this line:
+
+```js
+        applyScreenRenderCap(element);
+```
+
+At the bottom of the file, remove the CommonJS export block that exports `computeScreenRenderCap`.
+
+- [ ] **Step 7: Delete the render-cap test**
+
+Delete `core/viewer/screen-render-cap.test.js`.
+
+- [ ] **Step 8: Run viewer tests**
+
+Run:
+
+```powershell
+node --test 'F:\EC-worktrees\screen-sources-command\core\viewer\*.test.js'
+```
+
+Expected: all viewer tests pass, and no render-cap test remains.
+
+- [ ] **Step 9: Commit**
+
+Run:
+
+```powershell
+git add -- core/viewer/participants-fullscreen.js core/viewer/participants-grid.js core/viewer/video-diagnostics.test.js
+git add --update -- core/viewer/screen-render-cap.test.js
+git commit -m "fix(viewer): measure presented screen frames accurately"
+```
+
+---
+
+### Task 2: Extend Stats Schema for Presentation and Display Path Evidence
+
+**Files:**
+- Modify: `core/control/src/admin.rs`
+
+- [ ] **Step 1: Add schema fields**
+
+In `core/control/src/admin.rs`, add this field to `ClientStats` after `capture_health`:
+
+```rust
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) display_status: Option<ClientDisplayStatus>,
+```
+
+Add these fields to `SubscriptionStats` after `ice_remote_type`:
+
+```rust
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) presented_fps: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) presented_width: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) presented_height: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) presented_frames: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) presentation_age_ms: Option<u64>,
+```
+
+Add this struct after `SubscriptionStats`:
+
+```rust
+#[derive(Clone, Serialize, Deserialize, Default)]
+#[serde(default)]
+pub(crate) struct ClientDisplayStatus {
+    pub(crate) available: bool,
+    pub(crate) current_display_id: Option<String>,
+    pub(crate) current_display_name: Option<String>,
+    pub(crate) preferred_display_id: Option<String>,
+    pub(crate) on_preferred_display: bool,
+    pub(crate) window_spans_displays: bool,
+    pub(crate) window_x: i32,
+    pub(crate) window_y: i32,
+    pub(crate) window_width: u32,
+    pub(crate) window_height: u32,
+    pub(crate) scale_factor: Option<f64>,
+}
+```
+
+- [ ] **Step 2: Merge display status in `client_stats_report`**
+
+In `client_stats_report()`, inside the `Some(existing)` arm after the `capture_health` merge, add:
+
+```rust
+            if payload.display_status.is_some() {
+                existing.display_status = payload.display_status;
+            }
+```
+
+In the `None` arm, no special code is needed because `payload` is inserted as a whole after `updated_at` is assigned.
+
+- [ ] **Step 3: Run control-plane tests/check**
+
+Run:
+
+```powershell
+cargo check -p echo-core-control
+```
+
+Expected: `echo-core-control` checks successfully.
+
+- [ ] **Step 4: Commit**
+
+Run:
+
+```powershell
+git add -- core/control/src/admin.rs
+git commit -m "feat(control): accept display presentation stats"
+```
+
+---
+
+### Task 3: Add Native Display Placement Logic with Unit Tests
+
+**Files:**
+- Create: `core/client/src/display_placement.rs`
+- Modify: `core/client/src/main.rs`
+
+- [ ] **Step 1: Create the pure geometry and selection module**
+
+Create `core/client/src/display_placement.rs` with this complete content:
+
+```rust
+use serde::{Deserialize, Serialize};
+use tauri::{
+    Manager, PhysicalPosition, PhysicalSize, Position, Size, WebviewWindow,
+};
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct DisplayRect {
+    pub(crate) x: i32,
+    pub(crate) y: i32,
+    pub(crate) width: u32,
+    pub(crate) height: u32,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub(crate) struct EchoDisplayInfo {
+    pub(crate) id: String,
+    pub(crate) name: String,
+    pub(crate) rect: DisplayRect,
+    pub(crate) scale_factor: f64,
+    pub(crate) primary: bool,
+    pub(crate) preferred: bool,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub(crate) struct EchoDisplayStatus {
+    pub(crate) available: bool,
+    pub(crate) displays: Vec<EchoDisplayInfo>,
+    pub(crate) current_display_id: Option<String>,
+    pub(crate) current_display_name: Option<String>,
+    pub(crate) preferred_display_id: Option<String>,
+    pub(crate) on_preferred_display: bool,
+    pub(crate) window_spans_displays: bool,
+    pub(crate) window_x: i32,
+    pub(crate) window_y: i32,
+    pub(crate) window_width: u32,
+    pub(crate) window_height: u32,
+    pub(crate) scale_factor: Option<f64>,
+}
+
+impl DisplayRect {
+    fn right(&self) -> i32 {
+        self.x + self.width as i32
+    }
+
+    fn bottom(&self) -> i32 {
+        self.y + self.height as i32
+    }
+
+    fn area(&self) -> u64 {
+        self.width as u64 * self.height as u64
+    }
+
+    fn intersection_area(&self, other: &DisplayRect) -> u64 {
+        let left = self.x.max(other.x);
+        let top = self.y.max(other.y);
+        let right = self.right().min(other.right());
+        let bottom = self.bottom().min(other.bottom());
+        if right <= left || bottom <= top {
+            return 0;
+        }
+        (right - left) as u64 * (bottom - top) as u64
+    }
+}
+
+pub(crate) fn make_display_id(name: &str, rect: &DisplayRect) -> String {
+    format!("{}:{}:{}:{}:{}", name, rect.x, rect.y, rect.width, rect.height)
+}
+
+pub(crate) fn select_preferred_display<'a>(
+    displays: &'a [EchoDisplayInfo],
+    preferred_id: Option<&str>,
+) -> Option<&'a EchoDisplayInfo> {
+    if let Some(id) = preferred_id.filter(|s| !s.trim().is_empty()) {
+        if let Some(display) = displays.iter().find(|display| display.id == id) {
+            return Some(display);
+        }
+    }
+    displays
+        .iter()
+        .find(|display| display.primary)
+        .or_else(|| displays.first())
+}
+
+pub(crate) fn display_with_largest_overlap<'a>(
+    window_rect: &DisplayRect,
+    displays: &'a [EchoDisplayInfo],
+) -> Option<&'a EchoDisplayInfo> {
+    displays
+        .iter()
+        .max_by_key(|display| window_rect.intersection_area(&display.rect))
+}
+
+pub(crate) fn window_spans_displays(window_rect: &DisplayRect, displays: &[EchoDisplayInfo]) -> bool {
+    let overlap_count = displays
+        .iter()
+        .filter(|display| window_rect.intersection_area(&display.rect) > 0)
+        .count();
+    overlap_count > 1
+}
+
+fn centered_window_rect(display: &EchoDisplayInfo, width: u32, height: u32) -> DisplayRect {
+    let clamped_width = width.min(display.rect.width);
+    let clamped_height = height.min(display.rect.height);
+    DisplayRect {
+        x: display.rect.x + ((display.rect.width - clamped_width) / 2) as i32,
+        y: display.rect.y + ((display.rect.height - clamped_height) / 2) as i32,
+        width: clamped_width,
+        height: clamped_height,
+    }
+}
+
+fn preferred_display_from_settings(app: &tauri::AppHandle) -> Option<String> {
+    let settings_path = app.path().app_data_dir().ok()?.join("settings.json");
+    let settings = std::fs::read_to_string(settings_path).ok()?;
+    let json: serde_json::Value = serde_json::from_str(&settings).ok()?;
+    json.get("echo-preferred-display-id")
+        .and_then(|value| value.as_str())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+pub(crate) fn load_preferred_display_id(app: &tauri::AppHandle) -> Option<String> {
+    preferred_display_from_settings(app)
+}
+
+pub(crate) fn list_echo_displays(
+    window: &WebviewWindow,
+    preferred_id: Option<&str>,
+) -> Result<Vec<EchoDisplayInfo>, String> {
+    let primary_id = window
+        .primary_monitor()
+        .map_err(|e| e.to_string())?
+        .map(|monitor| {
+            let name = monitor.name().cloned().unwrap_or_else(|| "Display".to_string());
+            let pos = monitor.position();
+            let size = monitor.size();
+            let rect = DisplayRect {
+                x: pos.x,
+                y: pos.y,
+                width: size.width,
+                height: size.height,
+            };
+            make_display_id(&name, &rect)
+        });
+
+    let monitors = window.available_monitors().map_err(|e| e.to_string())?;
+    let displays = monitors
+        .into_iter()
+        .map(|monitor| {
+            let name = monitor.name().cloned().unwrap_or_else(|| "Display".to_string());
+            let pos = monitor.position();
+            let size = monitor.size();
+            let rect = DisplayRect {
+                x: pos.x,
+                y: pos.y,
+                width: size.width,
+                height: size.height,
+            };
+            let id = make_display_id(&name, &rect);
+            EchoDisplayInfo {
+                primary: primary_id.as_deref() == Some(id.as_str()),
+                preferred: preferred_id == Some(id.as_str()),
+                id,
+                name,
+                rect,
+                scale_factor: monitor.scale_factor(),
+            }
+        })
+        .collect();
+
+    Ok(displays)
+}
+
+pub(crate) fn build_display_status(
+    window: &WebviewWindow,
+    preferred_id: Option<&str>,
+) -> Result<EchoDisplayStatus, String> {
+    let displays = list_echo_displays(window, preferred_id)?;
+    let pos = window.outer_position().map_err(|e| e.to_string())?;
+    let size = window.outer_size().map_err(|e| e.to_string())?;
+    let window_rect = DisplayRect {
+        x: pos.x,
+        y: pos.y,
+        width: size.width,
+        height: size.height,
+    };
+    let current = display_with_largest_overlap(&window_rect, &displays);
+    let current_display_id = current.map(|display| display.id.clone());
+    let current_display_name = current.map(|display| display.name.clone());
+    let scale_factor = current.map(|display| display.scale_factor);
+    let spans = window_spans_displays(&window_rect, &displays);
+    let on_preferred = preferred_id
+        .filter(|value| !value.trim().is_empty())
+        .and_then(|id| current_display_id.as_ref().map(|current_id| current_id == id))
+        .unwrap_or(true);
+
+    Ok(EchoDisplayStatus {
+        available: !displays.is_empty(),
+        displays,
+        current_display_id,
+        current_display_name,
+        preferred_display_id: preferred_id.map(ToOwned::to_owned),
+        on_preferred_display: on_preferred,
+        window_spans_displays: spans,
+        window_x: window_rect.x,
+        window_y: window_rect.y,
+        window_width: window_rect.width,
+        window_height: window_rect.height,
+        scale_factor,
+    })
+}
+
+pub(crate) fn move_window_to_display(
+    window: &WebviewWindow,
+    display_id: &str,
+) -> Result<EchoDisplayStatus, String> {
+    let displays = list_echo_displays(window, Some(display_id))?;
+    let display = select_preferred_display(&displays, Some(display_id))
+        .ok_or_else(|| "No displays available".to_string())?;
+    let target = centered_window_rect(display, 1280, 800);
+
+    let _ = window.unmaximize();
+    window
+        .set_position(Position::Physical(PhysicalPosition::new(target.x, target.y)))
+        .map_err(|e| e.to_string())?;
+    window
+        .set_size(Size::Physical(PhysicalSize::new(target.width, target.height)))
+        .map_err(|e| e.to_string())?;
+    let _ = window.maximize();
+
+    build_display_status(window, Some(display_id))
+}
+
+pub(crate) fn move_window_to_saved_preferred_display(
+    app: &tauri::AppHandle,
+    window: &WebviewWindow,
+) -> Result<Option<EchoDisplayStatus>, String> {
+    let Some(display_id) = load_preferred_display_id(app) else {
+        return Ok(None);
+    };
+    move_window_to_display(window, &display_id).map(Some)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn display(id: &str, x: i32, y: i32, width: u32, height: u32, primary: bool) -> EchoDisplayInfo {
+        EchoDisplayInfo {
+            id: id.to_string(),
+            name: id.to_string(),
+            rect: DisplayRect { x, y, width, height },
+            scale_factor: 1.0,
+            primary,
+            preferred: false,
+        }
+    }
+
+    #[test]
+    fn selects_saved_preferred_display_first() {
+        let displays = vec![
+            display("intel", -2560, 0, 2560, 1440, false),
+            display("rtx", 0, 0, 2560, 1440, true),
+        ];
+
+        assert_eq!(
+            select_preferred_display(&displays, Some("intel")).unwrap().id,
+            "intel"
+        );
+    }
+
+    #[test]
+    fn falls_back_to_primary_without_saved_preference() {
+        let displays = vec![
+            display("left", -2560, 0, 2560, 1440, false),
+            display("primary", 0, 0, 2560, 1440, true),
+        ];
+
+        assert_eq!(
+            select_preferred_display(&displays, None).unwrap().id,
+            "primary"
+        );
+    }
+
+    #[test]
+    fn detects_window_spanning_two_displays() {
+        let displays = vec![
+            display("left", -2560, 0, 2560, 1440, false),
+            display("right", 0, 0, 2560, 1440, true),
+        ];
+        let window = DisplayRect { x: -100, y: 10, width: 400, height: 400 };
+
+        assert!(window_spans_displays(&window, &displays));
+    }
+
+    #[test]
+    fn does_not_flag_window_inside_one_display_as_spanning() {
+        let displays = vec![
+            display("left", -2560, 0, 2560, 1440, false),
+            display("right", 0, 0, 2560, 1440, true),
+        ];
+        let window = DisplayRect { x: 100, y: 10, width: 400, height: 400 };
+
+        assert!(!window_spans_displays(&window, &displays));
+    }
+}
+```
+
+- [ ] **Step 2: Run module tests**
+
+Near the existing Windows-only module declarations in `core/client/src/main.rs`, add:
+
+```rust
+#[cfg(target_os = "windows")]
+mod display_placement;
+```
+
+Then run:
+
+```powershell
+cargo test -p echo-core-client display_placement
+```
+
+Expected: the four `display_placement` unit tests pass.
+
+- [ ] **Step 3: Commit**
+
+Run:
+
+```powershell
+git add -- core/client/src/main.rs core/client/src/display_placement.rs
+git commit -m "test(client): cover Echo display placement logic"
+```
+
+---
+
+### Task 4: Wire Display Authority into the Tauri Client
+
+**Files:**
+- Modify: `core/client/src/main.rs`
+
+- [ ] **Step 1: Add Tauri commands**
+
+In `core/client/src/main.rs`, after `set_always_on_top()`, add:
+
+```rust
+#[cfg(target_os = "windows")]
+#[tauri::command]
+fn list_echo_displays(app: tauri::AppHandle, preferred_display_id: Option<String>) -> Result<Vec<display_placement::EchoDisplayInfo>, String> {
+    let window = app.get_webview_window("main").ok_or("window not found")?;
+    display_placement::list_echo_displays(&window, preferred_display_id.as_deref())
+}
+
+#[cfg(target_os = "windows")]
+#[tauri::command]
+fn get_echo_display_status(app: tauri::AppHandle, preferred_display_id: Option<String>) -> Result<display_placement::EchoDisplayStatus, String> {
+    let window = app.get_webview_window("main").ok_or("window not found")?;
+    display_placement::build_display_status(&window, preferred_display_id.as_deref())
+}
+
+#[cfg(target_os = "windows")]
+#[tauri::command]
+fn move_echo_to_display(app: tauri::AppHandle, display_id: String) -> Result<display_placement::EchoDisplayStatus, String> {
+    let window = app.get_webview_window("main").ok_or("window not found")?;
+    display_placement::move_window_to_display(&window, &display_id)
+}
+```
+
+- [ ] **Step 2: Register the commands**
+
+In the `tauri::generate_handler!` list in `core/client/src/main.rs`, after `report_encoder_implementation`, add:
+
+```rust
+            #[cfg(target_os = "windows")]
+            list_echo_displays,
+            #[cfg(target_os = "windows")]
+            get_echo_display_status,
+            #[cfg(target_os = "windows")]
+            move_echo_to_display,
+```
+
+- [ ] **Step 3: Apply saved preferred display on launch**
+
+In the setup block, replace the current one-shot build call:
+
+```rust
+            WebviewWindowBuilder::new(
+                app,
+                "main",
+                WebviewUrl::External(viewer_url.parse().unwrap()),
+            )
+            .title("Echo Chamber")
+            .inner_size(1280.0, 800.0)
+            .min_inner_size(800.0, 600.0)
+            .initialization_script("window.__ECHO_NATIVE__ = true;")
+            .build()?;
+```
+
+with:
+
+```rust
+            let main_window = WebviewWindowBuilder::new(
+                app,
+                "main",
+                WebviewUrl::External(viewer_url.parse().unwrap()),
+            )
+            .title("Echo Chamber")
+            .inner_size(1280.0, 800.0)
+            .min_inner_size(800.0, 600.0)
+            .initialization_script("window.__ECHO_NATIVE__ = true;")
+            .build()?;
+
+            #[cfg(target_os = "windows")]
+            {
+                let app_handle = app.handle().clone();
+                match display_placement::move_window_to_saved_preferred_display(&app_handle, &main_window) {
+                    Ok(Some(status)) => {
+                        eprintln!(
+                            "[display] moved Echo to preferred display {:?} current={:?} spans={}",
+                            status.preferred_display_id,
+                            status.current_display_name,
+                            status.window_spans_displays
+                        );
+                    }
+                    Ok(None) => {
+                        eprintln!("[display] no preferred Echo display saved");
+                    }
+                    Err(e) => {
+                        eprintln!("[display] preferred display move failed: {}", e);
+                    }
+                }
+            }
+```
+
+- [ ] **Step 4: Run client tests/check**
+
+Run:
+
+```powershell
+cargo test -p echo-core-client display_placement
+cargo check -p echo-core-client
+```
+
+Expected: both commands pass on Windows. Do not build macOS targets.
+
+- [ ] **Step 5: Commit**
+
+Run:
+
+```powershell
+git add -- core/client/src/main.rs core/client/src/display_placement.rs
+git commit -m "feat(client): prefer saved Echo display"
+```
+
+---
+
+### Task 5: Add Viewer Display Status and Stats Reporting
+
+**Files:**
+- Create: `core/viewer/display-status.js`
+- Create: `core/viewer/display-status.test.js`
+- Modify: `core/viewer/settings.js`
+- Modify: `core/viewer/index.html`
+- Modify: `core/viewer/screen-share-adaptive.js`
+- Modify: `core/viewer/style.css`
+
+- [ ] **Step 1: Add display settings keys**
+
+In `core/viewer/settings.js`, add these keys to `_SETTINGS_KEYS` after `"echo-performance-mode"`:
+
+```js
+  "echo-preferred-display-id", "echo-auto-move-to-preferred-display"
+```
+
+The final array ending should look like:
+
+```js
+  "echo-avatar-device", "echo-volume-prefs",
+  "echo-performance-mode",
+  "echo-preferred-display-id", "echo-auto-move-to-preferred-display"
+];
+```
+
+- [ ] **Step 2: Create the display-status test**
+
+Create `core/viewer/display-status.test.js` with:
+
+```js
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { isEchoDisplayWarning } = require("./display-status.js");
+
+test("display warning is false when native status is unavailable", () => {
+  assert.equal(isEchoDisplayWarning(null), false);
+  assert.equal(isEchoDisplayWarning({ available: false }), false);
+});
+
+test("display warning is true when Echo is off the preferred display", () => {
+  assert.equal(isEchoDisplayWarning({
+    available: true,
+    on_preferred_display: false,
+    window_spans_displays: false,
+  }), true);
+});
+
+test("display warning is true when Echo spans displays", () => {
+  assert.equal(isEchoDisplayWarning({
+    available: true,
+    on_preferred_display: true,
+    window_spans_displays: true,
+  }), true);
+});
+```
+
+- [ ] **Step 3: Create display-status.js**
+
+Create `core/viewer/display-status.js` with:
+
+```js
+/* =========================================================
+   DISPLAY STATUS — native Echo display-path badge and stats cache
+   ========================================================= */
+
+var _echoDisplayStatus = null;
+var _echoDisplayStatusTimer = null;
+
+function isEchoDisplayWarning(status) {
+  if (!status || status.available === false) return false;
+  return status.on_preferred_display === false || status.window_spans_displays === true;
+}
+
+function getEchoDisplayStatusSnapshot() {
+  return _echoDisplayStatus || null;
+}
+
+function getPreferredEchoDisplayId() {
+  return echoGet("echo-preferred-display-id") || "";
+}
+
+async function refreshEchoDisplayStatus() {
+  if (!window.__ECHO_NATIVE__ || !hasTauriIPC()) return null;
+  try {
+    var preferredId = getPreferredEchoDisplayId();
+    _echoDisplayStatus = await tauriInvoke("get_echo_display_status", {
+      preferredDisplayId: preferredId || null,
+    });
+    renderEchoDisplayStatus(_echoDisplayStatus);
+    return _echoDisplayStatus;
+  } catch (e) {
+    debugLog("[display] status failed: " + e);
+    return null;
+  }
+}
+
+async function moveEchoToPreferredDisplay() {
+  if (!window.__ECHO_NATIVE__ || !hasTauriIPC()) return null;
+  var preferredId = getPreferredEchoDisplayId();
+  if (!preferredId) {
+    showToast("No Echo display selected yet", 2500);
+    return null;
+  }
+  try {
+    _echoDisplayStatus = await tauriInvoke("move_echo_to_display", { displayId: preferredId });
+    renderEchoDisplayStatus(_echoDisplayStatus);
+    return _echoDisplayStatus;
+  } catch (e) {
+    showToast("Display move failed: " + e, 4000);
+    debugLog("[display] move failed: " + e);
+    return null;
+  }
+}
+
+async function saveCurrentEchoDisplayAsPreferred() {
+  var status = await refreshEchoDisplayStatus();
+  if (!status || !status.current_display_id) {
+    showToast("Could not detect current Echo display", 3000);
+    return;
+  }
+  echoSet("echo-preferred-display-id", status.current_display_id);
+  showToast("Echo display saved: " + (status.current_display_name || "current display"), 2500);
+  await refreshEchoDisplayStatus();
+}
+
+function renderEchoDisplayStatus(status) {
+  var el = document.getElementById("echo-display-status");
+  if (!el) return;
+  if (!status || status.available === false) {
+    el.classList.add("hidden");
+    return;
+  }
+
+  var warning = isEchoDisplayWarning(status);
+  var name = status.current_display_name || "Display";
+  var suffix = warning ? "Check display path" : "Full-tilt display";
+  el.textContent = suffix + ": " + name;
+  el.title = "Click to save this monitor as Echo's preferred full-performance display. Shift-click moves Echo to the saved display.";
+  el.classList.remove("hidden");
+  el.classList.toggle("display-warning", warning);
+}
+
+function startEchoDisplayStatusMonitor() {
+  if (_echoDisplayStatusTimer) return;
+  refreshEchoDisplayStatus();
+  _echoDisplayStatusTimer = setInterval(refreshEchoDisplayStatus, 5000);
+  var el = document.getElementById("echo-display-status");
+  if (el && !el._echoDisplayClickBound) {
+    el._echoDisplayClickBound = true;
+    el.addEventListener("click", function(e) {
+      if (e.shiftKey) moveEchoToPreferredDisplay();
+      else saveCurrentEchoDisplayAsPreferred();
+    });
+  }
+}
+
+if (typeof document !== "undefined") {
+  document.addEventListener("DOMContentLoaded", startEchoDisplayStatusMonitor);
+}
+
+if (typeof module === "object" && module.exports) {
+  module.exports = {
+    isEchoDisplayWarning,
+  };
+}
+```
+
+- [ ] **Step 4: Add the badge host and script**
+
+In `core/viewer/index.html`, change the grid header from:
+
+```html
+            <div class="grid-header">
+              <h2>Screens</h2>
+            </div>
+```
+
+to:
+
+```html
+            <div class="grid-header">
+              <h2>Screens</h2>
+              <button id="echo-display-status" type="button" class="echo-display-status hidden"></button>
+            </div>
+```
+
+Add the script after `settings.js` and before `identity.js`:
+
+```html
+    <script src="display-status.js?v=0.6.10-local.1.1776128211"></script>
+```
+
+- [ ] **Step 5: Include presentation stats in inbound reports**
+
+In `core/viewer/screen-share-adaptive.js`, add this helper near the top of the file after the header comment:
+
+```js
+function getScreenPresentationStatsForIdentity(identity) {
+  var tile = screenTileByIdentity.get(identity);
+  var video = tile ? tile.querySelector("video") : null;
+  if (typeof getVideoPresentationSnapshot === "function") {
+    return getVideoPresentationSnapshot(video);
+  }
+  return video?._echoPresentationStats || null;
+}
+```
+
+Inside the `inboundArr2.push({ ... })` block, before the push, add:
+
+```js
+          var presentation = source === "screen" ? getScreenPresentationStatsForIdentity(fromId) : null;
+          var presentationAge = presentation?.updatedAt
+            ? Math.max(0, Date.now() - presentation.updatedAt)
+            : null;
+```
+
+Then add these fields to the pushed object:
+
+```js
+            presented_fps: presentation ? presentation.fps : null,
+            presented_width: presentation ? presentation.width : null,
+            presented_height: presentation ? presentation.height : null,
+            presented_frames: presentation ? presentation.presentedFrames : null,
+            presentation_age_ms: presentationAge,
+```
+
+- [ ] **Step 6: Include display status in the stats POST**
+
+In the `body: JSON.stringify({ ... })` payload in `screen-share-adaptive.js`, add:
+
+```js
+              display_status: typeof getEchoDisplayStatusSnapshot === "function"
+                ? getEchoDisplayStatusSnapshot()
+                : null,
+```
+
+Place it after `capture_health: captureHealth`.
+
+- [ ] **Step 7: Style the badge**
+
+In `core/viewer/style.css`, after `.grid-header h2`, add:
+
+```css
+.grid-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.echo-display-status {
+  border: 1px solid rgba(56, 189, 248, 0.35);
+  background: rgba(8, 47, 73, 0.72);
+  color: rgba(226, 232, 240, 0.96);
+  border-radius: 6px;
+  padding: 4px 8px;
+  font-size: 11px;
+  line-height: 1.2;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.echo-display-status.display-warning {
+  border-color: rgba(245, 158, 11, 0.65);
+  background: rgba(69, 43, 8, 0.82);
+  color: #fde68a;
+}
+```
+
+- [ ] **Step 8: Run viewer tests**
+
+Run:
+
+```powershell
+node --test 'F:\EC-worktrees\screen-sources-command\core\viewer\*.test.js'
+```
+
+Expected: all viewer tests pass.
+
+- [ ] **Step 9: Commit**
+
+Run:
+
+```powershell
+git add -- core/viewer/display-status.js core/viewer/display-status.test.js core/viewer/settings.js core/viewer/index.html core/viewer/screen-share-adaptive.js core/viewer/style.css
+git commit -m "feat(viewer): report Echo display path"
+```
+
+---
+
+### Task 6: Protect the Screen Video Surface Without Lowering Quality
+
+**Files:**
+- Modify: `core/viewer/participants-grid.js`
+- Modify: `core/viewer/style.css`
+- Create: `core/viewer/screen-video-surface.test.js`
+
+- [ ] **Step 1: Write the regression test**
+
+Create `core/viewer/screen-video-surface.test.js` with:
+
+```js
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const gridJs = fs.readFileSync(path.join(__dirname, "participants-grid.js"), "utf8");
+const css = fs.readFileSync(path.join(__dirname, "style.css"), "utf8");
+
+test("screen tiles do not apply a render-size cap", () => {
+  assert.equal(gridJs.includes("computeScreenRenderCap"), false);
+  assert.equal(gridJs.includes("applyScreenRenderCap"), false);
+  assert.equal(gridJs.includes("maxWidth ="), false);
+  assert.equal(gridJs.includes("maxHeight ="), false);
+});
+
+test("screen video elements receive the protected surface class", () => {
+  assert.match(gridJs, /element\.classList\.add\("screen-video-surface"\)/);
+});
+
+test("protected video surface rules avoid direct filters and clipping", () => {
+  const match = css.match(/\.screens-grid \.tile video\.screen-video-surface\s*\{([^}]*)\}/);
+  assert.ok(match, "missing .screens-grid .tile video.screen-video-surface rule");
+  assert.equal(/filter\s*:/.test(match[1]), false);
+  assert.equal(/backdrop-filter\s*:/.test(match[1]), false);
+  assert.equal(/border-radius\s*:/.test(match[1]), false);
+  assert.equal(/box-shadow\s*:/.test(match[1]), false);
+});
+```
+
+- [ ] **Step 2: Mark screen videos as protected surfaces**
+
+In `core/viewer/participants-grid.js`, after `configureVideoElement(element, true);`, add:
+
+```js
+  element.classList.add("screen-video-surface");
+```
+
+- [ ] **Step 3: Move polish to wrapper/overlay layers**
+
+In `core/viewer/style.css`, replace the current `.screens-grid .tile video` rule with:
+
+```css
+.screens-grid .tile video.screen-video-surface {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  background: transparent;
+  flex: 1 1 0;
+  min-height: 0;
+  justify-self: center;
+  align-self: center;
+  transform: translateZ(0);
+  backface-visibility: hidden;
+  mix-blend-mode: normal;
+}
+```
+
+Replace the current `.screens-grid .tile` rule with:
+
+```css
+.screens-grid .tile {
+  min-height: 0;
+  min-width: 0;
+  max-height: 100%;
+  max-width: 100%;
+  overflow: visible;
+  aspect-ratio: 16 / 9;
+  justify-self: center;
+  align-self: center;
+  position: relative;
+  isolation: isolate;
+}
+
+.screens-grid .tile::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  border-radius: var(--radius);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.28), inset 0 1px 0 rgba(255, 255, 255, 0.04);
+  z-index: 3;
+}
+```
+
+Ensure existing overlays remain above the video:
+
+```css
+.screens-grid .tile .tile-overlay,
+.screens-grid .tile .tile-fullscreen-btn,
+.screens-grid .tile .tile-volume-wrap,
+.screens-grid .tile .tile-poster {
+  z-index: 4;
+}
+```
+
+- [ ] **Step 4: Run viewer tests**
+
+Run:
+
+```powershell
+node --test 'F:\EC-worktrees\screen-sources-command\core\viewer\*.test.js'
+```
+
+Expected: all viewer tests pass, including `screen-video-surface.test.js`.
+
+- [ ] **Step 5: Commit**
+
+Run:
+
+```powershell
+git add -- core/viewer/participants-grid.js core/viewer/style.css core/viewer/screen-video-surface.test.js
+git commit -m "feat(viewer): protect full-quality screen video surface"
+```
+
+---
+
+### Task 7: Verification and Live Test Protocol
+
+**Files:**
+- No required file changes.
+
+- [ ] **Step 1: Run automated verification**
+
+Run:
+
+```powershell
+node --test 'F:\EC-worktrees\screen-sources-command\core\viewer\*.test.js'
+cargo test -p echo-core-client display_placement
+cargo check -p echo-core-client
+cargo check -p echo-core-control
+```
+
+Expected: all commands pass. Do not build macOS targets.
+
+- [ ] **Step 2: Build the Windows client only when Sam is ready to test**
+
+Run:
+
+```powershell
+cargo build -p echo-core-client
+```
+
+Expected: Windows desktop client builds successfully.
+
+- [ ] **Step 3: Close and reopen Echo for Sam before validation**
+
+Tell Sam before starting:
+
+```text
+Close Echo now. I am going to reopen the freshly built client, move it to the saved full-performance display, and then start monitoring only after you say the remote screen is visible.
+```
+
+Then launch the built client using the repo's existing local-client workflow or the built binary path produced by Cargo.
+
+- [ ] **Step 4: Save the 4090 monitor as preferred**
+
+With Echo visibly on the 4090-connected monitor, tell Sam:
+
+```text
+Click the display badge next to Screens once. That saves this monitor as Echo's preferred full-performance display.
+```
+
+Expected: the badge says `Full-tilt display: <display name>` and `settings.json` contains `echo-preferred-display-id`.
+
+- [ ] **Step 5: Test non-maximized and maximized states**
+
+Tell Sam:
+
+```text
+Leave Echo non-maximized for 60 seconds while Spencer's screen is visible. I will read WebRTC receive FPS, presented FPS, and display path status. Then maximize Echo and keep the same stream visible for another 60 seconds.
+```
+
+Evidence to capture from `/admin/api/dashboard`:
+
+- `inbound[].fps`
+- `inbound[].presented_fps`
+- `inbound[].decoded`
+- `inbound[].dropped`
+- `display_status.current_display_name`
+- `display_status.on_preferred_display`
+- `display_status.window_spans_displays`
+
+- [ ] **Step 6: Decide whether WebView2 is the wall**
+
+Use this decision rule:
+
+- If WebRTC receive FPS and presented FPS both stay healthy when maximized, this batch fixed the issue.
+- If WebRTC receive FPS is healthy but presented FPS collapses while Echo is on the preferred 4090 display and not spanning monitors, WebView2 presentation is the wall.
+- If Echo is off the preferred display or spanning monitors, fix display placement first and rerun the test.
+
+- [ ] **Step 7: Commit verification notes**
+
+Create or update `docs/handovers/2026-05-02-full-quality-display-path-validation.md` with:
+
+```markdown
+# Full-Quality Display Path Validation
+
+Date: 2026-05-02
+Branch: codex/screen-sources-command-investigation
+
+## Build
+
+- Client build:
+- Viewer tests:
+- Client checks:
+- Control checks:
+
+## Display Path
+
+- Preferred display:
+- Current display:
+- Window spans displays:
+
+## Non-Maximized Result
+
+- WebRTC receive FPS:
+- Presented FPS:
+- Dropped frames:
+- Visible result:
+
+## Maximized Result
+
+- WebRTC receive FPS:
+- Presented FPS:
+- Dropped frames:
+- Visible result:
+
+## Decision
+
+- Result:
+- Next step:
+```
+
+Then run:
+
+```powershell
+git add -- docs/handovers/2026-05-02-full-quality-display-path-validation.md
+git commit -m "docs: record full-quality display validation"
+```
+
+---
+
+## Native Presenter Decision Gate
+
+Do not start native presenter work inside this batch. Start a separate design/spec only if Task 7 proves all of these at the same time:
+
+- Echo is on the saved preferred 4090 display.
+- Echo is not spanning displays.
+- WebRTC receive FPS is healthy.
+- Presented FPS collapses when maximized.
+- Removing direct video-surface effects did not restore smooth presentation.
+
+The next spec should target a minimal Direct3D/DirectComposition proof of concept for one received screen tile while keeping WebView2 as the surrounding UI shell.

--- a/docs/superpowers/plans/2026-05-02-guarded-native-screen-presenter-gate-1.md
+++ b/docs/superpowers/plans/2026-05-02-guarded-native-screen-presenter-gate-1.md
@@ -1,0 +1,1551 @@
+# Guarded Native Screen Presenter Gate 1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the guarded native receive spike for screen-share tracks: opt-in setting, receive-only token identity, Tauri IPC, Rust frame counter, and dashboard telemetry, with WebView2 still rendering all visible video.
+
+**Architecture:** The viewer remains the source of truth for rooms and tiles. JavaScript requests a hidden receive-only native presenter token for one eligible screen tile, then sends the target room/SFU/token/track metadata to the Windows desktop client. The Rust client connects as `<viewer>$native-presenter`, subscribes only to the requested screen track, counts native frames via `NativeVideoStream`, reports status through Tauri, and never hides or replaces the WebView2 `<video>` element in Gate 1.
+
+**Tech Stack:** Rust/Tauri 2, patched local `livekit` and `libwebrtc`, WebView2 JavaScript, Node test runner, Axum control plane.
+
+---
+
+## Scope
+
+This plan implements Gate 1 from the design spec:
+
+- Native receive feasibility.
+- Receive-only hidden/system identity.
+- Off/On/Auto setting plumbing, with `Off` as normal-user default.
+- One target screen tile at a time.
+- Native frame-rate telemetry.
+- Immediate disable/stop path.
+
+This plan does not draw native video, hide WebView2 video, create native child windows, or change stream quality. Those belong to the Gate 2 one-tile presentation plan after Gate 1 proves safe.
+
+## File Structure
+
+- Create `core/client/src/native_presenter.rs`: Windows-only native presenter manager, request/status types, identity helper, status state machine, LiveKit receive worker.
+- Modify `core/client/src/main.rs`: register the native presenter module, managed state, and Tauri commands.
+- Modify `core/client/Cargo.toml`: add direct Windows dependencies for `libwebrtc` and `futures-util`, and enable `tokio/sync`.
+- Modify `core/control/src/auth.rs`: classify `$native-presenter` identities as hidden receive-only companion identities.
+- Modify `core/control/src/admin.rs`: accept and merge native presenter telemetry.
+- Create `core/viewer/native-presenter.js`: viewer-side setting parser, target builder, token fetch, Tauri IPC calls, status snapshot helper.
+- Create `core/viewer/native-presenter.test.js`: Node tests for mode parsing, identity generation, tile geometry, and native report shaping.
+- Modify `core/viewer/settings.js`: persist the native presenter setting key.
+- Modify `core/viewer/index.html`: load `native-presenter.js` before screen tile registration code.
+- Modify `core/viewer/participants-fullscreen.js`: start/stop native receive probing from `registerScreenTrack` and `unregisterScreenTrack`.
+- Modify `core/viewer/participants-grid.js`: stop native receive probing from `clearMedia`.
+- Modify `core/viewer/screen-share-adaptive.js`: include native presenter status in `/api/client-stats-report`.
+- Modify `core/viewer/admin.js`: show a small native presenter status chip for live diagnostics.
+
+---
+
+### Task 1: Client Native Presenter State Model
+
+**Files:**
+- Create: `core/client/src/native_presenter.rs`
+- Modify: `core/client/src/main.rs`
+
+- [ ] **Step 1: Add the Windows module declaration**
+
+Modify `core/client/src/main.rs` near the other Windows-only modules:
+
+```rust
+#[cfg(target_os = "windows")]
+mod native_presenter;
+```
+
+- [ ] **Step 2: Write the failing state-model tests**
+
+Create `core/client/src/native_presenter.rs` with these tests first:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mode_defaults_to_off_for_unknown_values() {
+        assert_eq!(NativePresenterMode::from_setting("off"), NativePresenterMode::Off);
+        assert_eq!(NativePresenterMode::from_setting("on"), NativePresenterMode::On);
+        assert_eq!(NativePresenterMode::from_setting("auto"), NativePresenterMode::Auto);
+        assert_eq!(NativePresenterMode::from_setting(""), NativePresenterMode::Off);
+        assert_eq!(NativePresenterMode::from_setting("fast"), NativePresenterMode::Off);
+    }
+
+    #[test]
+    fn native_presenter_identity_is_derived_from_viewer_identity() {
+        assert_eq!(
+            native_presenter_identity("Sam-1234"),
+            "Sam-1234$native-presenter"
+        );
+        assert_eq!(
+            native_presenter_identity("Sam-1234$native-presenter"),
+            "Sam-1234$native-presenter"
+        );
+    }
+
+    #[test]
+    fn status_starts_disabled() {
+        let manager = NativePresenterManager::new();
+        let status = manager.status();
+        assert_eq!(status.state, NativePresenterState::Disabled);
+        assert_eq!(status.render_path, "webview2");
+        assert_eq!(status.native_receive_fps, None);
+    }
+
+    #[test]
+    fn rejected_start_records_fallback_reason() {
+        let manager = NativePresenterManager::new();
+        let request = NativePresenterStartRequest {
+            mode: NativePresenterMode::Off,
+            room: "main".to_string(),
+            sfu_url: "wss://example.invalid".to_string(),
+            token: "token".to_string(),
+            viewer_identity: "Sam-1234".to_string(),
+            participant_identity: "Spencer-2222".to_string(),
+            track_sid: "TR_screen".to_string(),
+            tile: NativePresenterTileRect { x: 0, y: 0, width: 1920, height: 1080, scale_factor: 1.0 },
+        };
+
+        let result = manager.validate_start_request(&request);
+
+        assert!(result.is_err());
+        assert_eq!(manager.status().state, NativePresenterState::Fallback);
+        assert_eq!(
+            manager.status().fallback_reason.as_deref(),
+            Some("native presenter mode is off")
+        );
+    }
+}
+```
+
+- [ ] **Step 3: Run the state-model tests and verify failure**
+
+Run:
+
+```powershell
+cargo test -p echo-core-client native_presenter
+```
+
+Expected: compile failure because the native presenter types do not exist yet.
+
+- [ ] **Step 4: Implement the state model**
+
+Replace `core/client/src/native_presenter.rs` with:
+
+```rust
+use parking_lot::Mutex;
+use serde::{Deserialize, Serialize};
+use std::sync::{
+    atomic::{AtomicU64, Ordering},
+    Arc,
+};
+use std::time::Instant;
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum NativePresenterMode {
+    Off,
+    On,
+    Auto,
+}
+
+impl NativePresenterMode {
+    pub(crate) fn from_setting(value: &str) -> Self {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "on" => Self::On,
+            "auto" => Self::Auto,
+            _ => Self::Off,
+        }
+    }
+}
+
+impl Default for NativePresenterMode {
+    fn default() -> Self {
+        Self::Off
+    }
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
+pub(crate) struct NativePresenterTileRect {
+    pub(crate) x: i32,
+    pub(crate) y: i32,
+    pub(crate) width: u32,
+    pub(crate) height: u32,
+    pub(crate) scale_factor: f64,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub(crate) struct NativePresenterStartRequest {
+    pub(crate) mode: NativePresenterMode,
+    pub(crate) room: String,
+    pub(crate) sfu_url: String,
+    pub(crate) token: String,
+    pub(crate) viewer_identity: String,
+    pub(crate) participant_identity: String,
+    pub(crate) track_sid: String,
+    pub(crate) tile: NativePresenterTileRect,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum NativePresenterState {
+    Disabled,
+    Starting,
+    Receiving,
+    Fallback,
+    Stopped,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub(crate) struct NativePresenterStatus {
+    pub(crate) state: NativePresenterState,
+    pub(crate) render_path: String,
+    pub(crate) target_identity: Option<String>,
+    pub(crate) target_track_sid: Option<String>,
+    pub(crate) native_receive_fps: Option<f64>,
+    pub(crate) native_presented_fps: Option<f64>,
+    pub(crate) native_frames_received: u64,
+    pub(crate) native_frames_dropped: u64,
+    pub(crate) queue_depth: u32,
+    pub(crate) tile_width: Option<u32>,
+    pub(crate) tile_height: Option<u32>,
+    pub(crate) fallback_reason: Option<String>,
+    pub(crate) updated_at_ms: u64,
+}
+
+impl Default for NativePresenterStatus {
+    fn default() -> Self {
+        Self {
+            state: NativePresenterState::Disabled,
+            render_path: "webview2".to_string(),
+            target_identity: None,
+            target_track_sid: None,
+            native_receive_fps: None,
+            native_presented_fps: None,
+            native_frames_received: 0,
+            native_frames_dropped: 0,
+            queue_depth: 0,
+            tile_width: None,
+            tile_height: None,
+            fallback_reason: None,
+            updated_at_ms: 0,
+        }
+    }
+}
+
+pub(crate) fn native_presenter_identity(viewer_identity: &str) -> String {
+    let trimmed = viewer_identity.trim();
+    if trimmed.ends_with("$native-presenter") {
+        trimmed.to_string()
+    } else {
+        format!("{trimmed}$native-presenter")
+    }
+}
+
+pub(crate) struct NativePresenterManager {
+    generation: AtomicU64,
+    status: Mutex<NativePresenterStatus>,
+    started_at: Instant,
+}
+
+impl NativePresenterManager {
+    pub(crate) fn new() -> Arc<Self> {
+        Arc::new(Self {
+            generation: AtomicU64::new(0),
+            status: Mutex::new(NativePresenterStatus::default()),
+            started_at: Instant::now(),
+        })
+    }
+
+    pub(crate) fn status(&self) -> NativePresenterStatus {
+        self.status.lock().clone()
+    }
+
+    pub(crate) fn validate_start_request(
+        &self,
+        request: &NativePresenterStartRequest,
+    ) -> Result<(), String> {
+        if request.mode == NativePresenterMode::Off {
+            self.set_fallback("native presenter mode is off");
+            return Err("native presenter mode is off".to_string());
+        }
+        if request.room.trim().is_empty() {
+            self.set_fallback("room is empty");
+            return Err("room is empty".to_string());
+        }
+        if request.sfu_url.trim().is_empty() {
+            self.set_fallback("sfu_url is empty");
+            return Err("sfu_url is empty".to_string());
+        }
+        if request.token.trim().is_empty() {
+            self.set_fallback("token is empty");
+            return Err("token is empty".to_string());
+        }
+        if request.viewer_identity.trim().is_empty() {
+            self.set_fallback("viewer_identity is empty");
+            return Err("viewer_identity is empty".to_string());
+        }
+        if request.participant_identity.trim().is_empty() {
+            self.set_fallback("participant_identity is empty");
+            return Err("participant_identity is empty".to_string());
+        }
+        if request.track_sid.trim().is_empty() {
+            self.set_fallback("track_sid is empty");
+            return Err("track_sid is empty".to_string());
+        }
+        if request.tile.width == 0 || request.tile.height == 0 {
+            self.set_fallback("tile has zero size");
+            return Err("tile has zero size".to_string());
+        }
+        Ok(())
+    }
+
+    pub(crate) fn mark_starting(&self, request: &NativePresenterStartRequest) -> u64 {
+        let generation = self.generation.fetch_add(1, Ordering::SeqCst) + 1;
+        let mut status = self.status.lock();
+        *status = NativePresenterStatus {
+            state: NativePresenterState::Starting,
+            render_path: "native_receive_probe".to_string(),
+            target_identity: Some(request.participant_identity.clone()),
+            target_track_sid: Some(request.track_sid.clone()),
+            native_receive_fps: None,
+            native_presented_fps: None,
+            native_frames_received: 0,
+            native_frames_dropped: 0,
+            queue_depth: 0,
+            tile_width: Some(request.tile.width),
+            tile_height: Some(request.tile.height),
+            fallback_reason: None,
+            updated_at_ms: self.elapsed_ms(),
+        };
+        generation
+    }
+
+    pub(crate) fn stop(&self, reason: &str) -> NativePresenterStatus {
+        self.generation.fetch_add(1, Ordering::SeqCst);
+        let mut status = self.status.lock();
+        status.state = NativePresenterState::Stopped;
+        status.render_path = "webview2".to_string();
+        status.fallback_reason = Some(reason.to_string());
+        status.updated_at_ms = self.elapsed_ms();
+        status.clone()
+    }
+
+    pub(crate) fn generation(&self) -> u64 {
+        self.generation.load(Ordering::SeqCst)
+    }
+
+    fn set_fallback(&self, reason: &str) {
+        let mut status = self.status.lock();
+        status.state = NativePresenterState::Fallback;
+        status.render_path = "webview2".to_string();
+        status.fallback_reason = Some(reason.to_string());
+        status.updated_at_ms = self.elapsed_ms();
+    }
+
+    fn elapsed_ms(&self) -> u64 {
+        self.started_at.elapsed().as_millis().min(u128::from(u64::MAX)) as u64
+    }
+}
+```
+
+Keep the tests from Step 2 at the end of the file.
+
+- [ ] **Step 5: Run the state-model tests and verify pass**
+
+Run:
+
+```powershell
+cargo test -p echo-core-client native_presenter
+```
+
+Expected: all native presenter state-model tests pass.
+
+- [ ] **Step 6: Commit Task 1**
+
+Run:
+
+```powershell
+git add core/client/src/main.rs core/client/src/native_presenter.rs
+git commit -m "feat(client): add native presenter state model"
+```
+
+---
+
+### Task 2: Hidden Receive-Only Token Identity
+
+**Files:**
+- Modify: `core/control/src/auth.rs`
+
+- [ ] **Step 1: Write helper tests for companion identity grants**
+
+Add this `#[cfg(test)]` module at the end of `core/control/src/auth.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn screen_companion_identity_gets_publish_only_grant() {
+        let kind = companion_identity_kind("Sam-1234$screen");
+        let grant = livekit_video_grant("main".to_string(), kind);
+
+        assert_eq!(kind, Some(CompanionIdentityKind::ScreenPublisher));
+        assert!(grant.canPublish);
+        assert!(!grant.canSubscribe);
+        assert!(grant.canPublishData);
+        assert!(skip_participant_tracking(kind));
+    }
+
+    #[test]
+    fn native_presenter_identity_gets_receive_only_grant() {
+        let kind = companion_identity_kind("Sam-1234$native-presenter");
+        let grant = livekit_video_grant("main".to_string(), kind);
+
+        assert_eq!(kind, Some(CompanionIdentityKind::NativePresenter));
+        assert!(!grant.canPublish);
+        assert!(grant.canSubscribe);
+        assert!(!grant.canPublishData);
+        assert!(skip_participant_tracking(kind));
+    }
+
+    #[test]
+    fn normal_identity_gets_normal_viewer_grant() {
+        let kind = companion_identity_kind("Sam-1234");
+        let grant = livekit_video_grant("main".to_string(), kind);
+
+        assert_eq!(kind, None);
+        assert!(grant.canPublish);
+        assert!(grant.canSubscribe);
+        assert!(grant.canPublishData);
+        assert!(!skip_participant_tracking(kind));
+    }
+}
+```
+
+- [ ] **Step 2: Run the helper tests and verify failure**
+
+Run:
+
+```powershell
+cargo test -p echo-core-control auth::tests
+```
+
+Expected: compile failure because the helper functions do not exist yet.
+
+- [ ] **Step 3: Add companion identity helpers**
+
+Add these helpers above `issue_token` in `core/control/src/auth.rs`:
+
+```rust
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum CompanionIdentityKind {
+    ScreenPublisher,
+    NativePresenter,
+}
+
+pub(crate) fn companion_identity_kind(identity: &str) -> Option<CompanionIdentityKind> {
+    if identity.ends_with("$screen") {
+        Some(CompanionIdentityKind::ScreenPublisher)
+    } else if identity.ends_with("$native-presenter") {
+        Some(CompanionIdentityKind::NativePresenter)
+    } else {
+        None
+    }
+}
+
+pub(crate) fn livekit_video_grant(
+    room: String,
+    kind: Option<CompanionIdentityKind>,
+) -> LiveKitVideoGrant {
+    match kind {
+        Some(CompanionIdentityKind::ScreenPublisher) => LiveKitVideoGrant {
+            room,
+            roomJoin: true,
+            canPublish: true,
+            canSubscribe: false,
+            canPublishData: true,
+        },
+        Some(CompanionIdentityKind::NativePresenter) => LiveKitVideoGrant {
+            room,
+            roomJoin: true,
+            canPublish: false,
+            canSubscribe: true,
+            canPublishData: false,
+        },
+        None => LiveKitVideoGrant {
+            room,
+            roomJoin: true,
+            canPublish: true,
+            canSubscribe: true,
+            canPublishData: true,
+        },
+    }
+}
+
+pub(crate) fn skip_participant_tracking(kind: Option<CompanionIdentityKind>) -> bool {
+    kind.is_some()
+}
+```
+
+- [ ] **Step 4: Replace the hard-coded `$screen` grant logic**
+
+In `issue_token`, replace:
+
+```rust
+// $screen identities are companion connections for native screen capture.
+// They publish video only (no subscribe needed) and skip name conflict checks.
+let is_screen_identity = payload.identity.ends_with("$screen");
+```
+
+with:
+
+```rust
+// Companion identities are system connections, not visible people.
+let companion_kind = companion_identity_kind(&payload.identity);
+```
+
+Replace the inline `video: LiveKitVideoGrant { ... }` block with:
+
+```rust
+video: livekit_video_grant(payload.room.clone(), companion_kind),
+```
+
+Replace:
+
+```rust
+// $screen identities skip participant tracking — they're not real users
+if is_screen_identity {
+    info!("issued $screen token for room={} identity={}", payload.room, payload.identity);
+    return Ok(Json(TokenResponse {
+        token,
+        expires_in_seconds: state.config.livekit_token_ttl_secs,
+    }));
+}
+```
+
+with:
+
+```rust
+// Companion identities skip participant tracking — they're not real users.
+if skip_participant_tracking(companion_kind) {
+    info!(
+        "issued companion token for room={} identity={} kind={:?}",
+        payload.room, payload.identity, companion_kind
+    );
+    return Ok(Json(TokenResponse {
+        token,
+        expires_in_seconds: state.config.livekit_token_ttl_secs,
+    }));
+}
+```
+
+- [ ] **Step 5: Run control auth tests and verify pass**
+
+Run:
+
+```powershell
+cargo test -p echo-core-control auth::tests
+```
+
+Expected: all auth helper tests pass.
+
+- [ ] **Step 6: Commit Task 2**
+
+Run:
+
+```powershell
+git add core/control/src/auth.rs
+git commit -m "feat(control): issue receive-only native presenter tokens"
+```
+
+---
+
+### Task 3: Tauri Native Presenter IPC
+
+**Files:**
+- Modify: `core/client/src/main.rs`
+- Modify: `core/client/src/native_presenter.rs`
+
+- [ ] **Step 1: Add command wrapper tests to the manager**
+
+Add these tests to `core/client/src/native_presenter.rs`:
+
+```rust
+#[test]
+fn start_validation_accepts_on_mode_with_complete_target() {
+    let manager = NativePresenterManager::new();
+    let request = NativePresenterStartRequest {
+        mode: NativePresenterMode::On,
+        room: "main".to_string(),
+        sfu_url: "wss://echo.example.invalid".to_string(),
+        token: "token".to_string(),
+        viewer_identity: "Sam-1234".to_string(),
+        participant_identity: "Spencer-2222".to_string(),
+        track_sid: "TR_screen".to_string(),
+        tile: NativePresenterTileRect { x: 10, y: 20, width: 1920, height: 1080, scale_factor: 1.0 },
+    };
+
+    assert!(manager.validate_start_request(&request).is_ok());
+}
+
+#[test]
+fn stop_returns_webview2_status() {
+    let manager = NativePresenterManager::new();
+
+    let status = manager.stop("user disabled native presenter");
+
+    assert_eq!(status.state, NativePresenterState::Stopped);
+    assert_eq!(status.render_path, "webview2");
+    assert_eq!(
+        status.fallback_reason.as_deref(),
+        Some("user disabled native presenter")
+    );
+}
+```
+
+- [ ] **Step 2: Run the manager tests and verify pass**
+
+Run:
+
+```powershell
+cargo test -p echo-core-client native_presenter
+```
+
+Expected: manager tests pass before IPC wiring.
+
+- [ ] **Step 3: Add command functions**
+
+In `core/client/src/main.rs`, add these imports near the existing imports:
+
+```rust
+#[cfg(target_os = "windows")]
+use crate::native_presenter::{
+    NativePresenterManager, NativePresenterStartRequest, NativePresenterStatus,
+};
+```
+
+Add these commands near the display placement commands:
+
+```rust
+#[cfg(target_os = "windows")]
+#[tauri::command]
+async fn start_native_presenter(
+    presenter: tauri::State<'_, Arc<NativePresenterManager>>,
+    request: NativePresenterStartRequest,
+) -> Result<NativePresenterStatus, String> {
+    presenter.start_receive_probe(request).await
+}
+
+#[cfg(target_os = "windows")]
+#[tauri::command]
+fn stop_native_presenter(
+    presenter: tauri::State<'_, Arc<NativePresenterManager>>,
+    reason: Option<String>,
+) -> Result<NativePresenterStatus, String> {
+    Ok(presenter.stop(reason.as_deref().unwrap_or("stopped by viewer")))
+}
+
+#[cfg(target_os = "windows")]
+#[tauri::command]
+fn get_native_presenter_status(
+    presenter: tauri::State<'_, Arc<NativePresenterManager>>,
+) -> Result<NativePresenterStatus, String> {
+    Ok(presenter.status())
+}
+```
+
+- [ ] **Step 4: Add a temporary receive-probe stub**
+
+Add this method to `impl NativePresenterManager` in `core/client/src/native_presenter.rs`:
+
+```rust
+pub(crate) async fn start_receive_probe(
+    self: &Arc<Self>,
+    request: NativePresenterStartRequest,
+) -> Result<NativePresenterStatus, String> {
+    self.validate_start_request(&request)?;
+    self.mark_starting(&request);
+    Ok(self.status())
+}
+```
+
+- [ ] **Step 5: Register managed state and commands**
+
+In `main.rs`, after the existing Windows `builder.manage(Arc::new(CaptureHealthState::new()))`, add:
+
+```rust
+#[cfg(target_os = "windows")]
+let builder = builder.manage(NativePresenterManager::new());
+```
+
+In the `tauri::generate_handler!` list, add:
+
+```rust
+#[cfg(target_os = "windows")]
+start_native_presenter,
+#[cfg(target_os = "windows")]
+stop_native_presenter,
+#[cfg(target_os = "windows")]
+get_native_presenter_status,
+```
+
+- [ ] **Step 6: Run client tests/check**
+
+Run:
+
+```powershell
+cargo test -p echo-core-client native_presenter
+cargo check -p echo-core-client
+```
+
+Expected: tests pass and client check completes.
+
+- [ ] **Step 7: Commit Task 3**
+
+Run:
+
+```powershell
+git add core/client/src/main.rs core/client/src/native_presenter.rs
+git commit -m "feat(client): expose native presenter ipc"
+```
+
+---
+
+### Task 4: Viewer Native Presenter Bridge
+
+**Files:**
+- Create: `core/viewer/native-presenter.js`
+- Create: `core/viewer/native-presenter.test.js`
+- Modify: `core/viewer/settings.js`
+- Modify: `core/viewer/index.html`
+- Modify: `core/viewer/participants-fullscreen.js`
+- Modify: `core/viewer/participants-grid.js`
+
+- [ ] **Step 1: Write viewer bridge tests**
+
+Create `core/viewer/native-presenter.test.js`:
+
+```javascript
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const {
+  normalizeNativePresenterMode,
+  nativePresenterIdentity,
+  buildNativePresenterTileRect,
+  buildNativePresenterReport,
+} = require("./native-presenter.js");
+
+test("native presenter mode defaults to off", () => {
+  assert.equal(normalizeNativePresenterMode("off"), "off");
+  assert.equal(normalizeNativePresenterMode("on"), "on");
+  assert.equal(normalizeNativePresenterMode("auto"), "auto");
+  assert.equal(normalizeNativePresenterMode(""), "off");
+  assert.equal(normalizeNativePresenterMode("turbo"), "off");
+});
+
+test("native presenter identity is a hidden companion identity", () => {
+  assert.equal(nativePresenterIdentity("Sam-1234"), "Sam-1234$native-presenter");
+  assert.equal(
+    nativePresenterIdentity("Sam-1234$native-presenter"),
+    "Sam-1234$native-presenter"
+  );
+});
+
+test("tile rect is converted to physical pixels", () => {
+  const tile = {
+    getBoundingClientRect() {
+      return { left: 10.25, top: 20.5, width: 640.5, height: 360.25 };
+    },
+  };
+  const rect = buildNativePresenterTileRect(tile, 1.5);
+  assert.deepEqual(rect, {
+    x: 15,
+    y: 31,
+    width: 961,
+    height: 540,
+    scale_factor: 1.5,
+  });
+});
+
+test("native presenter report is null when status is missing", () => {
+  assert.equal(buildNativePresenterReport(null), null);
+});
+
+test("native presenter report exposes safe telemetry names", () => {
+  const report = buildNativePresenterReport({
+    state: "receiving",
+    render_path: "native_receive_probe",
+    target_identity: "Spencer-2222",
+    target_track_sid: "TR_screen",
+    native_receive_fps: 59.7,
+    native_presented_fps: null,
+    native_frames_received: 120,
+    native_frames_dropped: 0,
+    queue_depth: 0,
+    fallback_reason: null,
+    tile_width: 1920,
+    tile_height: 1080,
+    updated_at_ms: 4567,
+  });
+
+  assert.equal(report.state, "receiving");
+  assert.equal(report.render_path, "native_receive_probe");
+  assert.equal(report.native_receive_fps, 59.7);
+  assert.equal(report.native_presented_fps, null);
+  assert.equal(report.target_identity, "Spencer-2222");
+});
+```
+
+- [ ] **Step 2: Run viewer bridge tests and verify failure**
+
+Run:
+
+```powershell
+node --test core/viewer/native-presenter.test.js
+```
+
+Expected: module-not-found failure because `native-presenter.js` does not exist yet.
+
+- [ ] **Step 3: Implement `native-presenter.js`**
+
+Create `core/viewer/native-presenter.js`:
+
+```javascript
+/* =========================================================
+   NATIVE PRESENTER - guarded native receive probe for screen tiles
+   ========================================================= */
+
+const NATIVE_PRESENTER_MODE_KEY = "echo-native-presenter-mode";
+var _nativePresenterStatus = null;
+var _nativePresenterActiveTrackSid = "";
+var _nativePresenterPollTimer = null;
+
+function normalizeNativePresenterMode(value) {
+  var mode = String(value || "off").toLowerCase();
+  return mode === "on" || mode === "auto" ? mode : "off";
+}
+
+function getNativePresenterMode() {
+  if (typeof echoGet !== "function") return "off";
+  return normalizeNativePresenterMode(echoGet(NATIVE_PRESENTER_MODE_KEY));
+}
+
+function nativePresenterIdentity(viewerIdentity) {
+  var identity = String(viewerIdentity || "").trim();
+  if (!identity) return "";
+  return identity.endsWith("$native-presenter") ? identity : identity + "$native-presenter";
+}
+
+function buildNativePresenterTileRect(tile, scaleFactor) {
+  var rect = tile.getBoundingClientRect();
+  var scale = Number(scaleFactor || window.devicePixelRatio || 1) || 1;
+  return {
+    x: Math.round(rect.left * scale),
+    y: Math.round(rect.top * scale),
+    width: Math.max(1, Math.round(rect.width * scale)),
+    height: Math.max(1, Math.round(rect.height * scale)),
+    scale_factor: scale,
+  };
+}
+
+function buildNativePresenterReport(status) {
+  if (!status) return null;
+  return {
+    state: status.state || "disabled",
+    render_path: status.render_path || "webview2",
+    target_identity: status.target_identity || null,
+    target_track_sid: status.target_track_sid || null,
+    native_receive_fps: status.native_receive_fps ?? null,
+    native_presented_fps: status.native_presented_fps ?? null,
+    native_frames_received: status.native_frames_received || 0,
+    native_frames_dropped: status.native_frames_dropped || 0,
+    queue_depth: status.queue_depth || 0,
+    fallback_reason: status.fallback_reason || null,
+    tile_width: status.tile_width || null,
+    tile_height: status.tile_height || null,
+    updated_at_ms: status.updated_at_ms || 0,
+  };
+}
+
+function getNativePresenterStatusSnapshot() {
+  return buildNativePresenterReport(_nativePresenterStatus);
+}
+
+function shouldNativePresenterProbeScreen(mode, tile) {
+  if (!window.__ECHO_NATIVE__ || typeof hasTauriIPC !== "function" || !hasTauriIPC()) return false;
+  if (mode === "off") return false;
+  if (!tile || !tile.dataset || !tile.dataset.trackSid || !tile.dataset.identity) return false;
+  if (mode === "on") return true;
+  var rect = tile.getBoundingClientRect();
+  return rect.width >= 1600 || rect.height >= 900;
+}
+
+async function fetchNativePresenterToken(identity) {
+  if (!adminToken) throw new Error("admin token unavailable");
+  var controlUrl = controlUrlInput.value.trim();
+  var roomId = currentRoomName || "main";
+  var presenterIdentity = nativePresenterIdentity(identity);
+  var presenterName = (nameInput.value.trim() || "Viewer") + " Native Presenter";
+  return fetchRoomToken(controlUrl, adminToken, roomId, presenterIdentity, presenterName);
+}
+
+async function maybeStartNativePresenterForScreenTrack(meta) {
+  try {
+    var mode = getNativePresenterMode();
+    var tile = meta && meta.tile;
+    if (!shouldNativePresenterProbeScreen(mode, tile)) return null;
+    var identity = meta.identity || (tile.dataset && tile.dataset.identity) || "";
+    var trackSid = meta.trackSid || (tile.dataset && tile.dataset.trackSid) || "";
+    if (!identity || !trackSid) return null;
+    if (_nativePresenterActiveTrackSid === trackSid) return _nativePresenterStatus;
+
+    var token = await fetchNativePresenterToken(room?.localParticipant?.identity || identityInput.value || identity);
+    var status = await tauriInvoke("start_native_presenter", {
+      request: {
+        mode: mode,
+        room: currentRoomName || "main",
+        sfu_url: sfuUrlInput.value.trim(),
+        token: token,
+        viewer_identity: room?.localParticipant?.identity || identityInput.value || "",
+        participant_identity: identity,
+        track_sid: trackSid,
+        tile: buildNativePresenterTileRect(tile, window.devicePixelRatio || 1),
+      },
+    });
+    _nativePresenterStatus = status;
+    _nativePresenterActiveTrackSid = trackSid;
+    startNativePresenterStatusPolling();
+    debugLog("[native-presenter] receive probe started for " + identity + " " + trackSid);
+    return status;
+  } catch (e) {
+    debugLog("[native-presenter] start failed: " + (e && e.message ? e.message : e));
+    return null;
+  }
+}
+
+async function stopNativePresenterForTrack(trackSid) {
+  if (!_nativePresenterActiveTrackSid || _nativePresenterActiveTrackSid !== trackSid) return null;
+  return stopAllNativePresenter("track removed");
+}
+
+async function stopAllNativePresenter(reason) {
+  if (!window.__ECHO_NATIVE__ || typeof hasTauriIPC !== "function" || !hasTauriIPC()) return null;
+  try {
+    var status = await tauriInvoke("stop_native_presenter", { reason: reason || "viewer stopped" });
+    _nativePresenterStatus = status;
+    _nativePresenterActiveTrackSid = "";
+    return status;
+  } catch (e) {
+    debugLog("[native-presenter] stop failed: " + (e && e.message ? e.message : e));
+    return null;
+  }
+}
+
+function startNativePresenterStatusPolling() {
+  if (_nativePresenterPollTimer) return;
+  _nativePresenterPollTimer = setInterval(async function() {
+    try {
+      if (!window.__ECHO_NATIVE__ || typeof hasTauriIPC !== "function" || !hasTauriIPC()) return;
+      _nativePresenterStatus = await tauriInvoke("get_native_presenter_status");
+    } catch (e) {
+      debugLog("[native-presenter] status failed: " + (e && e.message ? e.message : e));
+    }
+  }, 1000);
+}
+
+if (typeof module === "object" && module.exports) {
+  module.exports = {
+    normalizeNativePresenterMode,
+    nativePresenterIdentity,
+    buildNativePresenterTileRect,
+    buildNativePresenterReport,
+  };
+}
+```
+
+- [ ] **Step 4: Persist the setting key**
+
+In `core/viewer/settings.js`, add `"echo-native-presenter-mode"` to `_SETTINGS_KEYS` immediately after `"echo-performance-mode"`:
+
+```javascript
+"echo-performance-mode", "echo-native-presenter-mode",
+```
+
+- [ ] **Step 5: Load the script in the viewer**
+
+In `core/viewer/index.html`, insert this script after `display-status.js` and before `identity.js`:
+
+```html
+<script src="native-presenter.js?v=0.6.11.1777695458"></script>
+```
+
+Use the same stamp format already present in the file. The control server may restamp this file during local testing, so verify this script tag remains present before committing.
+
+- [ ] **Step 6: Start/stop probing from screen track registration**
+
+In `core/viewer/participants-fullscreen.js`, inside `registerScreenTrack` after `screenTrackMeta.set(...)`, add:
+
+```javascript
+if (typeof maybeStartNativePresenterForScreenTrack === "function") {
+  maybeStartNativePresenterForScreenTrack({ trackSid, publication, tile, identity }).catch(function(e) {
+    debugLog("[native-presenter] register start failed: " + (e && e.message ? e.message : e));
+  });
+}
+```
+
+In `unregisterScreenTrack`, before `screenTrackMeta.delete(trackSid)`, add:
+
+```javascript
+if (typeof stopNativePresenterForTrack === "function") {
+  stopNativePresenterForTrack(trackSid).catch(function(e) {
+    debugLog("[native-presenter] unregister stop failed: " + (e && e.message ? e.message : e));
+  });
+}
+```
+
+- [ ] **Step 7: Stop probing during full media cleanup**
+
+In `core/viewer/participants-grid.js`, at the top of `clearMedia()`, add:
+
+```javascript
+if (typeof stopAllNativePresenter === "function") {
+  stopAllNativePresenter("media cleared").catch(function(e) {
+    debugLog("[native-presenter] clearMedia stop failed: " + (e && e.message ? e.message : e));
+  });
+}
+```
+
+- [ ] **Step 8: Run viewer tests**
+
+Run:
+
+```powershell
+node --test core/viewer/native-presenter.test.js
+node --test core/viewer/*.test.js
+```
+
+Expected: all viewer tests pass.
+
+- [ ] **Step 9: Commit Task 4**
+
+Run:
+
+```powershell
+git add core/viewer/native-presenter.js core/viewer/native-presenter.test.js core/viewer/settings.js core/viewer/index.html core/viewer/participants-fullscreen.js core/viewer/participants-grid.js
+git commit -m "feat(viewer): add guarded native presenter bridge"
+```
+
+---
+
+### Task 5: Native Presenter Telemetry In Control And Dashboard
+
+**Files:**
+- Modify: `core/control/src/admin.rs`
+- Modify: `core/viewer/screen-share-adaptive.js`
+- Modify: `core/viewer/admin.js`
+
+- [ ] **Step 1: Add control-plane telemetry structs**
+
+In `core/control/src/admin.rs`, add this field to `ClientStats` after `display_status`:
+
+```rust
+#[serde(default, skip_serializing_if = "Option::is_none")]
+pub(crate) native_presenter: Option<NativePresenterReport>,
+```
+
+Add this struct after `ClientDisplayStatus`:
+
+```rust
+#[derive(Clone, Serialize, Deserialize, Default)]
+#[serde(default)]
+pub(crate) struct NativePresenterReport {
+    pub(crate) state: String,
+    pub(crate) render_path: String,
+    pub(crate) target_identity: Option<String>,
+    pub(crate) target_track_sid: Option<String>,
+    pub(crate) native_receive_fps: Option<f64>,
+    pub(crate) native_presented_fps: Option<f64>,
+    pub(crate) native_frames_received: u64,
+    pub(crate) native_frames_dropped: u64,
+    pub(crate) queue_depth: u32,
+    pub(crate) fallback_reason: Option<String>,
+    pub(crate) tile_width: Option<u32>,
+    pub(crate) tile_height: Option<u32>,
+    pub(crate) updated_at_ms: u64,
+}
+```
+
+- [ ] **Step 2: Merge telemetry reports**
+
+In `client_stats_report`, after the `display_status` merge, add:
+
+```rust
+if payload.native_presenter.is_some() {
+    existing.native_presenter = payload.native_presenter;
+}
+```
+
+- [ ] **Step 3: Add viewer POST field**
+
+In `core/viewer/screen-share-adaptive.js`, after `displayStatus`, add:
+
+```javascript
+var nativePresenter = typeof getNativePresenterStatusSnapshot === "function"
+  ? getNativePresenterStatusSnapshot()
+  : null;
+```
+
+Change the POST condition from:
+
+```javascript
+if (inboundArr2.length > 0 || captureHealth || displayStatus) {
+```
+
+to:
+
+```javascript
+if (inboundArr2.length > 0 || captureHealth || displayStatus || nativePresenter) {
+```
+
+Add this field to the JSON body:
+
+```javascript
+native_presenter: nativePresenter,
+```
+
+- [ ] **Step 4: Add a dashboard chip**
+
+In `core/viewer/admin.js`, inside `fetchAdminDashboard()` where participant chips are built, after the display/screen FPS chips, add:
+
+```javascript
+if (s.native_presenter && s.native_presenter.state && s.native_presenter.state !== "disabled") {
+  var np = s.native_presenter;
+  var npText = "native " + np.state;
+  if (np.native_receive_fps != null) npText += " " + Math.round(np.native_receive_fps) + "fps";
+  if (np.fallback_reason) npText += " · " + np.fallback_reason;
+  chips += '<span class="adm-chip" title="Native presenter receive probe">' + escAdm(npText) + '</span>';
+}
+```
+
+- [ ] **Step 5: Run checks**
+
+Run:
+
+```powershell
+cargo check -p echo-core-control
+node --test core/viewer/*.test.js
+```
+
+Expected: control check passes and viewer tests pass.
+
+- [ ] **Step 6: Commit Task 5**
+
+Run:
+
+```powershell
+git add core/control/src/admin.rs core/viewer/screen-share-adaptive.js core/viewer/admin.js
+git commit -m "feat(control): report native presenter telemetry"
+```
+
+---
+
+### Task 6: Native LiveKit Receive Worker
+
+**Files:**
+- Modify: `core/client/Cargo.toml`
+- Modify: `core/client/src/native_presenter.rs`
+
+- [ ] **Step 1: Add receive-worker unit tests**
+
+Add these tests to `core/client/src/native_presenter.rs`:
+
+```rust
+#[test]
+fn track_match_requires_target_sid_and_screen_source() {
+    assert!(is_target_screen_track(
+        "TR_screen",
+        "TR_screen",
+        NativeTrackSource::ScreenShare
+    ));
+    assert!(!is_target_screen_track(
+        "TR_screen",
+        "TR_camera",
+        NativeTrackSource::ScreenShare
+    ));
+    assert!(!is_target_screen_track(
+        "TR_screen",
+        "TR_screen",
+        NativeTrackSource::Camera
+    ));
+}
+
+#[test]
+fn frame_sample_updates_receive_fps() {
+    let manager = NativePresenterManager::new();
+    let request = NativePresenterStartRequest {
+        mode: NativePresenterMode::On,
+        room: "main".to_string(),
+        sfu_url: "wss://echo.example.invalid".to_string(),
+        token: "token".to_string(),
+        viewer_identity: "Sam-1234".to_string(),
+        participant_identity: "Spencer-2222".to_string(),
+        track_sid: "TR_screen".to_string(),
+        tile: NativePresenterTileRect { x: 0, y: 0, width: 1920, height: 1080, scale_factor: 1.0 },
+    };
+    manager.mark_starting(&request);
+
+    manager.record_native_frame_sample(120, 2.0);
+
+    let status = manager.status();
+    assert_eq!(status.state, NativePresenterState::Receiving);
+    assert_eq!(status.native_frames_received, 120);
+    assert_eq!(status.native_receive_fps, Some(60.0));
+}
+```
+
+- [ ] **Step 2: Run tests and verify failure**
+
+Run:
+
+```powershell
+cargo test -p echo-core-client native_presenter
+```
+
+Expected: compile failure because `NativeTrackSource`, `is_target_screen_track`, and `record_native_frame_sample` do not exist yet.
+
+- [ ] **Step 3: Add direct dependencies**
+
+In `core/client/Cargo.toml`, change:
+
+```toml
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }
+```
+
+to:
+
+```toml
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "time", "sync"] }
+```
+
+Under `[target.'cfg(windows)'.dependencies]`, add:
+
+```toml
+futures-util = "0.3"
+libwebrtc = "0.3.29"
+```
+
+- [ ] **Step 4: Add receive-worker helpers**
+
+In `core/client/src/native_presenter.rs`, add:
+
+```rust
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum NativeTrackSource {
+    ScreenShare,
+    Camera,
+    Other,
+}
+
+pub(crate) fn is_target_screen_track(
+    target_track_sid: &str,
+    publication_track_sid: &str,
+    source: NativeTrackSource,
+) -> bool {
+    source == NativeTrackSource::ScreenShare && target_track_sid == publication_track_sid
+}
+```
+
+Add this method to `impl NativePresenterManager`:
+
+```rust
+pub(crate) fn record_native_frame_sample(&self, frames: u64, elapsed_secs: f64) {
+    let fps = if elapsed_secs > 0.0 {
+        Some(((frames as f64 / elapsed_secs) * 10.0).round() / 10.0)
+    } else {
+        None
+    };
+    let mut status = self.status.lock();
+    status.state = NativePresenterState::Receiving;
+    status.native_frames_received = frames;
+    status.native_receive_fps = fps;
+    status.native_presented_fps = None;
+    status.queue_depth = 0;
+    status.updated_at_ms = self.elapsed_ms();
+}
+```
+
+- [ ] **Step 5: Replace the start stub with a LiveKit receive worker**
+
+Replace `start_receive_probe` with:
+
+```rust
+pub(crate) async fn start_receive_probe(
+    self: &Arc<Self>,
+    request: NativePresenterStartRequest,
+) -> Result<NativePresenterStatus, String> {
+    self.validate_start_request(&request)?;
+    let generation = self.mark_starting(&request);
+    let manager = Arc::clone(self);
+    tauri::async_runtime::spawn(async move {
+        if let Err(error) = run_receive_probe(manager.clone(), generation, request).await {
+            if manager.generation() == generation {
+                manager.set_fallback(&error);
+            }
+        }
+    });
+    Ok(self.status())
+}
+```
+
+Add the worker below the manager implementation:
+
+```rust
+#[cfg(target_os = "windows")]
+async fn run_receive_probe(
+    manager: Arc<NativePresenterManager>,
+    generation: u64,
+    request: NativePresenterStartRequest,
+) -> Result<(), String> {
+    use futures_util::StreamExt;
+    use libwebrtc::video_stream::native::{NativeVideoStream, NativeVideoStreamOptions};
+    use livekit::{prelude::*, Room, RoomEvent, RoomOptions};
+    use std::time::{Duration, Instant};
+
+    livekit::ensure_runtime_initialized();
+    let options = RoomOptions {
+        auto_subscribe: true,
+        adaptive_stream: false,
+        dynacast: false,
+        ..Default::default()
+    };
+    let (_room, mut events) = Room::connect(&request.sfu_url, &request.token, options)
+        .await
+        .map_err(|error| format!("native presenter connect failed: {error}"))?;
+
+    let startup_deadline = Instant::now() + Duration::from_secs(8);
+    loop {
+        if manager.generation() != generation {
+            return Ok(());
+        }
+        if Instant::now() > startup_deadline {
+            return Err("target screen track was not subscribed within 8 seconds".to_string());
+        }
+        let event = match tokio::time::timeout(Duration::from_millis(500), events.recv()).await {
+            Ok(Some(event)) => event,
+            Ok(None) => return Err("native presenter room event stream closed".to_string()),
+            Err(_) => continue,
+        };
+        let RoomEvent::TrackSubscribed { track, publication, .. } = event else {
+            continue;
+        };
+        let source = match publication.source() {
+            TrackSource::Screenshare => NativeTrackSource::ScreenShare,
+            TrackSource::Camera => NativeTrackSource::Camera,
+            _ => NativeTrackSource::Other,
+        };
+        if !is_target_screen_track(
+            &request.track_sid,
+            &publication.sid().to_string(),
+            source,
+        ) {
+            continue;
+        }
+        let RemoteTrack::Video(video_track) = track else {
+            continue;
+        };
+        let mut stream = NativeVideoStream::with_options(
+            video_track.rtc_track(),
+            NativeVideoStreamOptions { queue_size_frames: Some(1) },
+        );
+        let started = Instant::now();
+        let mut frames = 0u64;
+        while manager.generation() == generation {
+            let frame = tokio::time::timeout(Duration::from_millis(500), stream.next()).await;
+            match frame {
+                Ok(Some(frame)) => {
+                    let _width = frame.buffer.width();
+                    let _height = frame.buffer.height();
+                    frames += 1;
+                    let elapsed = started.elapsed().as_secs_f64();
+                    if frames == 1 || frames % 30 == 0 {
+                        manager.record_native_frame_sample(frames, elapsed);
+                    }
+                }
+                Ok(None) => return Err("native video stream ended".to_string()),
+                Err(_) => {
+                    if started.elapsed() > Duration::from_secs(2) {
+                        manager.record_native_frame_sample(frames, started.elapsed().as_secs_f64());
+                    }
+                }
+            }
+        }
+        stream.close();
+        return Ok(());
+    }
+}
+```
+
+- [ ] **Step 6: Run tests and checks**
+
+Run:
+
+```powershell
+cargo test -p echo-core-client native_presenter
+cargo check -p echo-core-client
+```
+
+Expected: tests pass and client check completes.
+
+- [ ] **Step 7: Commit Task 6**
+
+Run:
+
+```powershell
+git add core/client/Cargo.toml core/client/src/native_presenter.rs
+git commit -m "feat(client): receive native screen frames"
+```
+
+---
+
+### Task 7: Final Verification And Local Handoff
+
+**Files:**
+- Modify: `docs/handovers/2026-05-02-native-presenter-gate-1.md`
+
+- [ ] **Step 1: Run focused automated verification**
+
+Run:
+
+```powershell
+node --test core/viewer/*.test.js
+cargo test -p echo-core-client native_presenter
+cargo test -p echo-core-control auth::tests
+cargo check -p echo-core-client -p echo-core-control
+```
+
+Expected:
+
+- All viewer tests pass.
+- Native presenter client tests pass.
+- Control auth tests pass.
+- Cargo check passes for client and control.
+
+- [ ] **Step 2: Build the desktop client**
+
+Run:
+
+```powershell
+cargo build -p echo-core-client
+```
+
+Expected: debug desktop client builds successfully.
+
+- [ ] **Step 3: Write the Gate 1 handoff**
+
+Create `docs/handovers/2026-05-02-native-presenter-gate-1.md`:
+
+```markdown
+# Native Presenter Gate 1 Handoff
+
+Date: 2026-05-02
+Branch: codex/screen-sources-command-investigation
+
+## What Changed
+
+- Added a guarded Windows native presenter receive probe.
+- Added hidden receive-only `$native-presenter` LiveKit token support.
+- Added viewer opt-in setting plumbing with normal default `off`.
+- Added native receive FPS/status telemetry to client stats and dashboard.
+- Kept WebView2 as the visible rendering path.
+
+## What This Proves
+
+Gate 1 proves whether the desktop client can safely join as a hidden receive-only companion and receive the selected screen track natively without disturbing the normal viewer.
+
+## What This Does Not Do
+
+- It does not draw native video.
+- It does not hide or replace the WebView2 video element.
+- It does not reduce stream quality.
+- It does not deploy to friends.
+
+## Local Test Protocol
+
+1. Close Echo before testing a new desktop build.
+2. Open the branch debug client from `F:\EC-worktrees\screen-sources-command\core\target\debug\echo-core-client.exe`.
+3. Confirm the running client path before monitoring.
+4. Enable the native presenter setting only for Sam's local test.
+5. Join a room with one remote screen share.
+6. Confirm dashboard native presenter status shows `starting` then `receiving`.
+7. Compare WebView receive FPS, WebView presented FPS, and native receive FPS.
+8. Turn the setting off and confirm status returns to WebView2/stopped without restarting.
+
+## Next Decision
+
+If native receive FPS is healthy while WebView presented FPS remains low in maximized 4K mode, proceed to the Gate 2 one-tile native presentation plan.
+```
+
+- [ ] **Step 4: Verify no accidental generated-only changes are staged**
+
+Run:
+
+```powershell
+git status --short
+git diff -- core/viewer/index.html
+```
+
+Expected:
+
+- Only intentional code/docs changes remain.
+- `core/viewer/index.html` includes the `native-presenter.js` script tag.
+- Cache-busting stamp churn is understood before staging.
+
+- [ ] **Step 5: Commit Task 7**
+
+Run:
+
+```powershell
+git add docs/handovers/2026-05-02-native-presenter-gate-1.md
+git commit -m "docs: record native presenter gate 1 validation"
+```
+
+---
+
+## Full Verification Command Set
+
+Run before claiming Gate 1 is complete:
+
+```powershell
+node --test core/viewer/*.test.js
+cargo test -p echo-core-client native_presenter
+cargo test -p echo-core-control auth::tests
+cargo check -p echo-core-client -p echo-core-control
+cargo build -p echo-core-client
+```
+
+## Manual Test Gate
+
+Do not silently monitor. Tell Sam first:
+
+```text
+Close Echo now. I will reopen the branch debug client and confirm the running path before we test. After it opens, join the room and enable the native presenter setting. Then I will monitor the dashboard for native receive FPS versus WebView presented FPS.
+```
+
+Gate 1 passes only if:
+
+- The native presenter remains hidden from normal participants.
+- The dashboard shows native presenter `receiving` for the selected screen track.
+- Native receive FPS is plausible for the stream.
+- Turning the setting off stops the native probe without restarting Echo.
+- WebView2 remains the visible fallback at all times.
+
+## Self-Review
+
+- Spec coverage: Gate 1 covers hidden identity, opt-in setting, native receive feasibility, telemetry, fallback/stop, and no quality reduction.
+- Deferred by design: native video drawing, z-order handling, D3D11/DirectComposition, and hiding WebView video are Gate 2 work after receive is proven.
+- Risk control: normal default remains `off`, and Gate 1 never replaces the visible video path.

--- a/docs/superpowers/specs/2026-05-02-full-quality-screen-viewer-display-path-design.md
+++ b/docs/superpowers/specs/2026-05-02-full-quality-screen-viewer-display-path-design.md
@@ -1,0 +1,114 @@
+# Full-Quality Screen Viewer Display Path Design
+
+Status: Approved by Sam on 2026-05-02.
+
+## Problem
+
+Echo screen tiles can receive good WebRTC frames while the visible viewer still looks low-FPS or jittery, especially when Echo is maximized and the screen grid is large. Live testing showed the drop is tied to local presentation/compositing more than network, capture, or the sender.
+
+Sam's machine is also not a normal single-GPU display path. Main-branch notes already document a risky Windows compositor/display-present environment: RTX 4090, 4K/high-refresh monitors, mixed monitor routing, MPO mitigations, and prior full-reboot-only flicker incidents from capture/display transitions.
+
+The parked screen-source compatibility fix is separate. This design is for the viewer/display performance problem.
+
+## Goal
+
+Make Echo use one known-good, full-performance display path for Sam:
+
+- Echo should prefer the RTX 4090-connected monitor.
+- Screen streams should stay full quality: no intended bitrate, resolution, or FPS reduction.
+- The UI should keep its polished visual design.
+- The live video path should be measured and protected so WebView2/Windows can present frames cleanly.
+
+## Non-Goals
+
+- Do not reduce stream quality as the intended fix.
+- Do not use the render-size cap as the final product behavior.
+- Do not test WGC monitor capture on Sam's daily-driver PC.
+- Do not push, deploy, open a PR, or delete this worktree without Sam explicitly asking.
+- Do not rewrite the whole viewer or switch frontend frameworks for this fix.
+
+## Design Principles
+
+1. Full fidelity first.
+   Echo should try to present the real stream at full tile size. Any quality cap is a diagnostic or emergency fallback, not the solution.
+
+2. Protect the live video surface.
+   The `<video>` element should get the simplest possible compositor path. Visual polish can remain around it, but effects should not force the video itself into expensive paint/composite work.
+
+3. Make display placement explicit.
+   Echo should know which monitor it is on, prefer the 4090-connected display, and flag or fix risky placement such as the Intel/motherboard display or spanning monitors.
+
+4. Measure every stage.
+   The UI should distinguish stream receive health from local presentation health. A single `fps` badge is not enough.
+
+## Approach
+
+### Phase 1: Correct Diagnostics
+
+Add or keep diagnostics that separate:
+
+- Publisher/capture FPS.
+- WebRTC receive FPS from `getStats()`.
+- Decoded frames and dropped frames.
+- Presented/rendered frames from `requestVideoFrameCallback()` metadata.
+- Current monitor, window bounds, device scale factor, and whether the app spans monitors.
+
+This prevents chasing a bad badge when the network stream is healthy, and it proves whether maximized grid size is still collapsing local presentation.
+
+### Phase 2: Echo Display Authority
+
+Add native client support for a preferred Echo display:
+
+- Enumerate monitors with bounds, scale factor, refresh rate, and best available adapter/GPU identity.
+- Remember the preferred display in client settings.
+- On launch, move Echo to the preferred display before or during window setup.
+- Maximize only on the preferred display.
+- Warn when Echo is on the motherboard/Intel display or spanning displays.
+- Keep the existing high-performance GPU preference as a host-level support measure, not the only fix.
+
+This is a desktop-client binary change.
+
+### Phase 3: Full-Quality Video Presentation Path
+
+Keep the stream full quality and preserve the UI look, but make live screen video a protected surface:
+
+- Avoid filters, backdrop filters, blend modes, repeated canvas readbacks, heavy clipping, or expensive shadows directly on the video element.
+- Move visual effects to wrappers, overlays, or neighboring layers where they do not force video repaint work.
+- Keep badges, borders, hover controls, glow, and polish as long as they do not damage the video presentation path.
+- Remove the render-size cap from the intended product path, or keep it only behind an explicit debug/safe-mode flag.
+
+This is a viewer-served change unless native WebView2 flags are also needed.
+
+### Phase 4: Native Presenter Spike If WebView2 Is the Wall
+
+If Echo is on the 4090 display, receives healthy frames, and still cannot present a maximized multi-screen grid smoothly through WebView2, investigate a native Windows presenter:
+
+- A small Direct3D/DirectComposition proof of concept for one received screen tile.
+- WebView2 remains the UI shell.
+- Native presentation owns only the hot video surface if WebView2 cannot do it.
+
+This is the higher-effort "perfection ceiling" path and requires desktop-client binary work.
+
+## Testing Protocol
+
+Sam's live testing rule stays in force:
+
+- Before validating a new desktop-client build, close and reopen the Echo client.
+- Do not silently monitor UI-dependent tests. Tell Sam exactly what to open/maximize and when monitoring starts.
+- Test both non-maximized and maximized Echo on the preferred 4090 display.
+- Compare WebRTC receive FPS against presented/rendered FPS.
+- Do not run WGC monitor-capture experiments on Sam's daily-driver PC.
+
+## Acceptance Criteria
+
+- When a remote screen stream is healthy according to WebRTC stats, the visible screen tile should not collapse to low FPS just because Echo is maximized.
+- Full stream quality remains available. No intended resolution, bitrate, or FPS downgrade is part of the fix.
+- Echo can identify whether it is on the intended high-performance display path.
+- The UI keeps its polished look, with any compositor-sensitive effects moved off the hot video surface rather than deleted outright.
+- If WebView2 cannot meet the target, the next decision is a native presenter spike, not lowering stream quality.
+
+## Current WIP Notes
+
+- The `presentedFrames` diagnostic patch fits this design because it improves measurement.
+- The render-size cap patch does not fit as final behavior. Treat it as diagnostic evidence that tile size affects the presentation bottleneck.
+- The parked screen-source compatibility commits remain separate from this design.

--- a/docs/superpowers/specs/2026-05-02-guarded-native-screen-presenter-design.md
+++ b/docs/superpowers/specs/2026-05-02-guarded-native-screen-presenter-design.md
@@ -1,0 +1,246 @@
+# Guarded Native Screen Presenter Design
+
+Status: Draft for Sam review on 2026-05-02.
+
+## Problem
+
+Live validation showed a local presentation bottleneck on Sam's Windows desktop client. Echo can receive remote screen frames at healthy rates, but when the viewer grid is large or maximized on a 4K display, the visible tiles can drop hard and look jittery.
+
+This is not the same issue as the parked screen-source compatibility fix. It is also not a stream-quality reduction problem. The evidence points at WebView2 plus Windows desktop composition struggling to present large live video surfaces in Sam's current display setup.
+
+Important local evidence:
+
+- Sam's Echo window is on the RTX 4090 display, but the PC has mixed monitor routing: one display on the GPU and one on the motherboard/Intel path.
+- Maximized Echo reported a tiny display-boundary span, and large non-spanning windows were still bad.
+- A smaller 1920x1080 Echo window recovered strongly on the same RTX display.
+- WebView2's 3D/compositor process was the dominant Echo-side cost during bad states.
+- Friends saw the same streams more smoothly, which means the outgoing streams and SFU path were not the primary bottleneck.
+- A CSS-only probe that removed several direct video-surface effects did not fix the maximized case.
+
+## Goal
+
+Create a guarded Windows native presenter path for received screen-share video, so Echo can keep full stream quality while removing WebView2 from the hottest video presentation work when it is the bottleneck.
+
+The product goal is still perfection when possible: one strong display path, full quality, smooth presentation, no intentional bitrate/FPS/resolution downgrade as the fix.
+
+## Non-Goals
+
+- Do not make the native presenter the default for everyone immediately.
+- Do not reduce capture quality, sender encode quality, SFU quality, bitrate, resolution, or FPS as the intended fix.
+- Do not replace the whole viewer UI.
+- Do not change browser viewer support.
+- Do not build or test macOS targets.
+- Do not push, deploy, open a PR, or delete the worktree without Sam explicitly asking.
+- Do not silently monitor Sam's live client. Tell Sam what to open/maximize and when monitoring starts.
+
+## Approach Options
+
+### Option A: Keep Optimizing WebView2
+
+Keep the current viewer architecture and continue tuning CSS, layout, WebView2 flags, and video element styles.
+
+Pros:
+
+- Lowest implementation risk.
+- Server-delivered viewer updates are easy to roll out and roll back.
+- No duplicate media connection or native rendering surface.
+
+Cons:
+
+- We already tried the most suspicious video-surface CSS suspects and maximized mode stayed bad.
+- If WebView2/DWM is the wall, this path can only work around the bottleneck instead of removing it.
+- It risks drifting toward quality caps, which Sam explicitly does not want as the real answer.
+
+### Option B: Bridge WebView Frames To Native
+
+Keep receiving video in JavaScript, then copy frames from the WebView into a native surface through canvas, WebCodecs, IPC, or shared buffers.
+
+Pros:
+
+- Lets the existing JS viewer remain the only WebRTC subscriber.
+- Can be useful as a geometry or integration prototype.
+
+Cons:
+
+- Frame copies are exactly the kind of cost we are trying to remove.
+- Browser APIs and WebView2 support can vary.
+- It is unlikely to be the final high-performance path for 4K/high-refresh screen viewing.
+
+### Option C: Native Receive And Native Present
+
+Add a Windows desktop-client module that uses the Rust LiveKit stack to receive selected screen tracks and present them through a native Windows rendering surface. The WebView remains the UI and room-control shell.
+
+Pros:
+
+- Removes WebView2 from the hottest video presentation path.
+- Can use a frame-dropping queue and GPU-oriented presentation model instead of relying on WebView2 composition.
+- Fits the evidence: the stream can be healthy while local WebView presentation is not.
+- Can be guarded behind settings, telemetry, and fallback.
+
+Cons:
+
+- Highest engineering complexity.
+- Needs careful identity/subscription handling so it does not show up as a confusing extra participant.
+- Needs careful z-order, DPI, monitor, and lifecycle handling.
+- Requires a desktop binary update for users who opt in.
+
+Recommendation: use Option C, but ship it as a guarded Windows desktop viewer feature. Keep Option A as the fallback, not the ceiling.
+
+## Recommended Architecture
+
+The WebView remains Echo's main UI. It still owns login, room state, tile layout, controls, overlays, settings, diagnostics, and the default `<video>` rendering path.
+
+The native presenter is a Windows-only desktop-client module with three jobs:
+
+1. Join or attach to the room as a receive-only native screen presenter.
+2. Decode or receive selected remote screen video frames through Rust-native media APIs.
+3. Present those frames into a native child or overlay surface aligned to the corresponding screen tile.
+
+The viewer reports tile intent and geometry to the client:
+
+- Track identity and participant identity for the selected screen tile.
+- Tile rectangle in physical pixels.
+- Window/display/DPI status.
+- Whether the native presenter should be enabled, disabled, or allowed to auto-start.
+
+When native presentation is active, the WebView hides or pauses only the hot screen `<video>` surface for that tile. The surrounding tile UI remains in WebView: labels, buttons, badges, volume, fullscreen controls, and diagnostics. If native presentation fails, the WebView restores the normal video element immediately.
+
+Initial scope is one selected screen tile. Multi-tile native presentation waits until one tile is proven stable.
+
+## Native Media Path
+
+The existing local crates make the native receive path feasible:
+
+- `core/livekit-local` exposes remote video tracks.
+- `core/libwebrtc-local` has `NativeVideoStream` for pulling native video frames from a remote track.
+- Existing tests show subscribing to `RemoteTrack::Video(track)` and creating `NativeVideoStream::new(track.rtc_track())`.
+
+The first proof should use the simplest reliable frame path that proves end-to-end behavior. CPU frame conversion is acceptable for a short spike only if it helps validate subscription, tile targeting, fallback, and timing. The product path should move toward a GPU-friendly D3D11/DirectComposition renderer with a bounded queue size of 1 so stale frames are dropped instead of queued.
+
+## Identity And Subscription Policy
+
+The native presenter must not confuse room users.
+
+Preferred policy:
+
+- Use one receive-only native presenter connection per desktop client only when enabled.
+- Give it a hidden/system identity derived from the real viewer identity, such as `<viewer-id>$native-presenter`.
+- Mark it with metadata or server-side filtering so it is not shown as a normal human participant.
+- Subscribe only to target screen tracks.
+- Publish nothing.
+
+If hidden/system participants are not cleanly supported by the current control/viewer model, the first implementation plan must include that filtering before any friend rollout.
+
+## Settings And Rollout
+
+Add a desktop viewer setting:
+
+- `Off`: always use the normal WebView2 video path.
+- `On`: use native presentation for eligible selected screen tiles.
+- `Auto`: allow Echo to enable native presentation only when diagnostics match the known failure pattern.
+
+Initial default: `Off` for normal users.
+
+Sam's local test build can use `On` or `Auto` during validation. Friends should only use it after Sam's machine proves the path, and then only as opt-in/canary until the fallback behavior is boring and reliable.
+
+Auto mode should require all of these before switching:
+
+- Windows desktop client.
+- Received screen track, not camera video.
+- Healthy WebRTC receive FPS relative to the sender.
+- Poor presented FPS or large-window/maximized known-risk state.
+- Native presenter initializes and reports frames quickly.
+
+## Telemetry
+
+Extend diagnostics so the dashboard can explain which path is active:
+
+- `viewer_render_path`: `webview2` or `native`.
+- Native receive FPS.
+- Native presented FPS.
+- Native dropped-frame count.
+- Native queue depth or stale-frame drops.
+- Native active/error/fallback reason.
+- Target participant/track identity.
+- Tile size and display/DPI state.
+
+The existing split between receive FPS and presented FPS remains mandatory. A single FPS badge is not enough.
+
+## Fallback Rules
+
+Fallback to WebView2 immediately when:
+
+- Native initialization fails.
+- The target track disappears or changes unexpectedly.
+- No native frames arrive within a short startup timeout.
+- Native presentation stalls.
+- The native surface cannot align to the tile after resize/maximize/display move.
+- Z-order causes controls to become unusable.
+- The setting is switched to `Off`.
+
+Fallback should be visible in diagnostics but should not require a restart.
+
+## Test Plan
+
+Automated prework:
+
+- Rust unit tests for native-presenter state transitions: disabled, starting, active, fallback, stopped.
+- Rust tests for identity naming/filtering helpers.
+- JS tests for viewer settings, native-presenter command calls, tile geometry reporting, and fallback restoration.
+- Dashboard/control tests for new telemetry fields if server schema changes are needed.
+
+Local validation on Sam's machine:
+
+- Close and reopen Echo before each desktop-client build validation.
+- Confirm the running client path is the branch build.
+- Test WebView2 `Off` baseline first.
+- Test native `On` with one selected screen tile.
+- Test maximized Echo on the RTX display.
+- Test non-maximized 1920x1080-ish Echo on the RTX display.
+- Test moving Echo between displays and returning to the RTX display.
+- Test one remote screen first, then two or three remote screens with only one native-presented tile.
+- Compare receive FPS, WebView presented FPS, native presented FPS, GPU engine usage, and subjective jitter.
+
+Friend/canary validation:
+
+- Only after Sam's local path is stable.
+- Opt-in setting only.
+- Verify no extra visible participant appears.
+- Verify normal viewing still works when native presenter is disabled.
+- Verify users who stream a GPU-heavy game and view others do not regress.
+
+## Risks
+
+- Blank or frozen native surface.
+- Native surface appears above controls or behind the WebView.
+- DPI or monitor coordinates are wrong on mixed-scale displays.
+- Maximize creates tiny cross-display bounds that break alignment.
+- Extra LiveKit connection appears as a user or changes room counts.
+- More GPU work helps presentation but hurts someone actively gaming and watching.
+- Color, HDR, or scaling differs from WebView2.
+- Native renderer leaks resources across room switches.
+- Crash or panic takes down the desktop client instead of falling back.
+
+These risks are manageable only if the feature stays guarded and fallback remains first-class.
+
+## Decision Gates
+
+Gate 1: Native receive feasibility.
+
+Prove the client can subscribe to a target remote screen track natively, receive frames, report stats, and stop cleanly without disturbing the normal viewer.
+
+Gate 2: One-tile native presentation.
+
+Prove one selected screen tile can present smoothly at Sam's maximized 4K viewer size with full stream quality and usable controls.
+
+Gate 3: Safe fallback.
+
+Prove disabling the setting, losing the track, resizing, moving displays, and initialization failure all restore WebView2 rendering without a restart.
+
+Gate 4: Canary readiness.
+
+Only after Sam's path works, decide whether to let selected friends opt in. Do not make this globally default until canary results show no regressions.
+
+## Current Decision
+
+Proceed to an implementation plan for Option C after Sam reviews this written spec. The plan should start with a narrow native receive spike and state-machine/fallback tests, then move to one-tile native presentation. It should not push, deploy, open a PR, or remove the WebView2 path.


### PR DESCRIPTION
﻿## Summary
- Hardened screen sharing reliability for mixed-GPU/display-path setups, including RTX/high-performance GPU preference, saved preferred display placement, static WGC frame heartbeat, source visibility warnings, and protected full-quality screen video rendering.
- Added guarded native presenter plumbing and diagnostics behind existing fallback paths; normal WebView2 rendering remains the default.
- Prepared v0.6.12 release metadata, including desktop client version, control server version, changelog, and updater manifest.
- Linked issue: N/A

## User-facing impact
- [x] User-visible behavior changed
- [ ] No user-visible behavior change

## Release impact
- [ ] Server-only
- [ ] Desktop binary required
- [x] Both

## Repro + validation evidence
### Before (bug repro)
1. Maximized Echo on Sam's mixed Intel/NVIDIA display setup caused remote screen viewing FPS to collapse.
2. Sharing static or browser-like window content could disappear or starve frame delivery.
3. Raw Windows display names like `\\.\DISPLAY1` were visible to non-technical users and were confusing.

### After (fix verification)
1. Echo can prefer the saved high-performance display path and self-heal GPU preference for the app/WebView2 runtime.
2. Static WGC sources republish heartbeat frames so browser/static window shares keep flowing.
3. Display-path status is hidden when healthy and only appears as an actionable warning.
4. v0.6.12 Windows installer and updater manifest were built locally.

### Evidence (required)
- [ ] Logs attached
- [x] Video/GIF/screenshots attached
- [x] Manual verification notes attached

## Regression checklist (media/session)
- [x] Room switch works without UI/state desync
- [x] Screen-share stop/start retains expected audio behavior
- [x] Jam join/leave/listen state remains consistent on failures
- [x] Mic/camera/share indicators match actual publish state
- [x] Disconnect/reconnect leaves no stale listeners/timers

## Verification commands run
- [x] `node --test *.test.js` from `core/viewer` — 87 passed, 0 failed
- [x] `cargo test -p echo-core-client` from `core` — 52 passed, 0 failed
- [x] `cargo test -p echo-core-control` from `core` — 4 passed, 0 failed
- [x] `powershell -ExecutionPolicy Bypass -File core\deploy\build-release.ps1` — built `Echo Chamber_0.6.12_x64-setup.exe`, `.sig`, and `latest.json`
- [x] `git diff --check` — only normal CRLF warnings

## Risk
- [ ] Low
- [x] Medium
- [ ] High (explain)

Risk note: this touches native capture, viewer rendering/diagnostics, and release/update metadata. The native presenter path is guarded and fallback-first, but the screen-share surface area is inherently sensitive.

## Rollback plan
- If server/viewer behavior regresses, revert this PR and let the deploy watcher redeploy `main`.
- If desktop binary behavior regresses, publish a follow-up release restoring the previous client path and update `core/deploy/latest.json` back to the known-good release.
