### PR TITLE
[codex] Sync v0.6.25 updater manifest

### DIFF
--- a/core/deploy/latest.json
+++ b/core/deploy/latest.json
@@ -1,11 +1,11 @@
 {
     "platforms":  {
                       "windows-x86_64":  {
-                                             "signature":  "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVSQ3ByNFJuZlpjME0za1crQmJ0c3RpYXViT1NMb2RhMGR3elMvTk12d1BpdC9PZTA0Y05VTU0wTUEvaXJlNjQ4eW5sZ284K2hBTG1xdFp0RllYS0R0V2pud2pTYnM3R3dRPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzgwMjYwMjIzCWZpbGU6RWNobyBDaGFtYmVyXzAuNi4yNF94NjQtc2V0dXAuZXhlCk1ReVgxN1VIRDE1RWlUU2NpeE5TUTVkSHZDMWRCK21HdGxnN2JWTjBraWxrNGFqajFYeUZPckNIcmtOMG1Bc2RVejA0YWljMWh2RUtzSFAxcmNDRkNRPT0K",
-                                             "url":  "https://github.com/SamWatson86/echo-chamber/releases/download/v0.6.24/Echo.Chamber_0.6.24_x64-setup.exe"
+                                             "signature":  "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVSQ3ByNFJuZlpjMENIMTRwN0wrUXNxMlJEbGNEVEtPTklsWmIxWGVHTUNaeU9FUmFVWEovVHVGMWRBZ09DMmQraUZ6emFkdlhvcjBaWDV3dUJLdElzT091dnVtOXFBL0FnPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzgwMjYxMzUyCWZpbGU6RWNobyBDaGFtYmVyXzAuNi4yNV94NjQtc2V0dXAuZXhlCmRhZ1NBV1dRNWU2S0FRUG5LZUF0ek85MEg0dW9rMkJKMTYydTltOGZmaVBVMXFPTFhaMDREM0VpM3RlcFpiTlJUS1VPeGVVQ3ljZUMyR0Z6NXBodURRPT0K",
+                                             "url":  "https://github.com/SamWatson86/echo-chamber/releases/download/v0.6.25/Echo.Chamber_0.6.25_x64-setup.exe"
                                          }
                   },
-    "pub_date":  "2026-05-31T20:43:43Z",
-    "version":  "0.6.24",
-    "notes":  "Echo Chamber v0.6.24"
+    "pub_date":  "2026-05-31T21:02:33Z",
+    "version":  "0.6.25",
+    "notes":  "Echo Chamber v0.6.25"
 }


### PR DESCRIPTION
## Summary
- update core/deploy/latest.json to point Windows clients at v0.6.25
- record the v0.6.25 installer URL, signature, pub date, and notes

## Validation
- local release script published GitHub Release v0.6.25
- gh release view v0.6.25 shows installer, signature, and latest.json assets uploaded
- live updater endpoint returns version 0.6.25 after manifest copy
- git diff --cached --check