### PR TITLE
[codex] preserve native screenshare framerate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.6.18
+
+- Fix: Native screen shares now force WebRTC's framerate-preserving `ContentHint=Fluid` even when the track is labeled as a screenshare, preventing DXGI Desktop Duplication monitor/game streams from collapsing to single-digit FPS under CPU/backpressure adaptation.
+- Release: Desktop and control package versions are bumped to 0.6.18 for the required native binary update.
+
 ## 0.6.17
 
 - Change: Game sharing now defaults to Desktop Duplication with the game publish profile instead of silently falling through WGC.

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -1304,7 +1304,7 @@ dependencies = [
 
 [[package]]
 name = "echo-core-client"
-version = "0.6.17"
+version = "0.6.18"
 dependencies = [
  "base64 0.22.1",
  "futures-util",
@@ -1325,7 +1325,7 @@ dependencies = [
 
 [[package]]
 name = "echo-core-control"
-version = "0.6.17"
+version = "0.6.18"
 dependencies = [
  "argon2",
  "axum",

--- a/core/client/Cargo.toml
+++ b/core/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "echo-core-client"
-version = "0.6.17"
+version = "0.6.18"
 edition = "2021"
 description = "Echo Chamber native desktop client"
 

--- a/core/client/tauri.conf.json
+++ b/core/client/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "Echo Chamber",
-  "version": "0.6.17",
+  "version": "0.6.18",
   "identifier": "com.echochamber.app",
   "build": {
     "frontendDist": "../viewer"

--- a/core/control/Cargo.toml
+++ b/core/control/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "echo-core-control"
-version = "0.6.17"
+version = "0.6.18"
 edition = "2021"
 
 [dependencies]

--- a/core/docs/DECISIONS.md
+++ b/core/docs/DECISIONS.md
@@ -50,7 +50,7 @@ LiveKit SDK's `VIDEO_RIDS[0]` was `'q'` (LOW quality). Non-simulcast screen shar
 
 ## 2026-03-xx — ContentHint=Fluid
 
-WebRTC degrades FPS under bitrate pressure by default (`MAINTAIN_RESOLUTION` mode — reduces FPS to conserve quality). This caused viewer FPS to drop to 10fps even when NVENC was encoding at 45fps. Setting `ContentHint=Fluid` on the video track maps to `MAINTAIN_FRAMERATE` in peer_connection_factory, which prevents WebRTC from ever reducing FPS. Fixed in `core/livekit-local/`.
+WebRTC degrades FPS under bitrate pressure by default (`MAINTAIN_RESOLUTION` mode — reduces FPS to conserve quality). This caused viewer FPS to drop to 10fps even when NVENC was encoding at 45fps. Setting `ContentHint=Fluid` on native video tracks maps to `MAINTAIN_FRAMERATE` in peer_connection_factory, which prevents WebRTC from preserving resolution by collapsing FPS. Echo applies this to screenshare-labeled native tracks too, because DXGI Desktop Duplication monitor/game shares are interactive streams. Fixed in `core/livekit-local/`.
 
 ## 2026-04-xx — Audio Pipeline: startNativeAudioCapture() vs Raw IPC
 

--- a/core/docs/SDK_PATCHES.md
+++ b/core/docs/SDK_PATCHES.md
@@ -101,17 +101,18 @@ content types.
 **What changed:**
 
 ```cpp
-// After track creation, set degradation preference for non-screencast sources:
-if (!source->is_screencast()) {
-    track->set_content_hint(ContentHint::Fluid);
-    std::cerr << "[webrtc] set ContentHint=Fluid (MAINTAIN_FRAMERATE) for non-screencast track" << std::endl;
-}
+// After track creation, set degradation preference for all native video sources:
+track->set_content_hint(ContentHint::Fluid);
+std::cerr << "[webrtc] set ContentHint=Fluid (MAINTAIN_FRAMERATE) for native video track" << std::endl;
 ```
 
 **Why:** WebRTC's default `DegradationPreference` for video is `BALANCED`, which reduces
 *both* resolution and frame rate under bandwidth pressure. For game capture content,
 dropping FPS is far more damaging than dropping resolution. `ContentHint::Fluid` maps to
 `DegradationPreference::MAINTAIN_FRAMERATE` — WebRTC will reduce resolution before FPS.
+Echo applies this to all native video tracks, including LiveKit screenshare-labeled DXGI
+Desktop Duplication captures, because monitor/game shares are interactive streams and
+single-digit FPS is worse than temporary spatial degradation.
 
 Without this patch, WebRTC's bandwidth estimator calls `SetRates` with `fps=10` under
 load. The encoder accepts the low rate target and the capture pipeline throttles down

--- a/core/libwebrtc-local/src/native/peer_connection_factory.rs
+++ b/core/libwebrtc-local/src/native/peer_connection_factory.rs
@@ -106,6 +106,7 @@ impl PeerConnectionFactory {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::video_source::{native::NativeVideoSource, VideoResolution};
 
     #[tokio::test]
     async fn test_peer_connection_factory() {
@@ -114,6 +115,27 @@ mod tests {
         let factory = PeerConnectionFactory::default();
         let source = NativeVideoSource::default();
         let _track = factory.create_video_track("test", source);
+        drop(factory);
+    }
+
+    #[tokio::test]
+    async fn screencast_tracks_use_fluid_content_hint_to_preserve_framerate() {
+        let _ = env_logger::builder().is_test(true).try_init();
+
+        let factory = PeerConnectionFactory::default();
+        let source = NativeVideoSource::new(
+            VideoResolution {
+                width: 1920,
+                height: 1080,
+            },
+            true,
+        );
+        let track = factory.create_video_track("screen", source);
+
+        assert!(matches!(
+            track.handle.sys_handle.content_hint(),
+            webrtc_sys::video_track::ffi::ContentHint::Fluid
+        ));
         drop(factory);
     }
 }

--- a/core/viewer/changelog.js
+++ b/core/viewer/changelog.js
@@ -8,6 +8,14 @@
 
 var ECHO_CHANGELOG = [
   {
+    version: "v0.6.18",
+    title: "Screen Share Framerate Fix",
+    notes: [
+      "Native screen shares now force WebRTC's framerate-preserving mode even when the track is labeled as a screen share.",
+      "This targets the DXGI Desktop Duplication path where monitor/game streams could capture normally but WebRTC would throttle the sender down to single-digit FPS under CPU/backpressure adaptation."
+    ]
+  },
+  {
     version: "v0.6.17",
     title: "Game Capture Diagnostics",
     notes: [

--- a/core/webrtc-sys-local/src/peer_connection_factory.cpp
+++ b/core/webrtc-sys-local/src/peer_connection_factory.cpp
@@ -116,13 +116,11 @@ std::shared_ptr<VideoTrack> PeerConnectionFactory::create_video_track(
   auto track = std::static_pointer_cast<VideoTrack>(
       rtc_runtime_->get_or_create_media_stream_track(
           peer_factory_->CreateVideoTrack(source->get(), label.c_str())));
-  // For non-screencast sources (game/motion content), set ContentHint to Fluid.
-  // This makes WebRTC use DegradationPreference::MAINTAIN_FRAMERATE — it will
-  // reduce resolution rather than FPS when bandwidth is constrained.
-  if (!source->is_screencast()) {
-    track->set_content_hint(ContentHint::Fluid);
-    std::cerr << "[webrtc] set ContentHint=Fluid (MAINTAIN_FRAMERATE) for non-screencast track" << std::endl;
-  }
+  // Echo's native video tracks are interactive screen/game streams. Keep
+  // WebRTC in MAINTAIN_FRAMERATE mode even when LiveKit labels the track as a
+  // screencast, otherwise CPU/bandwidth adaptation can collapse to single-digit FPS.
+  track->set_content_hint(ContentHint::Fluid);
+  std::cerr << "[webrtc] set ContentHint=Fluid (MAINTAIN_FRAMERATE) for native video track" << std::endl;
   return track;
 }
 


### PR DESCRIPTION
## What changed
- Force every native WebRTC video track to use `ContentHint=Fluid`, including LiveKit screenshare-labeled DXGI Desktop Duplication tracks.
- Add a regression test in the local libwebrtc wrapper proving screencast native tracks get the framerate-preserving hint.
- Bump desktop/control package versions to 0.6.18 and add release/changelog notes.

## Why
David's capture log showed DXGI capture and NVENC were active, network loss was essentially zero, but the WebRTC sender sat at 6-8fps with `quality=Cpu` before later recovering. The old local WebRTC patch only applied `ContentHint=Fluid` to non-screencast tracks, so the DXGI screenshare path could still preserve resolution by collapsing framerate.

## Release impact
- Desktop binary required. Existing installed clients will not get this native WebRTC change from a viewer hotpatch.
- `core/deploy/latest.json` is intentionally unchanged; the release workflow generates the signed 0.6.18 updater manifest after the installer exists.

## Validation
- `cargo test -p libwebrtc screencast_tracks_use_fluid_content_hint_to_preserve_framerate` red before the fix, green after the fix while temporarily testing the local fork as a workspace member.
- `cargo check -p echo-core-client` passed.
- `cargo test -p echo-core-client capture_pipeline` passed: 7 passed, 0 failed.
- `cargo check -p echo-core-control` passed.
- `node --check core\viewer\changelog.js` passed.

## Known existing noise
- `cargo fmt --all -- --check` is already red on existing unrelated Rust formatting across `core/control` and `core/hook`; I did not include that formatting churn in this PR.