### PR TITLE
chore: add guardrail verification

### DIFF
--- a/docs/VALIDATION.md
+++ b/docs/VALIDATION.md
@@ -13,6 +13,7 @@ bash tools/verify/quick.sh
 
 What it does:
 
+- repo guardrail checks for release/workflow and archived capture boundaries
 - JS syntax checks for viewer files
 - deterministic JS state tests with `node --test core/viewer/*.test.js`
 - Rust compile check for the control plane with

--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
   "private": true,
   "description": "Echo Chamber repo metadata. Active development lives under core/.",
   "scripts": {
-    "verify:viewer": "node --check core/viewer/app.js && node --check core/viewer/jam.js && node --test core/viewer/*.test.js"
+    "verify:guardrails": "node tools/verify/guardrails.mjs",
+    "verify:viewer": "node --check core/viewer/app.js && node --check core/viewer/jam.js && node --test core/viewer/*.test.js",
+    "verify:quick": "npm run verify:guardrails && npm run verify:viewer"
   }
 }

--- a/tools/verify/guardrails.mjs
+++ b/tools/verify/guardrails.mjs
@@ -1,0 +1,153 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const root = path.resolve(import.meta.dirname, '..', '..');
+
+const failures = [];
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(root, relativePath), 'utf8');
+}
+
+function exists(relativePath) {
+  return fs.existsSync(path.join(root, relativePath));
+}
+
+function fail(message) {
+  failures.push(message);
+}
+
+function assert(condition, message) {
+  if (!condition) fail(message);
+}
+
+function listFiles(relativeDir, predicate = () => true) {
+  const dir = path.join(root, relativeDir);
+  if (!fs.existsSync(dir)) return [];
+
+  return fs
+    .readdirSync(dir, { withFileTypes: true })
+    .flatMap((entry) => {
+      const relativePath = path.join(relativeDir, entry.name);
+      if (entry.isDirectory()) return listFiles(relativePath, predicate);
+      return predicate(relativePath) ? [relativePath] : [];
+    });
+}
+
+function checkWorkflowGuardrails() {
+  const forbiddenFiles = [
+    '.github/workflows/release.yml',
+    '.github/workflows/build-macos.yml',
+  ];
+
+  for (const file of forbiddenFiles) {
+    assert(!exists(file), `${file} must not exist; releases are local Windows-only operations.`);
+  }
+
+  const workflowFiles = listFiles('.github/workflows', (file) => /\.ya?ml$/i.test(file));
+  const forbiddenPatterns = [
+    {
+      pattern: /cargo\s+tauri\s+build/i,
+      reason: 'GitHub workflows must not build Tauri installers.',
+    },
+    {
+      pattern: /macos-latest/i,
+      reason: 'GitHub workflows must not run macOS jobs.',
+    },
+    {
+      pattern: /build-macos/i,
+      reason: 'GitHub workflows must not keep macOS build jobs.',
+    },
+    {
+      pattern: /bundle\/dmg|bundle\\dmg|--bundles\s+(?:app,)?dmg/i,
+      reason: 'GitHub workflows must not build or upload DMG artifacts.',
+    },
+    {
+      pattern: /softprops\/action-gh-release/i,
+      reason: 'GitHub workflows must not publish release assets for normal releases.',
+    },
+  ];
+
+  for (const file of workflowFiles) {
+    const content = read(file);
+    for (const { pattern, reason } of forbiddenPatterns) {
+      assert(!pattern.test(content), `${file}: ${reason}`);
+    }
+  }
+}
+
+function checkRootPackageGuardrails() {
+  assert(!exists('package-lock.json'), 'package-lock.json must not return for the retired root npm workspace.');
+
+  const packageJson = JSON.parse(read('package.json'));
+  const workspaces = packageJson.workspaces ?? [];
+  assert(
+    !workspaces.some((workspace) => /^apps[\\/]/.test(workspace)),
+    'package.json must not point at retired apps/* workspaces.',
+  );
+}
+
+function checkCargoWorkspaceGuardrails() {
+  const cargoToml = read('core/Cargo.toml');
+  const membersMatch = cargoToml.match(/members\s*=\s*\[([\s\S]*?)\]/);
+  assert(Boolean(membersMatch), 'core/Cargo.toml must declare workspace members.');
+
+  const membersBlock = membersMatch?.[1] ?? '';
+  assert(!/"hook"/.test(membersBlock), 'core/hook must not be an active Cargo workspace member.');
+
+  assert(
+    /exclude\s*=\s*\[[\s\S]*"hook"[\s\S]*"client\/src\/archive\/hook"[\s\S]*\]/.test(cargoToml),
+    'core/Cargo.toml must explicitly exclude hook crates from the active workspace.',
+  );
+
+  const lockfile = read('core/Cargo.lock');
+  assert(!/name = "echo-game-hook"/.test(lockfile), 'core/Cargo.lock must not contain echo-game-hook.');
+  assert(!/name = "minhook"/.test(lockfile), 'core/Cargo.lock must not contain minhook from the archived hook.');
+}
+
+function checkArchiveGuardrails() {
+  const requiredFiles = [
+    'core/client/src/archive/AGENTS.md',
+    'core/client/src/archive/README.md',
+    'core/hook/AGENTS.md',
+    'core/hook/README.md',
+  ];
+
+  for (const file of requiredFiles) {
+    assert(exists(file), `${file} must exist to mark legacy capture code as archived.`);
+  }
+
+  assert(
+    /reference-only/i.test(read('core/client/src/archive/AGENTS.md')),
+    'core/client/src/archive/AGENTS.md must clearly mark the archive as reference-only.',
+  );
+  assert(
+    /not an active build target/i.test(read('core/hook/AGENTS.md')),
+    'core/hook/AGENTS.md must clearly state core/hook is not an active build target.',
+  );
+
+  const capturePipeline = read('core/docs/CAPTURE_PIPELINE.md');
+  assert(
+    /start_screen_share_monitor[\s\S]*not the production picker path/i.test(capturePipeline),
+    'core/docs/CAPTURE_PIPELINE.md must warn that WGC monitor capture is not production picker path.',
+  );
+  assert(
+    /DXGI Desktop Duplication/i.test(capturePipeline),
+    'core/docs/CAPTURE_PIPELINE.md must document DXGI Desktop Duplication as the monitor/fallback path.',
+  );
+}
+
+checkWorkflowGuardrails();
+checkRootPackageGuardrails();
+checkCargoWorkspaceGuardrails();
+checkArchiveGuardrails();
+
+if (failures.length > 0) {
+  console.error('[guardrails] failed');
+  for (const failure of failures) {
+    console.error(`- ${failure}`);
+  }
+  process.exit(1);
+}
+
+console.log('[guardrails] ok');

--- a/tools/verify/quick.sh
+++ b/tools/verify/quick.sh
@@ -6,6 +6,9 @@ cd "$ROOT_DIR"
 
 echo "[verify] starting quick verification"
 
+echo "[verify] repo guardrails"
+node tools/verify/guardrails.mjs
+
 echo "[verify] JS syntax checks"
 node --check core/viewer/app.js
 node --check core/viewer/jam.js


### PR DESCRIPTION
## Summary
- add a Node-based guardrail verification script for release/workflow and legacy capture boundaries
- run the guardrail check from quick verification
- expose npm scripts for local Windows-friendly verification

## Release impact
- Verification harness only
- No runtime behavior change
- No desktop release required

## Verification
- npm.cmd run verify:guardrails
- npm.cmd run verify:quick
- node --check tools/verify/guardrails.mjs
- cargo metadata --locked --no-deps --format-version 1
- git diff --check

## Notes
- No service restart
- No release performed
- No capture runtime code changed