### PR TITLE
[codex] Restore stable game capture cadence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.6.28
+
+- Fix: Game capture returns to the stable 1080p30 cadence after live testing showed the forced 60fps profile could crash or green-screen some publishers.
+- Tuning: The crisp 20 Mbps max / 8 Mbps minimum H264 game budget stays in place; only the frame cadence is reduced.
+- Release: Desktop and control package versions are bumped to 0.6.28.
+
 ## 0.6.27
 
 - Fix: Roll back the v0.6.26 Game capture minimum bitrate change after live testing showed updated clients could fail to start streams.

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -1304,7 +1304,7 @@ dependencies = [
 
 [[package]]
 name = "echo-core-client"
-version = "0.6.27"
+version = "0.6.28"
 dependencies = [
  "base64 0.22.1",
  "futures-util",
@@ -1325,7 +1325,7 @@ dependencies = [
 
 [[package]]
 name = "echo-core-control"
-version = "0.6.27"
+version = "0.6.28"
 dependencies = [
  "argon2",
  "axum",

--- a/core/client/Cargo.toml
+++ b/core/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "echo-core-client"
-version = "0.6.27"
+version = "0.6.28"
 edition = "2021"
 description = "Echo Chamber native desktop client"
 

--- a/core/client/src/capture_pipeline.rs
+++ b/core/client/src/capture_pipeline.rs
@@ -52,11 +52,12 @@ const MIN_FRAME_INTERVAL_SOFTWARE: std::time::Duration =
 /// main.rs's startup probe and never changes after that.
 pub static HAS_NVCUDA: AtomicBool = AtomicBool::new(false);
 
-/// Desktop wire-level publish framerate cap. Game/window capture opts into a
-/// high-motion 60fps cadence while keeping the higher bitrate budget added for
-/// v0.6.23.
+/// Desktop wire-level publish framerate cap. Game/window capture uses the
+/// stable 30fps cadence with the higher bitrate budget added for v0.6.23.
+/// Live tests showed forcing 60fps could make some publishers crash or render
+/// green frames, while the 30fps profile preserved the crisp image.
 pub const PUBLISH_TARGET_FPS: u32 = 30;
-pub const GAME_PUBLISH_TARGET_FPS: u32 = 60;
+pub const GAME_PUBLISH_TARGET_FPS: u32 = 30;
 pub const STATIC_FRAME_HEARTBEAT_INTERVAL: Duration = Duration::from_millis(200);
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq)]
@@ -778,11 +779,11 @@ mod tests {
     }
 
     #[test]
-    fn game_profile_keeps_60fps_with_compatible_floor() {
+    fn game_profile_uses_stable_1080p30_quality_profile() {
         let profile: PublishProfile = serde_json::from_str("\"game\"").expect("game profile");
 
         assert_eq!(profile, PublishProfile::Game);
-        assert_eq!(profile.target_fps(), 60);
+        assert_eq!(profile.target_fps(), 30);
         assert_eq!(profile.max_bitrate(), 20_000_000);
         assert_eq!(profile.min_bitrate(), 8_000_000);
     }

--- a/core/client/tauri.conf.json
+++ b/core/client/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "Echo Chamber",
-  "version": "0.6.27",
+  "version": "0.6.28",
   "identifier": "com.echochamber.app",
   "build": {
     "frontendDist": "../viewer"

--- a/core/control/Cargo.toml
+++ b/core/control/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "echo-core-control"
-version = "0.6.27"
+version = "0.6.28"
 edition = "2021"
 
 [dependencies]

--- a/core/viewer/changelog.js
+++ b/core/viewer/changelog.js
@@ -8,6 +8,14 @@
 
 var ECHO_CHANGELOG = [
   {
+    version: "v0.6.28",
+    title: "Stable Game Streaming",
+    notes: [
+      "Game capture returns to the stable 1080p30 cadence after live testing showed forced 60fps could crash or green-screen some publishers.",
+      "The crisp 20 Mbps max / 8 Mbps minimum H264 game budget stays in place."
+    ]
+  },
+  {
     version: "v0.6.27",
     title: "Game Streaming Rollback",
     notes: [


### PR DESCRIPTION
# Summary

- Restore the Game capture default to the stable 1080p30 cadence.
- Keep the crisp 20 Mbps max / 8 Mbps minimum H264 budget.
- Bump client/control package versions and changelog entries to 0.6.28.

# Why

Live testing showed the forced 60fps Game profile could crash or green-screen some publishers. The logs from the good state showed the stable quality profile was 30fps with the higher bitrate budget, not 60fps.

# Verification

- Red test first failed with left 60 / right 30.
- cargo test -p echo-core-client game_profile_uses_stable_1080p30_quality_profile
- cargo test -p echo-core-client
- cargo check -p echo-core-client
- cargo check -p echo-core-control
- node --check core\viewer\changelog.js
- rustfmt --edition 2021 --check client\src\capture_pipeline.rs
- git diff --check
