### PR TITLE
[codex] Fix H264 bitrate ramp for v0.6.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.6.19
+
+- Fix: H264 SDP bitrate hints now use the publish profile's real minimum bitrate and full target start bitrate, so game streams start/ramp at the intended budget instead of falling back to a low allocator hint.
+- Diagnostics: Desktop Duplication sender stats now emit once per 60 published frames instead of repeating when publisher pacing holds the frame counter steady.
+- Diagnostics: Windows client startup logs now include the desktop binary version.
+- Release: Desktop and control package versions are bumped to 0.6.19.
+
 ## 0.6.18
 
 - Fix: Native screen shares now force WebRTC's framerate-preserving `ContentHint=Fluid` even when the track is labeled as a screenshare, preventing DXGI Desktop Duplication monitor/game streams from collapsing to single-digit FPS under CPU/backpressure adaptation.

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -1304,7 +1304,7 @@ dependencies = [
 
 [[package]]
 name = "echo-core-client"
-version = "0.6.18"
+version = "0.6.19"
 dependencies = [
  "base64 0.22.1",
  "futures-util",
@@ -1325,7 +1325,7 @@ dependencies = [
 
 [[package]]
 name = "echo-core-control"
-version = "0.6.18"
+version = "0.6.19"
 dependencies = [
  "argon2",
  "axum",

--- a/core/client/Cargo.toml
+++ b/core/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "echo-core-client"
-version = "0.6.18"
+version = "0.6.19"
 edition = "2021"
 description = "Echo Chamber native desktop client"
 

--- a/core/client/src/desktop_capture.rs
+++ b/core/client/src/desktop_capture.rs
@@ -70,6 +70,46 @@ fn global_state() -> &'static Mutex<Option<DesktopShareHandle>> {
     STATE.get_or_init(|| Mutex::new(None))
 }
 
+fn should_emit_frame_count_stats(frame_count: u64, last_stats_frame_count: &mut u64) -> bool {
+    if frame_count == 0 || frame_count == *last_stats_frame_count || frame_count % 60 != 0 {
+        return false;
+    }
+
+    *last_stats_frame_count = frame_count;
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn frame_count_stats_gate_only_emits_once_per_60_frame_boundary() {
+        let mut last_stats_frame_count = 0;
+
+        assert!(!should_emit_frame_count_stats(
+            59,
+            &mut last_stats_frame_count
+        ));
+        assert!(should_emit_frame_count_stats(
+            60,
+            &mut last_stats_frame_count
+        ));
+        assert!(!should_emit_frame_count_stats(
+            60,
+            &mut last_stats_frame_count
+        ));
+        assert!(!should_emit_frame_count_stats(
+            61,
+            &mut last_stats_frame_count
+        ));
+        assert!(should_emit_frame_count_stats(
+            120,
+            &mut last_stats_frame_count
+        ));
+    }
+}
+
 fn windows_build_number() -> u32 {
     #[repr(C)]
     struct OsVersionInfoExW {
@@ -919,6 +959,8 @@ fn capture_loop_blocking(
     // (skip processing when the previous frame is identical) instead of
     // forcing the capture loop to sleep.
 
+    let mut last_stats_frame_count = 0u64;
+
     // 7. Frame loop
     while running.load(Ordering::SeqCst) {
         // Acquire next frame from compositor (blocks up to 100ms)
@@ -1289,8 +1331,9 @@ fn capture_loop_blocking(
             }
         }
 
-        // Stats every 60 frames
-        if frame_count % 60 == 0 {
+        // Stats every 60 published frames. If publisher pacing drops a frame,
+        // frame_count can stall on a multiple of 60; do not duplicate the block.
+        if should_emit_frame_count_stats(frame_count, &mut last_stats_frame_count) {
             if let Some(fps) = publisher.maybe_emit_stats(
                 app,
                 "desktop-capture-stats",

--- a/core/client/src/main.rs
+++ b/core/client/src/main.rs
@@ -617,8 +617,8 @@ fn main() {
     #[cfg(target_os = "windows")]
     {
         file_debug_log::append(&format!(
-            "[startup] echo-core-client boot server={} force_software_encoder={} auto_force_software_encoder={} windows_build={}",
-            server, force_software_encoder, auto_force_software_encoder, windows_build
+            "[startup] echo-core-client boot version={} server={} force_software_encoder={} auto_force_software_encoder={} windows_build={}",
+            env!("CARGO_PKG_VERSION"), server, force_software_encoder, auto_force_software_encoder, windows_build
         ));
     }
 

--- a/core/client/tauri.conf.json
+++ b/core/client/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "Echo Chamber",
-  "version": "0.6.18",
+  "version": "0.6.19",
   "identifier": "com.echochamber.app",
   "build": {
     "frontendDist": "../viewer"

--- a/core/control/Cargo.toml
+++ b/core/control/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "echo-core-control"
-version = "0.6.18"
+version = "0.6.19"
 edition = "2021"
 
 [dependencies]

--- a/core/docs/CAPTURE_PIPELINE.md
+++ b/core/docs/CAPTURE_PIPELINE.md
@@ -81,6 +81,8 @@ The JS side always derives the SFU URL from the control URL (`https→wss`) — 
 - Simulcast: disabled for screen share; single layer labeled `f` (HIGH RID) so SFU allocates full bandwidth
 - Non-simulcast bug fixed: `VIDEO_RIDS[0]` was `'q'` (LOW) — changed to `'f'` (HIGH) in `core/livekit-local/`
 
+- H264 SDP bitrate hints are aligned to the publish profile: game streams advertise the real min bitrate floor and start at the full target bitrate so WebRTC's allocator does not begin from the old low fallback.
+
 ## Performance Numbers (RTX 4090, 4K source)
 
 | Scenario | Capture FPS | Viewer FPS |

--- a/core/docs/DECISIONS.md
+++ b/core/docs/DECISIONS.md
@@ -69,3 +69,15 @@ Two capture methods available: WGC (Win11 24H2+) and DXGI DD (all Windows). Deci
 Control plane split from monolithic `main.rs` into 9 focused modules. Viewer JS split: `screen-share.js` → 5 files, `participants.js` → 4 files. Dead capture code moved to `archive/`. Documentation rewritten from scratch.
 
 Rationale: ~9200-line `app.js` and monolithic control plane were hitting token limits in AI-assisted development, causing incomplete reads and missed context. Smaller modules enable focused edits and better test coverage.
+
+## 2026-05-31 - H264 Bitrate Hints Track Publish Floors
+
+Live Crimson Desert testing showed Desktop Duplication + NVENC could briefly reach crisp
+60fps, but the sender spent too long at single-digit FPS while WebRTC's H264 SDP hint
+advertised a 1.5 Mbps minimum for a 12 Mbps game profile. The capture profile already
+requested a 4 Mbps floor; the SDK fork was discarding that floor when munging H264 SDP.
+
+Decision: carry both max and min publish bitrate bounds into `PeerTransport` and use
+them for H264 `x-google-min-bitrate`/`x-google-start-bitrate`. This keeps the allocator,
+encoder target, and game publish profile aligned without changing the active capture
+backend.

--- a/core/docs/SDK_PATCHES.md
+++ b/core/docs/SDK_PATCHES.md
@@ -50,6 +50,33 @@ Affects every app using non-simulcast video with this SDK.
 
 ---
 
+### Patch 1b - H264 Bitrate Hint Alignment
+
+**Files:**
+- `core/livekit-local/src/rtc_engine/peer_transport.rs`
+- `core/livekit-local/src/rtc_engine/rtc_session.rs`
+
+**What changed:**
+
+Echo stores both publish-side max and min bitrate bounds before creating the sender
+offer. For H264 offers, `x-google-min-bitrate` now uses the publish encoding's
+`min_bitrate` and `x-google-start-bitrate` uses the full publish target instead of a
+percentage of the target.
+
+**Why:** Live testing on Crimson Desert showed the sender using NVENC and Desktop
+Duplication with zero loss, but WebRTC negotiated `x-google-min-bitrate=1500` for a
+12 Mbps game profile that was supposed to have a 4 Mbps floor. The allocator eventually
+ramped to 60 fps, proving the path could carry the stream, but it started and stayed on
+the low hint for too long.
+
+**Impact:**
+- Before: game profile `max=12 Mbps`, `min=4 Mbps` advertised H264 hints as
+  `min=1.5 Mbps`, `start=8.4 Mbps`.
+- After: the same profile advertises `min=4 Mbps`, `start=12 Mbps`, aligning the SDP
+  hint with the publish profile that the capture pipeline already requested.
+
+---
+
 ## webrtc-sys-local
 
 ### Patch 2 — `is_screencast()` Method

--- a/core/livekit-local/src/rtc_engine/peer_transport.rs
+++ b/core/livekit-local/src/rtc_engine/peer_transport.rs
@@ -31,8 +31,9 @@ struct TransportInner {
     renegotiate: bool,
     restarting_ice: bool,
     single_pc_mode: bool,
-    // Publish-side target bitrate (bps) for offer munging
+    // Publish-side bitrate bounds (bps) for offer munging.
     max_send_bitrate_bps: Option<u64>,
+    min_send_bitrate_bps: Option<u64>,
 }
 
 pub struct PeerTransport {
@@ -64,6 +65,7 @@ impl PeerTransport {
                 restarting_ice: false,
                 single_pc_mode,
                 max_send_bitrate_bps: None,
+                min_send_bitrate_bps: None,
             })),
         }
     }
@@ -136,9 +138,10 @@ impl PeerTransport {
         Ok(answer)
     }
 
-    pub async fn set_max_send_bitrate_bps(&self, bps: Option<u64>) {
+    pub async fn set_send_bitrate_bounds_bps(&self, max_bps: Option<u64>, min_bps: Option<u64>) {
         let mut inner = self.inner.lock().await;
-        inner.max_send_bitrate_bps = bps;
+        inner.max_send_bitrate_bps = max_bps;
+        inner.min_send_bitrate_bps = min_bps;
     }
 
     fn compute_start_bitrate_kbps(ultimate_bps: Option<u64>) -> Option<u32> {
@@ -327,6 +330,25 @@ impl PeerTransport {
         munged
     }
 
+    fn compute_h264_bitrate_hints(
+        max_bitrate_bps: Option<u64>,
+        min_bitrate_bps: Option<u64>,
+    ) -> Option<(u32, u32)> {
+        let max_kbps = (max_bitrate_bps? / 1000) as u32;
+        if max_kbps < 1000 {
+            return None;
+        }
+
+        let fallback_min_kbps = (max_kbps as f64 * 0.125).round() as u32;
+        let min_kbps = min_bitrate_bps
+            .map(|bps| (bps / 1000) as u32)
+            .filter(|kbps| *kbps > 0)
+            .unwrap_or(fallback_min_kbps)
+            .min(max_kbps);
+
+        Some((min_kbps, max_kbps))
+    }
+
     fn munge_x_google_start_bitrate(sdp: &str, start_bitrate_kbps: u32) -> String {
         // Detect what line ending the original SDP uses
         let uses_crlf = sdp.contains("\r\n");
@@ -481,32 +503,27 @@ impl PeerTransport {
         // This prevents TWCC BWE from starving the encoder on localhost or low-jitter links.
         let is_h264 = sdp.contains(" H264/90000");
         if is_h264 {
-            if let Some(max_bps) = inner.max_send_bitrate_bps {
-                let max_kbps = (max_bps / 1000) as u32;
-                if max_kbps >= 1000 {
-                    // min = 12.5% of max (soft SDP hint), start = 70% of max.
-                    // The real hard floor is RtpEncodingParameters.min_bitrate_bps
-                    // set in capture_pipeline.rs; this SDP hint is aligned to it
-                    // so the encoder target and GoogCC allocator agree.
-                    let min_kbps = (max_kbps as f64 * 0.125).round() as u32;
-                    let start_kbps = (max_kbps as f64 * 0.7).round() as u32;
-                    log::info!(
-                        "Applying H264 bitrate hints: min={}kbps start={}kbps (max={}kbps)",
-                        min_kbps, start_kbps, max_kbps
-                    );
+            if let Some((min_kbps, start_kbps)) = Self::compute_h264_bitrate_hints(
+                inner.max_send_bitrate_bps,
+                inner.min_send_bitrate_bps,
+            ) {
+                let max_kbps = (inner.max_send_bitrate_bps.unwrap_or_default() / 1000) as u32;
+                log::info!(
+                    "Applying H264 bitrate hints: min={}kbps start={}kbps (max={}kbps)",
+                    min_kbps, start_kbps, max_kbps
+                );
 
-                    let munged = Self::munge_h264_bitrate_hints(&sdp, min_kbps, start_kbps);
-                    if munged != sdp {
-                        log::info!("SDP munged successfully (H264)");
-                        match SessionDescription::parse(&munged, offer.sdp_type()) {
-                            Ok(parsed) => {
-                                offer = parsed;
-                                // sdp = munged; // not needed, last use
-                            }
-                            Err(e) => log::warn!(
-                                "Failed to parse H264-munged SDP, falling back: {e}"
-                            ),
+                let munged = Self::munge_h264_bitrate_hints(&sdp, min_kbps, start_kbps);
+                if munged != sdp {
+                    log::info!("SDP munged successfully (H264)");
+                    match SessionDescription::parse(&munged, offer.sdp_type()) {
+                        Ok(parsed) => {
+                            offer = parsed;
+                            // sdp = munged; // not needed, last use
                         }
+                        Err(e) => log::warn!(
+                            "Failed to parse H264-munged SDP, falling back: {e}"
+                        ),
                     }
                 }
             }
@@ -537,6 +554,16 @@ a=rtpmap:96 VP8/90000\n\
 a=fmtp:96 some=param\n";
         let out = PeerTransport::munge_x_google_start_bitrate(sdp, 3200);
         assert_eq!(out, sdp, "should not change SDP if no VP9/AV1 present");
+    }
+
+    #[test]
+    fn h264_hints_use_publish_min_floor_and_full_start_bitrate() {
+        let (min_kbps, start_kbps) =
+            PeerTransport::compute_h264_bitrate_hints(Some(12_000_000), Some(4_000_000))
+                .expect("h264 bitrate hints");
+
+        assert_eq!(min_kbps, 4000);
+        assert_eq!(start_kbps, 12000);
     }
 
     #[test]

--- a/core/livekit-local/src/rtc_engine/rtc_session.rs
+++ b/core/livekit-local/src/rtc_engine/rtc_session.rs
@@ -1583,11 +1583,17 @@ impl SessionInner {
         // If video track, derive "ultimate" bitrate from encodings and stash it for offer munging.
         // Must be done before encodings is moved into RtpTransceiverInit.
         if track.kind() == TrackKind::Video {
-            let ultimate_bps: Option<u64> = {
-                let sum: u64 = encodings.iter().filter_map(|e| e.max_bitrate).sum();
-                (sum > 0).then_some(sum)
+            let (ultimate_bps, min_bps): (Option<u64>, Option<u64>) = {
+                let max_sum: u64 = encodings.iter().filter_map(|e| e.max_bitrate).sum();
+                let min_sum: u64 = encodings.iter().filter_map(|e| e.min_bitrate).sum();
+                (
+                    (max_sum > 0).then_some(max_sum),
+                    (min_sum > 0).then_some(min_sum),
+                )
             };
-            self.publisher_pc.set_max_send_bitrate_bps(ultimate_bps).await;
+            self.publisher_pc
+                .set_send_bitrate_bounds_bps(ultimate_bps, min_bps)
+                .await;
         }
 
         let init = RtpTransceiverInit {

--- a/core/viewer/changelog.js
+++ b/core/viewer/changelog.js
@@ -8,6 +8,14 @@
 
 var ECHO_CHANGELOG = [
   {
+    version: "v0.6.19",
+    title: "Game Stream Bitrate Ramp Fix",
+    notes: [
+      "Game streams now advertise the real game publish bitrate floor to WebRTC's H264 allocator instead of the old low fallback hint.",
+      "The desktop client startup log includes the installed binary version, and Desktop Duplication sender stats no longer repeat stale frame-count blocks when publisher pacing pauses."
+    ]
+  },
+  {
     version: "v0.6.18",
     title: "Screen Share Framerate Fix",
     notes: [


### PR DESCRIPTION
﻿## What changed
- Align H264 SDP bitrate hints with the actual game publish profile: 4 Mbps minimum and 12 Mbps start/target for the current game profile instead of 1.5 Mbps min / 8.4 Mbps start.
- Carry publish min bitrate from LiveKit encodings into offer munging so WebRTC bandwidth allocation sees the same floor the capture pipeline expects.
- Prevent duplicate desktop-capture stats blocks when sender pacing stalls on a 60-frame boundary.
- Bump client/control/app metadata and changelogs to 0.6.19.

## Why
Dave's logs showed NVENC + DXGI were active and loss/RTT were fine, but the negotiated H264 hints still advertised a much lower ramp floor/start than the 12 Mbps game profile. That gives WebRTC room to starve the stream after an initially clear burst.

## Validation
- cargo test -p echo-core-client frame_count_stats_gate_only_emits_once_per_60_frame_boundary
- cargo test -p livekit h264_hints_use_publish_min_floor_and_full_start_bitrate (with temporary workspace membership removed afterward)
- cargo check -p echo-core-client
- cargo check -p echo-core-control
- node --check core/viewer/changelog.js
- git diff --check origin/main..HEAD
