### PR TITLE
[codex] Tune WGC game bitrate for v0.6.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.6.23
+
+- Fix: WGC game shares now publish as screen-share tracks again while keeping the motion-friendly native source mode.
+- Tuning: Game capture now advertises a 20 Mbps max / 8 Mbps minimum H264 budget so WebRTC stops parking high-motion 1080p60 streams at the old 4 Mbps floor.
+- Diagnostics: Native capture startup logs now include the publish track source and screencast mode.
+- Release: Desktop and control package versions are bumped to 0.6.23.
+
 ## 0.6.22
 
 - Fix: Game capture no longer exposes Desktop Duplication as a normal picker mode on WGC-supported Windows; stale `desktop-dd` requests are coerced back to WGC before native capture starts.

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -1304,7 +1304,7 @@ dependencies = [
 
 [[package]]
 name = "echo-core-client"
-version = "0.6.22"
+version = "0.6.23"
 dependencies = [
  "base64 0.22.1",
  "futures-util",
@@ -1325,7 +1325,7 @@ dependencies = [
 
 [[package]]
 name = "echo-core-control"
-version = "0.6.22"
+version = "0.6.23"
 dependencies = [
  "argon2",
  "axum",

--- a/core/client/Cargo.toml
+++ b/core/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "echo-core-client"
-version = "0.6.22"
+version = "0.6.23"
 edition = "2021"
 description = "Echo Chamber native desktop client"
 

--- a/core/client/src/capture_pipeline.rs
+++ b/core/client/src/capture_pipeline.rs
@@ -84,14 +84,14 @@ impl PublishProfile {
     fn max_bitrate(self) -> u64 {
         match self {
             Self::Desktop => 6_000_000,
-            Self::Game => 12_000_000,
+            Self::Game => 20_000_000,
         }
     }
 
     fn min_bitrate(self) -> u64 {
         match self {
             Self::Desktop => 3_000_000,
-            Self::Game => 4_000_000,
+            Self::Game => 8_000_000,
         }
     }
 
@@ -211,7 +211,7 @@ impl CapturePublisher {
     ) -> Result<Self, String> {
         eprintln!("[{}] connecting to SFU: {}", log_prefix, sfu_url);
         file_debug_log::append(&format!(
-            "[{}] connect_and_publish start sfu_url={} enc={}x{} profile={:?} target_fps={} max_bitrate={} min_bitrate={}",
+            "[{}] connect_and_publish start sfu_url={} enc={}x{} profile={:?} target_fps={} max_bitrate={} min_bitrate={} track_source={:?} is_screencast={}",
             log_prefix,
             sfu_url,
             enc_w,
@@ -219,7 +219,9 @@ impl CapturePublisher {
             publish_profile,
             publish_profile.target_fps(),
             publish_profile.max_bitrate(),
-            publish_profile.min_bitrate()
+            publish_profile.min_bitrate(),
+            track_source,
+            is_screencast
         ));
 
         let (room, events) = Room::connect(sfu_url, token, RoomOptions::default())
@@ -259,9 +261,8 @@ impl CapturePublisher {
                 // motion more bits than the old 4 Mbps cap. Game shares opt
                 // into a higher-motion bitrate budget.
                 max_bitrate: publish_profile.max_bitrate(),
-                // 2.5 Mbps hard floor — prevents libwebrtc GoogCC from throttling
-                // to zero under packet loss / RTT spikes, so the stream stays
-                // visible instead of dropping to 0fps and slowly probing back up.
+                // Profile-selected hard floor. Game needs enough room for
+                // 1080p60 motion; desktop stays conservative for text sharing.
                 min_bitrate: publish_profile.min_bitrate(),
                 // Profile-selected wire target: desktop stays conservative;
                 // game/window capture gets the high-motion 60fps path.
@@ -318,7 +319,7 @@ impl CapturePublisher {
     ) -> Result<Self, String> {
         eprintln!("[{}] connecting to SFU: {}", log_prefix, sfu_url);
         file_debug_log::append(&format!(
-            "[{}] connect_and_publish_blocking start sfu_url={} enc={}x{} profile={:?} target_fps={} max_bitrate={} min_bitrate={}",
+            "[{}] connect_and_publish_blocking start sfu_url={} enc={}x{} profile={:?} target_fps={} max_bitrate={} min_bitrate={} track_source={:?} is_screencast={}",
             log_prefix,
             sfu_url,
             enc_w,
@@ -326,7 +327,9 @@ impl CapturePublisher {
             publish_profile,
             publish_profile.target_fps(),
             publish_profile.max_bitrate(),
-            publish_profile.min_bitrate()
+            publish_profile.min_bitrate(),
+            track_source,
+            is_screencast
         ));
 
         let (room, events) = rt
@@ -364,9 +367,8 @@ impl CapturePublisher {
                 // motion more bits than the old 4 Mbps cap. Game shares opt
                 // into a higher-motion bitrate budget.
                 max_bitrate: publish_profile.max_bitrate(),
-                // 2.5 Mbps hard floor — prevents libwebrtc GoogCC from throttling
-                // to zero under packet loss / RTT spikes, so the stream stays
-                // visible instead of dropping to 0fps and slowly probing back up.
+                // Profile-selected hard floor. Game needs enough room for
+                // 1080p60 motion; desktop stays conservative for text sharing.
                 min_bitrate: publish_profile.min_bitrate(),
                 // Profile-selected wire target: desktop stays conservative;
                 // game/window capture gets the high-motion 60fps path.
@@ -780,8 +782,8 @@ mod tests {
 
         assert_eq!(profile, PublishProfile::Game);
         assert_eq!(profile.target_fps(), 60);
-        assert_eq!(profile.max_bitrate(), 12_000_000);
-        assert_eq!(profile.min_bitrate(), 4_000_000);
+        assert_eq!(profile.max_bitrate(), 20_000_000);
+        assert_eq!(profile.min_bitrate(), 8_000_000);
     }
 
     fn pushed_frame_count(source_hz: u32, target_hz: u32, seconds: u32) -> usize {

--- a/core/client/src/screen_capture.rs
+++ b/core/client/src/screen_capture.rs
@@ -753,6 +753,26 @@ pub fn get_thumbnail(source_id: u64, is_monitor: bool) -> Option<String> {
 
 // ── Capture + Publish Loop ──
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct WgcPublishSettings {
+    track_source: TrackSource,
+    is_screencast: bool,
+}
+
+fn wgc_publish_settings(publish_profile: PublishProfile) -> WgcPublishSettings {
+    WgcPublishSettings {
+        track_source: TrackSource::Screenshare,
+        is_screencast: publish_profile == PublishProfile::Desktop,
+    }
+}
+
+fn wgc_monitor_publish_settings() -> WgcPublishSettings {
+    WgcPublishSettings {
+        track_source: TrackSource::Screenshare,
+        is_screencast: true,
+    }
+}
+
 async fn share_loop(
     source_id: u64,
     sfu_url: &str,
@@ -763,6 +783,7 @@ async fn share_loop(
     health: Arc<CaptureHealthState>,
 ) -> Result<(), String> {
     // 1. Connect to SFU and publish track via shared pipeline
+    let publish_settings = wgc_publish_settings(publish_profile);
     let mut publisher = CapturePublisher::connect_and_publish(
         sfu_url,
         token,
@@ -770,8 +791,8 @@ async fn share_loop(
         1080,
         publish_profile,
         "screen-capture",
-        TrackSource::Camera,
-        false,
+        publish_settings.track_source,
+        publish_settings.is_screencast,
     )
     .await?;
 
@@ -1158,6 +1179,7 @@ async fn share_loop_monitor(
     health: Arc<CaptureHealthState>,
 ) -> Result<(), String> {
     // 1. Connect to SFU and publish track via shared pipeline
+    let publish_settings = wgc_monitor_publish_settings();
     let mut publisher = CapturePublisher::connect_and_publish(
         sfu_url,
         token,
@@ -1165,8 +1187,8 @@ async fn share_loop_monitor(
         1080,
         PublishProfile::Desktop,
         "screen-capture-monitor",
-        TrackSource::Camera,
-        false,
+        publish_settings.track_source,
+        publish_settings.is_screencast,
     )
     .await?;
 
@@ -1515,6 +1537,22 @@ mod tests {
         };
 
         assert_eq!(window_overlap_ratio(source, cover), 0.5);
+    }
+
+    #[test]
+    fn wgc_game_share_publishes_as_screenshare_without_screencast_throttling() {
+        let settings = wgc_publish_settings(PublishProfile::Game);
+
+        assert_eq!(settings.track_source, TrackSource::Screenshare);
+        assert!(!settings.is_screencast);
+    }
+
+    #[test]
+    fn wgc_monitor_share_publishes_as_screenshare_with_screencast_semantics() {
+        let settings = wgc_monitor_publish_settings();
+
+        assert_eq!(settings.track_source, TrackSource::Screenshare);
+        assert!(settings.is_screencast);
     }
 
     #[test]

--- a/core/client/tauri.conf.json
+++ b/core/client/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "Echo Chamber",
-  "version": "0.6.22",
+  "version": "0.6.23",
   "identifier": "com.echochamber.app",
   "build": {
     "frontendDist": "../viewer"

--- a/core/control/Cargo.toml
+++ b/core/control/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "echo-core-control"
-version = "0.6.22"
+version = "0.6.23"
 edition = "2021"
 
 [dependencies]

--- a/core/viewer/changelog.js
+++ b/core/viewer/changelog.js
@@ -8,6 +8,15 @@
 
 var ECHO_CHANGELOG = [
   {
+    version: "v0.6.23",
+    title: "Sharper Game Streaming",
+    notes: [
+      "WGC game shares now publish as screen-share tracks while keeping the motion-friendly native source mode.",
+      "Game capture now advertises a 20 Mbps max / 8 Mbps minimum H264 budget for high-motion 1080p60 streams.",
+      "Native capture startup diagnostics now show the publish track source and screencast mode."
+    ]
+  },
+  {
     version: "v0.6.22",
     title: "WGC-Only Game Capture",
     notes: [


### PR DESCRIPTION
## Summary
- publish WGC game streams as screen-share tracks while keeping the native source in motion mode
- raise Game capture H264 budget to 20 Mbps max / 8 Mbps minimum
- bump desktop/control package versions and changelog to v0.6.23

## Root cause
The latest David log shows WGC is active and feeding frames, NVENC is active, and packet loss is zero, but WebRTC parks the sender near the old 4 Mbps game floor with quality=Bandwidth and drops encode/send FPS to about 15.

## Verification
- cargo test -p echo-core-client wgc_
- cargo test -p echo-core-client game_profile_is_high_motion
- cargo check -p echo-core-client
- cargo check -p echo-core-control
- node --check core/viewer/changelog.js
- git diff --check
- rustfmt --edition 2021 --check client/src/capture_pipeline.rs client/src/screen_capture.rs

Note: full cargo fmt --check still wants to reformat unrelated existing files, so this PR leaves that churn out of scope.