### PR TITLE
Fix native screen and jam audio capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.6.13
+
+- Fix: Native full-monitor screen sharing keeps publishing heartbeat frames when Windows Graphics Capture stops delivering repaint callbacks, preventing connected screen publishers from sitting at `0fps/0kbps`.
+- Fix: Jam start now fails cleanly if the Spotify audio bot cannot start, instead of leaving an active Jam with no bot and causing reconnect loops.
+
 ## 0.6.11
 
 - Fix: Windows 10 native Entire Screen sharing now auto-falls back to software H264 on the native DXGI Desktop Duplication path when no encoder override is configured, eliminating the blank `0fps` viewer tile on Win10 publishers like `SAM-PC`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.6.14
+
+- Fix: Native screen sharing now starts audio for window shares and full-monitor shares, including system loopback for entire-screen captures.
+- Fix: WASAPI process-loopback fallback now uses PCM16 44.1 kHz with autoconvert, matching Microsoft's ApplicationLoopback sample and avoiding silent fallback frames.
+- Fix: Jam Spotify capture finds the root Spotify process across sessions and logs frame levels for live verification.
+
 ## 0.6.13
 
 - Fix: Native full-monitor screen sharing keeps publishing heartbeat frames when Windows Graphics Capture stops delivering repaint callbacks, preventing connected screen publishers from sitting at `0fps/0kbps`.

--- a/CURRENT_SESSION.md
+++ b/CURRENT_SESSION.md
@@ -1,5 +1,44 @@
 # Echo Chamber - Current Session Handover
 
+## 2026-05-13 Jam Audio Silence Investigation
+
+**Worktree**: `F:\EC-worktrees\jam-audio-silence`
+**Branch**: `codex/jam-audio-silence-investigation`
+**Status**: Code patched and verified locally; not deployed live.
+
+Sam reported Jam audio was silent even though Spotify looked active. A Jam-only bot restart and Spotify playback resume did not fix it. Evidence showed the Jam audio WebSocket was sending correctly sized frames, but every decoded f32 sample was zero; Jam bot logs also stayed at `peak=0.000000 rms=0.000000`.
+
+Root-cause hypothesis now backed by code comparison: when process loopback `GetMixFormat` fails with `E_NOTIMPL`, Echo used a 48 kHz float32 fallback without `AUDCLNT_STREAMFLAGS_AUTOCONVERTPCM`. Microsoft's ApplicationLoopback sample uses fixed stereo PCM16 at 44.1 kHz with autoconvert. This branch changes Echo's fallback to that shape and keeps the existing PCM16-to-f32 conversion path. The same stale fallback also existed in the desktop/admin native screen-share audio capture copies, so this is not Jam-only.
+
+Changed files:
+
+- `core/control/src/audio_capture.rs`
+  - cross-session Spotify root PID lookup via ToolHelp snapshot
+  - tested fallback format helper: stereo PCM16, 44.1 kHz, 16-bit
+  - fallback init flags include `AUDCLNT_STREAMFLAGS_AUTOCONVERTPCM`
+- `core/client/src/audio_capture.rs`
+  - native screen-share audio fallback now uses stereo PCM16, 44.1 kHz, 16-bit
+  - fallback init flags include `AUDCLNT_STREAMFLAGS_AUTOCONVERTPCM`
+- `core/admin-client/src/audio_capture.rs`
+  - same fallback fix for the local admin shell copy
+- `core/docs/AUDIO_PIPELINE.md`
+  - documents the shared process-loopback fallback and current Tauri event names
+- `core/control/src/jam_bot.rs`
+  - frame-level peak/RMS logging retained for live verification
+- `core/control/Cargo.toml`
+  - adds `Win32_System_Diagnostics_ToolHelp`
+
+Verification from `F:\EC-worktrees\jam-audio-silence\core`:
+
+- `cargo test -p echo-core-control audio_capture`: 4 passed, 0 failed
+- `cargo test -p echo-core-client audio_capture`: 2 passed, 0 failed
+- `cargo test -p echo-core-admin audio_capture`: 2 passed, 0 failed
+- `cargo check -p echo-core-control`: exit 0
+- `cargo check -p echo-core-client`: exit 0
+- `cargo check -p echo-core-admin`: exit 0
+
+This is both a server/control binary change and a desktop/admin client binary change. It is not live until Sam approves a build/deploy/restart/relaunch window. Do not restart EchoCoreHost/control, relaunch Sam's local client, or disrupt connected friends without explicit approval.
+
 ## 2026-04-10 Codex Handover Override
 
 This block supersedes the older v0.6.6 summary below it.

--- a/START_HERE.md
+++ b/START_HERE.md
@@ -1,5 +1,16 @@
 # Start Here
 
+## Active Handover
+
+If Sam says `continue` in this worktree, load `docs/handovers/2026-05-13-jam-audio-silence.md` first. This worktree is for the broader Echo audio silence bug where Jam Spotify capture and native screen-share audio can both produce silent process-loopback frames.
+
+Current active fix lane:
+
+- Worktree: `F:\EC-worktrees\jam-audio-silence`
+- Branch: `codex/jam-audio-silence-investigation`
+- Status: control, desktop client, and admin-client process-loopback fallback code patched; targeted tests passed; not deployed live.
+- Deployment boundary: server/control restart plus desktop/admin client rebuild/relaunch required to test live, so ask Sam before deploying, restarting shared services, or closing/reopening Sam's local Echo client.
+
 If Sam starts a new Codex thread for Echo Chamber and says `continue`, read:
 
 1. `AGENTS.md`

--- a/START_HERE.md
+++ b/START_HERE.md
@@ -9,11 +9,11 @@ If Sam starts a new Codex thread for Echo Chamber and says `continue`, read:
 
 Then run the Echo preflight from `docs/OPERATIONS.md` before claiming the machine is ready, before release work, or before live troubleshooting.
 
-Current production baseline after the v0.6.12 screen-share release:
+Current production baseline after the v0.6.13 screen-share/Jam release:
 
 - Main repo path: `F:\EC-worktrees\main`
 - Production branch: `main`
