### PR TITLE
[codex] Restore WGC auto capture default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.6.20
+
+- Fix: Game and window Auto capture now tries WGC first again on supported Windows builds, with Desktop Duplication kept as the explicit Desktop mode and Auto fallback.
+- Release: Desktop and control package versions are bumped to 0.6.20.
+
 ## 0.6.19
 
 - Fix: H264 SDP bitrate hints now use the publish profile's real minimum bitrate and full target start bitrate, so game streams start/ramp at the intended budget instead of falling back to a low allocator hint.

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -1304,7 +1304,7 @@ dependencies = [
 
 [[package]]
 name = "echo-core-client"
-version = "0.6.19"
+version = "0.6.20"
 dependencies = [
  "base64 0.22.1",
  "futures-util",
@@ -1325,7 +1325,7 @@ dependencies = [
 
 [[package]]
 name = "echo-core-control"
-version = "0.6.19"
+version = "0.6.20"
 dependencies = [
  "argon2",
  "axum",

--- a/core/client/Cargo.toml
+++ b/core/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "echo-core-client"
-version = "0.6.19"
+version = "0.6.20"
 edition = "2021"
 description = "Echo Chamber native desktop client"
 

--- a/core/client/tauri.conf.json
+++ b/core/client/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "Echo Chamber",
-  "version": "0.6.19",
+  "version": "0.6.20",
   "identifier": "com.echochamber.app",
   "build": {
     "frontendDist": "../viewer"

--- a/core/control/Cargo.toml
+++ b/core/control/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "echo-core-control"
-version = "0.6.19"
+version = "0.6.20"
 edition = "2021"
 
 [dependencies]

--- a/core/viewer/changelog.js
+++ b/core/viewer/changelog.js
@@ -8,6 +8,14 @@
 
 var ECHO_CHANGELOG = [
   {
+    version: "v0.6.20",
+    title: "WGC Auto Capture Restored",
+    notes: [
+      "Game and window Auto capture now tries WGC first again on supported Windows builds.",
+      "Desktop Duplication stays available as the explicit Desktop mode and as the Auto fallback if WGC cannot start."
+    ]
+  },
+  {
     version: "v0.6.19",
     title: "Game Stream Bitrate Ramp Fix",
     notes: [

--- a/core/viewer/screen-share-native.js
+++ b/core/viewer/screen-share-native.js
@@ -249,14 +249,14 @@ async function startScreenShareManual() {
     // Step 3: start capture
     try {
       if (source.sourceType === 'game' || source.sourceType === 'window') {
-        // Auto/default window-like capture uses Desktop Duplication. WGC stays
-        // available only as a manual diagnostics path.
+        // Auto/default window-like capture uses WGC on supported Windows.
+        // Desktop Duplication remains the explicit Desktop mode and fallback.
         var captureStarted = false;
         var gameCaptureMode = String(source.captureMode || 'auto').toLowerCase();
         var publishProfile = source.sourceType === 'game' ? 'game' : 'desktop';
 
-        // 1. Manual WGC window capture (diagnostics path; Win11 24H2+)
-        if (!captureStarted && gameCaptureMode === 'wgc' && wgcSupported) {
+        // 1. WGC window capture (default Auto path, or explicit WGC mode)
+        if (!captureStarted && gameCaptureMode !== 'desktop-dd' && wgcSupported) {
           try {
             debugLog('[wgc] trying WGC window capture for HWND ' + source.id + ' (build ' + osBuild + ')');
             await tauriInvoke('start_screen_share', {
@@ -270,11 +270,11 @@ async function startScreenShareManual() {
           } catch (wgcErr) {
             debugLog('[wgc] start failed: ' + (wgcErr.message || wgcErr));
           }
-        } else if (!captureStarted && gameCaptureMode === 'wgc' && !wgcSupported) {
+        } else if (!captureStarted && gameCaptureMode !== 'desktop-dd' && !wgcSupported) {
           debugLog('[wgc] skipped — requires Win11 24H2+ (build 26100+), current: ' + osBuild);
         }
 
-        // 2. Auto/default DXGI Desktop Duplication (compositor capture)
+        // 2. DXGI Desktop Duplication (explicit Desktop mode, or Auto fallback)
         if (!captureStarted && gameCaptureMode !== 'wgc') {
           try {
             var ddResult = await tauriInvoke('check_desktop_capture_available');

--- a/core/viewer/screen-share-native.test.js
+++ b/core/viewer/screen-share-native.test.js
@@ -93,16 +93,16 @@ function assertFloatArrayApprox(actual, expected) {
   }
 }
 
-test("game auto capture does not silently fall back to WGC", async () => {
+test("game auto capture tries WGC before desktop duplication fallback", async () => {
   const { context, calls } = loadScreenShareNative();
 
   await context.startScreenShareManual();
 
+  assert.equal(calls.some((call) => call.command === "start_screen_share"), true);
   assert.equal(calls.some((call) => call.command === "check_desktop_capture_available"), true);
-  assert.equal(calls.some((call) => call.command === "start_screen_share"), false);
 });
 
-test("game auto capture uses Desktop Duplication before WGC", async () => {
+test("game auto capture uses WGC before Desktop Duplication", async () => {
   const { context, calls } = loadScreenShareNative();
   context.showCapturePicker = async () => ({
     sourceType: "game",
@@ -120,16 +120,16 @@ test("game auto capture uses Desktop Duplication before WGC", async () => {
 
   await context.startScreenShareManual();
 
-  const desktopStart = calls.find((call) => call.command === "start_desktop_capture");
-  assert.ok(desktopStart);
-  assert.equal(desktopStart.args.hwnd, 4242);
-  assert.equal(desktopStart.args.fullscreen, false);
-  assert.equal(desktopStart.args.publishProfile, "game");
-  assert.equal(calls.some((call) => call.command === "start_screen_share"), false);
-  assert.equal(context.window._echoNativeCaptureMode, "desktop-dd");
+  const wgcStart = calls.find((call) => call.command === "start_screen_share");
+  assert.ok(wgcStart);
+  assert.equal(wgcStart.args.sourceId, 4242);
+  assert.equal(wgcStart.args.publishProfile, "game");
+  assert.equal(calls.some((call) => call.command === "check_desktop_capture_available"), false);
+  assert.equal(calls.some((call) => call.command === "start_desktop_capture"), false);
+  assert.equal(context.window._echoNativeCaptureMode, "wgc");
 });
 
-test("window auto capture uses Desktop Duplication before WGC", async () => {
+test("window auto capture uses WGC before Desktop Duplication", async () => {
   const { context, calls } = loadScreenShareNative();
   context.showCapturePicker = async () => ({
     sourceType: "window",
@@ -147,11 +147,38 @@ test("window auto capture uses Desktop Duplication before WGC", async () => {
 
   await context.startScreenShareManual();
 
+  const wgcStart = calls.find((call) => call.command === "start_screen_share");
+  assert.ok(wgcStart);
+  assert.equal(wgcStart.args.sourceId, 4242);
+  assert.equal(wgcStart.args.publishProfile, "desktop");
+  assert.equal(calls.some((call) => call.command === "check_desktop_capture_available"), false);
+  assert.equal(calls.some((call) => call.command === "start_desktop_capture"), false);
+  assert.equal(context.window._echoNativeCaptureMode, "wgc");
+});
+
+test("manual Desktop game capture skips WGC", async () => {
+  const { context, calls } = loadScreenShareNative();
+  context.showCapturePicker = async () => ({
+    sourceType: "game",
+    id: 4242,
+    pid: 5678,
+    isMonitor: false,
+    captureMode: "desktop-dd",
+  });
+  context.tauriInvoke = async (command, args) => {
+    calls.push({ command, args });
+    if (command === "get_os_build_number") return 26100;
+    if (command === "check_desktop_capture_available") return [true, "available"];
+    return null;
+  };
+
+  await context.startScreenShareManual();
+
   const desktopStart = calls.find((call) => call.command === "start_desktop_capture");
   assert.ok(desktopStart);
   assert.equal(desktopStart.args.hwnd, 4242);
   assert.equal(desktopStart.args.fullscreen, false);
-  assert.equal(desktopStart.args.publishProfile, "desktop");
+  assert.equal(desktopStart.args.publishProfile, "game");
   assert.equal(calls.some((call) => call.command === "start_screen_share"), false);
   assert.equal(context.window._echoNativeCaptureMode, "desktop-dd");
 });


### PR DESCRIPTION
## Summary
- Restores WGC-first behavior for game/window Auto capture on supported Windows builds.
- Keeps Desktop Duplication available as the explicit Desktop mode and as Auto fallback if WGC cannot start.
- Bumps desktop/control release metadata to 0.6.20 and updates changelogs.

## Root cause
The temporary diagnostic choice from v0.6.17 made Auto capture use Desktop Duplication before WGC. That leaked into live testing, so David's Crimson Desert retest was exercising the DXGI/DD path instead of the intended WGC path.

## Release impact
Desktop binary release. No server restart required for the client updater metadata.

## Verification
- `node --test core/viewer/screen-share-native.test.js`
- `node --check core/viewer/screen-share-native.js`
- `node --check core/viewer/changelog.js`
- `git diff --check`
- `cargo check -p echo-core-client`
- `cargo check -p echo-core-control`
- Echo preflight: service running, host config verified, `/health` OK, updater currently serving 0.6.19 before this release.