### PR TITLE
chore: quarantine legacy capture paths

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -1350,14 +1350,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "echo-game-hook"
-version = "0.1.0"
-dependencies = [
- "minhook",
- "windows 0.58.0",
-]
-
-[[package]]
 name = "ed25519"
 version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3103,16 +3095,6 @@ checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
 dependencies = [
  "mime",
  "unicase",
-]
-
-[[package]]
-name = "minhook"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "455e088cb1600ffa5f1524c9702c9eeb0ba3604e0f4932efa165b99973272a8d"
-dependencies = [
- "cc",
- "tracing",
 ]
 
 [[package]]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -3,7 +3,10 @@ members = [
   "control",
   "client",
   "admin-client",
+]
+exclude = [
   "hook",
+  "client/src/archive/hook",
 ]
 default-members = [
   "control",

--- a/core/client/src/archive/AGENTS.md
+++ b/core/client/src/archive/AGENTS.md
@@ -1,0 +1,14 @@
+# Archived Capture Code
+
+This subtree is reference-only. Do not import, build, copy, or revive these
+modules unless Sam explicitly asks for a fresh capture-design task.
+
+For active production capture work, start from:
+
+- `core/client/src/screen_capture.rs`
+- `core/client/src/desktop_capture.rs`
+- `core/client/src/capture_pipeline.rs`
+- `core/viewer/screen-share-native.js`
+
+The Present-hook, injector, control-block, and NvFBC paths here are abandoned
+experiments.

--- a/core/client/src/archive/README.md
+++ b/core/client/src/archive/README.md
@@ -1,28 +1,44 @@
 # Archived Capture Methods
 
-These modules were removed from active use but preserved for reference.
-Each represents a capture approach that was fully implemented and tested
-before being abandoned due to platform limitations.
+This folder is reference-only. These modules are not production capture paths,
+must not be imported by active code, and must not be used as templates for new
+capture work without a fresh design review from Sam.
 
-## nvfbc_capture.rs (813 lines) — NVIDIA FrameBuffer Capture
-**What:** Captured GPU scanout buffer via NvFBC API. Highest quality — bypasses
-compositor, immune to game engine, anti-cheat, DLSS.
-**Why abandoned:** GeForce driver (595.79+) blocks NvFBC on consumer GPUs.
-Wrapper DLL attempted but driver detects and blocks. Also compositor-bound
-on Windows even when working.
-**Performance achieved:** N/A on GeForce. Would have been 60fps+ under any load.
-**Revival condition:** NVIDIA unblocks NvFBC on consumer GPUs.
+Active production capture lives in:
 
-## game_capture.rs (555 lines) + injector.rs (385 lines) + control_block_client.rs (107 lines) — Present() Hook
-**What:** Injected echo_game_hook.dll into game process, hooked DirectX Present(),
-captured frames via shared D3D11 texture with keyed mutex synchronization.
-**Why abandoned:** Fails with DLSS Frame Generation. The DLSS proxy swap chain
-sends garbled data across 4 channels. Not fixable from our side. Tested
-extensively with Crimson Desert 4K — frames are corrupted.
-**Performance achieved:** 30-60fps on DX11 games without DLSS FG.
-**Revival condition:** DLSS FG architecture changes, or game-specific workaround.
+- `core/client/src/screen_capture.rs` - WGC window/game capture
+- `core/client/src/desktop_capture.rs` - DXGI Desktop Duplication monitor and
+  fallback capture
+- `core/client/src/capture_pipeline.rs` - shared LiveKit publisher
 
-## hook/ (DLL source) — echo_game_hook.dll
-**What:** The DLL that game_capture.rs injects. Hooks Present() vtable,
-writes BGRA to shared texture, signals frame event.
-**Why archived:** Dead without game_capture.rs.
+## nvfbc_capture.rs - NVIDIA FrameBuffer Capture
+
+**What:** Captured GPU scanout buffer via NvFBC API.
+
+**Why abandoned:** GeForce driver 595.79+ blocks NvFBC on consumer GPUs. Wrapper
+DLL attempts were detected and blocked by the driver. On Windows it was also
+still compositor-bound when working.
+
+**Revival condition:** NVIDIA officially supports NvFBC on consumer GPUs, and
+Sam explicitly asks for a fresh capture design.
+
+## game_capture.rs + injector.rs + control_block_client.rs - Present Hook
+
+**What:** Injected `echo_game_hook.dll` into a game process, hooked DirectX
+`Present()`, and captured frames through a shared D3D11 texture with keyed mutex
+synchronization.
+
+**Why abandoned:** Failed with DLSS Frame Generation. The DLSS proxy swap chain
+sent empty or garbled data across multiple channels. This was not fixable from
+Echo's side.
+
+**Revival condition:** Treat as dead unless Sam explicitly asks for a fresh game
+capture design. Do not re-propose Present hooks as routine cleanup or bug-fix
+work.
+
+## hook/ - echo_game_hook.dll source
+
+**What:** DLL source used by the abandoned Present-hook path.
+
+**Why archived:** Dead without `game_capture.rs` and intentionally excluded from
+the active Cargo workspace.

--- a/core/docs/CAPTURE_PIPELINE.md
+++ b/core/docs/CAPTURE_PIPELINE.md
@@ -1,107 +1,92 @@
 # Capture Pipeline
 
-Screen capture runs in the Tauri client (Rust). Two active methods are used depending on OS version. The JS picker (`capture-picker.js`) selects the source; the Rust backend does the actual capture.
+Screen capture runs in the Tauri client. The viewer picker chooses the source,
+`screen-share-native.js` chooses the native path, and Rust captures/publishes
+through the shared LiveKit capture pipeline.
 
 ## Active Capture Methods
 
-### WGC — Windows.Graphics.Capture (Win11 24H2+ only)
+### WGC - Windows.Graphics.Capture
 
 - Module: `core/client/src/screen_capture.rs`
-- API: `windows-capture` crate wrapping WGC
-- Output: BGRA frames from GPU
-- Passes frames through `gpu_converter.rs` for HDR→SDR + downscale
-- Encoding: Media Foundation → NVENC (H264)
+- Used for window/game capture on supported Windows builds
+- Started through the `start_screen_share` Tauri command
+- Passes frames through `gpu_converter.rs`
+- Publishes through `capture_pipeline.rs`
 
-Activated when OS build ≥ 26100 (Win11 24H2). Detection in `screen-share-native.js`:
-
-```js
-var osBuild = await tauriInvoke('get_os_build_number');
-var useWgc = osBuild >= 26100;
-```
-
-### DXGI Desktop Duplication (fallback — Win10 / older builds)
+### DXGI Desktop Duplication
 
 - Module: `core/client/src/desktop_capture.rs`
-- API: `IDXGIOutputDuplication` (DWM compositor frames)
-- Works with every game in windowed/borderless regardless of DX version, DLSS FG, or anti-cheat
-- Also passes through `gpu_converter.rs`
+- Production monitor-capture path
+- Fallback path for older Windows builds and unsupported native sources
+- Started through the `start_desktop_capture` Tauri command
+- Passes frames through `gpu_converter.rs`
+- Publishes through `capture_pipeline.rs`
+
+The Tauri command `start_screen_share_monitor` exists for the older WGC monitor
+experiment, but it is not the production picker path. Do not call or revive that
+path for monitor sharing without a fresh design and explicit hardware-risk
+review. Current monitor shares should go through DXGI Desktop Duplication.
 
 ## GPU Shader Pipeline
 
 Shared module: `core/client/src/gpu_converter.rs`
 
-```
-Captured D3D11 texture (any format: BGRA8, RGBA16F/HDR)
-  │
-  ▼ CopyResource to GPU SRV texture (GPU→GPU, zero-copy)
-[GPU texture]
-  │
-  ▼ D3D11 compute shader dispatch (16×16 threadgroups)
-    • HDR→SDR: saturate() tonemap (no-op for SDR input)
-    • Downscale: nearest-neighbor to encode resolution
-    • R/B swap: HLSL outputs R8G8B8A8_UNORM (hardware UAV constraint)
-[BGRA8 texture @ encode resolution]
-  │
-  ▼ CopyResource to CPU staging texture (~8MB not ~66MB at 4K)
-[CPU memory]
-  │
-  ▼ libyuv BGRA→I420
-[I420 frame]
-  │
-  ▼ NativeVideoSource::capture_frame (Rust LiveKit SDK)
-[H264 via NVENC — RTX 4090]
-  │
-  ▼ RTP → SFU → viewer
-```
-
-HLSL shader summary:
-```hlsl
-Texture2D<float4> src : register(t0);
-RWTexture2D<unorm float4> dst : register(u0);
-// Nearest-neighbor sample from src, saturate(), write to dst
-// Note: UAV uses R8G8B8A8_UNORM — R/B swap done in HLSL
+```text
+Captured D3D11 texture
+  |
+  v
+GPU shader conversion / downscale
+  |
+  v
+CPU staging texture
+  |
+  v
+libyuv BGRA to I420
+  |
+  v
+NativeVideoSource::capture_frame
+  |
+  v
+H264 via NVENC
+  |
+  v
+RTP to SFU to viewer
 ```
 
 ## OS-Aware Fallback Chain
 
-Detection runs in JS (`screen-share-native.js`) before starting Tauri IPC capture:
+Detection runs in `core/viewer/screen-share-native.js` before starting native
+capture:
 
-1. Query `get_os_build_number` via Tauri IPC
-2. If build ≥ 26100: start `start_screen_share_wgc` (WGC path)
-3. Otherwise: start `start_screen_share_dxgi` (DXGI DD path)
-4. If Tauri IPC unavailable (browser fallback): use `getDisplayMedia` (browser capture, lower quality)
+1. Query `get_os_build_number` through Tauri IPC.
+2. For window/game sources on supported builds, call `start_screen_share`.
+3. For monitor sources, or when WGC is unsupported, call
+   `start_desktop_capture`.
+4. If Tauri IPC is unavailable, use browser `getDisplayMedia` fallback.
 
-The JS side always derives the SFU URL from the control URL (`https→wss`) — never connects to port 7880 directly.
+The JS side derives the SFU URL from the control URL. It does not connect to
+port 7880 directly.
 
 ## Encoding
 
-- Encoder: NVENC (H264) via webrtc-sys local fork
-- Local fork path: `core/webrtc-sys-local/` (fixes missing abseil headers that cause silent NVENC exclusion)
-- ContentHint: `fluid` — maps to MAINTAIN_FRAMERATE in libwebrtc, prevents WebRTC from reducing FPS under bitrate pressure
-- Simulcast: disabled for screen share; single layer labeled `f` (HIGH RID) so SFU allocates full bandwidth
-- Non-simulcast bug fixed: `VIDEO_RIDS[0]` was `'q'` (LOW) — changed to `'f'` (HIGH) in `core/livekit-local/`
-
-- H264 SDP bitrate hints are aligned to the publish profile: game streams advertise the real min bitrate floor and start at the full target bitrate so WebRTC's allocator does not begin from the old low fallback.
-
-## Performance Numbers (RTX 4090, 4K source)
-
-| Scenario | Capture FPS | Viewer FPS |
-|----------|------------|------------|
-| Desktop (no game) | 100+ | ~60 |
-| Light game (Megabonk) | 139 | ~60 |
-| Crimson Desert 4K borderless | 45-55 | 45-55 |
-| BF6 4K (WGC) | 53 | ~53 |
-
-Capture is limited by the DWM compositor under heavy GPU load, not by the pipeline.
+- Encoder: NVENC (H264) through the local `webrtc-sys` fork.
+- Local fork path: `core/webrtc-sys-local/`.
+- ContentHint: `fluid`, which maps to MAINTAIN_FRAMERATE in libwebrtc.
+- Simulcast: disabled for screen share.
+- Game streams advertise their real min bitrate floor and start bitrate.
 
 ## Archived Methods
 
-Dead methods live in `core/client/src/archive/`. Not compiled into the binary.
+Dead methods live in `core/client/src/archive/`. The old top-level `core/hook/`
+crate is also excluded from the active Cargo workspace. These paths are
+reference-only and must not be copied into production capture work without a
+fresh design review.
 
-| Method | File | Why Dead |
-|--------|------|----------|
-| NVFBC | `archive/nvfbc_capture.rs` | Blocked by NVIDIA driver 595.79 on GeForce. Also compositor-bound on Windows — no advantage over DXGI DD. |
-| Present() hook | `archive/hook/`, `archive/game_capture.rs`, `archive/injector.rs` | Fails with DLSS Frame Generation — swap chain buffers arrive empty/garbled. Not fixable. |
+| Method | File | Why dead |
+|---|---|---|
+| NVFBC | `archive/nvfbc_capture.rs` | Blocked by NVIDIA driver 595.79 on GeForce. |
+| Present hook | `archive/hook/`, `archive/game_capture.rs`, `archive/injector.rs` | Fails with DLSS Frame Generation. |
 | Control block client | `archive/control_block_client.rs` | Superseded by direct IPC approach. |
 
 See `core/client/src/archive/README.md` for details.

--- a/core/docs/CLIENT_MODULES.md
+++ b/core/docs/CLIENT_MODULES.md
@@ -2,104 +2,93 @@
 
 Source: `core/client/src/`
 
-The client is a Tauri v2 app. It opens a WebView2 window that loads the viewer from the server URL. Most functionality is in the viewer JS — the native binary exists for capture, audio, window management, and auto-update.
+The client is a Tauri v2 app. It opens a WebView2 window that loads the viewer
+from the configured server URL. The native binary exists for capture, audio,
+window management, and auto-update.
 
-## Modules
+## Active Modules
 
 | File | Platform | Purpose |
-|------|----------|---------|
+|---|---|---|
 | `main.rs` | all | Entry point, IPC command registration, window setup, updater |
-| `desktop_capture.rs` | Windows | DXGI Desktop Duplication capture + GPU pipeline |
-| `screen_capture.rs` | Windows | WGC (Windows.Graphics.Capture) capture + GPU pipeline |
-| `gpu_converter.rs` | Windows | Shared D3D11 compute shader: HDR→SDR + downscale |
+| `desktop_capture.rs` | Windows | DXGI Desktop Duplication monitor/fallback capture |
+| `screen_capture.rs` | Windows | WGC window/game capture |
+| `capture_pipeline.rs` | Windows | Shared LiveKit capture publisher |
+| `capture_health.rs` | Windows | Capture-health state and diagnostics |
+| `gpu_converter.rs` | Windows | Shared D3D11 shader conversion and downscale |
 | `audio_capture.rs` | Windows | WASAPI per-process loopback capture |
 | `audio_capture_stub.rs` | non-Windows | No-op stubs for audio capture types |
 | `audio_output.rs` | Windows | Output device enumeration |
 | `audio_output_stub.rs` | non-Windows | No-op stubs for audio output types |
-
-## Platform Abstraction
-
-Conditional compilation via `#[cfg(target_os = "windows")]`:
-
-```rust
-#[cfg(target_os = "windows")]
-mod audio_capture;
-#[cfg(not(target_os = "windows"))]
-mod audio_capture_stub;
-#[cfg(not(target_os = "windows"))]
-use audio_capture_stub as audio_capture;
-
-#[cfg(target_os = "windows")]
-mod screen_capture;
-
-#[cfg(target_os = "windows")]
-mod gpu_converter;
-#[cfg(target_os = "windows")]
-mod desktop_capture;
-```
-
-Non-Windows builds compile cleanly with stub modules. There is no macOS/Linux capture support.
+| `native_presenter.rs` | Windows | Guarded receive-side native presenter probe |
 
 ## IPC Command Routing
 
-All Tauri IPC commands are registered in `main.rs` via `tauri::generate_handler![]`.
+All Tauri IPC commands are registered in `main.rs` via
+`tauri::generate_handler![]`.
 
 | Command | Module | Purpose |
-|---------|--------|---------|
-| `get_app_info` | main.rs | Returns version, native flag, platform, server URL |
-| `get_control_url` | main.rs | Returns configured server URL |
-| `check_for_updates` | main.rs | Checks GitHub releases, downloads + installs if available |
-| `toggle_fullscreen` | main.rs | Toggles window fullscreen state |
-| `set_always_on_top` | main.rs | Pins window above all others |
-| `open_external_url` | main.rs | Opens http/https URL in system browser (rundll32 on Windows) |
-| `save_settings` | main.rs | Writes settings JSON to `%APPDATA%/echo-chamber/settings.json` |
-| `load_settings` | main.rs | Reads settings JSON (returns `{}` if missing) |
-| `get_os_build_number` | main.rs | Returns Windows build number (for WGC availability check) |
-| `list_capturable_windows` | audio_capture.rs | Lists visible windows with PID/title/exe |
-| `start_audio_capture` | audio_capture.rs | Starts WASAPI process loopback for given PID |
-| `stop_audio_capture` | audio_capture.rs | Stops WASAPI capture loop |
-| `list_audio_output_devices` | audio_output.rs | Enumerates audio output devices |
-| `list_capture_sources` | screen_capture.rs / desktop_capture.rs | Lists monitors + windows for picker |
-| `start_screen_share_wgc` | screen_capture.rs | Starts WGC capture + LiveKit publish |
-| `start_screen_share_dxgi` | desktop_capture.rs | Starts DXGI DD capture + LiveKit publish |
-| `stop_screen_share` | screen_capture.rs / desktop_capture.rs | Stops active capture |
-| `get_screen_share_stats` | screen_capture.rs / desktop_capture.rs | Returns FPS, resolution, encoder, bitrate |
+|---|---|---|
+| `get_app_info` | `main.rs` | Returns version, native flag, platform, server URL |
+| `get_control_url` | `main.rs` | Returns configured server URL |
+| `check_for_updates` | `main.rs` | Checks server-served update metadata |
+| `toggle_fullscreen` | `main.rs` | Toggles window fullscreen state |
+| `set_always_on_top` | `main.rs` | Pins window above all others |
+| `open_external_url` | `main.rs` | Opens http/https URL in the system browser |
+| `save_settings` | `main.rs` | Writes settings JSON |
+| `load_settings` | `main.rs` | Reads settings JSON |
+| `get_os_build_number` | `main.rs` | Returns Windows build number for WGC gating |
+| `list_capturable_windows` | `audio_capture.rs` | Lists visible windows with PID/title/exe |
+| `start_audio_capture` | `audio_capture.rs` | Starts WASAPI process loopback for a PID |
+| `stop_audio_capture` | `audio_capture.rs` | Stops WASAPI capture |
+| `list_audio_output_devices` | `audio_output.rs` | Enumerates audio output devices |
+| `list_screen_sources` | `screen_capture.rs` / `desktop_capture.rs` | Lists monitors and windows for picker |
+| `start_screen_share` | `screen_capture.rs` | Starts WGC window/game capture and LiveKit publish |
+| `start_screen_share_monitor` | `screen_capture.rs` | Dormant WGC monitor experiment; not the production monitor picker path |
+| `start_desktop_capture` | `desktop_capture.rs` | Starts DXGI DD monitor/fallback capture and LiveKit publish |
+| `stop_screen_share` | `screen_capture.rs` | Stops WGC capture |
+| `stop_desktop_capture` | `desktop_capture.rs` | Stops DXGI DD capture |
+| `get_capture_health` | `capture_health.rs` | Returns native capture-health snapshot |
 
-## Tauri Events (Rust → JS)
+## Tauri Events
 
 | Event | Source | Payload |
-|-------|--------|---------|
-| `audio-chunk` | audio_capture.rs | base64-encoded PCM float32 chunk |
-| `screen-share-stats` | screen_capture.rs / desktop_capture.rs | JSON with fps, width, height, bitrate_kbps, encoder |
+|---|---|---|
+| `audio-chunk` | `audio_capture.rs` | base64-encoded PCM float32 chunk |
+| `screen-capture-stats` | `screen_capture.rs` | WGC capture stats |
+| `desktop-capture-stats` | `desktop_capture.rs` | DXGI DD capture stats |
+| `screen-capture-stopped` | `screen_capture.rs` | WGC capture stopped |
+| `desktop-capture-stopped` | `desktop_capture.rs` | DXGI DD capture stopped |
 
 ## Configuration
 
-`config.json` sits next to the `.exe`. Loaded at startup by `load_config()`:
+`config.json` sits next to the `.exe`. It is loaded at startup by
+`load_config()`:
 
 ```json
 { "server": "https://echo.fellowshipoftheboatrace.party:9443" }
 ```
 
-If missing, defaults to `DEFAULT_SERVER` constant. BOM-stripped before JSON parse (PowerShell 5.1 BOM issue).
-
-Both debug (`core/target/debug/`) and release (`core/target/release/`) directories need their own `config.json`.
+If missing, the app falls back to `DEFAULT_SERVER`.
 
 ## Auto-Update
 
-Uses `tauri-plugin-updater`. Checks `/api/update/latest.json` on the control plane (which proxies from GitHub releases). On update found: downloads + installs + restarts. Triggered on startup and by `check_for_updates` IPC command.
-
-Cache is cleared on version upgrade: `clear_cache_on_upgrade()` removes WebView2 cache directories to prevent stale content after updates.
+The app uses `tauri-plugin-updater` and checks `/api/update/latest.json` on the
+control plane. The control plane serves release metadata generated by the local
+Windows release process.
 
 ## Archived Modules
 
-Dead code lives in `core/client/src/archive/`. Not included in any build.
+Dead code lives in `core/client/src/archive/`. The old top-level `core/hook/`
+crate is also excluded from the active Cargo workspace. These paths are
+reference-only and must not be used as production capture templates.
 
 | File | What it was |
-|------|------------|
-| `nvfbc_capture.rs` | NVFBC capture (blocked on GeForce by driver 595.79) |
+|---|---|
+| `nvfbc_capture.rs` | NVFBC capture blocked on GeForce by driver policy |
 | `game_capture.rs` | Game capture via injected DLL |
 | `injector.rs` | DLL injector for game capture hook |
-| `hook/` | Hook DLL source (Present() intercept — dead with DLSS FG) |
+| `hook/` | Hook DLL source for the abandoned Present-hook path |
 | `control_block_client.rs` | Earlier IPC approach, superseded |
 
-See `archive/README.md` for detailed post-mortems.
+See `core/client/src/archive/README.md` for detailed post-mortems.

--- a/core/docs/DECISIONS.md
+++ b/core/docs/DECISIONS.md
@@ -81,3 +81,18 @@ Decision: carry both max and min publish bitrate bounds into `PeerTransport` and
 them for H264 `x-google-min-bitrate`/`x-google-start-bitrate`. This keeps the allocator,
 encoder target, and game publish profile aligned without changing the active capture
 backend.
+
+## 2026-06-01 - Legacy Capture Quarantine
+
+The abandoned Present-hook DLL crate at `core/hook/` is excluded from the active
+Cargo workspace. It remains in the repo only as historical reference.
+
+Decision:
+
+- Active capture work starts from `screen_capture.rs`, `desktop_capture.rs`, and
+  `capture_pipeline.rs`.
+- `core/client/src/archive/` and `core/hook/` must not be imported, built, or
+  copied into production paths without a fresh design review.
+- Monitor sharing uses DXGI Desktop Duplication. The older WGC monitor IPC path
+  is not the production monitor path and must not be revived without explicit
+  hardware-risk review.

--- a/core/hook/AGENTS.md
+++ b/core/hook/AGENTS.md
@@ -1,0 +1,8 @@
+# Archived Present-Hook DLL
+
+This directory is not an active build target. Do not use it as a source of
+production capture patterns unless Sam explicitly asks for a fresh design.
+
+Active capture work belongs in `core/client/src/screen_capture.rs`,
+`core/client/src/desktop_capture.rs`, `core/client/src/capture_pipeline.rs`, and
+the viewer screen-share modules.

--- a/core/hook/README.md
+++ b/core/hook/README.md
@@ -1,0 +1,17 @@
+# Archived Present-Hook DLL
+
+This crate is an abandoned experiment for DirectX `Present()` hooking. It is
+intentionally excluded from the active Cargo workspace and is not part of the
+production desktop client.
+
+Do not build, import, copy, or revive this crate for routine capture work.
+
+Production capture lives in:
+
+- `core/client/src/screen_capture.rs` for WGC window/game capture
+- `core/client/src/desktop_capture.rs` for DXGI Desktop Duplication monitor and
+  fallback capture
+- `core/client/src/capture_pipeline.rs` for shared LiveKit publishing
+
+The archived copy under `core/client/src/archive/hook/` is the historical
+reference paired with the abandoned injector/game-capture code.


### PR DESCRIPTION
## Summary
- exclude the abandoned Present-hook crate from the active Cargo workspace
- prune stale echo-game-hook/minhook lockfile entries
- add archive-local AGENTS/README guardrails for legacy capture experiments
- document DXGI Desktop Duplication as the production monitor-capture path and WGC monitor capture as dormant/non-production

## Release impact
- Docs/workspace guardrails only
- No runtime capture behavior change
- No desktop release required

## Verification
- cargo metadata --locked --no-deps --format-version 1
- cargo check -p echo-core-control --locked
- git diff --cached --check

## Notes
- No services restarted
- No release performed
- Active capture implementation files were not changed