### PR TITLE
[codex] Prevent silent desktop capture fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.6.21
+
+- Fix: Game and window Auto capture on WGC-supported Windows no longer silently falls back to Desktop Duplication if WGC fails to start. The publisher now sees the WGC failure and can explicitly choose Desktop mode for diagnostics.
+- Release: Desktop and control package versions are bumped to 0.6.21.
+
 ## 0.6.20
 
 - Fix: Game and window Auto capture now tries WGC first again on supported Windows builds, with Desktop Duplication kept as the explicit Desktop mode and Auto fallback.

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -1304,7 +1304,7 @@ dependencies = [
 
 [[package]]
 name = "echo-core-client"
-version = "0.6.20"
+version = "0.6.21"
 dependencies = [
  "base64 0.22.1",
  "futures-util",
@@ -1325,7 +1325,7 @@ dependencies = [
 
 [[package]]
 name = "echo-core-control"
-version = "0.6.20"
+version = "0.6.21"
 dependencies = [
  "argon2",
  "axum",

--- a/core/client/Cargo.toml
+++ b/core/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "echo-core-client"
-version = "0.6.20"
+version = "0.6.21"
 edition = "2021"
 description = "Echo Chamber native desktop client"
 

--- a/core/client/tauri.conf.json
+++ b/core/client/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "Echo Chamber",
-  "version": "0.6.20",
+  "version": "0.6.21",
   "identifier": "com.echochamber.app",
   "build": {
     "frontendDist": "../viewer"

--- a/core/control/Cargo.toml
+++ b/core/control/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "echo-core-control"
-version = "0.6.20"
+version = "0.6.21"
 edition = "2021"
 
 [dependencies]

--- a/core/viewer/changelog.js
+++ b/core/viewer/changelog.js
@@ -8,6 +8,14 @@
 
 var ECHO_CHANGELOG = [
   {
+    version: "v0.6.21",
+    title: "WGC Fallback Guard",
+    notes: [
+      "Game and window Auto capture on WGC-supported Windows no longer silently swaps to Desktop Duplication if WGC fails to start.",
+      "Desktop Duplication remains available from the explicit Desktop capture mode for diagnostics."
+    ]
+  },
+  {
     version: "v0.6.20",
     title: "WGC Auto Capture Restored",
     notes: [

--- a/core/viewer/screen-share-native.js
+++ b/core/viewer/screen-share-native.js
@@ -254,6 +254,7 @@ async function startScreenShareManual() {
         var captureStarted = false;
         var gameCaptureMode = String(source.captureMode || 'auto').toLowerCase();
         var publishProfile = source.sourceType === 'game' ? 'game' : 'desktop';
+        var wgcStartError = null;
 
         // 1. WGC window capture (default Auto path, or explicit WGC mode)
         if (!captureStarted && gameCaptureMode !== 'desktop-dd' && wgcSupported) {
@@ -268,14 +269,15 @@ async function startScreenShareManual() {
             window._echoNativeCaptureMode = 'wgc';
             captureStarted = true;
           } catch (wgcErr) {
-            debugLog('[wgc] start failed: ' + (wgcErr.message || wgcErr));
+            wgcStartError = wgcErr.message || wgcErr;
+            debugLog('[wgc] start failed: ' + wgcStartError);
           }
         } else if (!captureStarted && gameCaptureMode !== 'desktop-dd' && !wgcSupported) {
           debugLog('[wgc] skipped — requires Win11 24H2+ (build 26100+), current: ' + osBuild);
         }
 
         // 2. DXGI Desktop Duplication (explicit Desktop mode, or Auto fallback)
-        if (!captureStarted && gameCaptureMode !== 'wgc') {
+        if (!captureStarted && (gameCaptureMode === 'desktop-dd' || (!wgcSupported && gameCaptureMode !== 'wgc'))) {
           try {
             var ddResult = await tauriInvoke('check_desktop_capture_available');
             if (ddResult && ddResult[0]) {
@@ -297,6 +299,9 @@ async function startScreenShareManual() {
           }
         }
         if (!captureStarted) {
+          if (wgcStartError && gameCaptureMode === 'auto') {
+            throw new Error('WGC capture failed; select Desktop mode to use Desktop Duplication: ' + wgcStartError);
+          }
           throw new Error('Window capture unavailable for mode ' + gameCaptureMode);
         }
       } else {

--- a/core/viewer/screen-share-native.test.js
+++ b/core/viewer/screen-share-native.test.js
@@ -93,13 +93,22 @@ function assertFloatArrayApprox(actual, expected) {
   }
 }
 
-test("game auto capture tries WGC before desktop duplication fallback", async () => {
+test("game auto capture does not silently fallback to desktop duplication on WGC-supported Windows", async () => {
   const { context, calls } = loadScreenShareNative();
+  context.tauriInvoke = async (command, args) => {
+    calls.push({ command, args });
+    if (command === "get_os_build_number") return 26100;
+    if (command === "start_screen_share") throw new Error("WGC start failed");
+    if (command === "check_desktop_capture_available") return [true, "available"];
+    return null;
+  };
 
   await context.startScreenShareManual();
 
   assert.equal(calls.some((call) => call.command === "start_screen_share"), true);
-  assert.equal(calls.some((call) => call.command === "check_desktop_capture_available"), true);
+  assert.equal(calls.some((call) => call.command === "check_desktop_capture_available"), false);
+  assert.equal(calls.some((call) => call.command === "start_desktop_capture"), false);
+  assert.equal(context.screenEnabled, false);
 });
 
 test("game auto capture uses WGC before Desktop Duplication", async () => {


### PR DESCRIPTION
## Summary
- Prevents Game/Window Auto capture on WGC-supported Windows from silently falling back to Desktop Duplication after WGC fails.
- Keeps explicit Desktop mode available for diagnostics and older unsupported Windows fallback behavior intact.
- Bumps desktop/control release metadata to 0.6.21.

## Root cause
David's v0.6.20 log shows the installed client is current, but the active share still started `desktop-capture` / `DuplicateOutput1` with `source=Screenshare`. That means the session did not exercise WGC; it landed on Desktop Duplication, where the sender again clamped around 5 Mbps and collapsed to ~13fps under `quality=Bandwidth`.

## Release impact
Desktop binary release. No server restart required.

## Verification
- `node --test core/viewer/screen-share-native.test.js`
- `node --check core/viewer/screen-share-native.js`
- `node --check core/viewer/changelog.js`
- `git diff --check`
- `cargo check -p echo-core-client`
- `cargo check -p echo-core-control`