### PR TITLE
[codex] Load saved remote avatars

### DIFF
--- a/core/viewer/connect.js
+++ b/core/viewer/connect.js
@@ -1130,6 +1130,11 @@ async function connectToRoom({ controlUrl, sfuUrl, roomId, identity, name, reuse
           // Map remote participant's identity to their device ID (for chime/profile lookups)
           deviceIdByIdentity.set(msg.identityBase, msg.deviceId);
           debugLog("[device-profile] mapped " + msg.identityBase + " -> " + msg.deviceId);
+          participantCards.forEach((cardRef, ident) => {
+            if (getIdentityBase(ident) === msg.identityBase) {
+              updateAvatarDisplay(ident);
+            }
+          });
           // Pre-fetch their chime buffers now that we know their device ID
           fetchChimeBuffer(msg.deviceId, "enter").catch(function() {});
           fetchChimeBuffer(msg.deviceId, "exit").catch(function() {});

--- a/core/viewer/participants-avatar.js
+++ b/core/viewer/participants-avatar.js
@@ -1010,6 +1010,60 @@ async function uploadAvatar(file) {
   }
 }
 
+function getServerAvatarCandidateUrls(identity, cardRef) {
+  if (typeof apiUrl !== "function") return [];
+  const identityBase = getIdentityBase(identity);
+  const candidates = [];
+  const seen = new Set();
+
+  function addCandidate(value) {
+    const trimmed = String(value || "").trim();
+    if (!trimmed || seen.has(trimmed)) return;
+    seen.add(trimmed);
+    candidates.push(apiUrl("/api/avatar/" + encodeURIComponent(trimmed)));
+  }
+
+  const deviceId = deviceIdByIdentity?.get?.(identityBase);
+  addCandidate(deviceId);
+  addCandidate(identityBase);
+
+  const label = cardRef?.card?.querySelector(".user-name")?.textContent || "";
+  if (typeof slugifyIdentity === "function") addCandidate(slugifyIdentity(label));
+
+  return candidates;
+}
+
+function showAvatarImage(cardRef, urls) {
+  const avatar = cardRef.avatar;
+  if (!avatar || !urls || urls.length === 0) return;
+
+  let img = avatar.querySelector("img.avatar-img");
+  if (!img) {
+    img = document.createElement("img");
+    img.className = "avatar-img";
+    img.alt = "Avatar";
+    avatar.appendChild(img);
+  }
+
+  img._avatarFallbackUrls = urls;
+  img._avatarFallbackIndex = 0;
+  img.onload = function() {
+    const textNodes = Array.from(avatar.childNodes).filter(n => n.nodeType === Node.TEXT_NODE);
+    textNodes.forEach(n => n.remove());
+  };
+  img.onerror = function() {
+    const nextIndex = (img._avatarFallbackIndex || 0) + 1;
+    const fallbackUrls = img._avatarFallbackUrls || [];
+    if (nextIndex < fallbackUrls.length) {
+      img._avatarFallbackIndex = nextIndex;
+      img.src = fallbackUrls[nextIndex];
+      return;
+    }
+    img.remove();
+  };
+  img.src = urls[0];
+}
+
 function updateAvatarDisplay(identity) {
   const cardRef = participantCards.get(identity);
   if (!cardRef) return;
@@ -1024,19 +1078,13 @@ function updateAvatarDisplay(identity) {
   const avatarUrl = avatarUrls.get(identityBase);
 
   if (avatarUrl) {
-    // Show avatar image
-    let img = avatar.querySelector("img.avatar-img");
-    if (!img) {
-      // Clear initials text nodes
-      const textNodes = Array.from(avatar.childNodes).filter(n => n.nodeType === Node.TEXT_NODE);
-      textNodes.forEach(n => n.remove());
+    showAvatarImage(cardRef, [avatarUrl]);
+    return;
+  }
 
-      img = document.createElement("img");
-      img.className = "avatar-img";
-      img.alt = "Avatar";
-      avatar.appendChild(img);
-    }
-    img.src = avatarUrl;
+  const serverUrls = getServerAvatarCandidateUrls(identity, cardRef);
+  if (serverUrls.length > 0) {
+    showAvatarImage(cardRef, serverUrls);
   } else {
     // No avatar -- show initials (current behavior)
     const img = avatar.querySelector("img.avatar-img");

--- a/core/viewer/participants-avatar.test.js
+++ b/core/viewer/participants-avatar.test.js
@@ -1,0 +1,105 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const vm = require("node:vm");
+
+function makeAvatarElement(initials = "Z") {
+  let img = null;
+  const textNode = {
+    nodeType: 3,
+    textContent: initials,
+    remove() {
+      const index = avatar.childNodes.indexOf(textNode);
+      if (index >= 0) avatar.childNodes.splice(index, 1);
+    },
+  };
+  const avatar = {
+    childNodes: [textNode],
+    appendChild(element) {
+      if (element.className === "avatar-img") img = element;
+      this.childNodes.push(element);
+      return element;
+    },
+    querySelector(selector) {
+      if (selector === "video") return null;
+      if (selector === "img.avatar-img") return img;
+      if (selector === 'input[type="file"]') return null;
+      return null;
+    },
+    get image() {
+      return img;
+    },
+  };
+  return avatar;
+}
+
+function loadParticipantsAvatar({ deviceId } = {}) {
+  const avatar = makeAvatarElement();
+  const card = {
+    dataset: { identity: "z-6826" },
+    querySelector(selector) {
+      if (selector === ".user-name") return { textContent: "Z" };
+      return null;
+    },
+  };
+  const context = {
+    participantCards: new Map([
+      ["z-6826", { avatar, card, isLocal: false }],
+    ]),
+    avatarUrls: new Map(),
+    deviceIdByIdentity: new Map(deviceId ? [["z", deviceId]] : []),
+    document: {
+      createElement(tag) {
+        return {
+          tagName: tag.toUpperCase(),
+          className: "",
+          alt: "",
+          src: "",
+          onerror: null,
+        };
+      },
+    },
+    apiUrl(pathname) {
+      return "https://echo.example.test:9443" + pathname;
+    },
+    getIdentityBase(identity) {
+      return identity ? identity.replace(/-\d+$/, "") : identity;
+    },
+    slugifyIdentity(text) {
+      return (text || "")
+        .trim()
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, "-")
+        .replace(/^-+|-+$/g, "");
+    },
+    debugLog() {},
+    console,
+  };
+  context.global = context;
+  vm.createContext(context);
+  const code = fs.readFileSync(path.join(__dirname, "participants-avatar.js"), "utf8");
+  vm.runInContext(code, context, { filename: "participants-avatar.js" });
+  return { context, avatar };
+}
+
+test("remote avatar falls back to the server identity avatar when no broadcast URL arrived", () => {
+  const { context, avatar } = loadParticipantsAvatar();
+
+  context.updateAvatarDisplay("z-6826");
+
+  assert.equal(avatar.image?.src, "https://echo.example.test:9443/api/avatar/z");
+});
+
+test("remote avatar prefers the mapped device avatar once the device id is known", () => {
+  const { context, avatar } = loadParticipantsAvatar({
+    deviceId: "70ff47ce-0128-4d5f-a29d",
+  });
+
+  context.updateAvatarDisplay("z-6826");
+
+  assert.equal(
+    avatar.image?.src,
+    "https://echo.example.test:9443/api/avatar/70ff47ce-0128-4d5f-a29d"
+  );
+});


### PR DESCRIPTION
## Summary
- Load saved remote avatars from the server when a live avatar broadcast was missed.
- Prefer device-keyed avatars once the remote device id is known, then fall back to the visible identity/name.
- Add deterministic viewer tests for both fallback paths.

## Root Cause
Remote avatar display only used URLs learned from LiveKit data-channel `avatar-update` messages. If a viewer missed that message, the saved server avatar existed but the card stayed on initials.

## Test Plan
- `node --test core\\viewer\\*.test.js`