### PR TITLE
[codex] Fix local release git command helper

### DIFF
--- a/core/deploy/local-release-lib.ps1
+++ b/core/deploy/local-release-lib.ps1
@@ -175,10 +175,10 @@ function Get-RequiredCommand([string]$Name) {
     return $command.Source
 }
 
-function Get-GitOutput([string]$Root, [string[]]$Args) {
-    $output = & git -C $Root @Args
+function Get-GitOutput([string]$Root, [string[]]$GitArgs) {
+    $output = & git -C $Root @GitArgs
     if ($LASTEXITCODE -ne 0) {
-        throw "git $($Args -join ' ') failed with exit code $LASTEXITCODE"
+        throw "git $($GitArgs -join ' ') failed with exit code $LASTEXITCODE"
     }
     return ($output -join [Environment]::NewLine).Trim()
 }

--- a/core/deploy/test-local-release-lib.ps1
+++ b/core/deploy/test-local-release-lib.ps1
@@ -64,6 +64,21 @@ version = "1.2.3"
     return $root
 }
 
+$gitRepo = Join-Path ([System.IO.Path]::GetTempPath()) ("echo-local-release-git-test-" + [Guid]::NewGuid().ToString("N"))
+New-Item -ItemType Directory -Path $gitRepo | Out-Null
+try {
+    & git -C $gitRepo init | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        throw "git init failed"
+    }
+
+    $isRepo = Get-GitOutput $gitRepo @("rev-parse", "--is-inside-work-tree")
+    Assert-Equal "true" $isRepo "Get-GitOutput forwards git arguments"
+}
+finally {
+    Remove-Item -LiteralPath $gitRepo -Recurse -Force
+}
+
 $repo = New-TestRepo
 try {
     $versions = Get-ReleaseVersionInfo -Root $repo


### PR DESCRIPTION
﻿## What changed
- Renames the `Get-GitOutput` argument parameter so PowerShell does not collide with the automatic `$Args` variable.
- Adds a regression test that initializes a temp git repo and verifies `Get-GitOutput` forwards subcommands/arguments.

## Why
The local release publisher stopped at its clean-git-state guard because the helper accidentally ran `git -C <repo>` with no subcommand.

## Validation
- powershell -NoProfile -ExecutionPolicy Bypass -File core\deploy\test-local-release-lib.ps1
- git diff --check
