### PR TITLE
[codex] release v0.6.17 diagnostics control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.6.17
+
+- Change: Game sharing now defaults to Desktop Duplication with the game publish profile instead of silently falling through WGC.
+- Diagnostics: WGC remains available as an explicit game capture mode for A/B testing.
+- Admin: Capture health now reports sender FPS, target bitrate, available outgoing bitrate, quality limitation, and encoder so live stream collapses are visible from the dashboard.
+- Release: Desktop and control versions are bumped to 0.6.17.
+
 ## 0.6.16
 
 - Improve: Native screen sharing now publishes desktop and game captures with higher bitrate budgets for sharper streams.

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -1304,7 +1304,7 @@ dependencies = [
 
 [[package]]
 name = "echo-core-client"
-version = "0.6.16"
+version = "0.6.17"
 dependencies = [
  "base64 0.22.1",
  "futures-util",
@@ -1325,7 +1325,7 @@ dependencies = [
 
 [[package]]
 name = "echo-core-control"
-version = "0.6.16"
+version = "0.6.17"
 dependencies = [
  "argon2",
  "axum",

--- a/core/client/Cargo.toml
+++ b/core/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "echo-core-client"
-version = "0.6.16"
+version = "0.6.17"
 edition = "2021"
 description = "Echo Chamber native desktop client"
 

--- a/core/client/src/capture_health.rs
+++ b/core/client/src/capture_health.rs
@@ -98,6 +98,25 @@ pub struct CaptureHealthSnapshot {
     /// Zero when capture is inactive.
     #[serde(default)]
     pub seconds_since_capture_started: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sender_fps: Option<f32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sender_target_bitrate_kbps: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sender_available_outgoing_bitrate_kbps: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sender_quality_limitation: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sender_encoder: Option<String>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct CaptureSenderDiagnostics {
+    pub fps: Option<f32>,
+    pub target_bitrate_kbps: Option<u32>,
+    pub available_outgoing_bitrate_kbps: Option<u32>,
+    pub quality_limitation: Option<String>,
+    pub encoder: Option<String>,
 }
 
 // ── State ───────────────────────────────────────────────────────────
@@ -112,6 +131,7 @@ pub struct CaptureHealthState {
     capture_active: AtomicBool,
     capture_mode: RwLock<CaptureMode>,
     encoder_type: RwLock<EncoderType>,
+    sender_diagnostics: RwLock<Option<CaptureSenderDiagnostics>>,
     /// Set when capture transitions from inactive→active. Used by the
     /// classifier to suppress fps-based checks during the COLD_START_GRACE
     /// window so the brief pre-first-frame period doesn't trigger Red.
@@ -135,6 +155,7 @@ impl CaptureHealthState {
             capture_active: AtomicBool::new(false),
             capture_mode: RwLock::new(CaptureMode::None),
             encoder_type: RwLock::new(EncoderType::None),
+            sender_diagnostics: RwLock::new(None),
             capture_started_at: Mutex::new(None),
             reinit_events: Mutex::new(Vec::new()),
             shader_error_events: Mutex::new(Vec::new()),
@@ -191,6 +212,10 @@ impl CaptureHealthState {
         self.last_capture_fps.store(fps, Ordering::Relaxed);
     }
 
+    pub fn record_sender_diagnostics(&self, diagnostics: CaptureSenderDiagnostics) {
+        *self.sender_diagnostics.write() = Some(diagnostics);
+    }
+
     pub fn set_active(&self, active: bool, mode: CaptureMode, encoder: EncoderType, target: u32) {
         let was_active = self.capture_active.swap(active, Ordering::Relaxed);
         *self.capture_mode.write() = mode;
@@ -221,6 +246,7 @@ impl CaptureHealthState {
         } else {
             self.last_capture_fps.store(0, Ordering::Relaxed);
             self.consecutive_timeouts.store(0, Ordering::Relaxed);
+            *self.sender_diagnostics.write() = None;
             *self.capture_started_at.lock() = None;
         }
     }
@@ -279,6 +305,7 @@ impl CaptureHealthState {
 
         let mode = self.capture_mode.read().clone();
         let encoder = self.encoder_type.read().clone();
+        let sender_diagnostics = self.sender_diagnostics.read().clone();
 
         let mut snap = CaptureHealthSnapshot {
             level: HealthLevel::Green,
@@ -305,6 +332,19 @@ impl CaptureHealthState {
                 let started = *self.capture_started_at.lock();
                 started.map(|t| t.elapsed().as_secs()).unwrap_or(0)
             },
+            sender_fps: sender_diagnostics.as_ref().and_then(|diag| diag.fps),
+            sender_target_bitrate_kbps: sender_diagnostics
+                .as_ref()
+                .and_then(|diag| diag.target_bitrate_kbps),
+            sender_available_outgoing_bitrate_kbps: sender_diagnostics
+                .as_ref()
+                .and_then(|diag| diag.available_outgoing_bitrate_kbps),
+            sender_quality_limitation: sender_diagnostics
+                .as_ref()
+                .and_then(|diag| diag.quality_limitation.clone()),
+            sender_encoder: sender_diagnostics
+                .as_ref()
+                .and_then(|diag| diag.encoder.clone()),
         };
         let (level, reasons) = classify(&snap);
         snap.level = level;
@@ -378,7 +418,9 @@ pub fn classify(snap: &CaptureHealthSnapshot) -> (HealthLevel, Vec<String>) {
     // as either consecutive_timeouts climbing or fps being well below
     // target steady-state — both are caught by the OTHER signals.
     let in_cold_start = snap.seconds_since_capture_started < COLD_START_GRACE.as_secs();
-    if !in_cold_start && snap.capture_mode == "DXGI-DD" && snap.target_fps > 0 {
+    let fps_check_applies =
+        snap.capture_mode == "DXGI-DD" || (snap.capture_mode == "WGC" && snap.target_fps >= 60);
+    if !in_cold_start && fps_check_applies && snap.target_fps > 0 {
         let frac = snap.current_fps as f32 / snap.target_fps as f32;
         if frac < RED_FPS_FRACTION {
             level = level.max(HealthLevel::Red);
@@ -453,6 +495,11 @@ mod tests {
             // need to verify cold-start suppression set this to a small
             // value explicitly.
             seconds_since_capture_started: 60,
+            sender_fps: None,
+            sender_target_bitrate_kbps: None,
+            sender_available_outgoing_bitrate_kbps: None,
+            sender_quality_limitation: None,
+            sender_encoder: None,
         }
     }
 
@@ -578,6 +625,52 @@ mod tests {
             "WGC low fps should not produce reasons, got {:?}",
             reasons
         );
+    }
+
+    #[test]
+    fn wgc_high_motion_low_fps_is_red() {
+        let mut s = nominal();
+        s.capture_mode = "WGC".into();
+        s.current_fps = 23;
+        s.target_fps = 60;
+        let (lvl, reasons) = classify(&s);
+        assert_eq!(lvl, HealthLevel::Red);
+        assert!(
+            reasons.iter().any(|r| r.contains("capture fps 23/60")),
+            "expected WGC game fps reason, got {:?}",
+            reasons
+        );
+    }
+
+    #[test]
+    fn snapshot_includes_sender_diagnostics_and_clears_when_inactive() {
+        let state = CaptureHealthState::new();
+        state.set_active(true, CaptureMode::DxgiDd, EncoderType::Nvenc, 60);
+        state.record_sender_diagnostics(CaptureSenderDiagnostics {
+            fps: Some(8.0),
+            target_bitrate_kbps: Some(5520),
+            available_outgoing_bitrate_kbps: Some(5615),
+            quality_limitation: Some("Cpu".into()),
+            encoder: Some("NVIDIA H264 Encoder".into()),
+        });
+
+        let active = state.snapshot();
+        assert_eq!(active.sender_fps, Some(8.0));
+        assert_eq!(active.sender_target_bitrate_kbps, Some(5520));
+        assert_eq!(active.sender_available_outgoing_bitrate_kbps, Some(5615));
+        assert_eq!(active.sender_quality_limitation.as_deref(), Some("Cpu"));
+        assert_eq!(
+            active.sender_encoder.as_deref(),
+            Some("NVIDIA H264 Encoder")
+        );
+
+        state.set_active(false, CaptureMode::None, EncoderType::None, 0);
+        let inactive = state.snapshot();
+        assert_eq!(inactive.sender_fps, None);
+        assert_eq!(inactive.sender_target_bitrate_kbps, None);
+        assert_eq!(inactive.sender_available_outgoing_bitrate_kbps, None);
+        assert_eq!(inactive.sender_quality_limitation, None);
+        assert_eq!(inactive.sender_encoder, None);
     }
 
     #[test]

--- a/core/client/src/capture_pipeline.rs
+++ b/core/client/src/capture_pipeline.rs
@@ -12,6 +12,7 @@ use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Emitter};
 use tokio::sync::mpsc::UnboundedReceiver;
 
+use crate::capture_health::{CaptureHealthState, CaptureSenderDiagnostics};
 use crate::file_debug_log;
 use livekit::options::{TrackPublishOptions, VideoCodec, VideoEncoding};
 use livekit::prelude::*;
@@ -508,7 +509,7 @@ impl CapturePublisher {
         self.start_time.elapsed()
     }
 
-    pub async fn log_sender_stats(&self, log_prefix: &str) {
+    pub async fn log_sender_stats(&self, log_prefix: &str, health: Option<&CaptureHealthState>) {
         match self.track.get_stats().await {
             Ok(stats) => {
                 let transport = stats.iter().find_map(|stat| match stat {
@@ -551,6 +552,7 @@ impl CapturePublisher {
                     RtcStats::OutboundRtp(outbound) => Some(outbound),
                     _ => None,
                 });
+                let mut sender_diagnostics: Option<CaptureSenderDiagnostics> = None;
                 if let Some(outbound) = outbound {
                     let codec = codec_by_id.get(outbound.stream.codec_id.as_str()).copied();
                     let remote_inbound = if outbound.outbound.remote_id.is_empty() {
@@ -604,6 +606,24 @@ impl CapturePublisher {
                     );
                     eprintln!("{}", sender_line);
                     file_debug_log::append(&sender_line);
+                    sender_diagnostics = Some(CaptureSenderDiagnostics {
+                        fps: Some(outbound.outbound.frames_per_second as f32),
+                        target_bitrate_kbps: if outbound.outbound.target_bitrate > 0.0 {
+                            Some((outbound.outbound.target_bitrate / 1000.0).round() as u32)
+                        } else {
+                            None
+                        },
+                        available_outgoing_bitrate_kbps: None,
+                        quality_limitation: Some(format!(
+                            "{:?}",
+                            outbound.outbound.quality_limitation_reason
+                        )),
+                        encoder: if outbound.outbound.encoder_implementation.is_empty() {
+                            None
+                        } else {
+                            Some(outbound.outbound.encoder_implementation.clone())
+                        },
+                    });
                 } else {
                     eprintln!("[{}] sender-stats no outbound RTP report", log_prefix);
                     file_debug_log::append(&format!(
@@ -666,6 +686,17 @@ impl CapturePublisher {
                             pair.candidate_pair.current_round_trip_time,
                             pair.candidate_pair.available_outgoing_bitrate,
                         ));
+                        if let Some(diag) = sender_diagnostics.as_mut() {
+                            diag.available_outgoing_bitrate_kbps =
+                                if pair.candidate_pair.available_outgoing_bitrate > 0.0 {
+                                    Some(
+                                        (pair.candidate_pair.available_outgoing_bitrate / 1000.0)
+                                            .round() as u32,
+                                    )
+                                } else {
+                                    None
+                                };
+                        }
                     } else {
                         eprintln!(
                             "[{}] candidate-pair missing for selected transport pair",
@@ -701,6 +732,9 @@ impl CapturePublisher {
                     eprintln!("[{}] transport stats missing", log_prefix);
                     file_debug_log::append(&format!("[{}] transport stats missing", log_prefix));
                 }
+                if let (Some(health), Some(diagnostics)) = (health, sender_diagnostics) {
+                    health.record_sender_diagnostics(diagnostics);
+                }
             }
             Err(e) => {
                 eprintln!("[{}] sender-stats error: {}", log_prefix, e);
@@ -709,8 +743,13 @@ impl CapturePublisher {
         }
     }
 
-    pub fn log_sender_stats_blocking(&self, rt: &tokio::runtime::Handle, log_prefix: &str) {
-        rt.block_on(self.log_sender_stats(log_prefix));
+    pub fn log_sender_stats_blocking(
+        &self,
+        rt: &tokio::runtime::Handle,
+        log_prefix: &str,
+        health: Option<&CaptureHealthState>,
+    ) {
+        rt.block_on(self.log_sender_stats(log_prefix, health));
     }
 
     /// Close the SFU room connection.

--- a/core/client/src/desktop_capture.rs
+++ b/core/client/src/desktop_capture.rs
@@ -1306,7 +1306,7 @@ fn capture_loop_blocking(
                 ));
                 health.record_capture_fps(fps);
             }
-            publisher.log_sender_stats_blocking(&rt, "desktop-capture");
+            publisher.log_sender_stats_blocking(&rt, "desktop-capture", Some(health.as_ref()));
         }
     }
 

--- a/core/client/src/screen_capture.rs
+++ b/core/client/src/screen_capture.rs
@@ -1068,7 +1068,9 @@ async fn share_loop(
         }
 
         if now.duration_since(last_sender_stats_at) >= std::time::Duration::from_secs(5) {
-            publisher.log_sender_stats("screen-capture").await;
+            publisher
+                .log_sender_stats("screen-capture", Some(health.as_ref()))
+                .await;
             last_sender_stats_at = now;
         }
 
@@ -1424,7 +1426,9 @@ async fn share_loop_monitor(
         }
 
         if now.duration_since(last_sender_stats_at) >= std::time::Duration::from_secs(5) {
-            publisher.log_sender_stats("screen-capture-monitor").await;
+            publisher
+                .log_sender_stats("screen-capture-monitor", Some(health.as_ref()))
+                .await;
             last_sender_stats_at = now;
         }
 

--- a/core/client/tauri.conf.json
+++ b/core/client/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "Echo Chamber",
-  "version": "0.6.16",
+  "version": "0.6.17",
   "identifier": "com.echochamber.app",
   "build": {
     "frontendDist": "../viewer"

--- a/core/control/Cargo.toml
+++ b/core/control/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "echo-core-control"
-version = "0.6.16"
+version = "0.6.17"
 edition = "2021"
 
 [dependencies]

--- a/core/viewer/admin-panel.js
+++ b/core/viewer/admin-panel.js
@@ -125,6 +125,28 @@ function renderInboundStreamStats(data) {
   return html;
 }
 
+function renderSenderDiagnostics(ch) {
+  if (!ch) return "";
+  const parts = [];
+  if (typeof ch.sender_fps === "number" && Number.isFinite(ch.sender_fps)) {
+    parts.push("sender " + formatStreamFps(ch.sender_fps));
+  }
+  if (typeof ch.sender_target_bitrate_kbps === "number" && Number.isFinite(ch.sender_target_bitrate_kbps)) {
+    parts.push("target " + formatStreamBitrate(ch.sender_target_bitrate_kbps));
+  }
+  if (typeof ch.sender_available_outgoing_bitrate_kbps === "number" && Number.isFinite(ch.sender_available_outgoing_bitrate_kbps)) {
+    parts.push("avail " + formatStreamBitrate(ch.sender_available_outgoing_bitrate_kbps));
+  }
+  if (ch.sender_quality_limitation) {
+    parts.push("quality " + ch.sender_quality_limitation);
+  }
+  if (ch.sender_encoder) {
+    parts.push(ch.sender_encoder);
+  }
+  if (parts.length === 0) return "";
+  return `<div class="admin-row3 admin-sender-row">${adminPanelEscape(parts.join(" Â· "))}</div>`;
+}
+
 function renderAdminPanel(data) {
   const body = document.getElementById("adminPanelBody");
   if (!body) return;
@@ -157,6 +179,7 @@ function renderAdminPanel(data) {
         const skip = `skip ${(ch.encoder_skip_rate_pct || 0).toFixed(1)}%`;
         const ct = `consec_to ${ch.consecutive_timeouts || 0}`;
         html += `<div class="admin-row2">fps ${fpsTxt}  ${reinits}  ${skip}  ${ct}</div>`;
+        html += renderSenderDiagnostics(ch);
         if (ch.reasons && ch.reasons.length > 0) {
           html += `<div class="admin-row3">└─ ${escapeHtml(ch.reasons.join("; "))}</div>`;
         }
@@ -257,5 +280,6 @@ if (typeof module === "object" && module.exports) {
     formatStreamBitrate,
     renderInboundStreamStats,
     renderParticipantInboundStreamStats,
+    renderSenderDiagnostics,
   };
 }

--- a/core/viewer/admin-panel.test.js
+++ b/core/viewer/admin-panel.test.js
@@ -4,6 +4,7 @@ const assert = require("node:assert/strict");
 const {
   formatStreamBitrate,
   renderInboundStreamStats,
+  renderSenderDiagnostics,
 } = require("./admin-panel.js");
 
 test("formats stream bitrate for admin diagnostics", () => {
@@ -54,4 +55,20 @@ test("renders receiver-side bitrate rows for every inbound stream", () => {
   assert.match(html, /loss 0 nack 0 pli 0 jitter 3ms/);
   assert.match(html, /David sees jeff-3333 camera/);
   assert.match(html, /30fps 1280x720 1\.2 Mbps/);
+});
+
+test("renders sender-side capture diagnostics", () => {
+  const html = renderSenderDiagnostics({
+    sender_fps: 8,
+    sender_target_bitrate_kbps: 5520,
+    sender_available_outgoing_bitrate_kbps: 5615,
+    sender_quality_limitation: "Cpu",
+    sender_encoder: "NVIDIA H264 Encoder",
+  });
+
+  assert.match(html, /sender 8fps/);
+  assert.match(html, /target 5\.5 Mbps/);
+  assert.match(html, /avail 5\.6 Mbps/);
+  assert.match(html, /quality Cpu/);
+  assert.match(html, /NVIDIA H264 Encoder/);
 });

--- a/core/viewer/capture-picker.css
+++ b/core/viewer/capture-picker.css
@@ -172,6 +172,41 @@
     border-top: 1px solid var(--glass-border, rgba(255, 255, 255, 0.08));
 }
 
+.capture-mode-control {
+    margin-right: auto;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+.capture-mode-control[hidden] {
+    display: none;
+}
+.capture-mode-label {
+    color: var(--text-secondary, rgba(255,255,255,0.55));
+    font-size: 11px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.6px;
+}
+.capture-mode-btn {
+    background: rgba(255, 255, 255, 0.08);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    color: var(--text-primary, #fff);
+    border-radius: 6px;
+    cursor: pointer;
+    font-size: 11px;
+    font-weight: 700;
+    min-width: 52px;
+    padding: 6px 8px;
+}
+.capture-mode-btn:hover {
+    background: rgba(255, 255, 255, 0.12);
+}
+.capture-mode-btn.active {
+    background: var(--accent, #7c3aed);
+    border-color: var(--accent, #7c3aed);
+}
+
 .capture-picker-btn {
     padding: 8px 20px;
     border-radius: 8px;

--- a/core/viewer/capture-picker.js
+++ b/core/viewer/capture-picker.js
@@ -6,6 +6,7 @@ var _capturePickerResolve = null;
 var _capturePickerReject = null;
 var _selectedSource = null;
 var _capturePickerSupport = null;
+var _selectedGameCaptureMode = 'auto';
 
 function isTauriCommandMissingError(err, commandName) {
     var msg = (err && err.message) ? err.message : String(err || '');
@@ -22,6 +23,7 @@ function showCapturePicker() {
         _capturePickerResolve = resolve;
         _capturePickerReject = reject;
         _selectedSource = null;
+        _selectedGameCaptureMode = 'auto';
         _buildPickerModal();
     });
 }
@@ -44,6 +46,12 @@ function _buildPickerModal() {
                 '<div style="text-align:center;padding:40px;color:rgba(255,255,255,0.5)">Loading sources...</div>' +
             '</div>' +
             '<div class="capture-picker-footer">' +
+                '<div class="capture-mode-control" id="cp-game-mode" hidden>' +
+                    '<span class="capture-mode-label">Game capture</span>' +
+                    '<button type="button" class="capture-mode-btn active" data-mode="auto">Auto</button>' +
+                    '<button type="button" class="capture-mode-btn" data-mode="desktop-dd">Desktop</button>' +
+                    '<button type="button" class="capture-mode-btn" data-mode="wgc">WGC</button>' +
+                '</div>' +
                 '<button class="capture-picker-btn secondary" id="cp-cancel">Cancel</button>' +
                 '<button class="capture-picker-btn primary" id="cp-share" disabled>Share</button>' +
             '</div>' +
@@ -60,6 +68,7 @@ function _buildPickerModal() {
     document.getElementById('cp-close').onclick = _cancelPicker;
     document.getElementById('cp-cancel').onclick = _cancelPicker;
     document.getElementById('cp-share').onclick = _confirmPicker;
+    _bindGameCaptureModeControl();
 
     // Close on overlay click (not modal body)
     overlay.onclick = function(e) {
@@ -112,6 +121,37 @@ function _closePicker() {
     }
 }
 
+function _bindGameCaptureModeControl() {
+    var control = document.getElementById('cp-game-mode');
+    if (!control) return;
+    control.querySelectorAll('.capture-mode-btn').forEach(function(btn) {
+        btn.onclick = function(e) {
+            e.stopPropagation();
+            _selectedGameCaptureMode = btn.dataset.mode || 'auto';
+            _syncGameCaptureModeControl();
+            if (_selectedSource && _selectedSource.sourceType === 'game') {
+                _selectedSource.captureMode = _selectedGameCaptureMode;
+            }
+        };
+    });
+    _syncGameCaptureModeControl();
+}
+
+function _setGameCaptureModeVisible(visible) {
+    var control = document.getElementById('cp-game-mode');
+    if (!control) return;
+    control.hidden = !visible;
+    if (visible) _syncGameCaptureModeControl();
+}
+
+function _syncGameCaptureModeControl() {
+    var control = document.getElementById('cp-game-mode');
+    if (!control) return;
+    control.querySelectorAll('.capture-mode-btn').forEach(function(btn) {
+        btn.classList.toggle('active', btn.dataset.mode === _selectedGameCaptureMode);
+    });
+}
+
 async function _loadSources() {
     var body = document.getElementById('cp-body');
     if (!body) return;
@@ -142,7 +182,7 @@ async function _loadSources() {
             html += _renderSection('Screens', null, monitors);
         }
         if (games.length > 0) {
-            html += _renderSection('Games', 'Hook Capture', games);
+            html += _renderSection('Games', 'Game Capture', games);
         }
         if (windows.length > 0) {
             html += _renderSection('Windows', null, windows);
@@ -166,12 +206,15 @@ async function _loadSources() {
                     c.classList.remove('selected');
                 });
                 card.classList.add('selected');
+                var sourceType = card.dataset.type;
+                _setGameCaptureModeVisible(sourceType === 'game');
                 _selectedSource = {
                     id: parseInt(card.dataset.id),
                     title: card.dataset.title,
-                    sourceType: card.dataset.type,
-                    isMonitor: card.dataset.type === 'monitor',
+                    sourceType: sourceType,
+                    isMonitor: sourceType === 'monitor',
                     pid: parseInt(card.dataset.pid) || 0,
+                    captureMode: sourceType === 'game' ? _selectedGameCaptureMode : null,
                 };
                 document.getElementById('cp-share').disabled = false;
             };

--- a/core/viewer/changelog.js
+++ b/core/viewer/changelog.js
@@ -8,6 +8,15 @@
 
 var ECHO_CHANGELOG = [
   {
+    version: "v0.6.17",
+    title: "Game Capture Diagnostics",
+    notes: [
+      "Game sharing now defaults to Desktop Duplication with the game publish profile after live logs showed WGC collapsing at the sender on Crimson Desert.",
+      "WGC remains available from the game capture mode control for diagnostics and A/B testing.",
+      "Admin capture health now reports sender FPS, target bitrate, available outgoing bitrate, quality limitation, and encoder so live bitrate/FPS failures are visible immediately."
+    ]
+  },
+  {
     version: "2026-05-04",
     title: "Screen Share Reliability Fixes (v0.6.12)",
     notes: [

--- a/core/viewer/screen-share-native.js
+++ b/core/viewer/screen-share-native.js
@@ -251,13 +251,13 @@ async function startScreenShareManual() {
     // Step 3: start capture
     try {
       if (source.sourceType === 'game') {
-        // Capture fallback chain: WGC (24H2+) → DXGI DD
-        // WGC = Windows.Graphics.Capture, 30-60fps (MPO-aware, Win11 24H2+ only)
-        // DXGI DD = DWM compositor, 4-35fps (universal fallback)
+        // Auto/default game capture uses Desktop Duplication. WGC stays
+        // available only as a manual diagnostics path.
         var captureStarted = false;
+        var gameCaptureMode = String(source.captureMode || 'auto').toLowerCase();
 
-        // 1. Try WGC window capture (MPO-aware, works at game's native FPS — requires Win11 24H2+)
-        if (!captureStarted && wgcSupported) {
+        // 1. Manual WGC window capture (diagnostics path; Win11 24H2+)
+        if (!captureStarted && gameCaptureMode === 'wgc' && wgcSupported) {
           try {
             debugLog('[wgc] trying WGC window capture for HWND ' + source.id + ' (build ' + osBuild + ')');
             await tauriInvoke('start_screen_share', {
@@ -271,12 +271,12 @@ async function startScreenShareManual() {
           } catch (wgcErr) {
             debugLog('[wgc] start failed: ' + (wgcErr.message || wgcErr));
           }
-        } else if (!captureStarted && !wgcSupported) {
+        } else if (!captureStarted && gameCaptureMode === 'wgc' && !wgcSupported) {
           debugLog('[wgc] skipped — requires Win11 24H2+ (build 26100+), current: ' + osBuild);
         }
 
-        // 2. Fall back to DXGI Desktop Duplication (compositor capture)
-        if (!captureStarted) {
+        // 2. Auto/default DXGI Desktop Duplication (compositor capture)
+        if (!captureStarted && gameCaptureMode !== 'wgc') {
           try {
             var ddResult = await tauriInvoke('check_desktop_capture_available');
             if (ddResult && ddResult[0]) {
@@ -296,6 +296,9 @@ async function startScreenShareManual() {
           } catch (ddErr) {
             debugLog('[desktop-dd] check/start failed: ' + (ddErr.message || ddErr));
           }
+        }
+        if (!captureStarted) {
+          throw new Error('Game capture unavailable for mode ' + gameCaptureMode);
         }
       } else {
         // Window/monitor capture
@@ -336,7 +339,11 @@ async function startScreenShareManual() {
       screenEnabled = true;
       window._echoNativeCaptureActive = true;
       _startSourceVisibilityMonitor(source);
-      _startQualityWarnListener();
+      try {
+        _startQualityWarnListener();
+      } catch (qualityWarnErr) {
+        debugLog('[screen-share] quality warning listener failed: ' + (qualityWarnErr.message || qualityWarnErr));
+      }
       renderPublishButtons();
       var modeLabel = window._echoNativeCaptureMode === 'desktop-dd' ? 'Desktop Duplication' : 'Window Capture';
       showToast('Screen sharing started (' + modeLabel + ')', 4000);
@@ -358,29 +365,8 @@ async function startScreenShareManual() {
       }
 
     } catch (err) {
-      var fallbackStarted = false;
       showToast('Capture failed: ' + (err.message || err), 8000);
-      // If game capture failed, try WGC fallback (only on 24H2+)
-      if (source.sourceType === 'game' && screenToken && wgcSupported) {
-        try {
-          await tauriInvoke('start_screen_share', {
-            sourceId: source.id,
-            sfuUrl: sfuUrl,
-            token: screenToken,
-            publishProfile: 'game',
-          });
-          window._echoNativeCaptureMode = 'wgc';
-          screenEnabled = true;
-          window._echoNativeCaptureActive = true;
-          _startSourceVisibilityMonitor(source);
-          renderPublishButtons();
-          fallbackStarted = true;
-          showToast('Using standard capture (game hook unavailable)', 5000);
-        } catch (e2) {
-          showToast('Fallback capture also failed: ' + (e2.message || e2), 8000);
-        }
-      }
-      if (!fallbackStarted) _stopNativeCaptureStopListeners();
+      _stopNativeCaptureStopListeners();
     }
     return;
   }

--- a/core/viewer/screen-share-native.test.js
+++ b/core/viewer/screen-share-native.test.js
@@ -93,14 +93,65 @@ function assertFloatArrayApprox(actual, expected) {
   }
 }
 
-test("game WGC fallback keeps the high-motion publish profile", async () => {
+test("game auto capture does not silently fall back to WGC", async () => {
   const { context, calls } = loadScreenShareNative();
 
   await context.startScreenShareManual();
 
-  const screenStarts = calls.filter((call) => call.command === "start_screen_share");
-  assert.equal(screenStarts.length, 2);
-  assert.equal(screenStarts[1].args.publishProfile, "game");
+  assert.equal(calls.some((call) => call.command === "check_desktop_capture_available"), true);
+  assert.equal(calls.some((call) => call.command === "start_screen_share"), false);
+});
+
+test("game auto capture uses Desktop Duplication before WGC", async () => {
+  const { context, calls } = loadScreenShareNative();
+  context.showCapturePicker = async () => ({
+    sourceType: "game",
+    id: 4242,
+    pid: 5678,
+    isMonitor: false,
+    captureMode: "auto",
+  });
+  context.tauriInvoke = async (command, args) => {
+    calls.push({ command, args });
+    if (command === "get_os_build_number") return 26100;
+    if (command === "check_desktop_capture_available") return [true, "available"];
+    return null;
+  };
+
+  await context.startScreenShareManual();
+
+  const desktopStart = calls.find((call) => call.command === "start_desktop_capture");
+  assert.ok(desktopStart);
+  assert.equal(desktopStart.args.hwnd, 4242);
+  assert.equal(desktopStart.args.fullscreen, false);
+  assert.equal(desktopStart.args.publishProfile, "game");
+  assert.equal(calls.some((call) => call.command === "start_screen_share"), false);
+  assert.equal(context.window._echoNativeCaptureMode, "desktop-dd");
+});
+
+test("manual WGC game capture keeps the WGC path available", async () => {
+  const { context, calls } = loadScreenShareNative();
+  context.showCapturePicker = async () => ({
+    sourceType: "game",
+    id: 4242,
+    pid: 5678,
+    isMonitor: false,
+    captureMode: "wgc",
+  });
+  context.tauriInvoke = async (command, args) => {
+    calls.push({ command, args });
+    if (command === "get_os_build_number") return 26100;
+    return null;
+  };
+
+  await context.startScreenShareManual();
+
+  const wgcStart = calls.find((call) => call.command === "start_screen_share");
+  assert.ok(wgcStart);
+  assert.equal(wgcStart.args.sourceId, 4242);
+  assert.equal(wgcStart.args.publishProfile, "game");
+  assert.equal(calls.some((call) => call.command === "start_desktop_capture"), false);
+  assert.equal(context.window._echoNativeCaptureMode, "wgc");
 });
 
 test("source visibility warning tells the publisher to keep the shared window visible", () => {


### PR DESCRIPTION
## Summary
- Default game capture now uses Desktop Duplication with the game publish profile.
- WGC stays available only as an explicit game capture diagnostics mode.
- Admin capture health now shows sender FPS, target bitrate, available outgoing bitrate, quality limitation, and encoder.
- Bumps desktop/control release metadata to v0.6.17 and adds changelog notes.

## Root cause
David's capture log showed WGC game capture briefly looking sharp, then settling around 23fps capture while the WebRTC sender collapsed to roughly 7-9fps with Bandwidth/Cpu quality limits. The Desktop Duplication path held about 29-30fps with quality=None, so the default game path now avoids silently falling back through WGC.

## Validation
- node --test core/viewer/*.test.js: 97 passed
- cargo test -p echo-core-client capture_health: 20 passed
- cargo check -p echo-core-client: passed with existing warnings
- cargo check -p echo-core-control: passed with existing warnings
- git diff --check: clean