### PR TITLE
Tune game bitrate floor for mic audio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.6.26
+
+- Fix: Game capture keeps the 1080p60 / 20 Mbps ceiling but lowers the forced H264 minimum from 8 Mbps to 2.5 Mbps so mic audio has room on constrained uplinks.
+- Diagnostics: Native capture startup logs continue to report the active max/min bitrate so live tests can confirm clients loaded the new profile.
+- Release: Desktop and control package versions are bumped to 0.6.26.
+
 ## 0.6.25
 
 - Fix: Game capture defaults back to 1080p60 so strong game publishers like Jeff are not capped at 30fps by the 0.6.24 experiment.

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -1304,7 +1304,7 @@ dependencies = [
 
 [[package]]
 name = "echo-core-client"
-version = "0.6.25"
+version = "0.6.26"
 dependencies = [
  "base64 0.22.1",
  "futures-util",
@@ -1325,7 +1325,7 @@ dependencies = [
 
 [[package]]
 name = "echo-core-control"
-version = "0.6.25"
+version = "0.6.26"
 dependencies = [
  "argon2",
  "axum",

--- a/core/client/Cargo.toml
+++ b/core/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "echo-core-client"
-version = "0.6.25"
+version = "0.6.26"
 edition = "2021"
 description = "Echo Chamber native desktop client"
 

--- a/core/client/src/capture_pipeline.rs
+++ b/core/client/src/capture_pipeline.rs
@@ -90,7 +90,9 @@ impl PublishProfile {
     fn min_bitrate(self) -> u64 {
         match self {
             Self::Desktop => 3_000_000,
-            Self::Game => 8_000_000,
+            // Game still gets the 20 Mbps ceiling, but the floor must leave
+            // room for the browser mic sender on constrained uplinks.
+            Self::Game => 2_500_000,
         }
     }
 
@@ -776,13 +778,13 @@ mod tests {
     }
 
     #[test]
-    fn game_profile_is_high_motion_1080p60() {
+    fn game_profile_keeps_60fps_with_mic_safe_floor() {
         let profile: PublishProfile = serde_json::from_str("\"game\"").expect("game profile");
 
         assert_eq!(profile, PublishProfile::Game);
         assert_eq!(profile.target_fps(), 60);
         assert_eq!(profile.max_bitrate(), 20_000_000);
-        assert_eq!(profile.min_bitrate(), 8_000_000);
+        assert_eq!(profile.min_bitrate(), 2_500_000);
     }
 
     fn pushed_frame_count(source_hz: u32, target_hz: u32, seconds: u32) -> usize {

--- a/core/client/tauri.conf.json
+++ b/core/client/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "Echo Chamber",
-  "version": "0.6.25",
+  "version": "0.6.26",
   "identifier": "com.echochamber.app",
   "build": {
     "frontendDist": "../viewer"

--- a/core/control/Cargo.toml
+++ b/core/control/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "echo-core-control"
-version = "0.6.25"
+version = "0.6.26"
 edition = "2021"
 
 [dependencies]

--- a/core/viewer/changelog.js
+++ b/core/viewer/changelog.js
@@ -8,6 +8,14 @@
 
 var ECHO_CHANGELOG = [
   {
+    version: "v0.6.26",
+    title: "Mic-Safe Game Streaming",
+    notes: [
+      "Game capture keeps the 1080p60 / 20 Mbps ceiling for high-motion streams.",
+      "The forced H264 minimum is reduced from 8 Mbps to 2.5 Mbps so mic audio has room on constrained uplinks."
+    ]
+  },
+  {
     version: "v0.6.25",
     title: "Game 60fps Restored",
     notes: [


### PR DESCRIPTION
## Summary
- keep Game capture at 1080p60 with the 20 Mbps ceiling
- lower the forced Game H264 minimum from 8 Mbps to 2.5 Mbps so mic audio has room on constrained uplinks
- bump desktop/control/changelog metadata to 0.6.26

## Verification
- cargo test -p echo-core-client game_profile_keeps_60fps_with_mic_safe_floor
- cargo test -p echo-core-client capture_pipeline::tests
- cargo test -p echo-core-client
- cargo check -p echo-core-client
- cargo check -p echo-core-control
- node --check core\\viewer\\changelog.js
- rustfmt --edition 2021 --check client\\src\\capture_pipeline.rs
- git diff --check

Note: cargo fmt --all -- --check still reports unrelated pre-existing formatting diffs across control/hook files, so this release was checked with rustfmt scoped to the touched Rust file.