### PR TITLE
[codex] Force game capture back to WGC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.6.22
+
+- Fix: Game capture no longer exposes Desktop Duplication as a normal picker mode on WGC-supported Windows; stale `desktop-dd` requests are coerced back to WGC before native capture starts.
+- Release: Desktop and control package versions are bumped to 0.6.22.
+
 ## 0.6.21
 
 - Fix: Game and window Auto capture on WGC-supported Windows no longer silently falls back to Desktop Duplication if WGC fails to start. The publisher now sees the WGC failure and can explicitly choose Desktop mode for diagnostics.

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -1304,7 +1304,7 @@ dependencies = [
 
 [[package]]
 name = "echo-core-client"
-version = "0.6.21"
+version = "0.6.22"
 dependencies = [
  "base64 0.22.1",
  "futures-util",
@@ -1325,7 +1325,7 @@ dependencies = [
 
 [[package]]
 name = "echo-core-control"
-version = "0.6.21"
+version = "0.6.22"
 dependencies = [
  "argon2",
  "axum",

--- a/core/client/Cargo.toml
+++ b/core/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "echo-core-client"
-version = "0.6.21"
+version = "0.6.22"
 edition = "2021"
 description = "Echo Chamber native desktop client"
 

--- a/core/client/tauri.conf.json
+++ b/core/client/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "Echo Chamber",
-  "version": "0.6.21",
+  "version": "0.6.22",
   "identifier": "com.echochamber.app",
   "build": {
     "frontendDist": "../viewer"

--- a/core/control/Cargo.toml
+++ b/core/control/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "echo-core-control"
-version = "0.6.21"
+version = "0.6.22"
 edition = "2021"
 
 [dependencies]

--- a/core/viewer/capture-picker.css
+++ b/core/viewer/capture-picker.css
@@ -172,41 +172,6 @@
     border-top: 1px solid var(--glass-border, rgba(255, 255, 255, 0.08));
 }
 
-.capture-mode-control {
-    margin-right: auto;
-    display: flex;
-    align-items: center;
-    gap: 6px;
-}
-.capture-mode-control[hidden] {
-    display: none;
-}
-.capture-mode-label {
-    color: var(--text-secondary, rgba(255,255,255,0.55));
-    font-size: 11px;
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 0.6px;
-}
-.capture-mode-btn {
-    background: rgba(255, 255, 255, 0.08);
-    border: 1px solid rgba(255, 255, 255, 0.1);
-    color: var(--text-primary, #fff);
-    border-radius: 6px;
-    cursor: pointer;
-    font-size: 11px;
-    font-weight: 700;
-    min-width: 52px;
-    padding: 6px 8px;
-}
-.capture-mode-btn:hover {
-    background: rgba(255, 255, 255, 0.12);
-}
-.capture-mode-btn.active {
-    background: var(--accent, #7c3aed);
-    border-color: var(--accent, #7c3aed);
-}
-
 .capture-picker-btn {
     padding: 8px 20px;
     border-radius: 8px;

--- a/core/viewer/capture-picker.js
+++ b/core/viewer/capture-picker.js
@@ -6,7 +6,6 @@ var _capturePickerResolve = null;
 var _capturePickerReject = null;
 var _selectedSource = null;
 var _capturePickerSupport = null;
-var _selectedGameCaptureMode = 'auto';
 
 function isTauriCommandMissingError(err, commandName) {
     var msg = (err && err.message) ? err.message : String(err || '');
@@ -23,7 +22,6 @@ function showCapturePicker() {
         _capturePickerResolve = resolve;
         _capturePickerReject = reject;
         _selectedSource = null;
-        _selectedGameCaptureMode = 'auto';
         _buildPickerModal();
     });
 }
@@ -46,12 +44,6 @@ function _buildPickerModal() {
                 '<div style="text-align:center;padding:40px;color:rgba(255,255,255,0.5)">Loading sources...</div>' +
             '</div>' +
             '<div class="capture-picker-footer">' +
-                '<div class="capture-mode-control" id="cp-game-mode" hidden>' +
-                    '<span class="capture-mode-label">Game capture</span>' +
-                    '<button type="button" class="capture-mode-btn active" data-mode="auto">Auto</button>' +
-                    '<button type="button" class="capture-mode-btn" data-mode="desktop-dd">Desktop</button>' +
-                    '<button type="button" class="capture-mode-btn" data-mode="wgc">WGC</button>' +
-                '</div>' +
                 '<button class="capture-picker-btn secondary" id="cp-cancel">Cancel</button>' +
                 '<button class="capture-picker-btn primary" id="cp-share" disabled>Share</button>' +
             '</div>' +
@@ -68,7 +60,6 @@ function _buildPickerModal() {
     document.getElementById('cp-close').onclick = _cancelPicker;
     document.getElementById('cp-cancel').onclick = _cancelPicker;
     document.getElementById('cp-share').onclick = _confirmPicker;
-    _bindGameCaptureModeControl();
 
     // Close on overlay click (not modal body)
     overlay.onclick = function(e) {
@@ -119,37 +110,6 @@ function _closePicker() {
         overlay.classList.remove('visible');
         setTimeout(function() { overlay.remove(); }, 200);
     }
-}
-
-function _bindGameCaptureModeControl() {
-    var control = document.getElementById('cp-game-mode');
-    if (!control) return;
-    control.querySelectorAll('.capture-mode-btn').forEach(function(btn) {
-        btn.onclick = function(e) {
-            e.stopPropagation();
-            _selectedGameCaptureMode = btn.dataset.mode || 'auto';
-            _syncGameCaptureModeControl();
-            if (_selectedSource && _selectedSource.sourceType === 'game') {
-                _selectedSource.captureMode = _selectedGameCaptureMode;
-            }
-        };
-    });
-    _syncGameCaptureModeControl();
-}
-
-function _setGameCaptureModeVisible(visible) {
-    var control = document.getElementById('cp-game-mode');
-    if (!control) return;
-    control.hidden = !visible;
-    if (visible) _syncGameCaptureModeControl();
-}
-
-function _syncGameCaptureModeControl() {
-    var control = document.getElementById('cp-game-mode');
-    if (!control) return;
-    control.querySelectorAll('.capture-mode-btn').forEach(function(btn) {
-        btn.classList.toggle('active', btn.dataset.mode === _selectedGameCaptureMode);
-    });
 }
 
 async function _loadSources() {
@@ -207,14 +167,13 @@ async function _loadSources() {
                 });
                 card.classList.add('selected');
                 var sourceType = card.dataset.type;
-                _setGameCaptureModeVisible(sourceType === 'game');
                 _selectedSource = {
                     id: parseInt(card.dataset.id),
                     title: card.dataset.title,
                     sourceType: sourceType,
                     isMonitor: sourceType === 'monitor',
                     pid: parseInt(card.dataset.pid) || 0,
-                    captureMode: sourceType === 'game' ? _selectedGameCaptureMode : null,
+                    captureMode: sourceType === 'game' ? 'auto' : null,
                 };
                 document.getElementById('cp-share').disabled = false;
             };

--- a/core/viewer/changelog.js
+++ b/core/viewer/changelog.js
@@ -8,6 +8,14 @@
 
 var ECHO_CHANGELOG = [
   {
+    version: "v0.6.22",
+    title: "WGC-Only Game Capture",
+    notes: [
+      "The Game picker no longer exposes Desktop Duplication as a normal capture mode.",
+      "If a stale Game capture request still asks for Desktop Duplication on a WGC-supported Windows build, Echo forces it back through WGC before native capture starts."
+    ]
+  },
+  {
     version: "v0.6.21",
     title: "WGC Fallback Guard",
     notes: [

--- a/core/viewer/screen-share-native.js
+++ b/core/viewer/screen-share-native.js
@@ -250,9 +250,13 @@ async function startScreenShareManual() {
     try {
       if (source.sourceType === 'game' || source.sourceType === 'window') {
         // Auto/default window-like capture uses WGC on supported Windows.
-        // Desktop Duplication remains the explicit Desktop mode and fallback.
+        // Desktop Duplication is only kept as an unsupported-WGC fallback.
         var captureStarted = false;
         var gameCaptureMode = String(source.captureMode || 'auto').toLowerCase();
+        if (source.sourceType === 'game' && gameCaptureMode === 'desktop-dd' && wgcSupported) {
+          debugLog('[capture] ignoring Desktop Duplication request for game capture on WGC-supported Windows');
+          gameCaptureMode = 'auto';
+        }
         var publishProfile = source.sourceType === 'game' ? 'game' : 'desktop';
         var wgcStartError = null;
 
@@ -276,7 +280,7 @@ async function startScreenShareManual() {
           debugLog('[wgc] skipped — requires Win11 24H2+ (build 26100+), current: ' + osBuild);
         }
 
-        // 2. DXGI Desktop Duplication (explicit Desktop mode, or Auto fallback)
+        // 2. DXGI Desktop Duplication (unsupported-WGC fallback or legacy explicit requests)
         if (!captureStarted && (gameCaptureMode === 'desktop-dd' || (!wgcSupported && gameCaptureMode !== 'wgc'))) {
           try {
             var ddResult = await tauriInvoke('check_desktop_capture_available');
@@ -300,7 +304,7 @@ async function startScreenShareManual() {
         }
         if (!captureStarted) {
           if (wgcStartError && gameCaptureMode === 'auto') {
-            throw new Error('WGC capture failed; select Desktop mode to use Desktop Duplication: ' + wgcStartError);
+            throw new Error('WGC capture failed: ' + wgcStartError);
           }
           throw new Error('Window capture unavailable for mode ' + gameCaptureMode);
         }

--- a/core/viewer/screen-share-native.test.js
+++ b/core/viewer/screen-share-native.test.js
@@ -165,7 +165,7 @@ test("window auto capture uses WGC before Desktop Duplication", async () => {
   assert.equal(context.window._echoNativeCaptureMode, "wgc");
 });
 
-test("manual Desktop game capture skips WGC", async () => {
+test("game capture ignores Desktop Duplication mode on WGC-supported Windows", async () => {
   const { context, calls } = loadScreenShareNative();
   context.showCapturePicker = async () => ({
     sourceType: "game",
@@ -183,13 +183,13 @@ test("manual Desktop game capture skips WGC", async () => {
 
   await context.startScreenShareManual();
 
-  const desktopStart = calls.find((call) => call.command === "start_desktop_capture");
-  assert.ok(desktopStart);
-  assert.equal(desktopStart.args.hwnd, 4242);
-  assert.equal(desktopStart.args.fullscreen, false);
-  assert.equal(desktopStart.args.publishProfile, "game");
-  assert.equal(calls.some((call) => call.command === "start_screen_share"), false);
-  assert.equal(context.window._echoNativeCaptureMode, "desktop-dd");
+  const wgcStart = calls.find((call) => call.command === "start_screen_share");
+  assert.ok(wgcStart);
+  assert.equal(wgcStart.args.sourceId, 4242);
+  assert.equal(wgcStart.args.publishProfile, "game");
+  assert.equal(calls.some((call) => call.command === "check_desktop_capture_available"), false);
+  assert.equal(calls.some((call) => call.command === "start_desktop_capture"), false);
+  assert.equal(context.window._echoNativeCaptureMode, "wgc");
 });
 
 test("manual WGC game capture keeps the WGC path available", async () => {


### PR DESCRIPTION
## What changed
- Removed the normal Game capture mode selector so users cannot choose Desktop Duplication for game shares.
- Coerced stale Game capture requests carrying captureMode=desktop-dd back to WGC on WGC-supported Windows builds.
- Bumped desktop/control versions and changelogs to 0.6.22.

## Why
David's 0.6.21 log still started [desktop-capture] using DuplicateOutput1 with profile=Game and no WGC lines. Since Auto fallback was already blocked, the remaining bad path was an explicit or retained Desktop Duplication mode for game capture.

## Release impact
- Desktop binary required: yes, for the versioned client release/update path.
- Server restart required: no.

## Verification
- node --test core/viewer/screen-share-native.test.js
- node --check core/viewer/screen-share-native.js
- node --check core/viewer/capture-picker.js
- node --check core/viewer/changelog.js
- git diff --check
- cargo check -p echo-core-client
- cargo check -p echo-core-control
- Echo preflight: /health OK, live /api/version reports latest_client 0.6.21 before this release.