### PR TITLE
[codex] use desktop capture for window shares by default

### DIFF
--- a/core/viewer/screen-share-native.js
+++ b/core/viewer/screen-share-native.js
@@ -250,11 +250,12 @@ async function startScreenShareManual() {
 
     // Step 3: start capture
     try {
-      if (source.sourceType === 'game') {
-        // Auto/default game capture uses Desktop Duplication. WGC stays
+      if (source.sourceType === 'game' || source.sourceType === 'window') {
+        // Auto/default window-like capture uses Desktop Duplication. WGC stays
         // available only as a manual diagnostics path.
         var captureStarted = false;
         var gameCaptureMode = String(source.captureMode || 'auto').toLowerCase();
+        var publishProfile = source.sourceType === 'game' ? 'game' : 'desktop';
 
         // 1. Manual WGC window capture (diagnostics path; Win11 24H2+)
         if (!captureStarted && gameCaptureMode === 'wgc' && wgcSupported) {
@@ -264,7 +265,7 @@ async function startScreenShareManual() {
               sourceId: source.id,
               sfuUrl: sfuUrl,
               token: screenToken,
-              publishProfile: 'game',
+              publishProfile: publishProfile,
             });
             window._echoNativeCaptureMode = 'wgc';
             captureStarted = true;
@@ -286,7 +287,7 @@ async function startScreenShareManual() {
                 fullscreen: source.isMonitor || false,
                 sfuUrl: sfuUrl,
                 token: screenToken,
-                publishProfile: 'game',
+                publishProfile: publishProfile,
               });
               window._echoNativeCaptureMode = 'desktop-dd';
               captureStarted = true;
@@ -298,17 +299,16 @@ async function startScreenShareManual() {
           }
         }
         if (!captureStarted) {
-          throw new Error('Game capture unavailable for mode ' + gameCaptureMode);
+          throw new Error('Window capture unavailable for mode ' + gameCaptureMode);
         }
       } else {
-        // Window/monitor capture
+        // Monitor capture
         // Monitors use DXGI Desktop Duplication. WGC monitor capture
         // (start_screen_share_monitor) is implemented but causes display flicker
         // on some HDR + high-refresh setups due to WGC's internal display state
         // polling. The Tauri command is left in place for future investigation.
         // Trade-off: DXGI DD doesn't include the mouse cursor in captured frames.
         // Cursor compositing into DXGI DD output is a v0.6.3 task.
-        // Windows use WGC on 24H2+, error on older.
         if (source.sourceType === 'monitor') {
           debugLog('[monitor] using DXGI DD for monitor capture');
           var ddResult = await tauriInvoke('check_desktop_capture_available');

--- a/core/viewer/screen-share-native.test.js
+++ b/core/viewer/screen-share-native.test.js
@@ -129,6 +129,33 @@ test("game auto capture uses Desktop Duplication before WGC", async () => {
   assert.equal(context.window._echoNativeCaptureMode, "desktop-dd");
 });
 
+test("window auto capture uses Desktop Duplication before WGC", async () => {
+  const { context, calls } = loadScreenShareNative();
+  context.showCapturePicker = async () => ({
+    sourceType: "window",
+    id: 4242,
+    pid: 5678,
+    isMonitor: false,
+    captureMode: "auto",
+  });
+  context.tauriInvoke = async (command, args) => {
+    calls.push({ command, args });
+    if (command === "get_os_build_number") return 26100;
+    if (command === "check_desktop_capture_available") return [true, "available"];
+    return null;
+  };
+
+  await context.startScreenShareManual();
+
+  const desktopStart = calls.find((call) => call.command === "start_desktop_capture");
+  assert.ok(desktopStart);
+  assert.equal(desktopStart.args.hwnd, 4242);
+  assert.equal(desktopStart.args.fullscreen, false);
+  assert.equal(desktopStart.args.publishProfile, "desktop");
+  assert.equal(calls.some((call) => call.command === "start_screen_share"), false);
+  assert.equal(context.window._echoNativeCaptureMode, "desktop-dd");
+});
+
 test("manual WGC game capture keeps the WGC path available", async () => {
   const { context, calls } = loadScreenShareNative();
   context.showCapturePicker = async () => ({


### PR DESCRIPTION
Root cause: David's Crimson Desert share was still publishing as WGC. The v0.6.17 DD-first logic only applied to sources categorized as Games; sources categorized as Windows still went straight to WGC.\n\nChange: route both game and window sources through the DD-first capture path. Manual WGC remains available when requested. Window sources use the desktop publish profile.\n\nValidation:\n- node --test core/viewer/screen-share-native.test.js\n- node --test core/viewer/*.test.js\n- live served viewer JS contains the new game-or-window DD-first routing