### PR TITLE
[codex] disable monitor system audio loopback

### DIFF
--- a/core/viewer/screen-share-native.js
+++ b/core/viewer/screen-share-native.js
@@ -28,9 +28,7 @@ function _captureSourceVisibilityToastMessage(status) {
 
 function nativeAudioCaptureRequestForSource(source) {
   if (!source) return null;
-  if (source.sourceType === 'monitor') {
-    return { mode: 'system', pid: 0, toast: 'System audio streaming' };
-  }
+  if (source.sourceType === 'monitor') return null;
   if ((source.sourceType === 'game' || source.sourceType === 'window') &&
       source.pid && source.pid > 0) {
     return {

--- a/core/viewer/screen-share-native.test.js
+++ b/core/viewer/screen-share-native.test.js
@@ -209,7 +209,7 @@ test("source visibility monitor is only enabled for native window-like sources",
   );
 });
 
-test("native audio capture request covers window and monitor shares", () => {
+test("native audio capture request avoids system loopback for monitor shares", () => {
   const { context } = loadScreenShareNative();
 
   assert.equal(
@@ -221,8 +221,8 @@ test("native audio capture request covers window and monitor shares", () => {
     JSON.stringify({ mode: "process", pid: 5678, toast: "Game audio streaming" })
   );
   assert.equal(
-    JSON.stringify(context.nativeAudioCaptureRequestForSource({ sourceType: "monitor", pid: 0 })),
-    JSON.stringify({ mode: "system", pid: 0, toast: "System audio streaming" })
+    context.nativeAudioCaptureRequestForSource({ sourceType: "monitor", pid: 0 }),
+    null
   );
   assert.equal(
     context.nativeAudioCaptureRequestForSource({ sourceType: "window", pid: 0 }),


### PR DESCRIPTION
Root cause: monitor capture auto-started system loopback audio. That rebroadcasts everything the publisher hears, including Echo mic playback from other users, creating an audio loop.\n\nChange: monitor shares no longer auto-start native audio capture. Game/window shares still use per-process PID audio when available.\n\nValidation:\n- node --test core/viewer/screen-share-native.test.js\n- node --test core/viewer/*.test.js\n- live served viewer JS no longer contains the monitor system-audio path