### PR TITLE
docs: capture release operation gotchas

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,10 @@ Echo Chamber is a self-hosted real-time communication app. In this repo, active 
 - Prefer small, focused diffs over broad rewrites.
 - Keep release impact explicit: server-only vs desktop-binary vs both.
 - Avoid one-off patterns; prefer conventional, maintainable approaches.
+- Windows-only product/release reality: do not add or run macOS build/release work unless Sam explicitly asks.
+- Before release, reboot validation, or live troubleshooting, run the Echo preflight in `docs/OPERATIONS.md`.
+- Do not assume the running server is from the repo you are editing. Verify `/api/version`, `/health`, `EchoCoreHost`, and `C:\ProgramData\Echo Chamber\echo-core-host.json`.
+- Do not touch SAM-PC, reload remote clients, or restart shared services unless Sam asked for that specific action. Tell Sam before closing/reopening his local Echo client.
 
 ## Quality expectations
 - Any user-facing behavior change should include verification evidence.
@@ -23,3 +27,4 @@ Echo Chamber is a self-hosted real-time communication app. In this repo, active 
 
 ## Key context
 Use `docs/RELEASE-BOUNDARIES.md` and `docs/TERMINOLOGY.md` to avoid server/client/binary confusion when planning or describing changes.
+Use `docs/OPERATIONS.md` for production service/restart rules and `docs/GITHUB.md` for release verification.

--- a/START_HERE.md
+++ b/START_HERE.md
@@ -1,25 +1,25 @@
 # Start Here
 
-If Sam starts a new Codex thread in this worktree and says `continue`, read:
+If Sam starts a new Codex thread for Echo Chamber and says `continue`, read:
 
 1. `AGENTS.md`
-2. `docs/handovers/2026-05-02-screen-sources-command.md`
+2. `docs/OPERATIONS.md`
+3. `docs/RELEASE-BOUNDARIES.md`
+4. the latest relevant file in `docs/handovers/` only if Sam names a parked workstream or bug
 
-Then continue from the handover's **Exact Prompt to Continue With** section.
+Then run the Echo preflight from `docs/OPERATIONS.md` before claiming the machine is ready, before release work, or before live troubleshooting.
 
-This worktree is for the screen sharing source-list bug:
+Current production baseline after the v0.6.12 screen-share release:
 
-- Path: `F:\EC-worktrees\screen-sources-command`
-- Branch: `codex/screen-sources-command-investigation`
-- Local commit: `e4c25e0 Add fallback for missing native screen source command`
-- Status: parked local compatibility fix; not pushed; no PR opened.
-- Official `main` worktree should remain clean.
+- Main repo path: `F:\EC-worktrees\main`
+- Production branch: `main`
+- Expected live version: `0.6.12`
+- Production startup owner: `EchoCoreHost` Windows service
+- Production control child should launch from `F:\EC-worktrees\main\core\target\release\echo-core-control.exe`
 
-Important context:
+Operational reminders:
 
-- Sam reported Zane later became able to share his screen, so this is not an active live emergency.
-- The branch still contains a real server/client compatibility fallback for older desktop shells missing `list_screen_sources`.
-- Zane's separate missing-avatar issue was fixed live without a server restart by registering the existing `zane` avatar under the current `z` identity. That avatar fix is server state only; it is not part of this branch's code diff.
-- In Codex Desktop, do not try to switch the `Echo Chamber - Main` project to this branch. Open this folder as its own Project instead, because this branch is already checked out by this worktree.
-
-If Sam asks to "start the work", confirm the worktree and branch, review the handover, and wait for a specific instruction before pushing, opening a PR, deploying, or deleting the branch.
+- Do not assume a running process came from the repo being edited; verify service config, host log, `/api/version`, and `/health`.
+- Do not push, deploy, open a PR, delete a worktree, reload SAM-PC, or restart shared services unless Sam explicitly asks.
+- Tell Sam before closing/reopening his local Echo client. For desktop-client tests, always close and reopen so the tested version is unambiguous.
+- Keep `F:\EC-worktrees\main` clean unless Sam explicitly asks for local docs/code changes there.

--- a/docs/GITHUB.md
+++ b/docs/GITHUB.md
@@ -36,3 +36,18 @@ Optional release impact labels for PRs/issues:
 - include release impact statement
 - include verification evidence
 - keep scope narrow unless batching foundational work intentionally