-- Expected live version: `0.6.12`
+- Expected live version: `0.6.13`
 - Production startup owner: `EchoCoreHost` Windows service
 - Production control child should launch from `F:\EC-worktrees\main\core\target\release\echo-core-control.exe`
 

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -1304,7 +1304,7 @@ dependencies = [
 
 [[package]]
 name = "echo-core-client"
-version = "0.6.12"
+version = "0.6.13"
 dependencies = [
  "base64 0.22.1",
  "futures-util",
@@ -1325,7 +1325,7 @@ dependencies = [
 
 [[package]]
 name = "echo-core-control"
-version = "0.6.12"
+version = "0.6.13"
 dependencies = [
  "argon2",
  "axum",

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -1304,7 +1304,7 @@ dependencies = [
 
 [[package]]
 name = "echo-core-client"
-version = "0.6.13"
+version = "0.6.14"
 dependencies = [
  "base64 0.22.1",
  "futures-util",
@@ -1325,7 +1325,7 @@ dependencies = [
 
 [[package]]
 name = "echo-core-control"
-version = "0.6.13"
+version = "0.6.14"
 dependencies = [
  "argon2",
  "axum",

--- a/core/admin-client/src/audio_capture.rs
+++ b/core/admin-client/src/audio_capture.rs
@@ -26,6 +26,7 @@ const ACTIVATION_TYPE_PROCESS_LOOPBACK: u32 = 1;
 const LOOPBACK_MODE_INCLUDE_TREE: u32 = 0;
 /// VT_BLOB variant type
 const VT_BLOB: u16 = 65;
+const BITS_PER_BYTE: u16 = 8;
 
 /// Manual repr(C) structs for process loopback activation params.
 /// These may not be available in all versions of the windows crate.
@@ -39,6 +40,32 @@ struct ProcessLoopbackParams {
 struct AudioClientActivationParams {
     activation_type: u32,
     loopback_params: ProcessLoopbackParams,
+}
+
+fn process_loopback_initialize_flags(use_autoconvert: bool) -> u32 {
+    let flags = AUDCLNT_STREAMFLAGS_EVENTCALLBACK | AUDCLNT_STREAMFLAGS_LOOPBACK;
+    if use_autoconvert {
+        flags | AUDCLNT_STREAMFLAGS_AUTOCONVERTPCM
+    } else {
+        flags
+    }
+}
+
+fn process_loopback_fallback_format() -> WAVEFORMATEX {
+    let channels = 2_u16;
+    let sample_rate = 44_100_u32;
+    let bits = 16_u16;
+    let block_align = channels * bits / BITS_PER_BYTE;
+
+    WAVEFORMATEX {
+        wFormatTag: WAVE_FORMAT_PCM as u16,
+        nChannels: channels,
+        nSamplesPerSec: sample_rate,
+        nAvgBytesPerSec: sample_rate * block_align as u32,
+        nBlockAlign: block_align,
+        wBitsPerSample: bits,
+        cbSize: 0,
+    }
 }
 
 // --- Public types ---
@@ -337,7 +364,7 @@ fn capture_loop(
         eprintln!("[audio-capture] activation completed — got IAudioClient");
 
         // Get mix format — may fail with E_NOTIMPL on process loopback
-        let (sample_rate, channels, bits, block_align, is_float, fmt_ptr_owned);
+        let (sample_rate, channels, bits, block_align, is_float);
         match client.GetMixFormat() {
             Ok(ptr) => {
                 let fmt = &*ptr;
@@ -386,7 +413,7 @@ fn capture_loop(
                 let buffer_duration: i64 = 200_000;
                 client.Initialize(
                     AUDCLNT_SHAREMODE_SHARED,
-                    AUDCLNT_STREAMFLAGS_EVENTCALLBACK | AUDCLNT_STREAMFLAGS_LOOPBACK,
+                    process_loopback_initialize_flags(false),
                     buffer_duration,
                     0,
                     ptr,
@@ -394,25 +421,14 @@ fn capture_loop(
                 )?;
             }
             Err(e) => {
-                eprintln!("[audio-capture] GetMixFormat failed: {} -- falling back to default float32 48kHz stereo", e);
+                eprintln!("[audio-capture] GetMixFormat failed: {} -- falling back to default 44.1kHz stereo PCM16", e);
 
-                // Build a default WAVEFORMATEX: float32, 48000 Hz, stereo
-                sample_rate = 48000;
-                channels = 2;
-                bits = 32;
-                block_align = channels as usize * bits as usize / 8; // 8 bytes per frame
-                is_float = true;
-
-                let default_fmt = WAVEFORMATEX {
-                    wFormatTag: 3, // WAVE_FORMAT_IEEE_FLOAT
-                    nChannels: channels as u16,
-                    nSamplesPerSec: sample_rate,
-                    nAvgBytesPerSec: sample_rate * block_align as u32,
-                    nBlockAlign: block_align as u16,
-                    wBitsPerSample: bits as u16,
-                    cbSize: 0,
-                };
-                fmt_ptr_owned = Some(default_fmt);
+                let default_fmt = process_loopback_fallback_format();
+                sample_rate = default_fmt.nSamplesPerSec;
+                channels = default_fmt.nChannels as u32;
+                bits = default_fmt.wBitsPerSample;
+                block_align = channels as usize * bits as usize / 8;
+                is_float = false;
 
                 eprintln!(
                     "[audio-capture] using default format: {}Hz {}ch {}bit blockAlign={} isFloat={}",
@@ -425,23 +441,22 @@ fn capture_loop(
                         "sampleRate": sample_rate,
                         "channels": channels,
                         "bitsPerSample": bits,
-                        "formatTag": 3,
-                        "isFloat": true,
+                        "formatTag": WAVE_FORMAT_PCM,
+                        "isFloat": false,
                     }),
                 );
 
-                // Initialize with default format + LOOPBACK flag
+                // Initialize with default format + LOOPBACK/AUTOCONVERTPCM flags
                 eprintln!(
-                    "[audio-capture] initializing audio client with default format + LOOPBACK flag"
+                    "[audio-capture] initializing audio client with default format + LOOPBACK/AUTOCONVERTPCM flags"
                 );
                 let buffer_duration: i64 = 200_000;
-                let fmt_ref = fmt_ptr_owned.as_ref().unwrap() as *const WAVEFORMATEX;
                 client.Initialize(
                     AUDCLNT_SHAREMODE_SHARED,
-                    AUDCLNT_STREAMFLAGS_EVENTCALLBACK | AUDCLNT_STREAMFLAGS_LOOPBACK,
+                    process_loopback_initialize_flags(true),
                     buffer_duration,
                     0,
-                    fmt_ref,
+                    &default_fmt as *const WAVEFORMATEX,
                     None,
                 )?;
             }
@@ -570,5 +585,43 @@ fn capture_loop(
 
         eprintln!("[audio-capture] stopped for PID {}", pid);
         Ok(())
+    }
+}
+
+#[cfg(all(test, windows))]
+mod tests {
+    use super::{process_loopback_fallback_format, process_loopback_initialize_flags};
+    use windows::Win32::Media::Audio::{
+        AUDCLNT_STREAMFLAGS_AUTOCONVERTPCM, AUDCLNT_STREAMFLAGS_EVENTCALLBACK,
+        AUDCLNT_STREAMFLAGS_LOOPBACK,
+    };
+
+    #[test]
+    fn process_loopback_fallback_uses_pcm16_format() {
+        let format = process_loopback_fallback_format();
+        let format_tag = format.wFormatTag;
+        let channels = format.nChannels;
+        let sample_rate = format.nSamplesPerSec;
+        let bits = format.wBitsPerSample;
+        let block_align = format.nBlockAlign;
+        let avg_bytes_per_sec = format.nAvgBytesPerSec;
+        let cb_size = format.cbSize;
+
+        assert_eq!(format_tag, 1);
+        assert_eq!(channels, 2);
+        assert_eq!(sample_rate, 44_100);
+        assert_eq!(bits, 16);
+        assert_eq!(block_align, 4);
+        assert_eq!(avg_bytes_per_sec, 176_400);
+        assert_eq!(cb_size, 0);
+    }
+
+    #[test]
+    fn process_loopback_fallback_enables_autoconvertpcm() {
+        let flags = process_loopback_initialize_flags(true);
+
+        assert_ne!(flags & AUDCLNT_STREAMFLAGS_EVENTCALLBACK, 0);
+        assert_ne!(flags & AUDCLNT_STREAMFLAGS_LOOPBACK, 0);
+        assert_ne!(flags & AUDCLNT_STREAMFLAGS_AUTOCONVERTPCM, 0);
     }
 }

--- a/core/client/Cargo.toml
+++ b/core/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "echo-core-client"
-version = "0.6.13"
+version = "0.6.14"
 edition = "2021"
 description = "Echo Chamber native desktop client"
 

--- a/core/client/Cargo.toml
+++ b/core/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "echo-core-client"
-version = "0.6.12"
+version = "0.6.13"
 edition = "2021"
 description = "Echo Chamber native desktop client"
 

--- a/core/client/src/audio_capture.rs
+++ b/core/client/src/audio_capture.rs
@@ -4,6 +4,7 @@
 //! AUDIOCLIENT_ACTIVATION_TYPE_PROCESS_LOOPBACK API and streams
 //! base64-encoded PCM float32 chunks via Tauri events.
 
+use crate::file_debug_log;
 use base64::Engine;
 use serde::Serialize;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -26,6 +27,7 @@ const ACTIVATION_TYPE_PROCESS_LOOPBACK: u32 = 1;
 const LOOPBACK_MODE_INCLUDE_TREE: u32 = 0;
 /// VT_BLOB variant type
 const VT_BLOB: u16 = 65;
+const BITS_PER_BYTE: u16 = 8;
 
 /// Manual repr(C) structs for process loopback activation params.
 /// These may not be available in all versions of the windows crate.
@@ -39,6 +41,58 @@ struct ProcessLoopbackParams {
 struct AudioClientActivationParams {
     activation_type: u32,
     loopback_params: ProcessLoopbackParams,
+}
+
+fn process_loopback_initialize_flags(use_autoconvert: bool) -> u32 {
+    let flags = system_loopback_initialize_flags();
+    if use_autoconvert {
+        flags | AUDCLNT_STREAMFLAGS_AUTOCONVERTPCM
+    } else {
+        flags
+    }
+}
+
+fn system_loopback_initialize_flags() -> u32 {
+    AUDCLNT_STREAMFLAGS_EVENTCALLBACK | AUDCLNT_STREAMFLAGS_LOOPBACK
+}
+
+fn process_loopback_fallback_format() -> WAVEFORMATEX {
+    let channels = 2_u16;
+    let sample_rate = 44_100_u32;
+    let bits = 16_u16;
+    let block_align = channels * bits / BITS_PER_BYTE;
+
+    WAVEFORMATEX {
+        wFormatTag: WAVE_FORMAT_PCM as u16,
+        nChannels: channels,
+        nSamplesPerSec: sample_rate,
+        nAvgBytesPerSec: sample_rate * block_align as u32,
+        nBlockAlign: block_align,
+        wBitsPerSample: bits,
+        cbSize: 0,
+    }
+}
+
+fn log_audio_capture(message: &str) {
+    eprintln!("{}", message);
+    file_debug_log::append(message);
+}
+
+fn audio_capture_peak_from_f32_bytes(bytes: &[u8]) -> f32 {
+    bytes
+        .chunks_exact(4)
+        .filter_map(|chunk| {
+            let sample = f32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]);
+            sample.is_finite().then_some(sample.abs())
+        })
+        .fold(0.0_f32, f32::max)
+}
+
+fn audio_capture_frame_diagnostic(frame_count: u64, sample_count: usize, peak: f32) -> String {
+    format!(
+        "[audio-capture] converted frame #{} samples={} peak={:.6}",
+        frame_count, sample_count, peak
+    )
 }
 
 // --- Public types ---
@@ -205,10 +259,14 @@ fn global_state() -> &'static Mutex<Option<CaptureHandle>> {
 pub fn start_capture(pid: u32, app: AppHandle) -> Result<()> {
     // Check if this Windows build supports process loopback
     if let Err(msg) = check_process_loopback_support() {
-        eprintln!("[audio-capture] {}", msg);
+        log_audio_capture(&format!("[audio-capture] {}", msg));
         return Err(Error::new(E_FAIL, msg));
     }
 
+    log_audio_capture(&format!(
+        "[audio-capture] start_capture requested pid={}",
+        pid
+    ));
     stop_capture();
 
     let running = Arc::new(AtomicBool::new(true));
@@ -216,11 +274,35 @@ pub fn start_capture(pid: u32, app: AppHandle) -> Result<()> {
 
     let thread = std::thread::spawn(move || {
         if let Err(e) = capture_loop(pid, &app, &r2) {
-            eprintln!("[audio-capture] error: {}", e);
+            log_audio_capture(&format!("[audio-capture] error: {}", e));
             let _ = app.emit("audio-capture-error", format!("{}", e));
         }
         let _ = app.emit("audio-capture-stopped", ());
-        eprintln!("[audio-capture] thread exited");
+        log_audio_capture("[audio-capture] thread exited");
+    });
+
+    *global_state().lock().unwrap() = Some(CaptureHandle {
+        running,
+        thread: Some(thread),
+    });
+
+    Ok(())
+}
+
+pub fn start_system_capture(app: AppHandle) -> Result<()> {
+    log_audio_capture("[audio-capture] start_system_capture requested");
+    stop_capture();
+
+    let running = Arc::new(AtomicBool::new(true));
+    let r2 = running.clone();
+
+    let thread = std::thread::spawn(move || {
+        if let Err(e) = capture_system_loop(&app, &r2) {
+            log_audio_capture(&format!("[audio-capture] error: {}", e));
+            let _ = app.emit("audio-capture-error", format!("{}", e));
+        }
+        let _ = app.emit("audio-capture-stopped", ());
+        log_audio_capture("[audio-capture] thread exited");
     });
 
     *global_state().lock().unwrap() = Some(CaptureHandle {
@@ -266,6 +348,286 @@ impl IActivateAudioInterfaceCompletionHandler_Impl for ActivationHandler_Impl {
     }
 }
 
+fn capture_with_audio_client(
+    client: IAudioClient,
+    app: &AppHandle,
+    running: &AtomicBool,
+    capture_label: &str,
+    started_pid: u32,
+) -> std::result::Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    unsafe {
+        // Get mix format - may fail with E_NOTIMPL on process loopback
+        let (sample_rate, channels, bits, block_align, is_float);
+        match client.GetMixFormat() {
+            Ok(ptr) => {
+                let fmt = &*ptr;
+                sample_rate = fmt.nSamplesPerSec;
+                channels = fmt.nChannels as u32;
+                bits = fmt.wBitsPerSample;
+                block_align = fmt.nBlockAlign as usize;
+                let format_tag = fmt.wFormatTag;
+
+                // Determine if the format is IEEE float32
+                is_float = if format_tag == 3 {
+                    true
+                } else if format_tag == 0xFFFE_u16 {
+                    let ext_ptr = ptr as *const u8;
+                    let sub_format_offset = std::mem::size_of::<WAVEFORMATEX>();
+                    let guid_offset = sub_format_offset + 2 + 4;
+                    let guid_bytes = std::slice::from_raw_parts(ext_ptr.add(guid_offset), 16);
+                    let first_u32 = u32::from_le_bytes([
+                        guid_bytes[0],
+                        guid_bytes[1],
+                        guid_bytes[2],
+                        guid_bytes[3],
+                    ]);
+                    first_u32 == 3
+                } else {
+                    false
+                };
+
+                log_audio_capture(&format!(
+                    "[audio-capture] format from GetMixFormat: {}Hz {}ch {}bit blockAlign={} formatTag={} isFloat={}",
+                    sample_rate, channels, bits, block_align, format_tag, is_float
+                ));
+                let _ = app.emit(
+                    "audio-capture-format",
+                    serde_json::json!({
+                        "sampleRate": sample_rate,
+                        "channels": channels,
+                        "bitsPerSample": bits,
+                        "formatTag": format_tag,
+                        "isFloat": is_float,
+                    }),
+                );
+
+                // Initialize with the mix format
+                log_audio_capture(
+                    "[audio-capture] initializing audio client (shared mode, event-driven, 20ms buffer)",
+                );
+                let buffer_duration: i64 = 200_000;
+                client.Initialize(
+                    AUDCLNT_SHAREMODE_SHARED,
+                    process_loopback_initialize_flags(false),
+                    buffer_duration,
+                    0,
+                    ptr,
+                    None,
+                )?;
+            }
+            Err(e) => {
+                log_audio_capture(&format!(
+                    "[audio-capture] GetMixFormat failed: {} -- falling back to default 44.1kHz stereo PCM16",
+                    e
+                ));
+
+                let default_fmt = process_loopback_fallback_format();
+                sample_rate = default_fmt.nSamplesPerSec;
+                channels = default_fmt.nChannels as u32;
+                bits = default_fmt.wBitsPerSample;
+                block_align = channels as usize * bits as usize / 8;
+                is_float = false;
+
+                log_audio_capture(&format!(
+                    "[audio-capture] using default format: {}Hz {}ch {}bit blockAlign={} isFloat={}",
+                    sample_rate, channels, bits, block_align, is_float
+                ));
+
+                let _ = app.emit(
+                    "audio-capture-format",
+                    serde_json::json!({
+                        "sampleRate": sample_rate,
+                        "channels": channels,
+                        "bitsPerSample": bits,
+                        "formatTag": WAVE_FORMAT_PCM,
+                        "isFloat": false,
+                    }),
+                );
+
+                // Initialize with default format + LOOPBACK/AUTOCONVERTPCM flags
+                log_audio_capture(
+                    "[audio-capture] initializing audio client with default format + LOOPBACK/AUTOCONVERTPCM flags"
+                );
+                let buffer_duration: i64 = 200_000;
+                client.Initialize(
+                    AUDCLNT_SHAREMODE_SHARED,
+                    process_loopback_initialize_flags(true),
+                    buffer_duration,
+                    0,
+                    &default_fmt as *const WAVEFORMATEX,
+                    None,
+                )?;
+            }
+        }
+        log_audio_capture("[audio-capture] audio client initialized");
+
+        // Event-driven capture
+        let event = CreateEventW(None, false, false, None)?;
+        client.SetEventHandle(event)?;
+
+        let capture: IAudioCaptureClient = client.GetService()?;
+        log_audio_capture("[audio-capture] got IAudioCaptureClient, starting capture");
+
+        client.Start()?;
+        log_audio_capture(&format!("[audio-capture] started for {}", capture_label));
+        let _ = app.emit("audio-capture-started", started_pid);
+
+        // Read loop
+        let mut frame_count: u64 = 0;
+        let mut silent_packet_count: u64 = 0;
+        while running.load(Ordering::SeqCst) {
+            let wait = WaitForSingleObject(event, 100);
+            if wait == WAIT_TIMEOUT {
+                continue;
+            }
+
+            // Drain all available packets
+            loop {
+                let mut buf_ptr: *mut u8 = std::ptr::null_mut();
+                let mut frames: u32 = 0;
+                let mut flags: u32 = 0;
+
+                let hr = capture.GetBuffer(&mut buf_ptr, &mut frames, &mut flags, None, None);
+
+                if hr.is_err() || frames == 0 {
+                    break;
+                }
+
+                let data_len = frames as usize * block_align;
+
+                // AUDCLNT_BUFFERFLAGS_SILENT = 0x2
+                let silent = (flags & 0x2) != 0;
+                if silent {
+                    silent_packet_count += 1;
+                    if silent_packet_count <= 3 || silent_packet_count % 100 == 0 {
+                        log_audio_capture(&format!(
+                            "[audio-capture] silent packet #{} frames={} len={}",
+                            silent_packet_count, frames, data_len
+                        ));
+                    }
+                }
+
+                if !silent && !buf_ptr.is_null() && data_len > 0 {
+                    let slice = std::slice::from_raw_parts(buf_ptr, data_len);
+
+                    // Log first few frames for diagnostics
+                    frame_count += 1;
+                    if frame_count <= 5 {
+                        let preview_bytes = std::cmp::min(slice.len(), 32);
+                        log_audio_capture(&format!(
+                            "[audio-capture] frame #{} len={} first_bytes={:?}",
+                            frame_count,
+                            data_len,
+                            &slice[..preview_bytes]
+                        ));
+                    }
+
+                    let send_bytes: Vec<u8> = if is_float {
+                        // Already float32 - send raw bytes as-is
+                        slice.to_vec()
+                    } else if bits == 16 {
+                        // Int16 PCM to Float32 conversion
+                        let sample_count = data_len / 2;
+                        let mut float_buf = Vec::with_capacity(sample_count * 4);
+                        let samples =
+                            std::slice::from_raw_parts(buf_ptr as *const i16, sample_count);
+                        for &s in samples {
+                            let f = s as f32 / 32768.0;
+                            float_buf.extend_from_slice(&f.to_le_bytes());
+                        }
+                        if frame_count <= 3 {
+                            log_audio_capture(&format!(
+                                "[audio-capture] int16->float32: {} samples, first few: {:?}",
+                                sample_count,
+                                &samples[..std::cmp::min(samples.len(), 8)]
+                            ));
+                        }
+                        float_buf
+                    } else if bits == 24 {
+                        // Int24 PCM to Float32 conversion
+                        let sample_count = data_len / 3;
+                        let mut float_buf = Vec::with_capacity(sample_count * 4);
+                        for i in 0..sample_count {
+                            let b0 = slice[i * 3] as i32;
+                            let b1 = slice[i * 3 + 1] as i32;
+                            let b2 = slice[i * 3 + 2] as i32;
+                            // Sign-extend 24-bit to 32-bit
+                            let raw = b0 | (b1 << 8) | (b2 << 16);
+                            let signed = if raw & 0x800000 != 0 {
+                                raw | !0xFFFFFF_i32
+                            } else {
+                                raw
+                            };
+                            let f = signed as f32 / 8388608.0;
+                            float_buf.extend_from_slice(&f.to_le_bytes());
+                        }
+                        if frame_count <= 3 {
+                            log_audio_capture(&format!(
+                                "[audio-capture] int24->float32: {} samples converted",
+                                sample_count
+                            ));
+                        }
+                        float_buf
+                    } else {
+                        // Unknown format - send raw and log warning
+                        if frame_count <= 3 {
+                            log_audio_capture(&format!(
+                                "[audio-capture] WARNING: unknown format {}bit, sending raw bytes",
+                                bits
+                            ));
+                        }
+                        slice.to_vec()
+                    };
+
+                    if frame_count <= 5 || frame_count % 50 == 0 {
+                        let sample_count = send_bytes.len() / 4;
+                        let peak = audio_capture_peak_from_f32_bytes(&send_bytes);
+                        log_audio_capture(&audio_capture_frame_diagnostic(
+                            frame_count,
+                            sample_count,
+                            peak,
+                        ));
+                    }
+
+                    let b64 = base64::engine::general_purpose::STANDARD.encode(&send_bytes);
+                    let _ = app.emit("audio-capture-data", b64);
+                }
+
+                capture.ReleaseBuffer(frames)?;
+            }
+        }
+
+        client.Stop()?;
+        let _ = CloseHandle(event);
+
+        log_audio_capture(&format!("[audio-capture] stopped for {}", capture_label));
+        Ok(())
+    }
+}
+
+fn capture_system_loop(
+    app: &AppHandle,
+    running: &AtomicBool,
+) -> std::result::Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    unsafe {
+        log_audio_capture("[audio-capture] system capture_loop starting");
+        CoInitializeEx(None, COINIT_MULTITHREADED).ok()?;
+        log_audio_capture("[audio-capture] COM initialized");
+
+        let enumerator: IMMDeviceEnumerator =
+            CoCreateInstance(&MMDeviceEnumerator, None, CLSCTX_ALL)?;
+        let device = enumerator.GetDefaultAudioEndpoint(eRender, eMultimedia)?;
+        log_audio_capture("[audio-capture] got default render endpoint");
+
+        let client: IAudioClient = device.Activate(CLSCTX_ALL, None)?;
+        log_audio_capture("[audio-capture] activated default render endpoint");
+
+        let result = capture_with_audio_client(client, app, running, "system loopback", 0);
+        CoUninitialize();
+        result
+    }
+}
+
 // --- Main capture loop ---
 
 fn capture_loop(
@@ -274,9 +636,12 @@ fn capture_loop(
     running: &AtomicBool,
 ) -> std::result::Result<(), Box<dyn std::error::Error + Send + Sync>> {
     unsafe {
-        eprintln!("[audio-capture] capture_loop starting for PID {}", pid);
+        log_audio_capture(&format!(
+            "[audio-capture] capture_loop starting for PID {}",
+            pid
+        ));
         CoInitializeEx(None, COINIT_MULTITHREADED).ok()?;
-        eprintln!("[audio-capture] COM initialized");
+        log_audio_capture("[audio-capture] COM initialized");
 
         // Build activation params
         let params = AudioClientActivationParams {
@@ -312,18 +677,18 @@ fn capture_loop(
 
         // Activate audio interface for process loopback
         // VIRTUAL_AUDIO_DEVICE_PROCESS_LOOPBACK = "VAD\\Process_Loopback"
-        eprintln!(
+        log_audio_capture(&format!(
             "[audio-capture] calling ActivateAudioInterfaceAsync for PID {} (params_size={})",
             pid, params_size
-        );
+        ));
         let _operation = ActivateAudioInterfaceAsync(
             w!("VAD\\Process_Loopback"),
             &IAudioClient::IID,
             Some(propvariant),
             &handler,
         )?;
-        eprintln!(
-            "[audio-capture] ActivateAudioInterfaceAsync call succeeded, waiting for completion..."
+        log_audio_capture(
+            "[audio-capture] ActivateAudioInterfaceAsync call succeeded, waiting for completion...",
         );
 
         // Wait for activation (5 second timeout)
@@ -331,244 +696,81 @@ fn capture_loop(
             .recv_timeout(std::time::Duration::from_secs(5))
             .map_err(|e| format!("activation timeout: {}", e))?
             .map_err(|e| {
-                eprintln!("[audio-capture] activation FAILED: {}", e);
+                log_audio_capture(&format!("[audio-capture] activation FAILED: {}", e));
                 format!("activation failed: {}", e)
             })?;
-        eprintln!("[audio-capture] activation completed — got IAudioClient");
+        log_audio_capture("[audio-capture] activation completed -- got IAudioClient");
 
-        // Get mix format — may fail with E_NOTIMPL on process loopback
-        let (sample_rate, channels, bits, block_align, is_float, fmt_ptr_owned);
-        match client.GetMixFormat() {
-            Ok(ptr) => {
-                let fmt = &*ptr;
-                sample_rate = fmt.nSamplesPerSec;
-                channels = fmt.nChannels as u32;
-                bits = fmt.wBitsPerSample;
-                block_align = fmt.nBlockAlign as usize;
-                let format_tag = fmt.wFormatTag;
-
-                // Determine if the format is IEEE float32
-                is_float = if format_tag == 3 {
-                    true
-                } else if format_tag == 0xFFFE_u16 {
-                    let ext_ptr = ptr as *const u8;
-                    let sub_format_offset = std::mem::size_of::<WAVEFORMATEX>();
-                    let guid_offset = sub_format_offset + 2 + 4;
-                    let guid_bytes = std::slice::from_raw_parts(ext_ptr.add(guid_offset), 16);
-                    let first_u32 = u32::from_le_bytes([
-                        guid_bytes[0],
-                        guid_bytes[1],
-                        guid_bytes[2],
-                        guid_bytes[3],
-                    ]);
-                    first_u32 == 3
-                } else {
-                    false
-                };
-
-                eprintln!(
-                    "[audio-capture] format from GetMixFormat: {}Hz {}ch {}bit blockAlign={} formatTag={} isFloat={}",
-                    sample_rate, channels, bits, block_align, format_tag, is_float
-                );
-                let _ = app.emit(
-                    "audio-capture-format",
-                    serde_json::json!({
-                        "sampleRate": sample_rate,
-                        "channels": channels,
-                        "bitsPerSample": bits,
-                        "formatTag": format_tag,
-                        "isFloat": is_float,
-                    }),
-                );
-
-                // Initialize with the mix format
-                eprintln!("[audio-capture] initializing audio client (shared mode, event-driven, 20ms buffer)");
-                let buffer_duration: i64 = 200_000;
-                client.Initialize(
-                    AUDCLNT_SHAREMODE_SHARED,
-                    AUDCLNT_STREAMFLAGS_EVENTCALLBACK | AUDCLNT_STREAMFLAGS_LOOPBACK,
-                    buffer_duration,
-                    0,
-                    ptr,
-                    None,
-                )?;
-            }
-            Err(e) => {
-                eprintln!("[audio-capture] GetMixFormat failed: {} -- falling back to default float32 48kHz stereo", e);
-
-                // Build a default WAVEFORMATEX: float32, 48000 Hz, stereo
-                sample_rate = 48000;
-                channels = 2;
-                bits = 32;
-                block_align = channels as usize * bits as usize / 8; // 8 bytes per frame
-                is_float = true;
-
-                let default_fmt = WAVEFORMATEX {
-                    wFormatTag: 3, // WAVE_FORMAT_IEEE_FLOAT
-                    nChannels: channels as u16,
-                    nSamplesPerSec: sample_rate,
-                    nAvgBytesPerSec: sample_rate * block_align as u32,
-                    nBlockAlign: block_align as u16,
-                    wBitsPerSample: bits as u16,
-                    cbSize: 0,
-                };
-                fmt_ptr_owned = Some(default_fmt);
-
-                eprintln!(
-                    "[audio-capture] using default format: {}Hz {}ch {}bit blockAlign={} isFloat={}",
-                    sample_rate, channels, bits, block_align, is_float
-                );
-
-                let _ = app.emit(
-                    "audio-capture-format",
-                    serde_json::json!({
-                        "sampleRate": sample_rate,
-                        "channels": channels,
-                        "bitsPerSample": bits,
-                        "formatTag": 3,
-                        "isFloat": true,
-                    }),
-                );
-
-                // Initialize with default format + LOOPBACK flag
-                eprintln!(
-                    "[audio-capture] initializing audio client with default format + LOOPBACK flag"
-                );
-                let buffer_duration: i64 = 200_000;
-                let fmt_ref = fmt_ptr_owned.as_ref().unwrap() as *const WAVEFORMATEX;
-                client.Initialize(
-                    AUDCLNT_SHAREMODE_SHARED,
-                    AUDCLNT_STREAMFLAGS_EVENTCALLBACK | AUDCLNT_STREAMFLAGS_LOOPBACK,
-                    buffer_duration,
-                    0,
-                    fmt_ref,
-                    None,
-                )?;
-            }
-        }
-        eprintln!("[audio-capture] audio client initialized");
-
-        // Event-driven capture
-        let event = CreateEventW(None, false, false, None)?;
-        client.SetEventHandle(event)?;
-
-        let capture: IAudioCaptureClient = client.GetService()?;
-        eprintln!("[audio-capture] got IAudioCaptureClient, starting capture");
-
-        client.Start()?;
-        eprintln!("[audio-capture] started for PID {}", pid);
-        let _ = app.emit("audio-capture-started", pid);
-
-        // Read loop
-        let mut frame_count: u64 = 0;
-        while running.load(Ordering::SeqCst) {
-            let wait = WaitForSingleObject(event, 100);
-            if wait == WAIT_TIMEOUT {
-                continue;
-            }
-
-            // Drain all available packets
-            loop {
-                let mut buf_ptr: *mut u8 = std::ptr::null_mut();
-                let mut frames: u32 = 0;
-                let mut flags: u32 = 0;
-
-                let hr = capture.GetBuffer(&mut buf_ptr, &mut frames, &mut flags, None, None);
-
-                if hr.is_err() || frames == 0 {
-                    break;
-                }
-
-                let data_len = frames as usize * block_align;
-
-                // AUDCLNT_BUFFERFLAGS_SILENT = 0x2
-                let silent = (flags & 0x2) != 0;
-
-                if !silent && !buf_ptr.is_null() && data_len > 0 {
-                    let slice = std::slice::from_raw_parts(buf_ptr, data_len);
-
-                    // Log first few frames for diagnostics
-                    frame_count += 1;
-                    if frame_count <= 5 {
-                        let preview_bytes = std::cmp::min(slice.len(), 32);
-                        eprintln!(
-                            "[audio-capture] frame #{} len={} first_bytes={:?}",
-                            frame_count,
-                            data_len,
-                            &slice[..preview_bytes]
-                        );
-                    }
-
-                    let send_bytes: Vec<u8> = if is_float {
-                        // Already float32 — send raw bytes as-is
-                        slice.to_vec()
-                    } else if bits == 16 {
-                        // Int16 PCM → Float32 conversion
-                        let sample_count = data_len / 2;
-                        let mut float_buf = Vec::with_capacity(sample_count * 4);
-                        let samples =
-                            std::slice::from_raw_parts(buf_ptr as *const i16, sample_count);
-                        for &s in samples {
-                            let f = s as f32 / 32768.0;
-                            float_buf.extend_from_slice(&f.to_le_bytes());
-                        }
-                        if frame_count <= 3 {
-                            eprintln!(
-                                "[audio-capture] int16->float32: {} samples, first few: {:?}",
-                                sample_count,
-                                &samples[..std::cmp::min(samples.len(), 8)]
-                            );
-                        }
-                        float_buf
-                    } else if bits == 24 {
-                        // Int24 PCM → Float32 conversion
-                        let sample_count = data_len / 3;
-                        let mut float_buf = Vec::with_capacity(sample_count * 4);
-                        for i in 0..sample_count {
-                            let b0 = slice[i * 3] as i32;
-                            let b1 = slice[i * 3 + 1] as i32;
-                            let b2 = slice[i * 3 + 2] as i32;
-                            // Sign-extend 24-bit to 32-bit
-                            let raw = b0 | (b1 << 8) | (b2 << 16);
-                            let signed = if raw & 0x800000 != 0 {
-                                raw | !0xFFFFFF_i32
-                            } else {
-                                raw
-                            };
-                            let f = signed as f32 / 8388608.0;
-                            float_buf.extend_from_slice(&f.to_le_bytes());
-                        }
-                        if frame_count <= 3 {
-                            eprintln!(
-                                "[audio-capture] int24->float32: {} samples converted",
-                                sample_count
-                            );
-                        }
-                        float_buf
-                    } else {
-                        // Unknown format — send raw and log warning
-                        if frame_count <= 3 {
-                            eprintln!(
-                                "[audio-capture] WARNING: unknown format {}bit, sending raw bytes",
-                                bits
-                            );
-                        }
-                        slice.to_vec()
-                    };
-
-                    let b64 = base64::engine::general_purpose::STANDARD.encode(&send_bytes);
-                    let _ = app.emit("audio-capture-data", b64);
-                }
-
-                capture.ReleaseBuffer(frames)?;
-            }
-        }
-
-        client.Stop()?;
-        let _ = CloseHandle(event);
+        let result = capture_with_audio_client(client, app, running, &format!("PID {}", pid), pid);
         CoUninitialize();
+        result
+    }
+}
 
-        eprintln!("[audio-capture] stopped for PID {}", pid);
-        Ok(())
+#[cfg(all(test, windows))]
+mod tests {
+    use super::{
+        audio_capture_frame_diagnostic, audio_capture_peak_from_f32_bytes,
+        process_loopback_fallback_format, process_loopback_initialize_flags,
+        system_loopback_initialize_flags,
+    };
+    use windows::Win32::Media::Audio::{
+        AUDCLNT_STREAMFLAGS_AUTOCONVERTPCM, AUDCLNT_STREAMFLAGS_EVENTCALLBACK,
+        AUDCLNT_STREAMFLAGS_LOOPBACK,
+    };
+
+    #[test]
+    fn process_loopback_fallback_uses_pcm16_format() {
+        let format = process_loopback_fallback_format();
+        let format_tag = format.wFormatTag;
+        let channels = format.nChannels;
+        let sample_rate = format.nSamplesPerSec;
+        let bits = format.wBitsPerSample;
+        let block_align = format.nBlockAlign;
+        let avg_bytes_per_sec = format.nAvgBytesPerSec;
+        let cb_size = format.cbSize;
+
+        assert_eq!(format_tag, 1);
+        assert_eq!(channels, 2);
+        assert_eq!(sample_rate, 44_100);
+        assert_eq!(bits, 16);
+        assert_eq!(block_align, 4);
+        assert_eq!(avg_bytes_per_sec, 176_400);
+        assert_eq!(cb_size, 0);
+    }
+
+    #[test]
+    fn process_loopback_fallback_enables_autoconvertpcm() {
+        let flags = process_loopback_initialize_flags(true);
+
+        assert_ne!(flags & AUDCLNT_STREAMFLAGS_EVENTCALLBACK, 0);
+        assert_ne!(flags & AUDCLNT_STREAMFLAGS_LOOPBACK, 0);
+        assert_ne!(flags & AUDCLNT_STREAMFLAGS_AUTOCONVERTPCM, 0);
+    }
+
+    #[test]
+    fn system_loopback_uses_event_loopback_flags() {
+        let flags = system_loopback_initialize_flags();
+
+        assert_ne!(flags & AUDCLNT_STREAMFLAGS_EVENTCALLBACK, 0);
+        assert_ne!(flags & AUDCLNT_STREAMFLAGS_LOOPBACK, 0);
+    }
+
+    #[test]
+    fn audio_capture_frame_diagnostic_includes_peak_level() {
+        let samples = [0.0_f32, -0.25, 0.5, f32::NAN, -0.125];
+        let bytes: Vec<u8> = samples
+            .iter()
+            .flat_map(|sample| sample.to_le_bytes())
+            .collect();
+
+        let peak = audio_capture_peak_from_f32_bytes(&bytes);
+        let line = audio_capture_frame_diagnostic(7, 5, peak);
+
+        assert_eq!(peak, 0.5);
+        assert_eq!(
+            line,
+            "[audio-capture] converted frame #7 samples=5 peak=0.500000"
+        );
     }
 }

--- a/core/client/src/audio_capture_stub.rs
+++ b/core/client/src/audio_capture_stub.rs
@@ -19,4 +19,8 @@ pub fn start_capture(_pid: u32, _app: tauri::AppHandle) -> Result<(), String> {
     Err("Per-process audio capture is not supported on this platform. Share your screen with system audio enabled instead.".to_string())
 }
 
+pub fn start_system_capture(_app: tauri::AppHandle) -> Result<(), String> {
+    Err("System audio capture is not supported on this platform.".to_string())
+}
+
 pub fn stop_capture() {}

--- a/core/client/src/main.rs
+++ b/core/client/src/main.rs
@@ -338,6 +338,11 @@ fn start_audio_capture(app: tauri::AppHandle, pid: u32) -> Result<(), String> {
 }
 
 #[tauri::command]
+fn start_system_audio_capture(app: tauri::AppHandle) -> Result<(), String> {
+    audio_capture::start_system_capture(app).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
 fn stop_audio_capture() -> Result<(), String> {
     audio_capture::stop_capture();
     Ok(())
@@ -647,6 +652,7 @@ fn main() {
             load_settings,
             list_capturable_windows,
             start_audio_capture,
+            start_system_audio_capture,
             stop_audio_capture,
             list_audio_output_devices,
             check_for_updates,

--- a/core/client/src/screen_capture.rs
+++ b/core/client/src/screen_capture.rs
@@ -1345,27 +1345,88 @@ async fn share_loop_monitor(
 
     let mut drop_count: u64 = 0;
     let mut yuv_total_us: u64 = 0;
+    let mut publish_attempt_count: u64 = 0;
+    let mut last_publish_log_at = std::time::Instant::now();
+    let mut last_publish_attempt_count: u64 = 0;
+    let mut last_publish_frame_count: u64 = 0;
+    let mut last_sender_stats_at = std::time::Instant::now();
+    let mut last_frame: Option<(Vec<u8>, u32, u32)> = None;
+    let mut heartbeat = StaticFrameHeartbeat::new(STATIC_FRAME_HEARTBEAT_INTERVAL);
+    let mut heartbeat_attempt_count: u64 = 0;
+    let mut heartbeat_pushed_count: u64 = 0;
 
     while running.load(Ordering::SeqCst) {
-        let frame = match frame_rx.recv_timeout(std::time::Duration::from_millis(100)) {
-            Ok(f) => f,
-            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => continue,
+        let from_heartbeat = match frame_rx.recv_timeout(std::time::Duration::from_millis(100)) {
+            Ok(frame) => {
+                let mut latest = frame;
+                while let Ok(newer) = frame_rx.try_recv() {
+                    drop_count += 1;
+                    latest = newer;
+                }
+                heartbeat.record_fresh_frame(std::time::Instant::now());
+                last_frame = Some(latest);
+                false
+            }
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+                let now = std::time::Instant::now();
+                if last_frame.is_none() || !heartbeat.should_publish(now) {
+                    continue;
+                }
+                true
+            }
             Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => break,
         };
 
-        let mut latest = frame;
-        while let Ok(newer) = frame_rx.try_recv() {
-            drop_count += 1;
-            latest = newer;
-        }
-        let (bgra_data, width, height) = latest;
+        let Some((bgra_data, width, height)) = last_frame.as_ref() else {
+            continue;
+        };
 
         let t0 = std::time::Instant::now();
-        publisher.push_frame(&bgra_data, width, height);
+        publish_attempt_count += 1;
+        if from_heartbeat {
+            heartbeat_attempt_count += 1;
+        }
+        let pushed = publisher.push_frame(bgra_data, *width, *height);
+        if from_heartbeat && pushed {
+            heartbeat_pushed_count += 1;
+        }
         let t1 = std::time::Instant::now();
 
         yuv_total_us += (t1 - t0).as_micros() as u64;
         let fc = publisher.frame_count();
+
+        let now = std::time::Instant::now();
+        let interval = now.duration_since(last_publish_log_at).as_secs_f64();
+        if interval >= 2.0 {
+            let attempt_delta = publish_attempt_count - last_publish_attempt_count;
+            let pushed_delta = fc - last_publish_frame_count;
+            let attempt_fps = attempt_delta as f64 / interval;
+            let pushed_fps = pushed_delta as f64 / interval;
+            let paced_drops = attempt_delta.saturating_sub(pushed_delta);
+            file_debug_log::append(&format!(
+                "[wgc-monitor-publish] interval attempts_fps={:.1} pushed_fps={:.1} paced_drops={} total_pushed={} channel_drops={} heartbeat_attempts={} heartbeat_pushed={} last_pushed={} last_heartbeat={}",
+                attempt_fps,
+                pushed_fps,
+                paced_drops,
+                fc,
+                drop_count,
+                heartbeat_attempt_count,
+                heartbeat_pushed_count,
+                pushed,
+                from_heartbeat
+            ));
+            health.record_capture_fps(pushed_fps.round() as u32);
+            last_publish_log_at = now;
+            last_publish_attempt_count = publish_attempt_count;
+            last_publish_frame_count = fc;
+            heartbeat_attempt_count = 0;
+            heartbeat_pushed_count = 0;
+        }
+
+        if now.duration_since(last_sender_stats_at) >= std::time::Duration::from_secs(5) {
+            publisher.log_sender_stats("screen-capture-monitor").await;
+            last_sender_stats_at = now;
+        }
 
         if fc % 30 == 0 {
             let elapsed = publisher.elapsed().as_secs_f64();
@@ -1387,8 +1448,8 @@ async fn share_loop_monitor(
                 app,
                 "screen-capture-stats",
                 "wgc-monitor",
-                width,
-                height,
+                *width,
+                *height,
                 30,
             ) {
                 health.record_capture_fps(emit_fps);
@@ -1450,5 +1511,27 @@ mod tests {
         };
 
         assert_eq!(window_overlap_ratio(source, cover), 0.5);
+    }
+
+    #[test]
+    fn monitor_share_loop_uses_static_frame_heartbeat() {
+        let source = include_str!("screen_capture.rs");
+        let start = source
+            .find("async fn share_loop_monitor")
+            .expect("share_loop_monitor exists");
+        let tail = &source[start..];
+        let end = tail
+            .find("running.store(false")
+            .expect("share_loop_monitor shutdown marker exists");
+        let body = &tail[..end];
+
+        assert!(
+            body.contains("StaticFrameHeartbeat::new"),
+            "monitor capture must republish the last good frame when WGC stops callbacks"
+        );
+        assert!(
+            body.contains("heartbeat.should_publish"),
+            "monitor capture must use heartbeat cadence during callback stalls"
+        );
     }
 }

--- a/core/client/tauri.conf.json
+++ b/core/client/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "Echo Chamber",
-  "version": "0.6.13",
+  "version": "0.6.14",
   "identifier": "com.echochamber.app",
   "build": {
     "frontendDist": "../viewer"

--- a/core/client/tauri.conf.json
+++ b/core/client/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "Echo Chamber",
-  "version": "0.6.12",
+  "version": "0.6.13",
   "identifier": "com.echochamber.app",
   "build": {
     "frontendDist": "../viewer"

--- a/core/control/Cargo.toml
+++ b/core/control/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "echo-core-control"
-version = "0.6.13"
+version = "0.6.14"
 edition = "2021"
 
 [dependencies]
@@ -33,6 +33,7 @@ features = [
     "Win32_Foundation",
     "Win32_Media_Audio",
     "Win32_System_Com",
+    "Win32_System_Diagnostics_ToolHelp",
     "Win32_Security",
     "Win32_System_Registry",
     "Win32_System_Threading",

--- a/core/control/Cargo.toml
+++ b/core/control/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "echo-core-control"
-version = "0.6.12"
+version = "0.6.13"
 edition = "2021"
 
 [dependencies]

--- a/core/control/src/audio_capture.rs
+++ b/core/control/src/audio_capture.rs
@@ -13,6 +13,10 @@ mod platform {
     use windows::Win32::Foundation::*;
     use windows::Win32::Media::Audio::*;
     use windows::Win32::System::Com::*;
+    use windows::Win32::System::Diagnostics::ToolHelp::{
+        CreateToolhelp32Snapshot, Process32FirstW, Process32NextW, PROCESSENTRY32W,
+        TH32CS_SNAPPROCESS,
+    };
     use windows::Win32::System::Registry::*;
     use windows::Win32::System::Threading::*;
     use windows::Win32::UI::WindowsAndMessaging::*;
@@ -22,6 +26,7 @@ mod platform {
     const ACTIVATION_TYPE_PROCESS_LOOPBACK: u32 = 1;
     const LOOPBACK_MODE_INCLUDE_TREE: u32 = 0;
     const VT_BLOB: u16 = 65;
+    const BITS_PER_BYTE: u16 = 8;
 
     #[repr(C)]
     struct ProcessLoopbackParams {
@@ -221,12 +226,96 @@ mod platform {
 
     // --- Find Spotify ---
 
-    /// Search capturable windows for Spotify.exe and return its PID.
+    fn process_entry_name(entry: &PROCESSENTRY32W) -> String {
+        let len = entry
+            .szExeFile
+            .iter()
+            .position(|&c| c == 0)
+            .unwrap_or(entry.szExeFile.len());
+        String::from_utf16_lossy(&entry.szExeFile[..len])
+    }
+
+    fn find_processes_by_name(exe_name: &str) -> Vec<(u32, u32)> {
+        let mut processes = Vec::new();
+
+        unsafe {
+            let Ok(snapshot) = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0) else {
+                return processes;
+            };
+
+            let mut entry = PROCESSENTRY32W {
+                dwSize: std::mem::size_of::<PROCESSENTRY32W>() as u32,
+                ..Default::default()
+            };
+
+            if Process32FirstW(snapshot, &mut entry).is_ok() {
+                loop {
+                    let name = process_entry_name(&entry);
+                    if name.eq_ignore_ascii_case(exe_name) {
+                        processes.push((entry.th32ProcessID, entry.th32ParentProcessID));
+                    }
+
+                    entry.dwSize = std::mem::size_of::<PROCESSENTRY32W>() as u32;
+                    if Process32NextW(snapshot, &mut entry).is_err() {
+                        break;
+                    }
+                }
+            }
+
+            let _ = CloseHandle(snapshot);
+        }
+
+        processes
+    }
+
+    pub(super) fn select_root_process_pid(processes: &[(u32, u32)]) -> Option<u32> {
+        let pids: std::collections::HashSet<u32> = processes.iter().map(|(pid, _)| *pid).collect();
+        processes
+            .iter()
+            .find(|(_, parent_pid)| !pids.contains(parent_pid))
+            .or_else(|| processes.first())
+            .map(|(pid, _)| *pid)
+    }
+
+    /// Search running processes for Spotify.exe and return its root PID.
+    ///
+    /// The control plane normally runs as a Windows service in session 0, so it
+    /// cannot reliably enumerate the interactive user's visible Spotify window.
+    /// Process snapshot lookup works across sessions and the WASAPI process
+    /// loopback uses INCLUDE_TREE to capture child renderer/audio processes.
     pub fn find_spotify_pid() -> Option<u32> {
-        list_capturable_windows()
-            .into_iter()
-            .find(|w| w.exe_name.eq_ignore_ascii_case("Spotify.exe"))
-            .map(|w| w.pid)
+        select_root_process_pid(&find_processes_by_name("Spotify.exe")).or_else(|| {
+            list_capturable_windows()
+                .into_iter()
+                .find(|w| w.exe_name.eq_ignore_ascii_case("Spotify.exe"))
+                .map(|w| w.pid)
+        })
+    }
+
+    pub(super) fn process_loopback_initialize_flags(use_autoconvert: bool) -> u32 {
+        let flags = AUDCLNT_STREAMFLAGS_EVENTCALLBACK | AUDCLNT_STREAMFLAGS_LOOPBACK;
+        if use_autoconvert {
+            flags | AUDCLNT_STREAMFLAGS_AUTOCONVERTPCM
+        } else {
+            flags
+        }
+    }
+
+    pub(super) fn process_loopback_fallback_format() -> WAVEFORMATEX {
+        let channels = 2_u16;
+        let sample_rate = 44_100_u32;
+        let bits = 16_u16;
+        let block_align = channels * bits / BITS_PER_BYTE;
+
+        WAVEFORMATEX {
+            wFormatTag: WAVE_FORMAT_PCM as u16,
+            nChannels: channels,
+            nSamplesPerSec: sample_rate,
+            nAvgBytesPerSec: sample_rate * block_align as u32,
+            nBlockAlign: block_align,
+            wBitsPerSample: bits,
+            cbSize: 0,
+        }
     }
 
     // --- Start / Stop ---
@@ -317,7 +406,7 @@ mod platform {
             eprintln!("[audio-capture] got IAudioClient");
 
             // Get mix format
-            let (sample_rate, channels, bits, block_align, is_float, fmt_ptr_owned);
+            let (sample_rate, channels, bits, block_align, is_float);
             match client.GetMixFormat() {
                 Ok(ptr) => {
                     let fmt = &*ptr;
@@ -353,45 +442,33 @@ mod platform {
                     let buffer_duration: i64 = 200_000;
                     client.Initialize(
                         AUDCLNT_SHAREMODE_SHARED,
-                        AUDCLNT_STREAMFLAGS_EVENTCALLBACK | AUDCLNT_STREAMFLAGS_LOOPBACK,
+                        process_loopback_initialize_flags(false),
                         buffer_duration,
                         0,
                         ptr,
                         None,
                     )?;
-                    fmt_ptr_owned = None;
                 }
                 Err(e) => {
                     eprintln!(
-                        "[audio-capture] GetMixFormat failed: {} — using default 48kHz stereo float32",
+                        "[audio-capture] GetMixFormat failed: {} — using default 44.1kHz stereo PCM16",
                         e
                     );
 
-                    sample_rate = 48000;
-                    channels = 2;
-                    bits = 32;
+                    let default_fmt = process_loopback_fallback_format();
+                    sample_rate = default_fmt.nSamplesPerSec;
+                    channels = default_fmt.nChannels as u32;
+                    bits = default_fmt.wBitsPerSample;
                     block_align = channels as usize * bits as usize / 8;
-                    is_float = true;
-
-                    let default_fmt = WAVEFORMATEX {
-                        wFormatTag: 3,
-                        nChannels: channels as u16,
-                        nSamplesPerSec: sample_rate,
-                        nAvgBytesPerSec: sample_rate * block_align as u32,
-                        nBlockAlign: block_align as u16,
-                        wBitsPerSample: bits as u16,
-                        cbSize: 0,
-                    };
-                    fmt_ptr_owned = Some(default_fmt);
+                    is_float = false;
 
                     let buffer_duration: i64 = 200_000;
-                    let fmt_ref = fmt_ptr_owned.as_ref().unwrap() as *const WAVEFORMATEX;
                     client.Initialize(
                         AUDCLNT_SHAREMODE_SHARED,
-                        AUDCLNT_STREAMFLAGS_EVENTCALLBACK | AUDCLNT_STREAMFLAGS_LOOPBACK,
+                        process_loopback_initialize_flags(true),
                         buffer_duration,
                         0,
-                        fmt_ref,
+                        &default_fmt as *const WAVEFORMATEX,
                         None,
                     )?;
                 }
@@ -504,6 +581,61 @@ mod platform {
             eprintln!("[audio-capture] stopped for PID {}", pid);
             Ok(())
         }
+    }
+}
+
+#[cfg(all(test, windows))]
+mod tests {
+    use super::platform::{
+        process_loopback_fallback_format, process_loopback_initialize_flags,
+        select_root_process_pid,
+    };
+    use windows::Win32::Media::Audio::{
+        AUDCLNT_STREAMFLAGS_AUTOCONVERTPCM, AUDCLNT_STREAMFLAGS_EVENTCALLBACK,
+        AUDCLNT_STREAMFLAGS_LOOPBACK,
+    };
+
+    #[test]
+    fn selects_root_spotify_process_for_include_tree_capture() {
+        let processes = vec![(19836, 2360), (29512, 19836), (30340, 19836)];
+
+        assert_eq!(select_root_process_pid(&processes), Some(19836));
+    }
+
+    #[test]
+    fn falls_back_to_first_process_when_all_parents_are_spotify() {
+        let processes = vec![(10, 11), (11, 10)];
+
+        assert_eq!(select_root_process_pid(&processes), Some(10));
+    }
+
+    #[test]
+    fn process_loopback_fallback_uses_pcm16_format() {
+        let format = process_loopback_fallback_format();
+        let format_tag = format.wFormatTag;
+        let channels = format.nChannels;
+        let sample_rate = format.nSamplesPerSec;
+        let bits = format.wBitsPerSample;
+        let block_align = format.nBlockAlign;
+        let avg_bytes_per_sec = format.nAvgBytesPerSec;
+        let cb_size = format.cbSize;
+
+        assert_eq!(format_tag, 1);
+        assert_eq!(channels, 2);
+        assert_eq!(sample_rate, 44_100);
+        assert_eq!(bits, 16);
+        assert_eq!(block_align, 4);
+        assert_eq!(avg_bytes_per_sec, 176_400);
+        assert_eq!(cb_size, 0);
+    }
+
+    #[test]
+    fn process_loopback_fallback_enables_autoconvertpcm() {
+        let flags = process_loopback_initialize_flags(true);
+
+        assert_ne!(flags & AUDCLNT_STREAMFLAGS_EVENTCALLBACK, 0);
+        assert_ne!(flags & AUDCLNT_STREAMFLAGS_LOOPBACK, 0);
+        assert_ne!(flags & AUDCLNT_STREAMFLAGS_AUTOCONVERTPCM, 0);
     }
 }
 

--- a/core/control/src/jam_bot.rs
+++ b/core/control/src/jam_bot.rs
@@ -95,15 +95,30 @@ async fn broadcast_loop(tx: broadcast::Sender<AudioFrame>, mut rx: mpsc::Receive
         // Drain full 20 ms frames
         while accum.len() >= FRAME_SAMPLES {
             let frame_data: Vec<f32> = accum.drain(..FRAME_SAMPLES).collect();
-            let frame = AudioFrame { data: frame_data };
 
             // broadcast::send only fails if there are zero receivers — that's fine
-            let _ = tx.send(frame);
-
             frame_count += 1;
             if frame_count == 1 {
                 info!("[jam-bot] first audio frame broadcast");
             }
+            if frame_count == 1 || frame_count % 250 == 0 {
+                let peak = frame_data
+                    .iter()
+                    .fold(0.0_f32, |acc, sample| acc.max(sample.abs()));
+                let rms = if frame_data.is_empty() {
+                    0.0
+                } else {
+                    let sum_sq: f32 = frame_data.iter().map(|sample| sample * sample).sum();
+                    (sum_sq / frame_data.len() as f32).sqrt()
+                };
+                info!(
+                    "[jam-bot] frame level frame={} peak={:.6} rms={:.6}",
+                    frame_count, peak, rms
+                );
+            }
+
+            let frame = AudioFrame { data: frame_data };
+            let _ = tx.send(frame);
         }
     }
 

--- a/core/control/src/jam_session.rs
+++ b/core/control/src/jam_session.rs
@@ -375,40 +375,51 @@ pub(crate) async fn stop_jam_bot(state: &AppState) {
     }
 }
 
+fn apply_jam_start_result(jam: &mut JamState, identity: String, bot_started: bool) -> bool {
+    if !bot_started {
+        return false;
+    }
+
+    jam.active = true;
+    jam.host_identity = identity.clone();
+    jam.listeners.insert(identity);
+    true
+}
+
 pub(crate) async fn jam_start(
     State(state): State<AppState>,
     headers: HeaderMap,
     Json(payload): Json<JamStartRequest>,
-) -> Result<Json<serde_json::Value>, StatusCode> {
-    ensure_admin(&state, &headers)?;
+) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
+    ensure_admin(&state, &headers).map_err(|status| (status, String::new()))?;
+
+    {
+        let jam = state.jam.lock().unwrap_or_else(|e| e.into_inner());
+        if jam.spotify_token.is_none() {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                "Spotify is not connected".to_string(),
+            ));
+        }
+    }
+
+    let bot = crate::jam_bot::JamBot::start().await.map_err(|e| {
+        warn!("Jam audio bot failed to start: {}", e);
+        (StatusCode::SERVICE_UNAVAILABLE, e)
+    })?;
+
+    stop_jam_bot(&state).await;
+    *state.jam_bot.lock().await = Some(bot);
+    info!("Jam audio bot started successfully");
 
     {
         let mut jam = state.jam.lock().unwrap_or_else(|e| e.into_inner());
-        if jam.spotify_token.is_none() {
-            return Err(StatusCode::BAD_REQUEST);
-        }
-        jam.active = true;
-        jam.host_identity = payload.identity.clone();
-        jam.listeners.insert(payload.identity);
+        apply_jam_start_result(&mut jam, payload.identity.clone(), true);
         info!(
             "Jam session started by {} (auto-joined as listener)",
             jam.host_identity
         );
     }
-
-    // Spawn the audio bot in background (don't block the response)
-    let bot_state = state.clone();
-    tokio::spawn(async move {
-        match crate::jam_bot::JamBot::start().await {
-            Ok(bot) => {
-                info!("Jam audio bot started successfully");
-                *bot_state.jam_bot.lock().await = Some(bot);
-            }
-            Err(e) => {
-                warn!("Jam audio bot failed to start: {}", e);
-            }
-        }
-    });
 
     Ok(Json(serde_json::json!({ "ok": true })))
 }
@@ -928,4 +939,47 @@ async fn jam_audio_ws_handler(mut socket: WebSocket, state: AppState) {
     }
 
     info!("[jam-audio-ws] client disconnected");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn spotify_token() -> SpotifyToken {
+        SpotifyToken {
+            access_token: "access".to_string(),
+            refresh_token: "refresh".to_string(),
+            expires_at: 999_999,
+        }
+    }
+
+    #[test]
+    fn failed_bot_start_does_not_activate_jam() {
+        let mut jam = JamState {
+            spotify_token: Some(spotify_token()),
+            ..JamState::default()
+        };
+
+        let activated = apply_jam_start_result(&mut jam, "sam-7475".to_string(), false);
+
+        assert!(!activated);
+        assert!(!jam.active);
+        assert!(jam.host_identity.is_empty());
+        assert!(jam.listeners.is_empty());
+    }
+
+    #[test]
+    fn successful_bot_start_activates_host_listener() {
+        let mut jam = JamState {
+            spotify_token: Some(spotify_token()),
+            ..JamState::default()
+        };
+
+        let activated = apply_jam_start_result(&mut jam, "sam-7475".to_string(), true);
+
+        assert!(activated);
+        assert!(jam.active);
+        assert_eq!(jam.host_identity, "sam-7475");
+        assert!(jam.listeners.contains("sam-7475"));
+    }
 }

--- a/core/docs/AUDIO_PIPELINE.md
+++ b/core/docs/AUDIO_PIPELINE.md
@@ -1,53 +1,57 @@
 # Audio Pipeline
 
-## Game Audio Capture (WASAPI Process Loopback)
+## Native Screen-Share Audio Capture (WASAPI Process Loopback)
 
 Captures audio output from a specific process using WASAPI's process loopback API, available on Windows 10 build 20348+ (Server 2022) and Windows 11.
 
 **SAM-PC (GTX 760, Win10 build 19045) does not support this.** Process loopback requires build 20348+.
 
-### Rust Module
+### Rust Modules
 
 `core/client/src/audio_capture.rs`
 
 Uses `AUDIOCLIENT_ACTIVATION_TYPE_PROCESS_LOOPBACK` (constant = 1) with `PROCESS_LOOPBACK_MODE_INCLUDE_TARGET_PROCESS_TREE` to capture all audio from the target process and its child processes.
 
+`core/admin-client/src/audio_capture.rs` carries the same local-admin capture path.
+
+When `IAudioClient::GetMixFormat` is unavailable for process loopback, Echo initializes with stereo PCM16 at 44.1 kHz plus `AUDCLNT_STREAMFLAGS_AUTOCONVERTPCM`, then converts captured PCM16 samples to float32 before sending them to the viewer. Do not fall back to raw 48 kHz float32 without autoconvert; that path can produce silent frames.
+
 ### Full Pipeline
 
-```
-[Game process — audio output]
-  │
-  ▼ WASAPI AUDIOCLIENT_ACTIVATION_TYPE_PROCESS_LOOPBACK
-[PCM float32 chunks — 44100/48000 Hz, stereo]
-  │
-  ▼ base64::encode (Engine::encode)
+```text
+[Target process audio output]
+  |
+  v WASAPI AUDIOCLIENT_ACTIVATION_TYPE_PROCESS_LOOPBACK
+[PCM float32 chunks - 44100/48000 Hz, stereo]
+  |
+  v base64::encode (Engine::encode)
 [base64 string]
-  │
-  ▼ tauri::Emitter — event "audio-chunk"
-[Tauri IPC event → WebView2]
-  │
-  ▼ JS event listener in screen-share-native.js
+  |
+  v tauri::Emitter - event "audio-capture-data"
+[Tauri IPC event -> WebView2]
+  |
+  v JS event listener in screen-share-native.js
 [ArrayBuffer from base64 decode]
-  │
-  ▼ AudioWorklet (rnnoise-processor.js or passthrough)
+  |
+  v AudioWorklet (rnnoise-processor.js or passthrough)
 [processed audio frames]
-  │
-  ▼ MediaStreamDestination node
+  |
+  v MediaStreamDestination node
 [MediaStream]
-  │
-  ▼ LiveKit publishTrack({ dtx: false, red: false, audioBitrate: 128000 })
-[Opus audio → SFU → all participants]
+  |
+  v LiveKit publishTrack({ dtx: false, red: false, audioBitrate: 128000 })
+[Opus audio -> SFU -> all participants]
 ```
 
 ### JS Entry Point
 
 `startNativeAudioCapture()` in `screen-share-native.js`:
 
-1. Calls `tauriInvoke('list_capturable_windows')` — returns `WindowInfo[]` (pid, hwnd, title, exe_name)
-2. User selects process from picker
-3. Calls `tauriInvoke('start_audio_capture', { pid })` — begins WASAPI capture loop in background thread
-4. Registers `window.__TAURI__.event.listen('audio-chunk', ...)` event handler
-5. Feeds PCM data into AudioWorklet → MediaStreamDestination → LiveKit track
+1. Calls `tauriInvoke('list_capturable_windows')` and receives `WindowInfo[]` (pid, hwnd, title, exe_name).
+2. User selects process from picker.
+3. Calls `tauriInvoke('start_audio_capture', { pid })`, which begins the WASAPI capture loop in a background thread.
+4. Registers `window.__TAURI__.event.listen('audio-capture-data', ...)`.
+5. Feeds PCM data into AudioWorklet -> MediaStreamDestination -> LiveKit track.
 
 **Important:** Use `startNativeAudioCapture()`, not a raw `tauriInvoke`. The function sets up the event listener, the AudioWorklet, and the LiveKit track in the correct order. Calling `tauriInvoke('start_audio_capture')` directly without the listener means audio data is emitted but nobody reads it.
 
@@ -55,16 +59,18 @@ Uses `AUDIOCLIENT_ACTIVATION_TYPE_PROCESS_LOOPBACK` (constant = 1) with `PROCESS
 
 | Command | Direction | Purpose |
 |---------|-----------|---------|
-| `list_capturable_windows` | JS → Rust | Enumerate visible windows with PIDs |
-| `start_audio_capture` | JS → Rust | Start WASAPI loop for given PID |
-| `stop_audio_capture` | JS → Rust | Stop capture loop |
-| `audio-chunk` event | Rust → JS | PCM float32 chunk as base64 |
+| `list_capturable_windows` | JS -> Rust | Enumerate visible windows with PIDs |
+| `start_audio_capture` | JS -> Rust | Start WASAPI loop for given PID |
+| `stop_audio_capture` | JS -> Rust | Stop capture loop |
+| `audio-capture-format` event | Rust -> JS | Captured WASAPI format metadata |
+| `audio-capture-data` event | Rust -> JS | PCM float32 chunk as base64 |
 
 ### DTX Must Be Disabled
 
-Screen share audio published with DTX (Discontinuous Transmission) enabled causes audio to cut out during screen shares — DTX suppresses "silent" frames which in the context of game audio means any pause in sound effects.
+Screen share audio published with DTX (Discontinuous Transmission) enabled causes audio to cut out during screen shares because DTX suppresses "silent" frames, which in the context of game audio means any pause in sound effects.
 
 Always publish with:
+
 ```js
 { dtx: false, red: false, audioBitrate: 128000 }
 ```
@@ -72,16 +78,19 @@ Always publish with:
 ## Standard Mic/Camera Audio
 
 Normal microphone audio uses the standard LiveKit SDK flow:
+
 - `room.localParticipant.setMicrophoneEnabled(true)`
-- WebRTC handles device enumeration, MediaStream acquisition, Opus encoding
-- RNNoise noise suppression applied via AudioWorklet (`rnnoise.js`, `rnnoise-processor.js`) if enabled in settings
+- WebRTC handles device enumeration, MediaStream acquisition, and Opus encoding
+- RNNoise noise suppression is applied via AudioWorklet (`rnnoise.js`, `rnnoise-processor.js`) if enabled in settings
 
 ## Jam Session Audio (Spotify)
 
-VB-Cable routes Spotify output as a virtual mic input. Sam selects the VB-Cable device as his microphone when hosting a Jam Session. The audio goes through normal WebRTC mic publish path.
+JamBot captures Spotify from the control plane with `core/control/src/audio_capture.rs`. It finds `Spotify.exe`, starts WASAPI process loopback with `INCLUDE_TARGET_PROCESS_TREE`, converts chunks to 48 kHz stereo 20 ms float32 frames, and serves them to viewers over `/api/jam/audio`.
 
-WASAPI output device switching (`set_audio_output_device`) was removed — changing the system-wide default is too dangerous. WebView2's `setSinkId` is a silent no-op.
+The control-plane capture path uses the same PCM16 44.1 kHz autoconvert fallback described above. Jam audio does not depend on WebRTC mic publishing or VB-Cable in this flow.
+
+WASAPI output device switching (`set_audio_output_device`) was removed because changing the system-wide default is too dangerous. WebView2's `setSinkId` is a silent no-op.
 
 ## Platform Stubs
 
-`core/client/src/audio_capture_stub.rs` and `audio_output_stub.rs` are compiled on non-Windows targets. They return empty lists and no-op all operations, keeping the build clean on macOS/Linux.
+`core/client/src/audio_capture_stub.rs`, `core/admin-client/src/audio_capture_stub.rs`, and `audio_output_stub.rs` are compiled on non-Windows targets. They return empty lists and no-op all operations, keeping the build clean on macOS/Linux.

--- a/core/viewer/screen-share-native.js
+++ b/core/viewer/screen-share-native.js
@@ -26,6 +26,22 @@ function _captureSourceVisibilityToastMessage(status) {
   return status.warning + '. Keep the shared window visible while sharing.';
 }
 
+function nativeAudioCaptureRequestForSource(source) {
+  if (!source) return null;
+  if (source.sourceType === 'monitor') {
+    return { mode: 'system', pid: 0, toast: 'System audio streaming' };
+  }
+  if ((source.sourceType === 'game' || source.sourceType === 'window') &&
+      source.pid && source.pid > 0) {
+    return {
+      mode: 'process',
+      pid: source.pid,
+      toast: source.sourceType === 'game' ? 'Game audio streaming' : 'Window audio streaming'
+    };
+  }
+  return null;
+}
+
 function _stopSourceVisibilityMonitor() {
   if (_sourceVisibilityInterval) {
     clearInterval(_sourceVisibilityInterval);
@@ -326,14 +342,16 @@ async function startScreenShareManual() {
       showToast('Screen sharing started (' + modeLabel + ')', 4000);
 
       // Immediately start WASAPI per-process audio + publish pipeline using picker's PID
-      if (source.sourceType === 'game' && source.pid && source.pid > 0) {
-        debugLog('[audio] auto-starting native audio capture+publish for PID ' + source.pid);
-        startNativeAudioCapture(source.pid).then(function() {
-          debugLog('[audio] native audio pipeline started for PID ' + source.pid);
-          showToast('Game audio streaming', 3000);
+      var audioRequest = nativeAudioCaptureRequestForSource(source);
+      if (audioRequest) {
+        var audioLabel = audioRequest.mode === 'system' ? 'system loopback' : 'PID ' + audioRequest.pid;
+        debugLog('[audio] auto-starting native audio capture+publish for ' + audioLabel);
+        startNativeAudioCapture(audioRequest.pid, { system: audioRequest.mode === 'system' }).then(function() {
+          debugLog('[audio] native audio pipeline started for ' + audioLabel);
+          showToast(audioRequest.toast, 3000);
         }).catch(function(e) {
           debugLog('[audio] native audio failed: ' + e);
-          showToast('Game audio failed: ' + e, 8000);
+          showToast('Screen audio failed: ' + e, 8000);
         });
       } else {
         debugLog('[audio] skipped — type=' + source.sourceType + ' pid=' + (source.pid || 'none'));
@@ -1290,6 +1308,7 @@ async function startNativeAudioCapture(pid, opts) {
   var LK = getLiveKitClient();
   var trackSource = opts.source || LK.Track.Source.ScreenShareAudio;
   var trackName = opts.name || undefined;
+  var useSystemLoopback = !!opts.system;
 
   // Create AudioContext — DON'T hardcode sample rate, let it match system default
   // WASAPI will report its actual format and we adapt
@@ -1383,8 +1402,13 @@ async function startNativeAudioCapture(pid, opts) {
   };
 
   // Start the WASAPI capture on Rust side
-  await tauriInvoke("start_audio_capture", { pid: pid });
-  debugLog("[native-audio] WASAPI started for PID " + pid);
+  if (useSystemLoopback) {
+    await tauriInvoke("start_system_audio_capture");
+    debugLog("[native-audio] WASAPI started for system loopback");
+  } else {
+    await tauriInvoke("start_audio_capture", { pid: pid });
+    debugLog("[native-audio] WASAPI started for PID " + pid);
+  }
 
   // Publish the audio track via LiveKit
   var audioTrack = _nativeAudioDest.stream.getAudioTracks()[0];

--- a/core/viewer/screen-share-native.test.js
+++ b/core/viewer/screen-share-native.test.js
@@ -103,3 +103,24 @@ test("source visibility monitor is only enabled for native window-like sources",
     false
   );
 });
+
+test("native audio capture request covers window and monitor shares", () => {
+  const { context } = loadScreenShareNative();
+
+  assert.equal(
+    JSON.stringify(context.nativeAudioCaptureRequestForSource({ sourceType: "window", pid: 1234 })),
+    JSON.stringify({ mode: "process", pid: 1234, toast: "Window audio streaming" })
+  );
+  assert.equal(
+    JSON.stringify(context.nativeAudioCaptureRequestForSource({ sourceType: "game", pid: 5678 })),
+    JSON.stringify({ mode: "process", pid: 5678, toast: "Game audio streaming" })
+  );
+  assert.equal(
+    JSON.stringify(context.nativeAudioCaptureRequestForSource({ sourceType: "monitor", pid: 0 })),
+    JSON.stringify({ mode: "system", pid: 0, toast: "System audio streaming" })
+  );
+  assert.equal(
+    context.nativeAudioCaptureRequestForSource({ sourceType: "window", pid: 0 }),
+    null
+  );
+});

--- a/docs/handovers/2026-05-13-jam-audio-silence.md
+++ b/docs/handovers/2026-05-13-jam-audio-silence.md
@@ -1,0 +1,78 @@
+# 2026-05-13 Jam Audio Silence Handover
+
+## Active Worktree
+
+- Path: `F:\EC-worktrees\jam-audio-silence`
+- Branch: `codex/jam-audio-silence-investigation`
+- Base: `main` at `ad8fd6d7` (`v0.6.13`)
+
+## Problem
+
+Sam reported that the Jam session had no audio even though Spotify looked active. Restarting the Jam bot and changing Spotify output did not restore audio.
+
+Sam later reported that Echo also could not receive screen-share audio, making this look like a broader process-loopback audio problem rather than a Jam-only problem.
+
+## Evidence Gathered
+
+- Live server reported `0.6.13` and was running from `F:\EC-worktrees\main\core\target\release\echo-core-control.exe`.
+- Jam bot connected and broadcast frames, but frame-level logs stayed at `peak=0.000000 rms=0.000000`.
+- A WebSocket sample from `/api/jam/audio` received 7680-byte binary frames, but decoded f32 samples were all zero.
+- Spotify playback was active after a Spotify API resume call.
+- Windows audio-session probing showed Spotify producing nonzero audio on an output endpoint in the earlier capture, so the silence was isolated to Echo's process-loopback capture path.
+- Microsoft's official ApplicationLoopback sample initializes process loopback with fixed PCM16 44.1 kHz format plus `AUDCLNT_STREAMFLAGS_AUTOCONVERTPCM`; Echo's fallback path was using 48 kHz float32 without autoconvert after `GetMixFormat` returned `E_NOTIMPL`.
+- Native screen-share audio uses duplicated process-loopback code in `core/client/src/audio_capture.rs`; that copy still had the same old 48 kHz float32 fallback. `core/admin-client/src/audio_capture.rs` had the same stale local-admin copy.
+
+## Code Changes In This Worktree
+
+- `core/control/src/audio_capture.rs`
+  - Keeps the cross-session Spotify process snapshot lookup and root PID selection.
+  - Adds a tested process-loopback fallback format: stereo PCM16, 44.1 kHz, 16-bit, 4-byte block align.
+  - Adds `AUDCLNT_STREAMFLAGS_AUTOCONVERTPCM` when using the fallback format.
+  - Converts fallback PCM16 samples to f32 through the existing int16 conversion path.
+- `core/client/src/audio_capture.rs`
+  - Applies the same tested PCM16 44.1 kHz fallback and `AUDCLNT_STREAMFLAGS_AUTOCONVERTPCM` to native screen-share audio capture.
+- `core/admin-client/src/audio_capture.rs`
+  - Applies the same fallback fix to the local admin shell copy.
+- `core/control/src/jam_bot.rs`
+  - Keeps frame-level peak/RMS logging at frame 1 and every 250 frames.
+- `core/control/Cargo.toml`
+  - Enables `Win32_System_Diagnostics_ToolHelp` for process snapshot lookup.
+- `core/docs/AUDIO_PIPELINE.md`
+  - Documents the shared process-loopback fallback and current `audio-capture-data` / `audio-capture-format` Tauri events.
+
+## Verification
+
+Run from `F:\EC-worktrees\jam-audio-silence\core`:
+
+```powershell
+cargo test -p echo-core-control audio_capture
+cargo test -p echo-core-client audio_capture
+cargo test -p echo-core-admin audio_capture
+cargo check -p echo-core-control
+cargo check -p echo-core-client
+cargo check -p echo-core-admin
+```
+
+Current results:
+
+- `cargo test -p echo-core-control audio_capture`: 4 passed, 0 failed.
+- `cargo test -p echo-core-client audio_capture`: 2 passed, 0 failed.
+- `cargo test -p echo-core-admin audio_capture`: 2 passed, 0 failed.
+- `cargo check -p echo-core-control`: exit 0.
+- `cargo check -p echo-core-client`: exit 0.
+- `cargo check -p echo-core-admin`: exit 0.
+- Existing warnings remain in unrelated files: unused imports in `chat.rs`, `rooms.rs`, generated dependency/local SDK warnings, and client capture/screen capture dead-code warnings.
+
+## Deployment Boundary
+
+This fix is not live yet. It changes the server/control binary and the desktop/admin client binaries. To test Jam live, build `echo-core-control.exe` from this worktree and restart the control service or EchoCoreHost-managed control child. To test native screen-share audio live, rebuild/relaunch the desktop client from this worktree. Those actions can disrupt connected users or Sam's local Echo client, so do not do them without Sam explicitly approving a restart/deploy/relaunch window.
+
+## Resume Prompt
+
+If Sam starts a fresh thread in this worktree and says `continue`, load `AGENTS.md`, `START_HERE.md`, `docs/OPERATIONS.md`, `docs/RELEASE-BOUNDARIES.md`, and this handover. Then:
+
+1. Confirm git status and live service state.
+2. Re-run `cargo test -p echo-core-control audio_capture`, `cargo test -p echo-core-client audio_capture`, and `cargo test -p echo-core-admin audio_capture`.
+3. Ask Sam before any build/deploy/restart/relaunch.
+4. If Sam approves Jam live testing, build the control binary, deploy it to the configured live path, restart the control service/host, restart the Jam bot, and confirm nonzero `[jam-bot] frame level` peak/RMS.
+5. If Sam approves screen-share audio live testing, rebuild/relaunch the desktop client, start a native game/window share with audio, and confirm `[native-audio] FIRST NON-SILENT chunk` plus remote screen-audio analyser activity.


### PR DESCRIPTION
## Summary
- start native screen-share audio for window and monitor shares, using system loopback for full-screen captures
- add the desktop IPC for system audio capture and fix WASAPI fallback to PCM16 44.1 kHz with autoconvert
- improve Jam Spotify process selection and add frame-level diagnostics

## Release impact
- Both: server/control restart for Jam capture changes and desktop binary release for native screen-share audio IPC/fallback

## Verification
- node --test core/viewer/screen-share-native.test.js
- cargo test -p echo-core-client audio_capture
- cargo test -p echo-core-control audio_capture
- cargo test -p echo-core-admin audio_capture
- cargo build --release -p echo-core-client
- cargo build --release -p echo-core-control
- live runtime viewer patched and verified over https://127.0.0.1:9443/viewer/screen-share-native.js