### PR TITLE
[codex] Rollback game bitrate floor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.6.27
+
+- Fix: Roll back the v0.6.26 Game capture minimum bitrate change after live testing showed updated clients could fail to start streams.
+- Tuning: Game capture returns to the known-compatible 1080p60 / 20 Mbps max / 8 Mbps minimum profile from v0.6.25.
+- Release: Desktop and control package versions are bumped to 0.6.27.
+
 ## 0.6.26
 
 - Fix: Game capture keeps the 1080p60 / 20 Mbps ceiling but lowers the forced H264 minimum from 8 Mbps to 2.5 Mbps so mic audio has room on constrained uplinks.

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -1304,7 +1304,7 @@ dependencies = [
 
 [[package]]
 name = "echo-core-client"
-version = "0.6.26"
+version = "0.6.27"
 dependencies = [
  "base64 0.22.1",
  "futures-util",
@@ -1325,7 +1325,7 @@ dependencies = [
 
 [[package]]
 name = "echo-core-control"
-version = "0.6.26"
+version = "0.6.27"
 dependencies = [
  "argon2",
  "axum",

--- a/core/client/Cargo.toml
+++ b/core/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "echo-core-client"
-version = "0.6.26"
+version = "0.6.27"
 edition = "2021"
 description = "Echo Chamber native desktop client"
 

--- a/core/client/src/capture_pipeline.rs
+++ b/core/client/src/capture_pipeline.rs
@@ -90,9 +90,9 @@ impl PublishProfile {
     fn min_bitrate(self) -> u64 {
         match self {
             Self::Desktop => 3_000_000,
-            // Game still gets the 20 Mbps ceiling, but the floor must leave
-            // room for the browser mic sender on constrained uplinks.
-            Self::Game => 2_500_000,
+            // Keep the known-compatible floor that shipped before v0.6.26.
+            // Lower values caused game streams to fail to start in live tests.
+            Self::Game => 8_000_000,
         }
     }
 
@@ -778,13 +778,13 @@ mod tests {
     }
 
     #[test]
-    fn game_profile_keeps_60fps_with_mic_safe_floor() {
+    fn game_profile_keeps_60fps_with_compatible_floor() {
         let profile: PublishProfile = serde_json::from_str("\"game\"").expect("game profile");
 
         assert_eq!(profile, PublishProfile::Game);
         assert_eq!(profile.target_fps(), 60);
         assert_eq!(profile.max_bitrate(), 20_000_000);
-        assert_eq!(profile.min_bitrate(), 2_500_000);
+        assert_eq!(profile.min_bitrate(), 8_000_000);
     }
 
     fn pushed_frame_count(source_hz: u32, target_hz: u32, seconds: u32) -> usize {

--- a/core/client/tauri.conf.json
+++ b/core/client/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "Echo Chamber",
-  "version": "0.6.26",
+  "version": "0.6.27",
   "identifier": "com.echochamber.app",
   "build": {
     "frontendDist": "../viewer"

--- a/core/control/Cargo.toml
+++ b/core/control/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "echo-core-control"
-version = "0.6.26"
+version = "0.6.27"
 edition = "2021"
 
 [dependencies]

--- a/core/viewer/changelog.js
+++ b/core/viewer/changelog.js
@@ -8,6 +8,14 @@
 
 var ECHO_CHANGELOG = [
   {
+    version: "v0.6.27",
+    title: "Game Streaming Rollback",
+    notes: [
+      "Game capture returns to the known-compatible 1080p60 profile from v0.6.25.",
+      "The forced H264 minimum is back to 8 Mbps after v0.6.26 caused stream-start failures in live testing."
+    ]
+  },
+  {
     version: "v0.6.26",
     title: "Mic-Safe Game Streaming",
     notes: [


### PR DESCRIPTION
# Summary

- Roll back the v0.6.26 Game capture minimum bitrate change from 2.5 Mbps to the known-compatible 8 Mbps floor.
- Bump desktop/control package versions and updater-facing changelog entries to 0.6.27.

# Why

Live testing after 0.6.26 showed updated clients could fail to start streams. The only runtime capture behavior change in that release was the Game bitrate floor, so this release ships the smallest forward rollback.

# Verification

- Red test first failed with left 2500000 / right 8000000.
- cargo test -p echo-core-client game_profile_keeps_60fps_with_compatible_floor
- cargo test -p echo-core-client
- node --check core\viewer\changelog.js
- rustfmt --edition 2021 --check client\src\capture_pipeline.rs
- git diff --check