+
+## Release verification gotchas
+
+- Windows-only unless Sam explicitly asks otherwise. Do not add or wait on macOS release jobs for normal Echo Chamber releases.
+- Do not claim a desktop release is done from a local build alone. Verify the GitHub Release/tag/assets and the updater manifest.
+- Keep version sources in sync for desktop releases:
+  - `core/client/tauri.conf.json`
+  - `core/client/Cargo.toml`
+  - `core/control/Cargo.toml` when the server/control version is part of the release
+  - `core/deploy/latest.json` after the published release manifest is available
+- Verify both live endpoints after shipping:
+  - `https://echo.fellowshipoftheboatrace.party:9443/api/version`
+  - `https://echo.fellowshipoftheboatrace.party:9443/api/update/latest.json`
+- An update banner in the app means the server-served updater metadata and the installed desktop version disagree. Check the manifest before assuming the client install failed.
+- If doing a manual viewer-only deploy, make sure the deploy watcher state is not left pointing at an older SHA that will trigger an unnecessary rebuild/restart later.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -2,6 +2,43 @@
 
 This runbook reflects the current Core stack reality (central host/server model).
 
+## Production startup reality
+
+Production boot is owned by the Windows service:
+
+```powershell
+Get-Service EchoCoreHost
+Get-CimInstance Win32_Service -Filter "Name='EchoCoreHost'" |
+  Select-Object Name,State,StartMode,PathName
+Get-Content "C:\ProgramData\Echo Chamber\echo-core-host.json" |
+  ConvertFrom-Json |
+  Select-Object core_root,control_exe,control_env_file,sfu_exe,turn_exe,logs_dir
+```
+
+Important gotcha from the v0.6.12 screen-share release: the service executable path can still point at a legacy host binary while the host config controls which control/SFU/TURN children actually run. Do not infer the live control version from the service `PathName` alone. Verify the host config and the service log.
+
+The deploy watcher is separate. It watches/builds/deploys from the clean repo path, but it is not the boot owner for the core stack.
+
+## Echo preflight
+
+Run this before a release claim, after a reboot, or before live troubleshooting:
+
+```powershell
+cd F:\EC-worktrees\main
+git status -sb
+git branch --show-current
+git rev-parse --short HEAD
+git rev-parse --short origin/main
+
+curl.exe -sk https://echo.fellowshipoftheboatrace.party:9443/api/version
+curl.exe -sk https://echo.fellowshipoftheboatrace.party:9443/health
+
+Get-Service EchoCoreHost
+Get-Content "C:\ProgramData\Echo Chamber\logs\echo-core-host.log" -Tail 20
+```
+
+Expected production state after v0.6.12: `/api/version` reports `0.6.12`, `/health` is OK, and the host log shows `control started ... F:\EC-worktrees\main\core\target\release\echo-core-control.exe`.
+
 ## Start / stop
 
 From repo root:
@@ -40,7 +77,7 @@ Get-Process -Id (Get-Content .\core\turn\echo-turn.pid)
 
 ## Logs
 
-Core runtime logs are written under `core/logs/`:
+Script-started development logs are written under `core/logs/`:
 
 - `core/logs/run-core.log`
 - `core/logs/core-control.out.log`
@@ -50,13 +87,32 @@ Core runtime logs are written under `core/logs/`:
 - `core/logs/turn.out.log`
 - `core/logs/turn.err.log`
 
+Service-started production logs are written under `C:\ProgramData\Echo Chamber\logs\`:
+
+- `echo-core-host.log`
+- `core-control.out.log`
+- `core-control.err.log`
+- `livekit.out.log`
+- `livekit.err.log`
+- `turn.out.log`
+- `turn.err.log`
+
 ## Quick incident flow
 
 1. Confirm health endpoint and viewer/admin reachability.
-2. Check `core/logs/core-control.err.log` first.
-3. Validate PID files are present and processes are alive.
-4. If needed, run `stop-core.ps1` then `run-core.ps1` for clean restart.
-5. Capture timestamps + action sequence + relevant logs in the issue.
+2. Confirm `/api/version`; health alone is not enough.
+3. Check `C:\ProgramData\Echo Chamber\logs\echo-core-host.log` first for production service launches.
+4. Validate the host config path and child process paths before rebuilding/restarting.
+5. If needed, batch restarts; a control-plane restart kicks connected clients.
+6. Capture timestamps + action sequence + relevant logs in the issue.
+
+## Live testing discipline
+
+- Tell Sam before closing/reopening his local Echo client.
+- For desktop-client validation, close and reopen the client so the tested binary/version is unambiguous.
+- Do not reload SAM-PC, restart its client, or change its stream unless Sam explicitly asks.
+- Before monitoring, confirm which machine is publishing, which machine is watching, and which version/path is under test.
+- Clear duplicate/old sessions before interpreting active-user or stream results.
 
 ## Change management
 


### PR DESCRIPTION
## Summary
- Capture the v0.6.12 release/reboot gotchas in project-wide operating docs
- Add an Echo preflight for version, health, service path, and host-log checks
- Replace stale START_HERE instructions that pointed at the deleted screen-source worktree

## Release impact
- Docs-only
- No server deploy or desktop binary release required

## Verification
- `git diff --check -- AGENTS.md START_HERE.md docs/OPERATIONS.md docs/GITHUB.md`
