### PR TITLE
[codex] Sync updater manifest for v0.6.28

### DIFF
--- a/core/deploy/latest.json
+++ b/core/deploy/latest.json
@@ -1,11 +1,11 @@
 {
     "platforms":  {
                       "windows-x86_64":  {
-                                             "signature":  "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVSQ3ByNFJuZlpjMEg5dHZYbFdKZ2dDSkNSWmJGSmRiRXVhaUhOeHo3RGkvQUxVZlc0VzZ3U2swMzdtdUxlczlITVhSUTBwQkR1V3JzcTYrL0Z0WktWa3lvcGNta1U5a2c0PQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzgwMjY2MjM5CWZpbGU6RWNobyBDaGFtYmVyXzAuNi4yN194NjQtc2V0dXAuZXhlCmJ2R3Nub3ZLZnRNazVQZy9aTkt4VjNCQUYvL0NocTFtU0tCWkJieENQSlZ1aGY1SVZZNHJXRS9JSWRQY0llcitTNHlkYXhIZlJPQTl1QTBqcDlDMURnPT0K",
-                                             "url":  "https://github.com/SamWatson86/echo-chamber/releases/download/v0.6.27/Echo.Chamber_0.6.27_x64-setup.exe"
+                                             "signature":  "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVSQ3ByNFJuZlpjMEo0UnQzMVFodHVmaEtTMTMyRUs1SGhVS2p1NmtDNmdYNWZWM0VjSnFQUHZtRlNHSytOdkY4VjdLM1VqbGhjK3BReW5sbGtkL2NtTEcwOFRLeHVmSlE0PQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzgwMzIwODEyCWZpbGU6RWNobyBDaGFtYmVyXzAuNi4yOF94NjQtc2V0dXAuZXhlCjVTQmlZbW5Qbk90L2pwZGwzOU1nRjhNNTlPZFZzNjZKZ3FzbEVhcTNDTENqVnhHTmdiRmlKQmFKOUpkbXF6ODQ2TkJlandwOUxWSnUwZ3RPZGxSRUNRPT0K",
+                                             "url":  "https://github.com/SamWatson86/echo-chamber/releases/download/v0.6.28/Echo.Chamber_0.6.28_x64-setup.exe"
                                          }
                   },
-    "pub_date":  "2026-05-31T22:23:59Z",
-    "version":  "0.6.27",
-    "notes":  "Echo Chamber v0.6.27"
+    "pub_date":  "2026-06-01T13:33:33Z",
+    "version":  "0.6.28",
+    "notes":  "Echo Chamber v0.6.28"
 }


### PR DESCRIPTION
Syncs core/deploy/latest.json to the v0.6.28 GitHub Release manifest that is already being served by the live updater endpoint. Verified live /api/update/latest.json reports 0.6.28 and /api/version reports latest_client 0.6.28.