### PR TITLE
[codex] Handle missing release checks in local publisher

### DIFF
--- a/core/deploy/publish-local-release.ps1
+++ b/core/deploy/publish-local-release.ps1
@@ -26,6 +26,29 @@ $buildScript = Join-Path $scriptDir "build-release.ps1"
 $testScript = Join-Path $scriptDir "test-local-release-lib.ps1"
 . (Join-Path $scriptDir "local-release-lib.ps1")
 
+function Test-GitHubReleaseExists([string]$RepoName, [string]$ReleaseTag) {
+    $previousErrorActionPreference = $ErrorActionPreference
+    $ErrorActionPreference = "Continue"
+    try {
+        $output = & gh release view $ReleaseTag --repo $RepoName --json tagName 2>&1
+        $exitCode = $LASTEXITCODE
+    }
+    finally {
+        $ErrorActionPreference = $previousErrorActionPreference
+    }
+
+    if ($exitCode -eq 0) {
+        return $true
+    }
+
+    $text = ($output | ForEach-Object { $_.ToString() }) -join [Environment]::NewLine
+    if ($text -match "release not found") {
+        return $false
+    }
+
+    throw "Failed to check GitHub Release ${ReleaseTag}: $text"
+}
+
 Get-RequiredCommand "git" | Out-Null
 Get-RequiredCommand "gh" | Out-Null
 Get-RequiredCommand "powershell" | Out-Null
@@ -44,8 +67,7 @@ if ($LASTEXITCODE -ne 0) {
     throw "gh is not authenticated for github.com"
 }
 
-& gh release view $tag --repo $Repo *> $null
-if ($LASTEXITCODE -eq 0) {
+if (Test-GitHubReleaseExists -RepoName $Repo -ReleaseTag $tag) {
     throw "GitHub Release already exists: $tag"
 }
 


### PR DESCRIPTION
﻿## What changed
- Makes the local publisher's GitHub Release existence check tolerate the expected `release not found` response.
- Keeps failing closed for any other `gh release view` error.

## Why
With `$ErrorActionPreference = "Stop"`, `gh release view v0.6.19` emits a terminating PowerShell error when the release does not exist, preventing the publisher from continuing to build/publish the new release.

## Validation
- powershell -NoProfile -ExecutionPolicy Bypass -File core\deploy\test-local-release-lib.ps1
- PowerShell parser check for core/deploy/publish-local-release.ps1
- git diff --check
