### PR TITLE
[codex] Release v0.6.16 screen bitrate diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.6.16
+
+- Improve: Native screen sharing now publishes desktop and game captures with higher bitrate budgets for sharper streams.
+- Admin: Add receiver-side stream bitrate diagnostics so live sessions can show who sees whose stream, at what resolution/FPS/bitrate, with loss and jitter counters.
+
 ## 0.6.15
 
 - Fix: Native screen-share audio now adapts WASAPI mono, multichannel, and sample-rate-mismatched formats to browser stereo before publishing, eliminating robotic or garbled shared audio.

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -1304,7 +1304,7 @@ dependencies = [
 
 [[package]]
 name = "echo-core-client"
-version = "0.6.15"
+version = "0.6.16"
 dependencies = [
  "base64 0.22.1",
  "futures-util",
@@ -1325,7 +1325,7 @@ dependencies = [
 
 [[package]]
 name = "echo-core-control"
-version = "0.6.15"
+version = "0.6.16"
 dependencies = [
  "argon2",
  "axum",

--- a/core/client/Cargo.toml
+++ b/core/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "echo-core-client"
-version = "0.6.15"
+version = "0.6.16"
 edition = "2021"
 description = "Echo Chamber native desktop client"
 

--- a/core/client/src/capture_pipeline.rs
+++ b/core/client/src/capture_pipeline.rs
@@ -82,15 +82,15 @@ impl PublishProfile {
 
     fn max_bitrate(self) -> u64 {
         match self {
-            Self::Desktop => 4_000_000,
-            Self::Game => 8_000_000,
+            Self::Desktop => 6_000_000,
+            Self::Game => 12_000_000,
         }
     }
 
     fn min_bitrate(self) -> u64 {
         match self {
-            Self::Desktop => 2_500_000,
-            Self::Game => 3_000_000,
+            Self::Desktop => 3_000_000,
+            Self::Game => 4_000_000,
         }
     }
 
@@ -254,8 +254,9 @@ impl CapturePublisher {
             video_codec: VideoCodec::H264,
             simulcast: false,
             video_encoding: Some(VideoEncoding {
-                // Desktop uses the conservative multi-publisher budget validated
-                // 2026-04-07. Game shares opt into a higher-motion bitrate budget.
+                // Desktop stays multi-publisher-friendly while giving text and
+                // motion more bits than the old 4 Mbps cap. Game shares opt
+                // into a higher-motion bitrate budget.
                 max_bitrate: publish_profile.max_bitrate(),
                 // 2.5 Mbps hard floor — prevents libwebrtc GoogCC from throttling
                 // to zero under packet loss / RTT spikes, so the stream stays
@@ -358,8 +359,9 @@ impl CapturePublisher {
             video_codec: VideoCodec::H264,
             simulcast: false,
             video_encoding: Some(VideoEncoding {
-                // Desktop uses the conservative multi-publisher budget validated
-                // 2026-04-07. Game shares opt into a higher-motion bitrate budget.
+                // Desktop stays multi-publisher-friendly while giving text and
+                // motion more bits than the old 4 Mbps cap. Game shares opt
+                // into a higher-motion bitrate budget.
                 max_bitrate: publish_profile.max_bitrate(),
                 // 2.5 Mbps hard floor — prevents libwebrtc GoogCC from throttling
                 // to zero under packet loss / RTT spikes, so the stream stays
@@ -727,10 +729,10 @@ mod tests {
     use super::*;
 
     #[test]
-    fn desktop_profile_stays_conservative() {
+    fn desktop_profile_uses_crisper_multi_publisher_budget() {
         assert_eq!(PublishProfile::Desktop.target_fps(), PUBLISH_TARGET_FPS);
-        assert_eq!(PublishProfile::Desktop.max_bitrate(), 4_000_000);
-        assert_eq!(PublishProfile::Desktop.min_bitrate(), 2_500_000);
+        assert_eq!(PublishProfile::Desktop.max_bitrate(), 6_000_000);
+        assert_eq!(PublishProfile::Desktop.min_bitrate(), 3_000_000);
     }
 
     #[test]
@@ -739,8 +741,8 @@ mod tests {
 
         assert_eq!(profile, PublishProfile::Game);
         assert_eq!(profile.target_fps(), 60);
-        assert_eq!(profile.max_bitrate(), 8_000_000);
-        assert_eq!(profile.min_bitrate(), 3_000_000);
+        assert_eq!(profile.max_bitrate(), 12_000_000);
+        assert_eq!(profile.min_bitrate(), 4_000_000);
     }
 
     fn pushed_frame_count(source_hz: u32, target_hz: u32, seconds: u32) -> usize {

--- a/core/client/tauri.conf.json
+++ b/core/client/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "Echo Chamber",
-  "version": "0.6.15",
+  "version": "0.6.16",
   "identifier": "com.echochamber.app",
   "build": {
     "frontendDist": "../viewer"

--- a/core/control/Cargo.toml
+++ b/core/control/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "echo-core-control"
-version = "0.6.15"
+version = "0.6.16"
 edition = "2021"
 
 [dependencies]

--- a/core/viewer/admin-panel.js
+++ b/core/viewer/admin-panel.js
@@ -59,6 +59,72 @@ const _adminMutedUntil = new Map();
 const _adminConsecutiveRed = new Map();
 const HYSTERESIS_RED_TICKS = 2; // require 2 consecutive Red polls (~6s) before alerting
 
+function adminPanelEscape(text) {
+  if (typeof escapeHtml === "function") return escapeHtml(text);
+  return String(text == null ? "" : text)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function formatStreamBitrate(kbps) {
+  if (typeof kbps !== "number" || !Number.isFinite(kbps) || kbps <= 0) return "? Mbps";
+  if (kbps >= 1000) return (kbps / 1000).toFixed(1) + " Mbps";
+  return Math.round(kbps) + " kbps";
+}
+
+function formatStreamFps(fps) {
+  if (typeof fps !== "number" || !Number.isFinite(fps)) return "?fps";
+  return Math.round(fps) + "fps";
+}
+
+function renderParticipantInboundStreamStats(participant) {
+  const stats = participant && participant.stats ? participant.stats : {};
+  const inbound = Array.isArray(stats.inbound) ? stats.inbound : [];
+  if (inbound.length === 0) return "";
+
+  const viewer = participant.name || participant.identity || "viewer";
+  return inbound
+    .slice()
+    .sort((a, b) => {
+      const sourceOrder = (a.source || "").localeCompare(b.source || "");
+      if (sourceOrder !== 0) return sourceOrder;
+      return (a.from || "").localeCompare(b.from || "");
+    })
+    .map((stream) => {
+      const source = stream.source || "stream";
+      const from = stream.from || "?";
+      const dims = stream.width && stream.height ? stream.width + "x" + stream.height : "?x?";
+      const primary = [
+        formatStreamFps(stream.fps),
+        dims,
+        formatStreamBitrate(stream.bitrate_kbps),
+      ].join(" ");
+      const network = [
+        "loss " + (stream.lost ?? 0),
+        "nack " + (stream.nack ?? 0),
+        "pli " + (stream.pli ?? 0),
+        "jitter " + (stream.jitter_ms ?? "?") + "ms",
+      ].join(" ");
+      const layer = stream.layer ? " " + stream.layer : "";
+      const ice = stream.ice_remote_type ? " " + stream.ice_remote_type : "";
+      return `<div class="admin-row3 admin-stream-row">${adminPanelEscape(viewer)} sees ${adminPanelEscape(from)} ${adminPanelEscape(source)}: ${adminPanelEscape(primary)}${adminPanelEscape(layer)}${adminPanelEscape(ice)} · ${adminPanelEscape(network)}</div>`;
+    })
+    .join("");
+}
+
+function renderInboundStreamStats(data) {
+  let html = "";
+  for (const room of (data && data.rooms ? data.rooms : [])) {
+    for (const participant of (room.participants || [])) {
+      html += renderParticipantInboundStreamStats(participant);
+    }
+  }
+  return html;
+}
+
 function renderAdminPanel(data) {
   const body = document.getElementById("adminPanelBody");
   if (!body) return;
@@ -95,6 +161,7 @@ function renderAdminPanel(data) {
           html += `<div class="admin-row3">└─ ${escapeHtml(ch.reasons.join("; "))}</div>`;
         }
       }
+      html += renderParticipantInboundStreamStats(p);
       html += `</div>`;
 
       // Hysteresis: track consecutive Red ticks per identity. Banner only
@@ -183,4 +250,12 @@ function playAdminAlertChime() {
 
 function escapeHtml(s) {
   return String(s).replace(/[&<>"']/g, c => ({"&":"&amp;","<":"&lt;",">":"&gt;","\"":"&quot;","'":"&#39;"}[c]));
+}
+
+if (typeof module === "object" && module.exports) {
+  module.exports = {
+    formatStreamBitrate,
+    renderInboundStreamStats,
+    renderParticipantInboundStreamStats,
+  };
 }

--- a/core/viewer/admin-panel.test.js
+++ b/core/viewer/admin-panel.test.js
@@ -1,0 +1,57 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  formatStreamBitrate,
+  renderInboundStreamStats,
+} = require("./admin-panel.js");
+
+test("formats stream bitrate for admin diagnostics", () => {
+  assert.equal(formatStreamBitrate(6420), "6.4 Mbps");
+  assert.equal(formatStreamBitrate(980), "980 kbps");
+  assert.equal(formatStreamBitrate(null), "? Mbps");
+});
+
+test("renders receiver-side bitrate rows for every inbound stream", () => {
+  const html = renderInboundStreamStats({
+    rooms: [{
+      room_id: "main",
+      participants: [{
+        identity: "david-2222",
+        name: "David",
+        stats: {
+          inbound: [{
+            from: "sam-1111",
+            source: "screen",
+            fps: 59.7,
+            width: 1920,
+            height: 1080,
+            bitrate_kbps: 6420,
+            lost: 0,
+            nack: 0,
+            pli: 0,
+            jitter_ms: 3,
+            layer: "HIGH",
+            ice_remote_type: "srflx",
+          }, {
+            from: "jeff-3333",
+            source: "camera",
+            fps: 29.9,
+            width: 1280,
+            height: 720,
+            bitrate_kbps: 1180,
+            lost: 2,
+            nack: 4,
+            pli: 1,
+          }],
+        },
+      }],
+    }],
+  });
+
+  assert.match(html, /David sees sam-1111 screen/);
+  assert.match(html, /60fps 1920x1080 6\.4 Mbps/);
+  assert.match(html, /loss 0 nack 0 pli 0 jitter 3ms/);
+  assert.match(html, /David sees jeff-3333 camera/);
+  assert.match(html, /30fps 1280x720 1\.2 Mbps/);
+});


### PR DESCRIPTION
﻿# Summary

- Raises native screen capture publish caps from 4 Mbps desktop / 8 Mbps game to 6 Mbps desktop / 12 Mbps game, with stronger bitrate floors.
- Adds receiver-side inbound stream bitrate diagnostics to the admin panel.
- Prepares v0.6.16 release metadata from current v0.6.15 main.

# Release impact

Desktop binary required for the native bitrate cap change. Admin diagnostics are server/viewer-served and included in the release branch. Windows-only path; no macOS release work.

# Verification

- `node --check core/viewer/app.js`
- `node --check core/viewer/jam.js`
- `node --test core/viewer/*.test.js` -> 94 passed
- `cargo test -p echo-core-client capture_pipeline` -> 7 passed
- `cargo check -p echo-core-control` -> passed, warnings only
- `cargo check -p echo-core-client` -> passed, warnings only
- `git diff --check` -> clean except normal CRLF warnings

# Notes

This replaces PR #172, which was based on an older stabilization branch and should not be merged. After merge, tag v0.6.16 to trigger the Windows release workflow, then verify the GitHub release asset and updater latest.json.
