### PR TITLE
[codex] Tune game capture for 1080p30 quality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.6.24
+
+- Tuning: Game capture keeps the crisp 20 Mbps max / 8 Mbps minimum H264 budget but targets 1080p30 instead of 1080p60, reducing encoder pressure in heavy foreground games like Crimson Desert while preserving the improved image quality from 0.6.23.
+- Release: Desktop and control package versions are bumped to 0.6.24.
+
 ## 0.6.23
 
 - Fix: WGC game shares now publish as screen-share tracks again while keeping the motion-friendly native source mode.

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -1304,7 +1304,7 @@ dependencies = [
 
 [[package]]
 name = "echo-core-client"
-version = "0.6.23"
+version = "0.6.24"
 dependencies = [
  "base64 0.22.1",
  "futures-util",
@@ -1325,7 +1325,7 @@ dependencies = [
 
 [[package]]
 name = "echo-core-control"
-version = "0.6.23"
+version = "0.6.24"
 dependencies = [
  "argon2",
  "axum",

--- a/core/client/Cargo.toml
+++ b/core/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "echo-core-client"
-version = "0.6.23"
+version = "0.6.24"
 edition = "2021"
 description = "Echo Chamber native desktop client"
 

--- a/core/client/src/capture_pipeline.rs
+++ b/core/client/src/capture_pipeline.rs
@@ -52,12 +52,11 @@ const MIN_FRAME_INTERVAL_SOFTWARE: std::time::Duration =
 /// main.rs's startup probe and never changes after that.
 pub static HAS_NVCUDA: AtomicBool = AtomicBool::new(false);
 
-/// Desktop wire-level publish framerate cap. Game/window capture can opt into
-/// the high-motion profile below. The capture loop runs at native display
-/// refresh rate (often 144+ Hz), but the publisher paces frames to the selected
-/// profile's wire target.
+/// Desktop wire-level publish framerate cap. Game/window capture uses the same
+/// 30fps cadence with a much higher bitrate budget, preserving the crisp image
+/// quality v0.6.23 showed under heavy foreground-game load.
 pub const PUBLISH_TARGET_FPS: u32 = 30;
-pub const GAME_PUBLISH_TARGET_FPS: u32 = 60;
+pub const GAME_PUBLISH_TARGET_FPS: u32 = 30;
 pub const STATIC_FRAME_HEARTBEAT_INTERVAL: Duration = Duration::from_millis(200);
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq)]
@@ -777,11 +776,11 @@ mod tests {
     }
 
     #[test]
-    fn game_profile_is_high_motion() {
+    fn game_profile_is_quality_biased_1080p30() {
         let profile: PublishProfile = serde_json::from_str("\"game\"").expect("game profile");
 
         assert_eq!(profile, PublishProfile::Game);
-        assert_eq!(profile.target_fps(), 60);
+        assert_eq!(profile.target_fps(), 30);
         assert_eq!(profile.max_bitrate(), 20_000_000);
         assert_eq!(profile.min_bitrate(), 8_000_000);
     }

--- a/core/client/tauri.conf.json
+++ b/core/client/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "Echo Chamber",
-  "version": "0.6.23",
+  "version": "0.6.24",
   "identifier": "com.echochamber.app",
   "build": {
     "frontendDist": "../viewer"

--- a/core/control/Cargo.toml
+++ b/core/control/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "echo-core-control"
-version = "0.6.23"
+version = "0.6.24"
 edition = "2021"
 
 [dependencies]

--- a/core/viewer/changelog.js
+++ b/core/viewer/changelog.js
@@ -8,6 +8,14 @@
 
 var ECHO_CHANGELOG = [
   {
+    version: "v0.6.24",
+    title: "Game Quality Mode",
+    notes: [
+      "Game capture keeps the crisp 20 Mbps max / 8 Mbps minimum H264 budget from v0.6.23.",
+      "The Game profile now targets 1080p30 instead of 1080p60 to reduce encoder pressure in heavy foreground games while preserving image quality."
+    ]
+  },
+  {
     version: "v0.6.23",
     title: "Sharper Game Streaming",
     notes: [


### PR DESCRIPTION
## What changed

- Changes the Game publish profile from 1080p60 to quality-biased 1080p30.
- Keeps the v0.6.23 20 Mbps max / 8 Mbps minimum H264 budget.
- Bumps desktop/control versions and user-facing changelog to v0.6.24.

## Why

Live Crimson Desert logs show v0.6.23 solved the bitrate/network problem and produced a much better image, but the foreground game path still forces the sender to about 13-14 fps while WGC is publishing about 40 fps. This experiment reduces encoder pressure without sacrificing the crisp image baseline.

## Validation

- Red/green: `cargo test -p echo-core-client game_profile_is_quality_biased_1080p30`
- `cargo test -p echo-core-client capture_pipeline::tests`
- `cargo test -p echo-core-client`
- `cargo check -p echo-core-client`
- `cargo check -p echo-core-control`
- `rustfmt --edition 2021 --check client\src\capture_pipeline.rs`
- `node --check core\viewer\changelog.js`
- `git diff --check`