### PR TITLE
[codex] Stabilize live 0.6.14 screen quality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.6.13
+
+- Fix: Native full-monitor screen sharing keeps publishing heartbeat frames when Windows Graphics Capture stops delivering repaint callbacks, preventing connected screen publishers from sitting at `0fps/0kbps`.
+- Fix: Jam start now fails cleanly if the Spotify audio bot cannot start, instead of leaving an active Jam with no bot and causing reconnect loops.
+
 ## 0.6.11
 
 - Fix: Windows 10 native Entire Screen sharing now auto-falls back to software H264 on the native DXGI Desktop Duplication path when no encoder override is configured, eliminating the blank `0fps` viewer tile on Win10 publishers like `SAM-PC`

--- a/START_HERE.md
+++ b/START_HERE.md
@@ -9,11 +9,11 @@ If Sam starts a new Codex thread for Echo Chamber and says `continue`, read:
 
 Then run the Echo preflight from `docs/OPERATIONS.md` before claiming the machine is ready, before release work, or before live troubleshooting.
 
-Current production baseline after the v0.6.12 screen-share release:
+Current production baseline after the v0.6.13 screen-share/Jam release:
 
 - Main repo path: `F:\EC-worktrees\main`
 - Production branch: `main`
-- Expected live version: `0.6.12`
+- Expected live version: `0.6.13`
 - Production startup owner: `EchoCoreHost` Windows service
 - Production control child should launch from `F:\EC-worktrees\main\core\target\release\echo-core-control.exe`
 

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -1304,7 +1304,7 @@ dependencies = [
 
 [[package]]
 name = "echo-core-client"
-version = "0.6.12"
+version = "0.6.13"
 dependencies = [
  "base64 0.22.1",
  "futures-util",
@@ -1325,7 +1325,7 @@ dependencies = [
 
 [[package]]
 name = "echo-core-control"
-version = "0.6.12"
+version = "0.6.13"
 dependencies = [
  "argon2",
  "axum",

--- a/core/client/Cargo.toml
+++ b/core/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "echo-core-client"
-version = "0.6.13"
+version = "0.6.14"
 edition = "2021"
 description = "Echo Chamber native desktop client"
 

--- a/core/client/Cargo.toml
+++ b/core/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "echo-core-client"
-version = "0.6.12"
+version = "0.6.13"
 edition = "2021"
 description = "Echo Chamber native desktop client"
 

--- a/core/client/src/capture_pipeline.rs
+++ b/core/client/src/capture_pipeline.rs
@@ -82,15 +82,15 @@ impl PublishProfile {
 
     fn max_bitrate(self) -> u64 {
         match self {
-            Self::Desktop => 4_000_000,
-            Self::Game => 8_000_000,
+            Self::Desktop => 6_000_000,
+            Self::Game => 12_000_000,
         }
     }
 
     fn min_bitrate(self) -> u64 {
         match self {
-            Self::Desktop => 2_500_000,
-            Self::Game => 3_000_000,
+            Self::Desktop => 3_000_000,
+            Self::Game => 4_000_000,
         }
     }
 
@@ -254,8 +254,9 @@ impl CapturePublisher {
             video_codec: VideoCodec::H264,
             simulcast: false,
             video_encoding: Some(VideoEncoding {
-                // Desktop uses the conservative multi-publisher budget validated
-                // 2026-04-07. Game shares opt into a higher-motion bitrate budget.
+                // Desktop stays multi-publisher-friendly while giving text and
+                // motion more bits than the old 4 Mbps cap. Game shares opt
+                // into a higher-motion bitrate budget.
                 max_bitrate: publish_profile.max_bitrate(),
                 // 2.5 Mbps hard floor — prevents libwebrtc GoogCC from throttling
                 // to zero under packet loss / RTT spikes, so the stream stays
@@ -358,8 +359,9 @@ impl CapturePublisher {
             video_codec: VideoCodec::H264,
             simulcast: false,
             video_encoding: Some(VideoEncoding {
-                // Desktop uses the conservative multi-publisher budget validated
-                // 2026-04-07. Game shares opt into a higher-motion bitrate budget.
+                // Desktop stays multi-publisher-friendly while giving text and
+                // motion more bits than the old 4 Mbps cap. Game shares opt
+                // into a higher-motion bitrate budget.
                 max_bitrate: publish_profile.max_bitrate(),
                 // 2.5 Mbps hard floor — prevents libwebrtc GoogCC from throttling
                 // to zero under packet loss / RTT spikes, so the stream stays
@@ -727,10 +729,10 @@ mod tests {
     use super::*;
 
     #[test]
-    fn desktop_profile_stays_conservative() {
+    fn desktop_profile_uses_crisper_multi_publisher_budget() {
         assert_eq!(PublishProfile::Desktop.target_fps(), PUBLISH_TARGET_FPS);
-        assert_eq!(PublishProfile::Desktop.max_bitrate(), 4_000_000);
-        assert_eq!(PublishProfile::Desktop.min_bitrate(), 2_500_000);
+        assert_eq!(PublishProfile::Desktop.max_bitrate(), 6_000_000);
+        assert_eq!(PublishProfile::Desktop.min_bitrate(), 3_000_000);
     }
 
     #[test]
@@ -739,8 +741,8 @@ mod tests {
 
         assert_eq!(profile, PublishProfile::Game);
         assert_eq!(profile.target_fps(), 60);
-        assert_eq!(profile.max_bitrate(), 8_000_000);
-        assert_eq!(profile.min_bitrate(), 3_000_000);
+        assert_eq!(profile.max_bitrate(), 12_000_000);
+        assert_eq!(profile.min_bitrate(), 4_000_000);
     }
 
     fn pushed_frame_count(source_hz: u32, target_hz: u32, seconds: u32) -> usize {

--- a/core/client/src/screen_capture.rs
+++ b/core/client/src/screen_capture.rs
@@ -1345,27 +1345,88 @@ async fn share_loop_monitor(
 
     let mut drop_count: u64 = 0;
     let mut yuv_total_us: u64 = 0;
+    let mut publish_attempt_count: u64 = 0;
+    let mut last_publish_log_at = std::time::Instant::now();
+    let mut last_publish_attempt_count: u64 = 0;
+    let mut last_publish_frame_count: u64 = 0;
+    let mut last_sender_stats_at = std::time::Instant::now();
+    let mut last_frame: Option<(Vec<u8>, u32, u32)> = None;
+    let mut heartbeat = StaticFrameHeartbeat::new(STATIC_FRAME_HEARTBEAT_INTERVAL);
+    let mut heartbeat_attempt_count: u64 = 0;
+    let mut heartbeat_pushed_count: u64 = 0;
 
     while running.load(Ordering::SeqCst) {
-        let frame = match frame_rx.recv_timeout(std::time::Duration::from_millis(100)) {
-            Ok(f) => f,
-            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => continue,
+        let from_heartbeat = match frame_rx.recv_timeout(std::time::Duration::from_millis(100)) {
+            Ok(frame) => {
+                let mut latest = frame;
+                while let Ok(newer) = frame_rx.try_recv() {
+                    drop_count += 1;
+                    latest = newer;
+                }
+                heartbeat.record_fresh_frame(std::time::Instant::now());
+                last_frame = Some(latest);
+                false
+            }
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+                let now = std::time::Instant::now();
+                if last_frame.is_none() || !heartbeat.should_publish(now) {
+                    continue;
+                }
+                true
+            }
             Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => break,
         };
 
-        let mut latest = frame;
-        while let Ok(newer) = frame_rx.try_recv() {
-            drop_count += 1;
-            latest = newer;
-        }
-        let (bgra_data, width, height) = latest;
+        let Some((bgra_data, width, height)) = last_frame.as_ref() else {
+            continue;
+        };
 
         let t0 = std::time::Instant::now();
-        publisher.push_frame(&bgra_data, width, height);
+        publish_attempt_count += 1;
+        if from_heartbeat {
+            heartbeat_attempt_count += 1;
+        }
+        let pushed = publisher.push_frame(bgra_data, *width, *height);
+        if from_heartbeat && pushed {
+            heartbeat_pushed_count += 1;
+        }
         let t1 = std::time::Instant::now();
 
         yuv_total_us += (t1 - t0).as_micros() as u64;
         let fc = publisher.frame_count();
+
+        let now = std::time::Instant::now();
+        let interval = now.duration_since(last_publish_log_at).as_secs_f64();
+        if interval >= 2.0 {
+            let attempt_delta = publish_attempt_count - last_publish_attempt_count;
+            let pushed_delta = fc - last_publish_frame_count;
+            let attempt_fps = attempt_delta as f64 / interval;
+            let pushed_fps = pushed_delta as f64 / interval;
+            let paced_drops = attempt_delta.saturating_sub(pushed_delta);
+            file_debug_log::append(&format!(
+                "[wgc-monitor-publish] interval attempts_fps={:.1} pushed_fps={:.1} paced_drops={} total_pushed={} channel_drops={} heartbeat_attempts={} heartbeat_pushed={} last_pushed={} last_heartbeat={}",
+                attempt_fps,
+                pushed_fps,
+                paced_drops,
+                fc,
+                drop_count,
+                heartbeat_attempt_count,
+                heartbeat_pushed_count,
+                pushed,
+                from_heartbeat
+            ));
+            health.record_capture_fps(pushed_fps.round() as u32);
+            last_publish_log_at = now;
+            last_publish_attempt_count = publish_attempt_count;
+            last_publish_frame_count = fc;
+            heartbeat_attempt_count = 0;
+            heartbeat_pushed_count = 0;
+        }
+
+        if now.duration_since(last_sender_stats_at) >= std::time::Duration::from_secs(5) {
+            publisher.log_sender_stats("screen-capture-monitor").await;
+            last_sender_stats_at = now;
+        }
 
         if fc % 30 == 0 {
             let elapsed = publisher.elapsed().as_secs_f64();
@@ -1387,8 +1448,8 @@ async fn share_loop_monitor(
                 app,
                 "screen-capture-stats",
                 "wgc-monitor",
-                width,
-                height,
+                *width,
+                *height,
                 30,
             ) {
                 health.record_capture_fps(emit_fps);
@@ -1450,5 +1511,27 @@ mod tests {
         };
 
         assert_eq!(window_overlap_ratio(source, cover), 0.5);
+    }
+
+    #[test]
+    fn monitor_share_loop_uses_static_frame_heartbeat() {
+        let source = include_str!("screen_capture.rs");
+        let start = source
+            .find("async fn share_loop_monitor")
+            .expect("share_loop_monitor exists");
+        let tail = &source[start..];
+        let end = tail
+            .find("running.store(false")
+            .expect("share_loop_monitor shutdown marker exists");
+        let body = &tail[..end];
+
+        assert!(
+            body.contains("StaticFrameHeartbeat::new"),
+            "monitor capture must republish the last good frame when WGC stops callbacks"
+        );
+        assert!(
+            body.contains("heartbeat.should_publish"),
+            "monitor capture must use heartbeat cadence during callback stalls"
+        );
     }
 }

--- a/core/client/tauri.conf.json
+++ b/core/client/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "Echo Chamber",
-  "version": "0.6.13",
+  "version": "0.6.14",
   "identifier": "com.echochamber.app",
   "build": {
     "frontendDist": "../viewer"

--- a/core/client/tauri.conf.json
+++ b/core/client/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "Echo Chamber",
-  "version": "0.6.12",
+  "version": "0.6.13",
   "identifier": "com.echochamber.app",
   "build": {
     "frontendDist": "../viewer"

--- a/core/control/Cargo.toml
+++ b/core/control/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "echo-core-control"
-version = "0.6.12"
+version = "0.6.13"
 edition = "2021"
 
 [dependencies]

--- a/core/control/src/jam_session.rs
+++ b/core/control/src/jam_session.rs
@@ -375,40 +375,51 @@ pub(crate) async fn stop_jam_bot(state: &AppState) {
     }
 }
 
+fn apply_jam_start_result(jam: &mut JamState, identity: String, bot_started: bool) -> bool {
+    if !bot_started {
+        return false;
+    }
+
+    jam.active = true;
+    jam.host_identity = identity.clone();
+    jam.listeners.insert(identity);
+    true
+}
+
 pub(crate) async fn jam_start(
     State(state): State<AppState>,
     headers: HeaderMap,
     Json(payload): Json<JamStartRequest>,
-) -> Result<Json<serde_json::Value>, StatusCode> {
-    ensure_admin(&state, &headers)?;
+) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
+    ensure_admin(&state, &headers).map_err(|status| (status, String::new()))?;
+
+    {
+        let jam = state.jam.lock().unwrap_or_else(|e| e.into_inner());
+        if jam.spotify_token.is_none() {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                "Spotify is not connected".to_string(),
+            ));
+        }
+    }
+
+    let bot = crate::jam_bot::JamBot::start().await.map_err(|e| {
+        warn!("Jam audio bot failed to start: {}", e);
+        (StatusCode::SERVICE_UNAVAILABLE, e)
+    })?;
+
+    stop_jam_bot(&state).await;
+    *state.jam_bot.lock().await = Some(bot);
+    info!("Jam audio bot started successfully");
 
     {
         let mut jam = state.jam.lock().unwrap_or_else(|e| e.into_inner());
-        if jam.spotify_token.is_none() {
-            return Err(StatusCode::BAD_REQUEST);
-        }
-        jam.active = true;
-        jam.host_identity = payload.identity.clone();
-        jam.listeners.insert(payload.identity);
+        apply_jam_start_result(&mut jam, payload.identity.clone(), true);
         info!(
             "Jam session started by {} (auto-joined as listener)",
             jam.host_identity
         );
     }
-
-    // Spawn the audio bot in background (don't block the response)
-    let bot_state = state.clone();
-    tokio::spawn(async move {
-        match crate::jam_bot::JamBot::start().await {
-            Ok(bot) => {
-                info!("Jam audio bot started successfully");
-                *bot_state.jam_bot.lock().await = Some(bot);
-            }
-            Err(e) => {
-                warn!("Jam audio bot failed to start: {}", e);
-            }
-        }
-    });
 
     Ok(Json(serde_json::json!({ "ok": true })))
 }
@@ -928,4 +939,47 @@ async fn jam_audio_ws_handler(mut socket: WebSocket, state: AppState) {
     }
 
     info!("[jam-audio-ws] client disconnected");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn spotify_token() -> SpotifyToken {
+        SpotifyToken {
+            access_token: "access".to_string(),
+            refresh_token: "refresh".to_string(),
+            expires_at: 999_999,
+        }
+    }
+
+    #[test]
+    fn failed_bot_start_does_not_activate_jam() {
+        let mut jam = JamState {
+            spotify_token: Some(spotify_token()),
+            ..JamState::default()
+        };
+
+        let activated = apply_jam_start_result(&mut jam, "sam-7475".to_string(), false);
+
+        assert!(!activated);
+        assert!(!jam.active);
+        assert!(jam.host_identity.is_empty());
+        assert!(jam.listeners.is_empty());
+    }
+
+    #[test]
+    fn successful_bot_start_activates_host_listener() {
+        let mut jam = JamState {
+            spotify_token: Some(spotify_token()),
+            ..JamState::default()
+        };
+
+        let activated = apply_jam_start_result(&mut jam, "sam-7475".to_string(), true);
+
+        assert!(activated);
+        assert!(jam.active);
+        assert_eq!(jam.host_identity, "sam-7475");
+        assert!(jam.listeners.contains("sam-7475"));
+    }
 }

--- a/core/viewer/admin-panel.js
+++ b/core/viewer/admin-panel.js
@@ -59,6 +59,72 @@ const _adminMutedUntil = new Map();
 const _adminConsecutiveRed = new Map();
 const HYSTERESIS_RED_TICKS = 2; // require 2 consecutive Red polls (~6s) before alerting
 
+function adminPanelEscape(text) {
+  if (typeof escapeHtml === "function") return escapeHtml(text);
+  return String(text == null ? "" : text)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function formatStreamBitrate(kbps) {
+  if (typeof kbps !== "number" || !Number.isFinite(kbps) || kbps <= 0) return "? Mbps";
+  if (kbps >= 1000) return (kbps / 1000).toFixed(1) + " Mbps";
+  return Math.round(kbps) + " kbps";
+}
+
+function formatStreamFps(fps) {
+  if (typeof fps !== "number" || !Number.isFinite(fps)) return "?fps";
+  return Math.round(fps) + "fps";
+}
+
+function renderParticipantInboundStreamStats(participant) {
+  const stats = participant && participant.stats ? participant.stats : {};
+  const inbound = Array.isArray(stats.inbound) ? stats.inbound : [];
+  if (inbound.length === 0) return "";
+
+  const viewer = participant.name || participant.identity || "viewer";
+  return inbound
+    .slice()
+    .sort((a, b) => {
+      const sourceOrder = (a.source || "").localeCompare(b.source || "");
+      if (sourceOrder !== 0) return sourceOrder;
+      return (a.from || "").localeCompare(b.from || "");
+    })
+    .map((stream) => {
+      const source = stream.source || "stream";
+      const from = stream.from || "?";
+      const dims = stream.width && stream.height ? stream.width + "x" + stream.height : "?x?";
+      const primary = [
+        formatStreamFps(stream.fps),
+        dims,
+        formatStreamBitrate(stream.bitrate_kbps),
+      ].join(" ");
+      const network = [
+        "loss " + (stream.lost ?? 0),
+        "nack " + (stream.nack ?? 0),
+        "pli " + (stream.pli ?? 0),
+        "jitter " + (stream.jitter_ms ?? "?") + "ms",
+      ].join(" ");
+      const layer = stream.layer ? " " + stream.layer : "";
+      const ice = stream.ice_remote_type ? " " + stream.ice_remote_type : "";
+      return `<div class="admin-row3 admin-stream-row">${adminPanelEscape(viewer)} sees ${adminPanelEscape(from)} ${adminPanelEscape(source)}: ${adminPanelEscape(primary)}${adminPanelEscape(layer)}${adminPanelEscape(ice)} · ${adminPanelEscape(network)}</div>`;
+    })
+    .join("");
+}
+
+function renderInboundStreamStats(data) {
+  let html = "";
+  for (const room of (data && data.rooms ? data.rooms : [])) {
+    for (const participant of (room.participants || [])) {
+      html += renderParticipantInboundStreamStats(participant);
+    }
+  }
+  return html;
+}
+
 function renderAdminPanel(data) {
   const body = document.getElementById("adminPanelBody");
   if (!body) return;
@@ -95,6 +161,7 @@ function renderAdminPanel(data) {
           html += `<div class="admin-row3">└─ ${escapeHtml(ch.reasons.join("; "))}</div>`;
         }
       }
+      html += renderParticipantInboundStreamStats(p);
       html += `</div>`;
 
       // Hysteresis: track consecutive Red ticks per identity. Banner only
@@ -183,4 +250,12 @@ function playAdminAlertChime() {
 
 function escapeHtml(s) {
   return String(s).replace(/[&<>"']/g, c => ({"&":"&amp;","<":"&lt;",">":"&gt;","\"":"&quot;","'":"&#39;"}[c]));
+}
+
+if (typeof module === "object" && module.exports) {
+  module.exports = {
+    formatStreamBitrate,
+    renderInboundStreamStats,
+    renderParticipantInboundStreamStats,
+  };
 }

--- a/core/viewer/admin-panel.test.js
+++ b/core/viewer/admin-panel.test.js
@@ -1,0 +1,57 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  formatStreamBitrate,
+  renderInboundStreamStats,
+} = require("./admin-panel.js");
+
+test("formats stream bitrate for admin diagnostics", () => {
+  assert.equal(formatStreamBitrate(6420), "6.4 Mbps");
+  assert.equal(formatStreamBitrate(980), "980 kbps");
+  assert.equal(formatStreamBitrate(null), "? Mbps");
+});
+
+test("renders receiver-side bitrate rows for every inbound stream", () => {
+  const html = renderInboundStreamStats({
+    rooms: [{
+      room_id: "main",
+      participants: [{
+        identity: "david-2222",
+        name: "David",
+        stats: {
+          inbound: [{
+            from: "sam-1111",
+            source: "screen",
+            fps: 59.7,
+            width: 1920,
+            height: 1080,
+            bitrate_kbps: 6420,
+            lost: 0,
+            nack: 0,
+            pli: 0,
+            jitter_ms: 3,
+            layer: "HIGH",
+            ice_remote_type: "srflx",
+          }, {
+            from: "jeff-3333",
+            source: "camera",
+            fps: 29.9,
+            width: 1280,
+            height: 720,
+            bitrate_kbps: 1180,
+            lost: 2,
+            nack: 4,
+            pli: 1,
+          }],
+        },
+      }],
+    }],
+  });
+
+  assert.match(html, /David sees sam-1111 screen/);
+  assert.match(html, /60fps 1920x1080 6\.4 Mbps/);
+  assert.match(html, /loss 0 nack 0 pli 0 jitter 3ms/);
+  assert.match(html, /David sees jeff-3333 camera/);
+  assert.match(html, /30fps 1280x720 1\.2 Mbps/);
+});


### PR DESCRIPTION
﻿# Summary

- Raise native screen capture publish caps from 4 Mbps desktop / 8 Mbps game to 6 Mbps desktop / 12 Mbps game, with stronger bitrate floors.
- Expose receiver-side inbound stream diagnostics in the admin panel: viewer, publisher, source, FPS, resolution, bitrate, loss, NACK, PLI, jitter, layer, and ICE type.
- Bump the desktop client package to 0.6.14 so a Windows release build can produce a newer installer/update.
- This branch also carries the existing live-stabilization commits already present before this bitrate pass.

# Release impact

Desktop binary required for the native bitrate cap change. The admin diagnostics are viewer/server-served and will also be bundled into the desktop client. Windows-only release path; macOS remains disabled.

# Verification

- `node --test core/viewer/*.test.js` -> 100 passed.
- `cargo test -p echo-core-client capture_pipeline` -> 7 passed.
- `git diff --check -- core/viewer/admin-panel.js core/viewer/admin-panel.test.js core/client/src/capture_pipeline.rs` -> clean except normal CRLF warnings.

# Release notes

After merge, tag `v0.6.14` to trigger `.github/workflows/release.yml`. Verify the GitHub Release contains the Windows NSIS installer plus `latest.json`, then verify the live updater endpoint before telling users to install/update.
