### PR TITLE
[codex] Release v0.6.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.15
+
+- Fix: Native screen-share audio now adapts WASAPI mono, multichannel, and sample-rate-mismatched formats to browser stereo before publishing, eliminating robotic or garbled shared audio.
+
 ## 0.6.14
 
 - Fix: Native screen sharing now starts audio for window shares and full-monitor shares, including system loopback for entire-screen captures.

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -1304,7 +1304,7 @@ dependencies = [
 
 [[package]]
 name = "echo-core-client"
-version = "0.6.14"
+version = "0.6.15"
 dependencies = [
  "base64 0.22.1",
  "futures-util",
@@ -1325,7 +1325,7 @@ dependencies = [
 
 [[package]]
 name = "echo-core-control"
-version = "0.6.14"
+version = "0.6.15"
 dependencies = [
  "argon2",
  "axum",

--- a/core/client/Cargo.toml
+++ b/core/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "echo-core-client"
-version = "0.6.14"
+version = "0.6.15"
 edition = "2021"
 description = "Echo Chamber native desktop client"
 

--- a/core/client/tauri.conf.json
+++ b/core/client/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "Echo Chamber",
-  "version": "0.6.14",
+  "version": "0.6.15",
   "identifier": "com.echochamber.app",
   "build": {
     "frontendDist": "../viewer"

--- a/core/control/Cargo.toml
+++ b/core/control/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "echo-core-control"
-version = "0.6.14"
+version = "0.6.15"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
## What changed

- Bump Echo Chamber release metadata to `0.6.15`.
- Add changelog notes for the native screen-share audio format adaptation fix.
- Refresh `Cargo.lock` package versions for the control and client crates.

## Why

The live server and GitHub `main` now include the screen-share audio worklet fix from PR #170, but the latest public GitHub release artifact is still `v0.6.14`. This makes the packaged installer/updater release match the current fixed code so Spencer can pull or install the most recent version from GitHub.

## Validation

- `node --test core\viewer\screen-share-native.test.js core\viewer\jam-source.test.js`
- `cargo test -p echo-core-control audio_capture`
- `cargo test -p echo-core-control jam_session`
