### PR TITLE
[codex] Add fast local Windows release publisher

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,13 @@
 name: Release
 
-# Triggered by:
-#   - pushing a version tag: `git tag v0.3.1 && git push --tags`
-#   - manual workflow_dispatch for dry-run validation (no GitHub release
-#     published; just builds the installer to confirm CUDA/NVENC compile
-#     succeeds on the runner)
+# Normal Windows releases are published from Sam's PC with:
+#   powershell -ExecutionPolicy Bypass -File core\deploy\publish-local-release.ps1
+#
+# This workflow remains as a manual fallback/dry-run path only. It no longer
+# runs on tag push because GitHub's Windows runner spends most of the release
+# delay installing CUDA and rebuilding Tauri artifacts that Sam's PC can build
+# locally.
 on:
-  push:
-    tags:
-      - 'v*'
   workflow_dispatch:
     inputs:
       dry_run:
@@ -19,6 +18,10 @@ on:
         options:
           - 'true'
           - 'false'
+      release_tag:
+        description: 'Release tag to publish when dry_run=false, e.g. v0.6.19'
+        required: false
+        type: string
 
 env:
   CARGO_TERM_COLOR: always
@@ -128,12 +131,28 @@ jobs:
           fi
           echo "$NOTES" > release-notes.txt
 
+      - name: Validate release tag
+        if: github.event.inputs.dry_run != 'true'
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ github.event.inputs.release_tag }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          if [ -z "$RELEASE_TAG" ]; then
+            echo "release_tag is required when dry_run=false"
+            exit 1
+          fi
+          if [ "$RELEASE_TAG" != "v$VERSION" ]; then
+            echo "release_tag ($RELEASE_TAG) must match v$VERSION"
+            exit 1
+          fi
+
       - name: Create GitHub Release
-        if: github.event_name == 'push' || github.event.inputs.dry_run != 'true'
+        if: github.event.inputs.dry_run != 'true'
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ github.ref_name }}
-          name: Echo Chamber ${{ github.ref_name }}
+          tag_name: ${{ github.event.inputs.release_tag }}
+          name: Echo Chamber ${{ github.event.inputs.release_tag }}
           body_path: release-notes.txt
           draft: false
           prerelease: false
@@ -228,9 +247,9 @@ jobs:
 
   publish-manifest:
     name: Publish Update Manifest
-    # Only on real tag-triggered releases, not dry-run workflow_dispatch.
+    # Only on explicit manual fallback publishes, not dry-run workflow_dispatch.
     # No longer needs build-macos since macOS is disabled — Windows-only.
-    if: github.event_name == 'push'
+    if: github.event.inputs.dry_run != 'true'
     runs-on: ubuntu-latest
     needs: [build-windows]
     permissions:
@@ -251,7 +270,7 @@ jobs:
         shell: bash
         run: |
           VERSION="${{ steps.version.outputs.version }}"
-          TAG="${{ github.ref_name }}"
+          TAG="${{ github.event.inputs.release_tag }}"
           WIN_SIG="${{ needs.build-windows.outputs.win_sig }}"
           # macOS build is disabled (Windows-only project) — empty MAC_SIG
           # makes the latest.json generator fall through to the windows-only
@@ -307,5 +326,5 @@ jobs:
       - name: Upload latest.json to release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ github.ref_name }}
+          tag_name: ${{ github.event.inputs.release_tag }}
           files: latest.json

--- a/core/deploy/build-release.ps1
+++ b/core/deploy/build-release.ps1
@@ -7,6 +7,9 @@
 #   - Echo Chamber_<version>_x64-setup.exe       (installer for friends)
 #   - Echo Chamber_<version>_x64-setup.exe.sig   (signature for auto-updates)
 #   - latest.json                                 (update manifest for GitHub Releases)
