### PR TITLE
[codex] Sync updater manifest to v0.6.19

### DIFF
--- a/core/deploy/latest.json
+++ b/core/deploy/latest.json
@@ -1,11 +1,11 @@
 {
-  "version": "0.6.18",
-  "notes": "Update to v0.6.18",
-  "pub_date": "2026-05-31T17:12:45Z",
-  "platforms": {
-    "windows-x86_64": {
-      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVSQ3ByNFJuZlpjMEpXTmlUdXh5QTRRRTV0MkdtRE95YU54cWFxclFkSEJidTVrWjBRMzI4TjBxTTlJaUpxWWxkZzFPSkZ3MWNValYraFhlRmJZNzc2N1BJeGkwbzRBY1F3PQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzgwMjQ3NTA1CWZpbGU6RWNobyBDaGFtYmVyXzAuNi4xOF94NjQtc2V0dXAuZXhlCk54cG9pQ2NHdHR2MkE0cm4zc1VDOWNuOUU2Sm54eDFVczRxZEtub2RDdUlXWnlKYVhMdWRPYU9PZEdDM3NlQ2ZtSlMxS1pCUGFycUtySG5Sdm4veUJ3PT0K",
-      "url": "https://github.com/SamWatson86/echo-chamber/releases/download/v0.6.18/Echo.Chamber_0.6.18_x64-setup.exe"
-    }
-  }
+    "platforms":  {
+                      "windows-x86_64":  {
+                                             "signature":  "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVSQ3ByNFJuZlpjMEpuY1d2ZkgzRHVvaGpXeWJXeGFNOWNqb2dtbGo5Nnd2aWVzOVhIZkQxdjlQVmVGK05idGJMbFpRVVc4M20zUW1pYUFWS0pXeDZtb3RKcGdoSUppRXdRPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzgwMjUyMTI4CWZpbGU6RWNobyBDaGFtYmVyXzAuNi4xOV94NjQtc2V0dXAuZXhlCkJsTHZXVFh2WkpVQ015VmNMTkg1Ykdreit6RXhBbmZsU0o2Snh5WElZTGxOSGNlc1ZjTEdZTi92bi9FRVNQNVFWdDBzanN4c2VNd28yaVVKdEp6dEJnPT0K",
+                                             "url":  "https://github.com/SamWatson86/echo-chamber/releases/download/v0.6.19/Echo.Chamber_0.6.19_x64-setup.exe"
+                                         }
+                  },
+    "pub_date":  "2026-05-31T18:28:48Z",
+    "version":  "0.6.19",
+    "notes":  "Echo Chamber v0.6.19"
 }


### PR DESCRIPTION
﻿## What changed
- Syncs `core/deploy/latest.json` to the published `v0.6.19` Windows installer/signature.

## Why
The local publisher generated and uploaded the release manifest. This PR records the same updater metadata in `main` after live sync.

## Validation
- Published GitHub Release `v0.6.19` contains installer, signature, and `latest.json`.
- `https://echo.fellowshipoftheboatrace.party:9443/api/update/latest.json` serves version `0.6.19`.
- `https://echo.fellowshipoftheboatrace.party:9443/api/version` reports `latest_client: 0.6.19`.
- Parsed `core/deploy/latest.json` locally as version `0.6.19`.
- git diff --check
