### PR TITLE
[codex] Fix native audio format adaptation

### DIFF
--- a/core/viewer/screen-share-native.js
+++ b/core/viewer/screen-share-native.js
@@ -1160,25 +1160,85 @@ var _nativeAudioWorkletCode = [
   "class NativeAudioProcessor extends AudioWorkletProcessor {",
   "  constructor() {",
   "    super();",
-  "    this.buf = new Float32Array(96000);", // ~1s at 48kHz stereo
-  "    this.wr = 0; this.rd = 0; this.len = 96000;",
+  "    this.frameCap = 48000;",
+  "    this.buf = new Float32Array(this.frameCap * 2);",
+  "    this.wr = 0; this.rd = 0; this.available = 0;",
+  "    this.inputChannels = 2;",
+  "    this.inputSampleRate = sampleRate;",
+  "    this.resamplePos = 0;",
   "    this.port.onmessage = (e) => {",
-  "      var samples = e.data;",
-  "      for (var i = 0; i < samples.length; i++) {",
-  "        this.buf[this.wr] = samples[i];",
-  "        this.wr = (this.wr + 1) % this.len;",
+  "      var msg = e.data;",
+  "      if (msg && msg.type === 'format') {",
+  "        this.inputChannels = Math.max(1, Math.min(8, msg.channels || 2));",
+  "        this.inputSampleRate = Math.max(8000, Math.min(192000, msg.sampleRate || sampleRate));",
+  "        this.resamplePos = 0;",
+  "        return;",
   "      }",
+  "      var samples = msg && msg.type === 'samples' ? msg.samples : msg;",
+  "      if (!samples || !samples.length) return;",
+  "      this.writeSamples(samples);",
   "    };",
+  "  }",
+  "  readFrame(samples, frame, channels) {",
+  "    var base = frame * channels;",
+  "    var l = samples[base] || 0;",
+  "    var r = channels > 1 ? (samples[base + 1] || 0) : l;",
+  "    if (channels === 3) {",
+  "      l += (samples[base + 2] || 0) * 0.707;",
+  "      r += (samples[base + 2] || 0) * 0.707;",
+  "    } else if (channels === 4) {",
+  "      l = (l + (samples[base + 2] || 0)) * 0.707;",
+  "      r = (r + (samples[base + 3] || 0)) * 0.707;",
+  "    } else if (channels >= 5) {",
+  "      l += (samples[base + 2] || 0) * 0.707;",
+  "      r += (samples[base + 2] || 0) * 0.707;",
+  "      l += (samples[base + 4] || 0) * 0.5;",
+  "      r += (samples[base + 5] || 0) * 0.5;",
+  "      if (channels >= 8) {",
+  "        l += (samples[base + 6] || 0) * 0.5;",
+  "        r += (samples[base + 7] || 0) * 0.5;",
+  "      }",
+  "      l *= 0.75; r *= 0.75;",
+  "    }",
+  "    return [Math.max(-1, Math.min(1, l)), Math.max(-1, Math.min(1, r))];",
+  "  }",
+  "  writeFrame(l, r) {",
+  "    var pos = this.wr * 2;",
+  "    this.buf[pos] = l; this.buf[pos + 1] = r;",
+  "    this.wr = (this.wr + 1) % this.frameCap;",
+  "    if (this.available < this.frameCap) this.available++;",
+  "    else this.rd = (this.rd + 1) % this.frameCap;",
+  "  }",
+  "  writeSamples(samples) {",
+  "    var channels = this.inputChannels || 2;",
+  "    var srcFrames = Math.floor(samples.length / channels);",
+  "    if (srcFrames <= 0) return;",
+  "    var ratio = (this.inputSampleRate || sampleRate) / sampleRate;",
+  "    var pos = Math.max(0, this.resamplePos || 0);",
+  "    while (pos < srcFrames) {",
+  "      var idx = Math.floor(pos);",
+  "      var frac = pos - idx;",
+  "      var a = this.readFrame(samples, idx, channels);",
+  "      var b = this.readFrame(samples, Math.min(idx + 1, srcFrames - 1), channels);",
+  "      this.writeFrame(a[0] + (b[0] - a[0]) * frac, a[1] + (b[1] - a[1]) * frac);",
+  "      pos += ratio;",
+  "    }",
+  "    this.resamplePos = pos - srcFrames;",
   "  }",
   "  process(inputs, outputs) {",
   "    var out = outputs[0];",
-  "    var ch = out.length;",
   "    for (var i = 0; i < out[0].length; i++) {",
-  "      for (var c = 0; c < ch; c++) {",
-  "        if (this.rd !== this.wr) {",
-  "          out[c][i] = this.buf[this.rd];",
-  "          this.rd = (this.rd + 1) % this.len;",
-  "        } else { out[c][i] = 0; }",
+  "      if (this.available > 0) {",
+  "        var pos = this.rd * 2;",
+  "        var l = this.buf[pos];",
+  "        var r = this.buf[pos + 1];",
+  "        this.rd = (this.rd + 1) % this.frameCap;",
+  "        this.available--;",
+  "        out[0][i] = l;",
+  "        if (out.length > 1) out[1][i] = r;",
+  "      } else {",
+  "        out[0][i] = 0;",
+  "        if (out.length > 1) out[1][i] = 0;",
   "      }",
   "    }",
   "    return true;",
@@ -1340,6 +1400,17 @@ async function startNativeAudioCapture(pid, opts) {
   var formatUn = await tauriListen("audio-capture-format", function (ev) {
     captureFormat = ev.payload;
     debugLog("[native-audio] WASAPI format: " + JSON.stringify(captureFormat));
+    if (_nativeAudioWorklet) {
+      _nativeAudioWorklet.port.postMessage({
+        type: "format",
+        channels: Number(captureFormat && captureFormat.channels) || 2,
+        sampleRate: Number(captureFormat && captureFormat.sampleRate) || _nativeAudioCtx.sampleRate,
+      });
+    }
+    if (captureFormat && (Number(captureFormat.channels) !== 2 || Number(captureFormat.sampleRate) !== _nativeAudioCtx.sampleRate)) {
+      debugLog("[native-audio] adapting WASAPI " + captureFormat.channels + "ch @" + captureFormat.sampleRate +
+        "Hz to browser stereo @" + _nativeAudioCtx.sampleRate + "Hz");
+    }
   });
 
   _nativeAudioUnlisten = await tauriListen("audio-capture-data", function (ev) {
@@ -1377,7 +1448,7 @@ async function startNativeAudioCapture(pid, opts) {
 
       // Send to AudioWorklet
       if (_nativeAudioWorklet) {
-        _nativeAudioWorklet.port.postMessage(floats);
+        _nativeAudioWorklet.port.postMessage({ type: "samples", samples: floats });
       }
     } catch (e) {
       debugLog("[native-audio] decode error: " + e);

--- a/core/viewer/screen-share-native.test.js
+++ b/core/viewer/screen-share-native.test.js
@@ -66,6 +66,33 @@ function loadScreenShareNative() {
   return { context, calls };
 }
 
+function loadNativeAudioProcessor(code) {
+  const registered = {};
+  const context = {
+    sampleRate: 48000,
+    Float32Array,
+    Math,
+    AudioWorkletProcessor: class {
+      constructor() {
+        this.port = { onmessage: null };
+      }
+    },
+    registerProcessor(name, processor) {
+      registered[name] = processor;
+    },
+  };
+  vm.createContext(context);
+  vm.runInContext(code, context, { filename: "native-audio-worklet.js" });
+  return new registered["native-audio-proc"]();
+}
+
+function assertFloatArrayApprox(actual, expected) {
+  assert.equal(actual.length, expected.length);
+  for (let i = 0; i < actual.length; i++) {
+    assert.ok(Math.abs(actual[i] - expected[i]) < 1e-6, `index ${i}: ${actual[i]} !== ${expected[i]}`);
+  }
+}
+
 test("game WGC fallback keeps the high-motion publish profile", async () => {
   const { context, calls } = loadScreenShareNative();
 
@@ -123,4 +150,40 @@ test("native audio capture request covers window and monitor shares", () => {
     context.nativeAudioCaptureRequestForSource({ sourceType: "window", pid: 0 }),
     null
   );
+});
+
+test("native audio worklet downmixes multichannel WASAPI frames to stereo", () => {
+  const { context } = loadScreenShareNative();
+  const processor = loadNativeAudioProcessor(context._nativeAudioWorkletCode);
+
+  processor.port.onmessage({ data: { type: "format", channels: 4, sampleRate: 48000 } });
+  processor.port.onmessage({
+    data: {
+      type: "samples",
+      samples: new Float32Array([
+        0.1, 0.2, 0.3, 0.4,
+        0.5, 0.6, 0.7, 0.8,
+      ]),
+    },
+  });
+
+  const out = [[new Float32Array(3), new Float32Array(3)]];
+  processor.process([], out);
+
+  assertFloatArrayApprox(Array.from(out[0][0]), [(0.1 + 0.3) * 0.707, (0.5 + 0.7) * 0.707, 0]);
+  assertFloatArrayApprox(Array.from(out[0][1]), [(0.2 + 0.4) * 0.707, (0.6 + 0.8) * 0.707, 0]);
+});
+
+test("native audio worklet duplicates mono WASAPI frames", () => {
+  const { context } = loadScreenShareNative();
+  const processor = loadNativeAudioProcessor(context._nativeAudioWorkletCode);
+
+  processor.port.onmessage({ data: { type: "format", channels: 1, sampleRate: 48000 } });
+  processor.port.onmessage({ data: { type: "samples", samples: new Float32Array([0.25, -0.5]) } });
+
+  const out = [[new Float32Array(2), new Float32Array(2)]];
+  processor.process([], out);
+
+  assert.deepEqual(Array.from(out[0][0]), [0.25, -0.5]);
+  assert.deepEqual(Array.from(out[0][1]), [0.25, -0.5]);
 });


### PR DESCRIPTION
## What changed

- Adapt native WASAPI packets in the browser audio worklet before publishing.
- Downmix mono and multichannel device formats to stereo.
- Resample capture input when the WASAPI sample rate differs from the browser AudioContext rate.
- Add regression coverage for multichannel downmix and mono duplication.

## Why

Screen-share audio was no longer silent after the 0.6.14 native capture fix, but it could sound robotic or garbled when Windows returned a non-stereo endpoint format. The previous worklet assumed every packet was already stereo at the browser output rate and read raw interleaved samples directly into a stereo output.

## Validation

- `node --test core\viewer\screen-share-native.test.js core\viewer\jam-source.test.js`
- Live runtime hotfix deployed and force-reloaded on the Echo server; David reconnected and published fresh `SCREEN_SHARE_AUDIO` plus `$screen` video after reload.