+#
+# To publish the release end-to-end from this PC, use:
+#   powershell -ExecutionPolicy Bypass -File core\deploy\publish-local-release.ps1
 
 param(
     [switch]$SkipBuild

--- a/core/deploy/local-release-lib.ps1
+++ b/core/deploy/local-release-lib.ps1
@@ -1,0 +1,231 @@
+$ErrorActionPreference = "Stop"
+
+function Write-ReleaseStatus([string]$Message, [string]$Color = "Cyan") {
+    Write-Host "[local-release] " -NoNewline -ForegroundColor DarkGray
+    Write-Host $Message -ForegroundColor $Color
+}
+
+function ConvertTo-GitHubAssetName([string]$FileName) {
+    return $FileName -replace ' ', '.'
+}
+
+function Get-TomlPackageVersion([string]$Path) {
+    if (!(Test-Path $Path)) {
+        throw "Missing version file: $Path"
+    }
+
+    $match = Select-String -Path $Path -Pattern '^\s*version\s*=\s*"([^"]+)"' | Select-Object -First 1
+    if (!$match) {
+        throw "Could not find package version in $Path"
+    }
+
+    return $match.Matches[0].Groups[1].Value
+}
+
+function Test-ChangelogHasVersion([string]$Root, [string]$Version) {
+    $path = Join-Path $Root "CHANGELOG.md"
+    if (!(Test-Path $path)) {
+        return $false
+    }
+
+    $content = Get-Content $path -Raw
+    $escaped = [regex]::Escape($Version)
+    return [bool]($content -match "(?m)^##\s+$escaped\s*$")
+}
+
+function Get-ReleaseVersionInfo([string]$Root) {
+    $clientCargoPath = Join-Path $Root "core\client\Cargo.toml"
+    $controlCargoPath = Join-Path $Root "core\control\Cargo.toml"
+    $tauriConfigPath = Join-Path $Root "core\client\tauri.conf.json"
+
+    if (!(Test-Path $tauriConfigPath)) {
+        throw "Missing Tauri config: $tauriConfigPath"
+    }
+
+    $clientCargoVersion = Get-TomlPackageVersion $clientCargoPath
+    $controlCargoVersion = Get-TomlPackageVersion $controlCargoPath
+    $tauriVersion = (Get-Content $tauriConfigPath -Raw | ConvertFrom-Json).version
+
+    $versions = @($clientCargoVersion, $controlCargoVersion, $tauriVersion) | Select-Object -Unique
+    if ($versions.Count -ne 1) {
+        throw "Version files disagree: client Cargo=$clientCargoVersion, control Cargo=$controlCargoVersion, tauri=$tauriVersion"
+    }
+
+    if (!(Test-ChangelogHasVersion -Root $Root -Version $tauriVersion)) {
+        throw "CHANGELOG.md is missing a '## $tauriVersion' release entry"
+    }
+
+    return [pscustomobject]@{
+        Version = $tauriVersion
+        ClientCargoVersion = $clientCargoVersion
+        ControlCargoVersion = $controlCargoVersion
+        TauriVersion = $tauriVersion
+    }
+}
+
+function Get-ReleaseBundle([string]$Root, [string]$Version) {
+    $bundleDir = Join-Path $Root "core\target\release\bundle\nsis"
+    if (!(Test-Path $bundleDir)) {
+        throw "NSIS bundle directory does not exist: $bundleDir"
+    }
+
+    $installer = Get-ChildItem $bundleDir -Filter "*_${Version}_*-setup.exe" |
+        Sort-Object LastWriteTimeUtc -Descending |
+        Select-Object -First 1
+    $signature = Get-ChildItem $bundleDir -Filter "*_${Version}_*-setup.exe.sig" |
+        Sort-Object LastWriteTimeUtc -Descending |
+        Select-Object -First 1
+    $manifestPath = Join-Path $bundleDir "latest.json"
+
+    if (!$installer) {
+        throw "Missing installer for version $Version in $bundleDir"
+    }
+    if (!$signature) {
+        throw "Missing installer signature for version $Version in $bundleDir"
+    }
+    if (!(Test-Path $manifestPath)) {
+        throw "Missing latest.json in $bundleDir"
+    }
+
+    $manifest = Get-Content $manifestPath -Raw | ConvertFrom-Json
+    if ($manifest.version -ne $Version) {
+        throw "latest.json version '$($manifest.version)' does not match $Version"
+    }
+
+    $platform = $manifest.platforms.'windows-x86_64'
+    if (!$platform) {
+        throw "latest.json is missing platforms.windows-x86_64"
+    }
+    if ([string]::IsNullOrWhiteSpace($platform.signature)) {
+        throw "latest.json windows-x86_64 signature is empty"
+    }
+
+    $githubInstallerName = ConvertTo-GitHubAssetName $installer.Name
+    $expectedUrlFragment = "/releases/download/v$Version/$githubInstallerName"
+    if ($platform.url -notlike "*$expectedUrlFragment") {
+        throw "latest.json URL '$($platform.url)' does not point at $expectedUrlFragment"
+    }
+
+    return [pscustomobject]@{
+        BundleDir = $bundleDir
+        InstallerPath = $installer.FullName
+        SignaturePath = $signature.FullName
+        ManifestPath = $manifestPath
+        GitHubInstallerName = $githubInstallerName
+        GitHubSignatureName = ConvertTo-GitHubAssetName $signature.Name
+    }
+}
+
+function New-ReleaseNotesFile([string]$Root, [string]$Version, [string]$OutputPath) {
+    $path = Join-Path $Root "CHANGELOG.md"
+    if (!(Test-Path $path)) {
+        throw "Missing CHANGELOG.md"
+    }
+
+    $lines = Get-Content $path
+    $notes = New-Object System.Collections.Generic.List[string]
+    $inSection = $false
+    $versionPattern = '^\s*##\s+' + [regex]::Escape($Version) + '\s*$'
+
+    foreach ($line in $lines) {
+        if ($line -match '^\s*##\s+') {
+            if ($inSection) {
+                break
+            }
+            if ($line -match $versionPattern) {
+                $inSection = $true
+                continue
+            }
+        }
+
+        if ($inSection) {
+            $notes.Add($line)
+        }
+    }
+
+    $text = ($notes -join [Environment]::NewLine).Trim()
+    if ([string]::IsNullOrWhiteSpace($text)) {
+        $text = "Update to v$Version"
+    }
+
+    [System.IO.File]::WriteAllText($OutputPath, $text)
+}
+
+function Invoke-CheckedCommand([string]$FilePath, [string[]]$ArgumentList, [string]$WorkingDirectory, [string]$Label) {
+    Write-ReleaseStatus $Label
+    Push-Location $WorkingDirectory
+    try {
+        & $FilePath @ArgumentList
+        $exitCode = $LASTEXITCODE
+    }
+    finally {
+        Pop-Location
+    }
+
+    if ($exitCode -ne 0) {
+        throw "$Label failed with exit code $exitCode"
+    }
+}
+
+function Get-RequiredCommand([string]$Name) {
+    $command = Get-Command $Name -ErrorAction SilentlyContinue
+    if (!$command) {
+        throw "Required command not found on PATH: $Name"
+    }
+    return $command.Source
+}
+
+function Get-GitOutput([string]$Root, [string[]]$Args) {
+    $output = & git -C $Root @Args
+    if ($LASTEXITCODE -ne 0) {
+        throw "git $($Args -join ' ') failed with exit code $LASTEXITCODE"
+    }
+    return ($output -join [Environment]::NewLine).Trim()
+}
+
+function Assert-LocalReleaseGitState([string]$Root, [string]$Remote, [string]$Branch, [string]$Tag) {
+    $status = Get-GitOutput $Root @("status", "--porcelain")
+    if (![string]::IsNullOrWhiteSpace($status)) {
+        throw "Working tree must be clean before publishing a local release"
+    }
+
+    $currentBranch = Get-GitOutput $Root @("branch", "--show-current")
+    if ($currentBranch -ne $Branch) {
+        throw "Local release must run from branch '$Branch'; current branch is '$currentBranch'"
+    }
+
+    $head = Get-GitOutput $Root @("rev-parse", "HEAD")
+    $remoteHead = Get-GitOutput $Root @("rev-parse", "$Remote/$Branch")
+    if ($head -ne $remoteHead) {
+        throw "HEAD ($head) does not match $Remote/$Branch ($remoteHead). Pull/merge first."
+    }
+
+    $localTag = Get-GitOutput $Root @("tag", "--list", $Tag)
+    if (![string]::IsNullOrWhiteSpace($localTag)) {
+        throw "Local tag already exists: $Tag"
+    }
+
+    $remoteTag = Get-GitOutput $Root @("ls-remote", "--tags", $Remote, "refs/tags/$Tag")
+    if (![string]::IsNullOrWhiteSpace($remoteTag)) {
+        throw "Remote tag already exists: $Tag"
+    }
+}
+
+function Copy-ReleaseUploadAssets([object]$Bundle, [string]$Version) {
+    $uploadDir = Join-Path $Bundle.BundleDir "upload-v$Version"
+    New-Item -ItemType Directory -Path $uploadDir -Force | Out-Null
+
+    $installerUpload = Join-Path $uploadDir $Bundle.GitHubInstallerName
+    $signatureUpload = Join-Path $uploadDir $Bundle.GitHubSignatureName
+    $manifestUpload = Join-Path $uploadDir "latest.json"
+
+    Copy-Item -LiteralPath $Bundle.InstallerPath -Destination $installerUpload -Force
+    Copy-Item -LiteralPath $Bundle.SignaturePath -Destination $signatureUpload -Force
+    Copy-Item -LiteralPath $Bundle.ManifestPath -Destination $manifestUpload -Force
+
+    return [pscustomobject]@{
+        InstallerPath = $installerUpload
+        SignaturePath = $signatureUpload
+        ManifestPath = $manifestUpload
+    }
+}

--- a/core/deploy/publish-local-release.ps1
+++ b/core/deploy/publish-local-release.ps1
@@ -1,0 +1,113 @@
+# Echo Chamber - Fast local Windows release publisher
+#
+# Builds/signs the Windows installer on this PC, publishes the GitHub Release,
+# uploads the updater manifest, then copies latest.json into core/deploy/ so
+# the live control plane can serve it immediately.
+#
+# Normal use from a clean, up-to-date main branch:
+#   powershell -ExecutionPolicy Bypass -File core\deploy\publish-local-release.ps1
+
+param(
+    [string]$Repo = "SamWatson86/echo-chamber",
+    [string]$Remote = "origin",
+    [string]$Branch = "main",
+    [switch]$SkipBuild,
+    [switch]$SkipChecks,
+    [switch]$Draft,
+    [switch]$NoManifestSync
+)
+
+$ErrorActionPreference = "Stop"
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$root = Split-Path (Split-Path $scriptDir -Parent) -Parent
+$coreDir = Join-Path $root "core"
+$buildScript = Join-Path $scriptDir "build-release.ps1"
+$testScript = Join-Path $scriptDir "test-local-release-lib.ps1"
+. (Join-Path $scriptDir "local-release-lib.ps1")
+
+Get-RequiredCommand "git" | Out-Null
+Get-RequiredCommand "gh" | Out-Null
+Get-RequiredCommand "powershell" | Out-Null
+
+$versionInfo = Get-ReleaseVersionInfo -Root $root
+$version = $versionInfo.Version
+$tag = "v$version"
+
+Write-ReleaseStatus "Preparing local Windows release $tag"
+
+Invoke-CheckedCommand "git" @("fetch", $Remote, $Branch, "--tags") $root "Fetching $Remote/$Branch and tags"
+Assert-LocalReleaseGitState -Root $root -Remote $Remote -Branch $Branch -Tag $tag
+
+& gh auth status -h github.com
+if ($LASTEXITCODE -ne 0) {
+    throw "gh is not authenticated for github.com"
+}
+
+& gh release view $tag --repo $Repo *> $null
+if ($LASTEXITCODE -eq 0) {
+    throw "GitHub Release already exists: $tag"
+}
+
+if (!$SkipChecks) {
+    Invoke-CheckedCommand "powershell" @("-NoProfile", "-ExecutionPolicy", "Bypass", "-File", $testScript) $root "Running local release helper tests"
+    Invoke-CheckedCommand "cargo" @("check", "-p", "echo-core-control") $coreDir "Checking control package"
+    Invoke-CheckedCommand "node" @("--check", "core\viewer\changelog.js") $root "Checking viewer changelog syntax"
+}
+
+$buildArgs = @("-NoProfile", "-ExecutionPolicy", "Bypass", "-File", $buildScript)
+if ($SkipBuild) {
+    $buildArgs += "-SkipBuild"
+}
+Invoke-CheckedCommand "powershell" $buildArgs $root "Building signed Windows installer"
+
+$bundle = Get-ReleaseBundle -Root $root -Version $version
+$uploadAssets = Copy-ReleaseUploadAssets -Bundle $bundle -Version $version
+
+$notesPath = Join-Path $bundle.BundleDir "release-notes-$tag.txt"
+New-ReleaseNotesFile -Root $root -Version $version -OutputPath $notesPath
+
+$targetSha = Get-GitOutput $root @("rev-parse", "HEAD")
+$releaseArgs = @(
+    "release", "create", $tag,
+    "--repo", $Repo,
+    "--target", $targetSha,
+    "--title", "Echo Chamber $tag",
+    "--notes-file", $notesPath
+)
+if ($Draft) {
+    $releaseArgs += "--draft"
+}
+$releaseArgs += @(
+    $uploadAssets.InstallerPath,
+    $uploadAssets.SignaturePath,
+    $uploadAssets.ManifestPath
+)
+
+Invoke-CheckedCommand "gh" $releaseArgs $root "Creating GitHub Release $tag"
+
+$releaseJson = & gh release view $tag --repo $Repo --json tagName,url,assets,isDraft | ConvertFrom-Json
+if ($releaseJson.tagName -ne $tag) {
+    throw "Release verification returned tag '$($releaseJson.tagName)', expected '$tag'"
+}
+
+$assetNames = @($releaseJson.assets | ForEach-Object { $_.name })
+foreach ($requiredAsset in @($bundle.GitHubInstallerName, $bundle.GitHubSignatureName, "latest.json")) {
+    if ($assetNames -notcontains $requiredAsset) {
+        throw "Release $tag is missing asset '$requiredAsset'"
+    }
+}
+
+if (!$NoManifestSync) {
+    $deployManifest = Join-Path $scriptDir "latest.json"
+    Copy-Item -LiteralPath $bundle.ManifestPath -Destination $deployManifest -Force
+    $synced = Get-Content $deployManifest -Raw | ConvertFrom-Json
+    if ($synced.version -ne $version) {
+        throw "Synced core\deploy\latest.json version '$($synced.version)' does not match $version"
+    }
+    Write-ReleaseStatus "Synced core\deploy\latest.json to $version" Green
+    Write-ReleaseStatus "core\deploy\latest.json is now a local metadata change; commit it through the normal PR path after verification." Yellow
+}
+
+Write-ReleaseStatus "Published ${tag}: $($releaseJson.url)" Green
+Write-ReleaseStatus "Friends can download: https://github.com/$Repo/releases/tag/$tag" Green

--- a/core/deploy/test-local-release-lib.ps1
+++ b/core/deploy/test-local-release-lib.ps1
@@ -1,0 +1,106 @@
+$ErrorActionPreference = "Stop"
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+. (Join-Path $scriptDir "local-release-lib.ps1")
+
+function Assert-True([bool]$Condition, [string]$Message) {
+    if (-not $Condition) {
+        throw "Assertion failed: $Message"
+    }
+}
+
+function Assert-Equal([object]$Expected, [object]$Actual, [string]$Message) {
+    if ($Expected -ne $Actual) {
+        throw "Assertion failed: $Message. Expected '$Expected', got '$Actual'"
+    }
+}
+
+function New-TestRepo {
+    $root = Join-Path ([System.IO.Path]::GetTempPath()) ("echo-local-release-test-" + [Guid]::NewGuid().ToString("N"))
+    New-Item -ItemType Directory -Path $root | Out-Null
+    New-Item -ItemType Directory -Path (Join-Path $root "core\client") -Force | Out-Null
+    New-Item -ItemType Directory -Path (Join-Path $root "core\control") -Force | Out-Null
+    New-Item -ItemType Directory -Path (Join-Path $root "core\target\release\bundle\nsis") -Force | Out-Null
+
+    Set-Content -Path (Join-Path $root "core\client\Cargo.toml") -Value @"
+[package]
+name = "echo-core-client"
+version = "1.2.3"
+"@
+    Set-Content -Path (Join-Path $root "core\control\Cargo.toml") -Value @"
+[package]
+name = "echo-core-control"
+version = "1.2.3"
+"@
+    Set-Content -Path (Join-Path $root "core\client\tauri.conf.json") -Value '{"version":"1.2.3"}'
+    Set-Content -Path (Join-Path $root "CHANGELOG.md") -Value @"
+# Changelog
+
+## 1.2.3
+
+- Fix: Local releases are fast.
+- Safety: Release guardrails verify assets.
+
+## 1.2.2
+
+- Previous release.
+"@
+
+    $bundleDir = Join-Path $root "core\target\release\bundle\nsis"
+    Set-Content -Path (Join-Path $bundleDir "Echo Chamber_1.2.3_x64-setup.exe") -Value "exe"
+    Set-Content -Path (Join-Path $bundleDir "Echo Chamber_1.2.3_x64-setup.exe.sig") -Value "signature"
+    Set-Content -Path (Join-Path $bundleDir "latest.json") -Value @"
+{
+  "version": "1.2.3",
+  "platforms": {
+    "windows-x86_64": {
+      "signature": "signature",
+      "url": "https://github.com/SamWatson86/echo-chamber/releases/download/v1.2.3/Echo.Chamber_1.2.3_x64-setup.exe"
+    }
+  }
+}
+"@
+
+    return $root
+}
+
+$repo = New-TestRepo
+try {
+    $versions = Get-ReleaseVersionInfo -Root $repo
+    Assert-Equal "1.2.3" $versions.Version "version info returns the shared release version"
+    Assert-Equal "1.2.3" $versions.ClientCargoVersion "client Cargo version is parsed"
+    Assert-Equal "1.2.3" $versions.ControlCargoVersion "control Cargo version is parsed"
+    Assert-Equal "1.2.3" $versions.TauriVersion "Tauri version is parsed"
+
+    Assert-Equal "Echo.Chamber_1.2.3_x64-setup.exe" (ConvertTo-GitHubAssetName "Echo Chamber_1.2.3_x64-setup.exe") "GitHub asset name replaces spaces with dots"
+
+    $bundle = Get-ReleaseBundle -Root $repo -Version "1.2.3"
+    Assert-True (Test-Path $bundle.InstallerPath) "installer path exists"
+    Assert-True (Test-Path $bundle.SignaturePath) "signature path exists"
+    Assert-True (Test-Path $bundle.ManifestPath) "manifest path exists"
+    Assert-Equal "Echo.Chamber_1.2.3_x64-setup.exe" $bundle.GitHubInstallerName "bundle returns upload-safe installer name"
+
+    $notesPath = Join-Path $repo "release-notes.txt"
+    New-ReleaseNotesFile -Root $repo -Version "1.2.3" -OutputPath $notesPath
+    $notes = Get-Content $notesPath -Raw
+    Assert-True ($notes.Contains("Local releases are fast")) "release notes include current version entry"
+    Assert-True (-not $notes.Contains("Previous release")) "release notes stop at the next version"
+
+    Set-Content -Path (Join-Path $repo "core\control\Cargo.toml") -Value @"
+[package]
+name = "echo-core-control"
+version = "9.9.9"
+"@
+    $threw = $false
+    try {
+        Get-ReleaseVersionInfo -Root $repo | Out-Null
+    } catch {
+        $threw = $true
+    }
+    Assert-True $threw "mismatched version files fail closed"
+}
+finally {
+    Remove-Item -LiteralPath $repo -Recurse -Force
+}
+
+Write-Host "local-release-lib tests passed"

--- a/docs/GITHUB.md
+++ b/docs/GITHUB.md
@@ -40,6 +40,7 @@ Optional release impact labels for PRs/issues:
 ## Release verification gotchas
 
 - Windows-only unless Sam explicitly asks otherwise. Do not add or wait on macOS release jobs for normal Echo Chamber releases.
+- Normal desktop releases are published locally from Sam's PC with `core/deploy/publish-local-release.ps1`; the GitHub release workflow is manual fallback only and no longer runs on tag push.
 - Do not claim a desktop release is done from a local build alone. Verify the GitHub Release/tag/assets and the updater manifest.
 - Keep version sources in sync for desktop releases:
   - `core/client/tauri.conf.json`
@@ -51,3 +52,40 @@ Optional release impact labels for PRs/issues:
   - `https://echo.fellowshipoftheboatrace.party:9443/api/update/latest.json`
 - An update banner in the app means the server-served updater metadata and the installed desktop version disagree. Check the manifest before assuming the client install failed.
 - If doing a manual viewer-only deploy, make sure the deploy watcher state is not left pointing at an older SHA that will trigger an unnecessary rebuild/restart later.
+
+## Fast local Windows desktop release
+
+Use this path for live testing with friends when a new desktop binary is needed and `main` already contains the merged release commit.
+
+Prerequisites:
+- Run from a clean, up-to-date `main` branch.
+- `gh` is installed and authenticated.
+- `core/client/.tauri-keys` is present on the release machine.
+- Version files and `CHANGELOG.md` are already bumped for the release.
+
+Command:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File core\deploy\publish-local-release.ps1
+```
+
+What the script enforces:
+- Fails if the worktree is dirty, not on `main`, or not equal to `origin/main`.
+- Fails if the local/remote tag or GitHub Release already exists.
+- Fails if `core/client/tauri.conf.json`, `core/client/Cargo.toml`, `core/control/Cargo.toml`, and `CHANGELOG.md` disagree.
+- Runs local release helper tests, `cargo check -p echo-core-control`, and `node --check core/viewer/changelog.js`.
+- Builds the signed Windows NSIS installer with `core/deploy/build-release.ps1`.
+- Uploads the installer, `.sig`, and `latest.json` to GitHub Releases.
+- Verifies the release assets exist.
+- Copies the generated manifest to `core/deploy/latest.json` so `/api/update/latest.json` can serve the new version immediately.
+- Leaves `core/deploy/latest.json` as a local metadata change; commit that manifest update through the normal PR path after release verification.
+
+After publishing, verify:
+
+```powershell
+gh release view vX.Y.Z --json tagName,assets,url
+curl.exe -sk https://echo.fellowshipoftheboatrace.party:9443/api/update/latest.json
+curl.exe -sk https://echo.fellowshipoftheboatrace.party:9443/api/version
+```
+
+If GitHub-hosted fallback is needed, use the manual `Release` workflow with `dry_run=false` and an explicit `release_tag` matching the checked-out version. Do not push tags expecting Actions to build automatically.


### PR DESCRIPTION
## Summary
- Add a local Windows release publisher that builds/signs on Sam's PC, uploads GitHub Release assets, verifies assets, and syncs latest.json locally.
- Add PowerShell helper tests for version sync, asset naming, bundle validation, and changelog release-note extraction.
- Change the GitHub Release workflow to manual fallback only so tag pushes no longer trigger the slow hosted Windows build.
- Document the fast local release runbook in docs/GITHUB.md.

## Verification
- powershell -NoProfile -ExecutionPolicy Bypass -File core\deploy\test-local-release-lib.ps1
- PowerShell parser checks for local-release-lib.ps1, publish-local-release.ps1, test-local-release-lib.ps1, build-release.ps1
- git diff --check
- cargo check -p echo-core-control
- node --check core/viewer/changelog.js

## Release impact
Desktop release process only. No runtime app behavior change.
