### PR TITLE
[codex] Restore game capture 60fps default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.6.25
+
+- Fix: Game capture defaults back to 1080p60 so strong game publishers like Jeff are not capped at 30fps by the 0.6.24 experiment.
+- Tuning: The 20 Mbps max / 8 Mbps minimum H264 game budget remains in place.
+- Release: Desktop and control package versions are bumped to 0.6.25.
+
 ## 0.6.24
 
 - Tuning: Game capture keeps the crisp 20 Mbps max / 8 Mbps minimum H264 budget but targets 1080p30 instead of 1080p60, reducing encoder pressure in heavy foreground games like Crimson Desert while preserving the improved image quality from 0.6.23.

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -1304,7 +1304,7 @@ dependencies = [
 
 [[package]]
 name = "echo-core-client"
-version = "0.6.24"
+version = "0.6.25"
 dependencies = [
  "base64 0.22.1",
  "futures-util",
@@ -1325,7 +1325,7 @@ dependencies = [
 
 [[package]]
 name = "echo-core-control"
-version = "0.6.24"
+version = "0.6.25"
 dependencies = [
  "argon2",
  "axum",

--- a/core/client/Cargo.toml
+++ b/core/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "echo-core-client"
-version = "0.6.24"
+version = "0.6.25"
 edition = "2021"
 description = "Echo Chamber native desktop client"
 

--- a/core/client/src/capture_pipeline.rs
+++ b/core/client/src/capture_pipeline.rs
@@ -52,11 +52,11 @@ const MIN_FRAME_INTERVAL_SOFTWARE: std::time::Duration =
 /// main.rs's startup probe and never changes after that.
 pub static HAS_NVCUDA: AtomicBool = AtomicBool::new(false);
 
-/// Desktop wire-level publish framerate cap. Game/window capture uses the same
-/// 30fps cadence with a much higher bitrate budget, preserving the crisp image
-/// quality v0.6.23 showed under heavy foreground-game load.
+/// Desktop wire-level publish framerate cap. Game/window capture opts into a
+/// high-motion 60fps cadence while keeping the higher bitrate budget added for
+/// v0.6.23.
 pub const PUBLISH_TARGET_FPS: u32 = 30;
-pub const GAME_PUBLISH_TARGET_FPS: u32 = 30;
+pub const GAME_PUBLISH_TARGET_FPS: u32 = 60;
 pub const STATIC_FRAME_HEARTBEAT_INTERVAL: Duration = Duration::from_millis(200);
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq)]
@@ -776,11 +776,11 @@ mod tests {
     }
 
     #[test]
-    fn game_profile_is_quality_biased_1080p30() {
+    fn game_profile_is_high_motion_1080p60() {
         let profile: PublishProfile = serde_json::from_str("\"game\"").expect("game profile");
 
         assert_eq!(profile, PublishProfile::Game);
-        assert_eq!(profile.target_fps(), 30);
+        assert_eq!(profile.target_fps(), 60);
         assert_eq!(profile.max_bitrate(), 20_000_000);
         assert_eq!(profile.min_bitrate(), 8_000_000);
     }

--- a/core/client/tauri.conf.json
+++ b/core/client/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "Echo Chamber",
-  "version": "0.6.24",
+  "version": "0.6.25",
   "identifier": "com.echochamber.app",
   "build": {
     "frontendDist": "../viewer"

--- a/core/control/Cargo.toml
+++ b/core/control/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "echo-core-control"
-version = "0.6.24"
+version = "0.6.25"
 edition = "2021"
 
 [dependencies]

--- a/core/viewer/changelog.js
+++ b/core/viewer/changelog.js
@@ -8,6 +8,14 @@
 
 var ECHO_CHANGELOG = [
   {
+    version: "v0.6.25",
+    title: "Game 60fps Restored",
+    notes: [
+      "Game capture defaults back to 1080p60 so strong game publishers are not capped by the v0.6.24 quality experiment.",
+      "The 20 Mbps max / 8 Mbps minimum H264 game budget remains in place."
+    ]
+  },
+  {
     version: "v0.6.24",
     title: "Game Quality Mode",
     notes: [


### PR DESCRIPTION
## Summary
- restore Game/window capture default to 1080p60 after v0.6.24 capped it at 30fps
- keep the 20 Mbps max / 8 Mbps min game bitrate budget from v0.6.23
- bump desktop/control versions and changelogs to 0.6.25

## Root cause
The v0.6.24 quality experiment changed GAME_PUBLISH_TARGET_FPS from 60 to 30 globally. That helped avoid extra pressure on Dave's heavy-game stream but also capped strong publishers like Jeff who were previously holding 60fps.

## Validation
- cargo test -p echo-core-client capture_pipeline::tests
- cargo test -p echo-core-client
- cargo check -p echo-core-client
- cargo check -p echo-core-control
- node --check core\\viewer\\changelog.js
- rustfmt --edition 2021 --check client\\src\\capture_pipeline.rs
- git diff --check