### PR TITLE
[codex] Sync updater manifest for v0.6.20

### DIFF
--- a/core/deploy/latest.json
+++ b/core/deploy/latest.json
@@ -1,11 +1,11 @@
 {
     "platforms":  {
                       "windows-x86_64":  {
-                                             "signature":  "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVSQ3ByNFJuZlpjMEpuY1d2ZkgzRHVvaGpXeWJXeGFNOWNqb2dtbGo5Nnd2aWVzOVhIZkQxdjlQVmVGK05idGJMbFpRVVc4M20zUW1pYUFWS0pXeDZtb3RKcGdoSUppRXdRPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzgwMjUyMTI4CWZpbGU6RWNobyBDaGFtYmVyXzAuNi4xOV94NjQtc2V0dXAuZXhlCkJsTHZXVFh2WkpVQ015VmNMTkg1Ykdreit6RXhBbmZsU0o2Snh5WElZTGxOSGNlc1ZjTEdZTi92bi9FRVNQNVFWdDBzanN4c2VNd28yaVVKdEp6dEJnPT0K",
-                                             "url":  "https://github.com/SamWatson86/echo-chamber/releases/download/v0.6.19/Echo.Chamber_0.6.19_x64-setup.exe"
+                                             "signature":  "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVSQ3ByNFJuZlpjMERUSEkyc0QyWlZlWGdmSWJaVURJSVZnL0lkM3IzeUJ1UndNRHpGQVJwK0dJSGpsQnZON2tidDg4d1VqT3RybDVtMWt0YWpweW5PWC83SW03aEd2eVF3PQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzgwMjUzOTAwCWZpbGU6RWNobyBDaGFtYmVyXzAuNi4yMF94NjQtc2V0dXAuZXhlCmlydUdzb3pJWmZrL2xBYTV2MHV5SXJyMEllVkU2Mmw4VVpDd1Fxdi9mc2FEanpOT3pKcXVSL0hUS2VLaDFBc3RRMCt6K0dzV1kvWHV1d08vSjl0dkR3PT0K",
+                                             "url":  "https://github.com/SamWatson86/echo-chamber/releases/download/v0.6.20/Echo.Chamber_0.6.20_x64-setup.exe"
                                          }
                   },
-    "pub_date":  "2026-05-31T18:28:48Z",
-    "version":  "0.6.19",
-    "notes":  "Echo Chamber v0.6.19"
+    "pub_date":  "2026-05-31T18:58:20Z",
+    "version":  "0.6.20",
+    "notes":  "Echo Chamber v0.6.20"
 }


### PR DESCRIPTION
## Summary
- Syncs `core/deploy/latest.json` to the published v0.6.20 Windows installer/signature.

## Release impact
Updater metadata only. The live server is already serving this manifest from `F:\EC-worktrees\main\core\deploy\latest.json`.

## Verification
- `gh release view v0.6.20 --json tagName,targetCommitish,assets,url`
- `curl.exe -sk https://echo.fellowshipoftheboatrace.party:9443/api/update/latest.json` -> version 0.6.20
- `curl.exe -sk https://echo.fellowshipoftheboatrace.party:9443/api/version` -> latest_client 0.6.20
- `git diff --check`