### PR TITLE
[codex] Sync updater manifest for v0.6.22

### DIFF
--- a/core/deploy/latest.json
+++ b/core/deploy/latest.json
@@ -1,11 +1,11 @@
 {
     "platforms":  {
                       "windows-x86_64":  {
-                                             "signature":  "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVSQ3ByNFJuZlpjME9EWiszOTh2ZTh0cHhKeXAzd0RqYVBPY3FKRFZXYTlKc0R0SnlzUnRYVG9ZV3A0L1F0aThWQ3MxZ2kvNTRLS0toZ0pIam0wbW0xdm9BTVVaWkZDMkFFPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzgwMjU0NzIzCWZpbGU6RWNobyBDaGFtYmVyXzAuNi4yMV94NjQtc2V0dXAuZXhlCjRZV2Y3Wk95YTA5aUFJQ2hxN0ZITVVKNHhLYkhoa2wrTE9od0pkMWVqUVg5clNZbUh0WmE4aElJb0h4aEhuZW1UOGs4Z1lYRjdPa1NHM1lGYS8yTkJ3PT0K",
-                                             "url":  "https://github.com/SamWatson86/echo-chamber/releases/download/v0.6.21/Echo.Chamber_0.6.21_x64-setup.exe"
+                                             "signature":  "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVSQ3ByNFJuZlpjME56K1kzWkk4ajZjbWE4ckhvaEtPVUIwY3Z3cElMR3JlRkxlR2NLS09RSUdNVFArT3dUWlpGWm9hL3p3QnJVS3lTdDA2dEs5WEZ3Q2dBc01zUEdOVmdJPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzgwMjU1Njc0CWZpbGU6RWNobyBDaGFtYmVyXzAuNi4yMl94NjQtc2V0dXAuZXhlClRuNTR0QzdQUU9GRU9xeGZFZHFrcGZ1Sk5jbExtZE5GT2MvaHloOGFkdkdFRkZ5WGFYOXdWM2NHeEFTd01naDJlTnpGWHVkM2dnWUY5U2t4WWcvWkNRPT0K",
+                                             "url":  "https://github.com/SamWatson86/echo-chamber/releases/download/v0.6.22/Echo.Chamber_0.6.22_x64-setup.exe"
                                          }
                   },
-    "pub_date":  "2026-05-31T19:12:03Z",
-    "version":  "0.6.21",
-    "notes":  "Echo Chamber v0.6.21"
+    "pub_date":  "2026-05-31T19:27:54Z",
+    "version":  "0.6.22",
+    "notes":  "Echo Chamber v0.6.22"
 }


### PR DESCRIPTION
## What changed
- Updates core/deploy/latest.json to the signed v0.6.22 Windows installer manifest.

## Why
The local release publisher already published v0.6.22 and the live updater endpoint is serving this manifest. This keeps the repository copy in sync with production metadata.

## Release impact
- Metadata only. No server restart required.

## Verification
- GitHub Release v0.6.22 exists with installer, signature, and latest.json assets.
- Live /api/update/latest.json returns version 0.6.22.
- Live /api/version reports latest_client 0.6.22.