### PR TITLE
[codex] Stabilize screen audio, chimes, and avatar state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.6.29
+
+- Fix: Entire monitor audio capture uses Windows process-loopback exclusion so Echo voice playback is blocked while other system audio can still be shared.
+- Fix: Native screen-share stop now clears stuck local screen tiles and removes the hidden screen companion publisher.
+- Fix: Remote avatars now preload replacement images and keep the last good avatar instead of going dark on failed image loads.
+- Fix: Uploaded intro and exit chimes resolve stable identity/device keys and resume the shared chime audio context before playback.
+- Diagnostics: Screen-share admin telemetry now reports selected source type, capture route, and publish profile.
+- Release: Desktop and control package versions are bumped to 0.6.29.
+
 ## 0.6.28
 
 - Fix: Game capture returns to the stable 1080p30 cadence after live testing showed the forced 60fps profile could crash or green-screen some publishers.

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -1304,7 +1304,7 @@ dependencies = [
 
 [[package]]
 name = "echo-core-client"
-version = "0.6.28"
+version = "0.6.29"
 dependencies = [
  "base64 0.22.1",
  "futures-util",
@@ -1325,7 +1325,7 @@ dependencies = [
 
 [[package]]
 name = "echo-core-control"
-version = "0.6.28"
+version = "0.6.29"
 dependencies = [
  "argon2",
  "axum",

--- a/core/client/Cargo.toml
+++ b/core/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "echo-core-client"
-version = "0.6.28"
+version = "0.6.29"
 edition = "2021"
 description = "Echo Chamber native desktop client"
 

--- a/core/client/src/audio_capture.rs
+++ b/core/client/src/audio_capture.rs
@@ -15,6 +15,7 @@ use windows::core::*;
 use windows::Win32::Foundation::*;
 use windows::Win32::Media::Audio::*;
 use windows::Win32::System::Com::*;
+use windows::Win32::System::Diagnostics::ToolHelp::*;
 use windows::Win32::System::Registry::*;
 use windows::Win32::System::Threading::*;
 use windows::Win32::UI::WindowsAndMessaging::*;
@@ -25,9 +26,12 @@ use windows::Win32::UI::WindowsAndMessaging::*;
 const ACTIVATION_TYPE_PROCESS_LOOPBACK: u32 = 1;
 /// PROCESS_LOOPBACK_MODE_INCLUDE_TARGET_PROCESS_TREE = 0
 const LOOPBACK_MODE_INCLUDE_TREE: u32 = 0;
+/// PROCESS_LOOPBACK_MODE_EXCLUDE_TARGET_PROCESS_TREE = 1
+const LOOPBACK_MODE_EXCLUDE_TREE: u32 = 1;
 /// VT_BLOB variant type
 const VT_BLOB: u16 = 65;
 const BITS_PER_BYTE: u16 = 8;
+const KNOWN_ECHO_PROCESS_NAMES: [&str; 2] = ["Echo Chamber.exe", "echo-core-client.exe"];
 
 /// Manual repr(C) structs for process loopback activation params.
 /// These may not be available in all versions of the windows crate.
@@ -188,6 +192,98 @@ fn get_exe_name(pid: u32) -> Option<String> {
     }
 }
 
+fn process_entry_name(entry: &PROCESSENTRY32W) -> String {
+    let len = entry
+        .szExeFile
+        .iter()
+        .position(|&c| c == 0)
+        .unwrap_or(entry.szExeFile.len());
+    String::from_utf16_lossy(&entry.szExeFile[..len])
+}
+
+fn find_processes_by_name(exe_name: &str) -> Vec<(u32, u32)> {
+    let mut processes = Vec::new();
+
+    unsafe {
+        let Ok(snapshot) = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0) else {
+            return processes;
+        };
+
+        let mut entry = PROCESSENTRY32W {
+            dwSize: std::mem::size_of::<PROCESSENTRY32W>() as u32,
+            ..Default::default()
+        };
+
+        if Process32FirstW(snapshot, &mut entry).is_ok() {
+            loop {
+                let name = process_entry_name(&entry);
+                if name.eq_ignore_ascii_case(exe_name) {
+                    processes.push((entry.th32ProcessID, entry.th32ParentProcessID));
+                }
+
+                entry.dwSize = std::mem::size_of::<PROCESSENTRY32W>() as u32;
+                if Process32NextW(snapshot, &mut entry).is_err() {
+                    break;
+                }
+            }
+        }
+
+        let _ = CloseHandle(snapshot);
+    }
+
+    processes
+}
+
+fn select_root_process_pid(processes: &[(u32, u32)]) -> Option<u32> {
+    let pids: std::collections::HashSet<u32> = processes.iter().map(|(pid, _)| *pid).collect();
+    processes
+        .iter()
+        .find(|(_, parent_pid)| !pids.contains(parent_pid))
+        .or_else(|| processes.first())
+        .map(|(pid, _)| *pid)
+}
+
+fn select_preferred_playback_exclusion_process<'a>(
+    candidates: &'a [(&'a str, Vec<(u32, u32)>)],
+) -> Option<(&'a str, u32)> {
+    candidates
+        .iter()
+        .find_map(|(name, processes)| select_root_process_pid(processes).map(|pid| (*name, pid)))
+}
+
+fn playback_exclusion_process_names() -> Vec<String> {
+    let mut names = Vec::new();
+    if let Ok(path) = std::env::current_exe() {
+        if let Some(file_name) = path.file_name().and_then(|name| name.to_str()) {
+            names.push(file_name.to_string());
+        }
+    }
+    for name in KNOWN_ECHO_PROCESS_NAMES {
+        if !names
+            .iter()
+            .any(|existing| existing.eq_ignore_ascii_case(name))
+        {
+            names.push(name.to_string());
+        }
+    }
+    names
+}
+
+fn find_playback_feedback_exclusion_pid() -> Option<(String, u32)> {
+    let names = playback_exclusion_process_names();
+    let candidates = names
+        .iter()
+        .map(|name| (name.as_str(), find_processes_by_name(name)))
+        .collect::<Vec<_>>();
+
+    select_preferred_playback_exclusion_process(&candidates)
+        .map(|(name, pid)| (name.to_string(), pid))
+}
+
+fn system_audio_feedback_capture_loopback_mode() -> u32 {
+    LOOPBACK_MODE_EXCLUDE_TREE
+}
+
 // --- Windows build check ---
 
 /// Process loopback capture requires Windows 10 build 20348+.
@@ -273,7 +369,13 @@ pub fn start_capture(pid: u32, app: AppHandle) -> Result<()> {
     let r2 = running.clone();
 
     let thread = std::thread::spawn(move || {
-        if let Err(e) = capture_loop(pid, &app, &r2) {
+        if let Err(e) = capture_loop(
+            pid,
+            LOOPBACK_MODE_INCLUDE_TREE,
+            "process include-tree",
+            &app,
+            &r2,
+        ) {
             log_audio_capture(&format!("[audio-capture] error: {}", e));
             let _ = app.emit("audio-capture-error", format!("{}", e));
         }
@@ -298,6 +400,52 @@ pub fn start_system_capture(app: AppHandle) -> Result<()> {
 
     let thread = std::thread::spawn(move || {
         if let Err(e) = capture_system_loop(&app, &r2) {
+            log_audio_capture(&format!("[audio-capture] error: {}", e));
+            let _ = app.emit("audio-capture-error", format!("{}", e));
+        }
+        let _ = app.emit("audio-capture-stopped", ());
+        log_audio_capture("[audio-capture] thread exited");
+    });
+
+    *global_state().lock().unwrap() = Some(CaptureHandle {
+        running,
+        thread: Some(thread),
+    });
+
+    Ok(())
+}
+
+pub fn start_system_capture_excluding_echo(app: AppHandle) -> Result<()> {
+    if let Err(msg) = check_process_loopback_support() {
+        log_audio_capture(&format!("[audio-capture] {}", msg));
+        return Err(Error::new(E_FAIL, msg));
+    }
+
+    let Some((exe_name, exclude_pid)) = find_playback_feedback_exclusion_pid() else {
+        let msg =
+            "Cannot find Echo playback process to exclude; refusing unsafe system audio capture";
+        log_audio_capture(&format!("[audio-capture] {}", msg));
+        return Err(Error::new(E_FAIL, msg));
+    };
+
+    log_audio_capture(&format!(
+        "[audio-capture] start_system_capture_excluding_echo requested exclude={} pid={}",
+        exe_name, exclude_pid
+    ));
+    stop_capture();
+
+    let running = Arc::new(AtomicBool::new(true));
+    let r2 = running.clone();
+    let label = format!("system excluding {} tree", exe_name);
+
+    let thread = std::thread::spawn(move || {
+        if let Err(e) = capture_loop(
+            exclude_pid,
+            system_audio_feedback_capture_loopback_mode(),
+            &label,
+            &app,
+            &r2,
+        ) {
             log_audio_capture(&format!("[audio-capture] error: {}", e));
             let _ = app.emit("audio-capture-error", format!("{}", e));
         }
@@ -632,13 +780,15 @@ fn capture_system_loop(
 
 fn capture_loop(
     pid: u32,
+    process_loopback_mode: u32,
+    label: &str,
     app: &AppHandle,
     running: &AtomicBool,
 ) -> std::result::Result<(), Box<dyn std::error::Error + Send + Sync>> {
     unsafe {
         log_audio_capture(&format!(
-            "[audio-capture] capture_loop starting for PID {}",
-            pid
+            "[audio-capture] capture_loop starting for {} PID {}",
+            label, pid
         ));
         CoInitializeEx(None, COINIT_MULTITHREADED).ok()?;
         log_audio_capture("[audio-capture] COM initialized");
@@ -648,7 +798,7 @@ fn capture_loop(
             activation_type: ACTIVATION_TYPE_PROCESS_LOOPBACK,
             loopback_params: ProcessLoopbackParams {
                 target_process_id: pid,
-                process_loopback_mode: LOOPBACK_MODE_INCLUDE_TREE,
+                process_loopback_mode,
             },
         };
         let params_size = std::mem::size_of::<AudioClientActivationParams>() as u32;
@@ -701,7 +851,7 @@ fn capture_loop(
             })?;
         log_audio_capture("[audio-capture] activation completed -- got IAudioClient");
 
-        let result = capture_with_audio_client(client, app, running, &format!("PID {}", pid), pid);
+        let result = capture_with_audio_client(client, app, running, label, pid);
         CoUninitialize();
         result
     }
@@ -712,7 +862,8 @@ mod tests {
     use super::{
         audio_capture_frame_diagnostic, audio_capture_peak_from_f32_bytes,
         process_loopback_fallback_format, process_loopback_initialize_flags,
-        system_loopback_initialize_flags,
+        select_preferred_playback_exclusion_process, system_audio_feedback_capture_loopback_mode,
+        system_loopback_initialize_flags, LOOPBACK_MODE_EXCLUDE_TREE,
     };
     use windows::Win32::Media::Audio::{
         AUDCLNT_STREAMFLAGS_AUTOCONVERTPCM, AUDCLNT_STREAMFLAGS_EVENTCALLBACK,
@@ -754,6 +905,40 @@ mod tests {
 
         assert_ne!(flags & AUDCLNT_STREAMFLAGS_EVENTCALLBACK, 0);
         assert_ne!(flags & AUDCLNT_STREAMFLAGS_LOOPBACK, 0);
+    }
+
+    #[test]
+    fn system_audio_feedback_capture_uses_exclude_tree_mode() {
+        assert_eq!(
+            system_audio_feedback_capture_loopback_mode(),
+            LOOPBACK_MODE_EXCLUDE_TREE
+        );
+    }
+
+    #[test]
+    fn selects_echo_client_root_for_feedback_exclusion() {
+        let candidates = vec![
+            ("Echo Chamber.exe", vec![(50, 10), (51, 50)]),
+            ("echo-core-client.exe", vec![(80, 12)]),
+        ];
+
+        assert_eq!(
+            select_preferred_playback_exclusion_process(&candidates),
+            Some(("Echo Chamber.exe", 50))
+        );
+    }
+
+    #[test]
+    fn falls_back_to_known_client_name_for_feedback_exclusion() {
+        let candidates = vec![
+            ("Echo Chamber.exe", vec![]),
+            ("echo-core-client.exe", vec![(80, 12)]),
+        ];
+
+        assert_eq!(
+            select_preferred_playback_exclusion_process(&candidates),
+            Some(("echo-core-client.exe", 80))
+        );
     }
 
     #[test]

--- a/core/client/src/audio_capture_stub.rs
+++ b/core/client/src/audio_capture_stub.rs
@@ -23,4 +23,8 @@ pub fn start_system_capture(_app: tauri::AppHandle) -> Result<(), String> {
     Err("System audio capture is not supported on this platform.".to_string())
 }
 
+pub fn start_system_capture_excluding_echo(_app: tauri::AppHandle) -> Result<(), String> {
+    Err("System audio capture is not supported on this platform.".to_string())
+}
+
 pub fn stop_capture() {}

--- a/core/client/src/main.rs
+++ b/core/client/src/main.rs
@@ -343,6 +343,11 @@ fn start_system_audio_capture(app: tauri::AppHandle) -> Result<(), String> {
 }
 
 #[tauri::command]
+fn start_system_audio_capture_excluding_echo(app: tauri::AppHandle) -> Result<(), String> {
+    audio_capture::start_system_capture_excluding_echo(app).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
 fn stop_audio_capture() -> Result<(), String> {
     audio_capture::stop_capture();
     Ok(())
@@ -653,6 +658,7 @@ fn main() {
             list_capturable_windows,
             start_audio_capture,
             start_system_audio_capture,
+            start_system_audio_capture_excluding_echo,
             stop_audio_capture,
             list_audio_output_devices,
             check_for_updates,

--- a/core/client/tauri.conf.json
+++ b/core/client/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "Echo Chamber",
-  "version": "0.6.28",
+  "version": "0.6.29",
   "identifier": "com.echochamber.app",
   "build": {
     "frontendDist": "../viewer"

--- a/core/control/Cargo.toml
+++ b/core/control/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "echo-core-control"
-version = "0.6.28"
+version = "0.6.29"
 edition = "2021"
 
 [dependencies]

--- a/core/control/src/admin.rs
+++ b/core/control/src/admin.rs
@@ -65,6 +65,8 @@ pub(crate) struct ClientStats {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) capture_health: Option<CaptureHealth>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) capture_source: Option<CaptureSourceReport>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) display_status: Option<ClientDisplayStatus>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) native_presenter: Option<NativePresenterReport>,
@@ -156,8 +158,26 @@ pub(crate) struct NativePresenterReport {
 
 #[derive(Clone, Serialize, Deserialize, Default)]
 #[serde(default)]
+pub(crate) struct CaptureSourceReport {
+    pub(crate) source_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) source_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) source_title: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) capture_route: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) publish_profile: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) monitor_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) fullscreen_like: Option<bool>,
+}
+
+#[derive(Clone, Serialize, Deserialize, Default)]
+#[serde(default)]
 pub(crate) struct CaptureHealth {
-    pub(crate) level: String,                       // "Green" | "Yellow" | "Red"
+    pub(crate) level: String, // "Green" | "Yellow" | "Red"
     pub(crate) reasons: Vec<String>,
     pub(crate) capture_active: bool,
     pub(crate) capture_mode: String,
@@ -401,7 +421,11 @@ pub(crate) async fn admin_dashboard(
         ts: now,
         rooms,
         total_online: total,
-        server_version: state.viewer_stamp.read().unwrap_or_else(|e| e.into_inner()).clone(),
+        server_version: state
+            .viewer_stamp
+            .read()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone(),
     }))
 }
 
@@ -473,7 +497,11 @@ pub(crate) async fn admin_dashboard_metrics(
     // Count unique users by display name (not identity, which has random suffixes)
     let mut unique_names: HashSet<String> = HashSet::new();
     for ev in &all_events {
-        let key = if ev.name.is_empty() { ev.identity.clone() } else { ev.name.clone() };
+        let key = if ev.name.is_empty() {
+            ev.identity.clone()
+        } else {
+            ev.name.clone()
+        };
         unique_names.insert(key);
     }
     let unique_users = unique_names.len();
@@ -488,7 +516,11 @@ pub(crate) async fn admin_dashboard_metrics(
     // --- Per-user stats (grouped by display name, not identity) ---
     let mut user_map: HashMap<String, (usize, u64)> = HashMap::new();
     for ev in &leaves {
-        let key = if ev.name.is_empty() { ev.identity.clone() } else { ev.name.clone() };
+        let key = if ev.name.is_empty() {
+            ev.identity.clone()
+        } else {
+            ev.name.clone()
+        };
         let entry = user_map.entry(key).or_insert((0, 0));
         entry.0 += 1;
         entry.1 += ev.duration_secs.unwrap_or(0);
@@ -612,6 +644,9 @@ fn merge_client_stats(existing: &mut ClientStats, payload: ClientStats, now: u64
     }
     if payload.capture_health.is_some() {
         existing.capture_health = payload.capture_health;
+    }
+    if payload.capture_source.is_some() {
+        existing.capture_source = payload.capture_source;
     }
     if payload.display_status.is_some() {
         existing.display_status = payload.display_status;
@@ -768,7 +803,10 @@ pub(crate) async fn admin_metrics(
                 *enc_counts.entry(e.clone()).or_default() += 1;
             }
         }
-        let encoder = enc_counts.into_iter().max_by_key(|(_, c)| *c).map(|(e, _)| e);
+        let encoder = enc_counts
+            .into_iter()
+            .max_by_key(|(_, c)| *c)
+            .map(|(e, _)| e);
 
         // Most common ICE types
         let mut ice_local_counts: HashMap<String, usize> = HashMap::new();
@@ -868,7 +906,9 @@ pub(crate) async fn submit_bug_report(
         if let Ok(Some((number, url))) = tokio::time::timeout(
             std::time::Duration::from_secs(10),
             create_github_issue(client, pat, repo, gh_report, uploads_dir),
-        ).await {
+        )
+        .await
+        {
             report.github_issue_number = Some(number);
             report.github_issue_url = Some(url);
         }
@@ -957,7 +997,12 @@ pub(crate) async fn admin_deploys(
     // Run git log for recent commits on origin/main
     // Use ||| as field delimiter and %x00 as record separator (body can contain newlines)
     let git_output = std::process::Command::new("git")
-        .args(["log", "--format=%H|||%an|||%s|||%aI|||%b%x00", "-30", "origin/main"])
+        .args([
+            "log",
+            "--format=%H|||%an|||%s|||%aI|||%b%x00",
+            "-30",
+            "origin/main",
+        ])
         .output();
 
     let mut commits = vec![];
@@ -977,7 +1022,11 @@ pub(crate) async fn admin_deploys(
             let author = parts[1];
             let message = parts[2];
             let timestamp = parts[3];
-            let body = if parts.len() >= 5 { parts[4].trim() } else { "" };
+            let body = if parts.len() >= 5 {
+                parts[4].trim()
+            } else {
+                ""
+            };
 
             // Extract PR number from merge commit subjects like "Merge pull request #61 from ..."
             let pr_number: Option<u64> = if message.starts_with("Merge pull request #") {
@@ -1003,9 +1052,7 @@ pub(crate) async fn admin_deploys(
                         .get("error")
                         .and_then(|v| v.as_str())
                         .map(|s| s.to_string());
-                    let dur = event
-                        .get("duration_seconds")
-                        .and_then(|v| v.as_i64());
+                    let dur = event.get("duration_seconds").and_then(|v| v.as_i64());
                     (Some(status.to_string()), ts, err, dur)
                 } else {
                     (None, None, None, None)
@@ -1079,7 +1126,13 @@ pub(crate) fn append_bug_report(dir: &std::path::Path, report: &BugReport) {
 /// Create a GitHub Issue from a bug report.
 /// Returns (issue_number, html_url) on success.
 /// Silently returns None if creation fails.
-pub(crate) async fn create_github_issue(client: reqwest::Client, pat: String, repo: String, report: BugReport, uploads_dir: PathBuf) -> Option<(u64, String)> {
+pub(crate) async fn create_github_issue(
+    client: reqwest::Client,
+    pat: String,
+    repo: String,
+    report: BugReport,
+    uploads_dir: PathBuf,
+) -> Option<(u64, String)> {
     let feedback_type = report.feedback_type.as_deref().unwrap_or("bug");
     let prefix = match feedback_type {
         "enhancement" => "Enhancement",
@@ -1164,7 +1217,10 @@ pub(crate) async fn create_github_issue(client: reqwest::Client, pat: String, re
                     }
                 }
                 Err(_) => {
-                    body.push_str(&format!("\n### Screenshot\nScreenshot referenced but file not found: `{}`\n", file_name));
+                    body.push_str(&format!(
+                        "\n### Screenshot\nScreenshot referenced but file not found: `{}`\n",
+                        file_name
+                    ));
                 }
             }
         }
@@ -1187,7 +1243,10 @@ pub(crate) async fn create_github_issue(client: reqwest::Client, pat: String, re
         }
     }
 
-    body.push_str(&format!("\n---\n*Auto-created from in-app feedback ({})*", feedback_type));
+    body.push_str(&format!(
+        "\n---\n*Auto-created from in-app feedback ({})*",
+        feedback_type
+    ));
 
     let url = format!("https://api.github.com/repos/{}/issues", repo);
     let payload = serde_json::json!({
@@ -1216,10 +1275,16 @@ pub(crate) async fn create_github_issue(client: reqwest::Client, pat: String, re
                 let number = body["number"].as_u64();
                 let html_url = body["html_url"].as_str().map(|s| s.to_string());
                 if let (Some(n), Some(u)) = (number, html_url) {
-                    info!("GitHub Issue #{} created for bug report from {}", n, report.name);
+                    info!(
+                        "GitHub Issue #{} created for bug report from {}",
+                        n, report.name
+                    );
                     return Some((n, u));
                 }
-                info!("GitHub Issue created for bug report from {} (could not parse response)", report.name);
+                info!(
+                    "GitHub Issue created for bug report from {} (could not parse response)",
+                    report.name
+                );
             } else {
                 let status = resp.status();
                 let body = resp.text().await.unwrap_or_default();
@@ -1280,7 +1345,10 @@ pub(crate) async fn admin_force_reload(
     }
     let viewer_dir = resolve_viewer_dir();
     stamp_viewer_index(&viewer_dir, &new_stamp);
-    info!("force-reload: bumped viewer_stamp to {} (index.html updated)", new_stamp);
+    info!(
+        "force-reload: bumped viewer_stamp to {} (index.html updated)",
+        new_stamp
+    );
 
     // 2. Iterate every LiveKit room and kick everyone in it.
     // We use LiveKit's ListRooms as the source of truth (the control plane's
@@ -1298,9 +1366,7 @@ pub(crate) async fn admin_force_reload(
                     Ok(identities) => {
                         for ident in identities {
                             match crate::rooms::livekit_remove_participant(
-                                &state,
-                                &room_name,
-                                &ident,
+                                &state, &room_name, &ident,
                             )
                             .await
                             {
@@ -1310,10 +1376,14 @@ pub(crate) async fn admin_force_reload(
                                     identities_kicked.push(ident);
                                 }
                                 Ok(false) => {
-                                    info!("force-reload: {} already gone from {}", ident, room_name);
+                                    info!(
+                                        "force-reload: {} already gone from {}",
+                                        ident, room_name
+                                    );
                                 }
                                 Err(e) => {
-                                    let msg = format!("kick {} from {} failed: {}", ident, room_name, e);
+                                    let msg =
+                                        format!("kick {} from {} failed: {}", ident, room_name, e);
                                     warn!("{}", msg);
                                     errors.push(msg);
                                 }
@@ -1402,5 +1472,38 @@ mod tests {
         assert_eq!(native.render_path, "native_receive_probe");
         assert_eq!(native.native_receive_fps, Some(59.7));
         assert_eq!(native.target_identity.as_deref(), Some("Spencer-2222"));
+    }
+
+    #[test]
+    fn client_stats_merge_preserves_capture_source_report() {
+        let mut existing = ClientStats {
+            identity: "Zane-1234".to_string(),
+            name: "Zane".to_string(),
+            room: "main".to_string(),
+            updated_at: 1,
+            ..Default::default()
+        };
+        let payload = ClientStats {
+            capture_source: Some(CaptureSourceReport {
+                source_type: "game".to_string(),
+                source_id: Some("123456".to_string()),
+                source_title: Some("Brotato".to_string()),
+                capture_route: Some("wgc-game-monitor".to_string()),
+                publish_profile: Some("game".to_string()),
+                monitor_id: Some("654321".to_string()),
+                fullscreen_like: Some(true),
+            }),
+            ..Default::default()
+        };
+
+        merge_client_stats(&mut existing, payload, 42);
+
+        let source = existing.capture_source.expect("capture source report");
+        assert_eq!(existing.updated_at, 42);
+        assert_eq!(source.source_type, "game");
+        assert_eq!(source.source_title.as_deref(), Some("Brotato"));
+        assert_eq!(source.capture_route.as_deref(), Some("wgc-game-monitor"));
+        assert_eq!(source.publish_profile.as_deref(), Some("game"));
+        assert_eq!(source.fullscreen_like, Some(true));
     }
 }

--- a/core/viewer/admin-panel.js
+++ b/core/viewer/admin-panel.js
@@ -80,6 +80,30 @@ function formatStreamFps(fps) {
   return Math.round(fps) + "fps";
 }
 
+function formatCaptureRoute(route) {
+  if (route === "wgc-game-monitor") return "Fullscreen Game Capture";
+  if (route === "wgc-monitor") return "Monitor Capture";
+  if (route === "desktop-dd") return "Desktop Duplication";
+  if (route === "wgc") return "Window Capture";
+  if (route === "browser") return "Browser Capture";
+  return route || "?";
+}
+
+function renderCaptureSourceDiagnostics(stats) {
+  const source = stats && stats.capture_source;
+  if (!source) return "";
+  const parts = [];
+  if (source.source_type) parts.push("source " + source.source_type);
+  if (source.capture_route) parts.push("route " + formatCaptureRoute(source.capture_route));
+  if (source.publish_profile) parts.push("profile " + source.publish_profile);
+  if (typeof source.fullscreen_like === "boolean") {
+    parts.push("fullscreen-like " + (source.fullscreen_like ? "yes" : "no"));
+  }
+  if (source.source_title) parts.push(source.source_title);
+  if (parts.length === 0) return "";
+  return `<div class="admin-row3 admin-source-row">${adminPanelEscape(parts.join(" | "))}</div>`;
+}
+
 function renderParticipantInboundStreamStats(participant) {
   const stats = participant && participant.stats ? participant.stats : {};
   const inbound = Array.isArray(stats.inbound) ? stats.inbound : [];
@@ -180,9 +204,12 @@ function renderAdminPanel(data) {
         const ct = `consec_to ${ch.consecutive_timeouts || 0}`;
         html += `<div class="admin-row2">fps ${fpsTxt}  ${reinits}  ${skip}  ${ct}</div>`;
         html += renderSenderDiagnostics(ch);
+        html += renderCaptureSourceDiagnostics(stats);
         if (ch.reasons && ch.reasons.length > 0) {
           html += `<div class="admin-row3">└─ ${escapeHtml(ch.reasons.join("; "))}</div>`;
         }
+      } else {
+        html += renderCaptureSourceDiagnostics(stats);
       }
       html += renderParticipantInboundStreamStats(p);
       html += `</div>`;
@@ -278,6 +305,7 @@ function escapeHtml(s) {
 if (typeof module === "object" && module.exports) {
   module.exports = {
     formatStreamBitrate,
+    renderCaptureSourceDiagnostics,
     renderInboundStreamStats,
     renderParticipantInboundStreamStats,
     renderSenderDiagnostics,

--- a/core/viewer/admin-panel.test.js
+++ b/core/viewer/admin-panel.test.js
@@ -3,6 +3,7 @@ const assert = require("node:assert/strict");
 
 const {
   formatStreamBitrate,
+  renderCaptureSourceDiagnostics,
   renderInboundStreamStats,
   renderSenderDiagnostics,
 } = require("./admin-panel.js");
@@ -71,4 +72,22 @@ test("renders sender-side capture diagnostics", () => {
   assert.match(html, /avail 5\.6 Mbps/);
   assert.match(html, /quality Cpu/);
   assert.match(html, /NVIDIA H264 Encoder/);
+});
+
+test("renders selected capture source diagnostics", () => {
+  const html = renderCaptureSourceDiagnostics({
+    capture_source: {
+      source_type: "game",
+      source_title: "Brotato",
+      capture_route: "wgc-game-monitor",
+      publish_profile: "game",
+      fullscreen_like: true,
+    },
+  });
+
+  assert.match(html, /source game/);
+  assert.match(html, /Fullscreen Game Capture/);
+  assert.match(html, /profile game/);
+  assert.match(html, /fullscreen-like yes/);
+  assert.match(html, /Brotato/);
 });

--- a/core/viewer/chimes.js
+++ b/core/viewer/chimes.js
@@ -11,6 +11,17 @@ function getChimeCtx() {
   return chimeAudioCtx;
 }
 
+function primeChimeAudio() {
+  const ctx = getChimeCtx();
+  try {
+    const p = ctx.resume?.();
+    if (p && typeof p.catch === "function") {
+      p.catch(() => {});
+    }
+  } catch {}
+  return ctx;
+}
+
 function playJoinChime(volume) {
   try {
     var vol = (volume != null ? volume : 1);
@@ -196,14 +207,49 @@ function playCustomChime(buffer, volume) {
   } catch {}
 }
 
+function uniqueChimeKeys(keys) {
+  var out = [];
+  var seen = new Set();
+  (keys || []).forEach(function(key) {
+    var value = String(key || "").trim();
+    if (!value || seen.has(value)) return;
+    seen.add(value);
+    out.push(value);
+  });
+  return out;
+}
+
+function getChimeCandidateKeys(identity) {
+  var identityBase = getIdentityBase(identity);
+  var deviceId = identityBase && deviceIdByIdentity && deviceIdByIdentity.get
+    ? deviceIdByIdentity.get(identityBase)
+    : null;
+  return uniqueChimeKeys([deviceId, identityBase]);
+}
+
+function getLocalChimeKeys() {
+  var identity = room && room.localParticipant ? room.localParticipant.identity : "";
+  var identityBase = identity ? getIdentityBase(identity) : "";
+  var deviceId = (typeof getLocalDeviceId === "function") ? getLocalDeviceId() : "";
+  return uniqueChimeKeys([deviceId, identityBase]);
+}
+
+async function fetchFirstChimeBuffer(keys, kind) {
+  var candidates = uniqueChimeKeys(keys);
+  for (var i = 0; i < candidates.length; i++) {
+    var buffer = await fetchChimeBuffer(candidates[i], kind);
+    if (buffer) return buffer;
+  }
+  return null;
+}
+
 async function playChimeForIdentities(identities, kind) {
   // Look up chime volume from first identity
   var volId = identities.length > 0 ? getIdentityBase(identities[0]) : null;
   var volState = volId ? participantState.get(volId) : null;
   var vol = (volState && volState.chimeVolume != null) ? volState.chimeVolume : 0.5;
   for (const id of identities) {
-    var chimeKey = getChimeKey(id);
-    const buffer = await fetchChimeBuffer(chimeKey, kind);
+    const buffer = await fetchFirstChimeBuffer(getChimeCandidateKeys(id), kind);
     if (buffer) {
       playCustomChime(buffer, vol);
       return;
@@ -215,10 +261,8 @@ async function playChimeForIdentities(identities, kind) {
 
 // Get the chime lookup key for a participant — deviceId if known, else identityBase (fallback)
 function getChimeKey(identity) {
-  var identityBase = getIdentityBase(identity);
-  // Check if we know this participant's device ID
-  var deviceId = deviceIdByIdentity.get(identityBase);
-  return deviceId || identityBase;
+  var keys = getChimeCandidateKeys(identity);
+  return keys[0] || "";
 }
 
 // Pre-fetch chime buffers for all participants in the current room so playback is instant
@@ -227,10 +271,12 @@ function prefetchChimeBuffersForRoom() {
   if (_isMobileDevice) return;
   if (!room || !room.remoteParticipants) return;
   room.remoteParticipants.forEach(function(participant) {
-    var chimeKey = getChimeKey(participant.identity);
+    var chimeKeys = getChimeCandidateKeys(participant.identity);
     // Fetch both enter and exit chimes into cache
-    fetchChimeBuffer(chimeKey, "enter").catch(function() {});
-    fetchChimeBuffer(chimeKey, "exit").catch(function() {});
+    chimeKeys.forEach(function(chimeKey) {
+      fetchChimeBuffer(chimeKey, "enter").catch(function() {});
+      fetchChimeBuffer(chimeKey, "exit").catch(function() {});
+    });
   });
 }
 
@@ -244,12 +290,11 @@ async function playChimeForParticipant(identity, kind) {
     if (kind === "enter") playJoinChime(vol); else playLeaveChime(vol);
     return;
   }
-  var chimeKey = getChimeKey(identity);
   // Look up this participant's chime volume preference
   var identityBase = getIdentityBase(identity);
   var pState = participantState.get(identityBase);
   var vol = (pState && pState.chimeVolume != null) ? pState.chimeVolume : 0.5;
-  var buffer = await fetchChimeBuffer(chimeKey, kind);
+  var buffer = await fetchFirstChimeBuffer(getChimeCandidateKeys(identity), kind);
   if (buffer) {
     playCustomChime(buffer, vol);
   } else if (kind === "enter") {

--- a/core/viewer/chimes.test.js
+++ b/core/viewer/chimes.test.js
@@ -1,0 +1,129 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const vm = require("node:vm");
+
+function makeAudioContext() {
+  return class AudioContext {
+    constructor() {
+      this.currentTime = 0;
+      this.destination = {};
+      this.state = "suspended";
+      this.resumeCalls = 0;
+    }
+    createBufferSource() {
+      return {
+        buffer: null,
+        connect() { return this; },
+        start() {},
+        stop() {},
+      };
+    }
+    createGain() {
+      return {
+        gain: {
+          value: 0,
+          setValueAtTime() {},
+          linearRampToValueAtTime() {},
+          exponentialRampToValueAtTime() {},
+        },
+        connect() { return this; },
+      };
+    }
+    createOscillator() {
+      return {
+        type: "",
+        frequency: {
+          value: 0,
+          setValueAtTime() {},
+          exponentialRampToValueAtTime() {},
+        },
+        connect() { return this; },
+        start() {},
+        stop() {},
+      };
+    }
+    async decodeAudioData() {
+      return { decoded: true };
+    }
+    async resume() {
+      this.resumeCalls += 1;
+      this.state = "running";
+    }
+  };
+}
+
+function loadChimesContext({ deviceId, localIdentity = "zane-1234", foundKeys = [] } = {}) {
+  const fetches = [];
+  const context = {
+    window: {},
+    roomAudioMuted: false,
+    _isMobileDevice: false,
+    participantState: new Map([["zane", { chimeVolume: 0.5 }]]),
+    deviceIdByIdentity: new Map(deviceId ? [["zane", deviceId]] : []),
+    room: { localParticipant: { identity: localIdentity } },
+    getLocalDeviceId() {
+      return "device-uuid-1";
+    },
+    getIdentityBase(identity) {
+      return identity ? identity.replace(/-\d+$/, "") : identity;
+    },
+    apiUrl(pathname) {
+      return "https://echo.example.test" + pathname;
+    },
+    fetch: async (url) => {
+      fetches.push(String(url));
+      const key = decodeURIComponent(String(url).match(/\/api\/chime\/([^/]+)\//)?.[1] || "");
+      if (!foundKeys.includes(key)) {
+        return { ok: false };
+      }
+      return {
+        ok: true,
+        async arrayBuffer() {
+          return new ArrayBuffer(8);
+        },
+      };
+    },
+    console,
+  };
+  context.window.AudioContext = makeAudioContext();
+  context.window.webkitAudioContext = context.window.AudioContext;
+  context.AudioContext = context.window.AudioContext;
+  context.webkitAudioContext = context.window.AudioContext;
+  context.global = context;
+  vm.createContext(context);
+  const code = fs.readFileSync(path.join(__dirname, "chimes.js"), "utf8");
+  vm.runInContext(code, context, { filename: "chimes.js" });
+  return { context, fetches };
+}
+
+test("custom chime playback falls back to identity key when mapped device key has no upload", async () => {
+  const { context, fetches } = loadChimesContext({
+    deviceId: "device-uuid-1",
+    foundKeys: ["zane"],
+  });
+
+  await context.playChimeForParticipant("zane-1234", "enter");
+
+  assert.deepEqual(
+    fetches.map((url) => decodeURIComponent(url.match(/\/api\/chime\/([^/]+)\//)[1])),
+    ["device-uuid-1", "zane"]
+  );
+});
+
+test("local chime keys include stable device and current visible identity", () => {
+  const { context } = loadChimesContext();
+
+  assert.deepEqual(Array.from(context.getLocalChimeKeys()), ["device-uuid-1", "zane"]);
+});
+
+test("primeChimeAudio resumes the shared chime context", () => {
+  const { context } = loadChimesContext();
+
+  context.primeChimeAudio();
+  const ctx = context.getChimeCtx();
+
+  assert.equal(ctx.state, "running");
+  assert.equal(ctx.resumeCalls, 1);
+});

--- a/core/viewer/connect.js
+++ b/core/viewer/connect.js
@@ -1563,6 +1563,7 @@ async function connect() {
   // This MUST happen IMMEDIATELY while we still have the user gesture from the button click
   // Also prime soundboard AudioContext NOW (user gesture) so remote sound-play events work
   getSoundboardContext();
+  if (typeof primeChimeAudio === "function") primeChimeAudio();
   try {
     // Create a silent audio loop to maintain autoplay permission
     const audioContext = new (window.AudioContext || window.webkitAudioContext)();
@@ -1892,7 +1893,7 @@ function buildChimeSettingsUI() {
 
     var fileInput = document.createElement("input");
     fileInput.type = "file";
-    fileInput.accept = "audio/mpeg,audio/wav,audio/ogg,audio/webm,.mp3,.wav,.ogg,.webm";
+    fileInput.accept = "audio/mpeg,audio/wav,audio/ogg,audio/webm,audio/mp4,audio/aac,audio/flac,.mp3,.wav,.ogg,.webm,.m4a,.aac,.flac,.opus";
     fileInput.className = "hidden";
 
     var uploadBtn = document.createElement("button");
@@ -1928,7 +1929,6 @@ function buildChimeSettingsUI() {
       }
       statusEl.textContent = "Uploading...";
       try {
-        var identityBase = getIdentityBase(room.localParticipant.identity);
         // Infer MIME from extension if browser doesn't provide one
         var mime = file.type;
         if (!mime || mime === "application/octet-stream") {
@@ -1936,20 +1936,28 @@ function buildChimeSettingsUI() {
           var mimeMap = { mp3: "audio/mpeg", wav: "audio/wav", ogg: "audio/ogg", webm: "audio/webm", m4a: "audio/mp4", aac: "audio/aac", flac: "audio/flac", opus: "audio/ogg" };
           mime = mimeMap[ext] || "audio/mpeg";
         }
-        var chimeDeviceId = getLocalDeviceId();
-        var res = await fetch(apiUrl("/api/chime/upload?identity=" + encodeURIComponent(chimeDeviceId) + "&kind=" + kind), {
-          method: "POST",
-          headers: { Authorization: "Bearer " + adminToken, "Content-Type": mime },
-          body: file
-        });
-        var data = await res.json().catch(function() { return {}; });
-        if (data && data.ok) {
+        var chimeKeys = (typeof getLocalChimeKeys === "function") ? getLocalChimeKeys() : [getLocalDeviceId()];
+        var uploadError = "";
+        for (var ki = 0; ki < chimeKeys.length; ki++) {
+          var chimeKey = chimeKeys[ki];
+          var res = await fetch(apiUrl("/api/chime/upload?identity=" + encodeURIComponent(chimeKey) + "&kind=" + kind), {
+            method: "POST",
+            headers: { Authorization: "Bearer " + adminToken, "Content-Type": mime },
+            body: file
+          });
+          var data = await res.json().catch(function() { return {}; });
+          if (!res.ok || !data || !data.ok) {
+            uploadError = (data && data.error) || "Upload failed";
+            break;
+          }
+          chimeBufferCache.delete(chimeKey + "-" + kind);
+        }
+        if (uploadError) {
+          statusEl.textContent = uploadError;
+        } else {
           statusEl.textContent = file.name;
           previewBtn.classList.remove("hidden");
           removeBtn.classList.remove("hidden");
-          chimeBufferCache.delete(chimeDeviceId + "-" + kind);
-        } else {
-          statusEl.textContent = (data && data.error) || "Upload failed";
         }
       } catch (e) {
         statusEl.textContent = "Upload error";
@@ -1958,21 +1966,29 @@ function buildChimeSettingsUI() {
     });
 
     previewBtn.addEventListener("click", async function() {
-      var chimeDeviceId = getLocalDeviceId();
-      chimeBufferCache.delete(chimeDeviceId + "-" + kind);
-      var buf = await fetchChimeBuffer(chimeDeviceId, kind);
+      if (typeof primeChimeAudio === "function") primeChimeAudio();
+      var chimeKeys = (typeof getLocalChimeKeys === "function") ? getLocalChimeKeys() : [getLocalDeviceId()];
+      chimeKeys.forEach(function(chimeKey) {
+        chimeBufferCache.delete(chimeKey + "-" + kind);
+      });
+      var buf = (typeof fetchFirstChimeBuffer === "function")
+        ? await fetchFirstChimeBuffer(chimeKeys, kind)
+        : await fetchChimeBuffer(chimeKeys[0], kind);
       if (buf) playCustomChime(buf);
     });
 
     removeBtn.addEventListener("click", async function() {
-      var chimeDeviceId = getLocalDeviceId();
+      var chimeKeys = (typeof getLocalChimeKeys === "function") ? getLocalChimeKeys() : [getLocalDeviceId()];
       try {
-        await fetch(apiUrl("/api/chime/delete"), {
-          method: "POST",
-          headers: { Authorization: "Bearer " + adminToken, "Content-Type": "application/json" },
-          body: JSON.stringify({ identity: chimeDeviceId, kind: kind })
-        });
-        chimeBufferCache.delete(chimeDeviceId + "-" + kind);
+        for (var di = 0; di < chimeKeys.length; di++) {
+          var chimeKey = chimeKeys[di];
+          await fetch(apiUrl("/api/chime/delete"), {
+            method: "POST",
+            headers: { Authorization: "Bearer " + adminToken, "Content-Type": "application/json" },
+            body: JSON.stringify({ identity: chimeKey, kind: kind })
+          });
+          chimeBufferCache.delete(chimeKey + "-" + kind);
+        }
         previewBtn.classList.add("hidden");
         removeBtn.classList.add("hidden");
         statusEl.textContent = "";
@@ -1982,13 +1998,17 @@ function buildChimeSettingsUI() {
     // Check if chime already exists
     (async function() {
       if (!room || !room.localParticipant) return;
-      var chimeDeviceId = getLocalDeviceId();
+      var chimeKeys = (typeof getLocalChimeKeys === "function") ? getLocalChimeKeys() : [getLocalDeviceId()];
       try {
-        var res = await fetch(apiUrl("/api/chime/" + encodeURIComponent(chimeDeviceId) + "/" + kind), { method: "HEAD" });
-        if (res.ok) {
-          previewBtn.classList.remove("hidden");
-          removeBtn.classList.remove("hidden");
-          statusEl.textContent = "Custom sound set";
+        for (var hi = 0; hi < chimeKeys.length; hi++) {
+          var chimeKey = chimeKeys[hi];
+          var res = await fetch(apiUrl("/api/chime/" + encodeURIComponent(chimeKey) + "/" + kind), { method: "HEAD" });
+          if (res.ok) {
+            previewBtn.classList.remove("hidden");
+            removeBtn.classList.remove("hidden");
+            statusEl.textContent = "Custom sound set";
+            break;
+          }
         }
       } catch (e) {}
     })();

--- a/core/viewer/participants-avatar.js
+++ b/core/viewer/participants-avatar.js
@@ -1036,6 +1036,8 @@ function getServerAvatarCandidateUrls(identity, cardRef) {
 function showAvatarImage(cardRef, urls) {
   const avatar = cardRef.avatar;
   if (!avatar || !urls || urls.length === 0) return;
+  const requestId = (avatar._avatarRequestId || 0) + 1;
+  avatar._avatarRequestId = requestId;
 
   let img = avatar.querySelector("img.avatar-img");
   if (!img) {
@@ -1045,23 +1047,35 @@ function showAvatarImage(cardRef, urls) {
     avatar.appendChild(img);
   }
 
-  img._avatarFallbackUrls = urls;
-  img._avatarFallbackIndex = 0;
-  img.onload = function() {
+  function commitLoadedAvatar(url) {
+    if (avatar._avatarRequestId !== requestId) return;
+    img.src = url;
     const textNodes = Array.from(avatar.childNodes).filter(n => n.nodeType === Node.TEXT_NODE);
     textNodes.forEach(n => n.remove());
-  };
-  img.onerror = function() {
-    const nextIndex = (img._avatarFallbackIndex || 0) + 1;
-    const fallbackUrls = img._avatarFallbackUrls || [];
-    if (nextIndex < fallbackUrls.length) {
-      img._avatarFallbackIndex = nextIndex;
-      img.src = fallbackUrls[nextIndex];
+  }
+
+  function failAllCandidates() {
+    if (avatar._avatarRequestId !== requestId) return;
+    if (!img.src && typeof img.remove === "function") img.remove();
+  }
+
+  function tryCandidate(index) {
+    if (avatar._avatarRequestId !== requestId) return;
+    if (index >= urls.length) {
+      failAllCandidates();
       return;
     }
-    img.remove();
-  };
-  img.src = urls[0];
+    const loader = new Image();
+    loader.onload = function() {
+      commitLoadedAvatar(urls[index]);
+    };
+    loader.onerror = function() {
+      tryCandidate(index + 1);
+    };
+    loader.src = urls[index];
+  }
+
+  tryCandidate(0);
 }
 
 function updateAvatarDisplay(identity) {

--- a/core/viewer/participants-avatar.test.js
+++ b/core/viewer/participants-avatar.test.js
@@ -18,6 +18,11 @@ function makeAvatarElement(initials = "Z") {
     childNodes: [textNode],
     appendChild(element) {
       if (element.className === "avatar-img") img = element;
+      element.remove = function() {
+        const index = avatar.childNodes.indexOf(element);
+        if (index >= 0) avatar.childNodes.splice(index, 1);
+        if (img === element) img = null;
+      };
       this.childNodes.push(element);
       return element;
     },
@@ -34,7 +39,7 @@ function makeAvatarElement(initials = "Z") {
   return avatar;
 }
 
-function loadParticipantsAvatar({ deviceId } = {}) {
+function loadParticipantsAvatar({ deviceId, imageResults } = {}) {
   const avatar = makeAvatarElement();
   const card = {
     dataset: { identity: "z-6826" },
@@ -60,6 +65,20 @@ function loadParticipantsAvatar({ deviceId } = {}) {
         };
       },
     },
+    Image: class {
+      set src(value) {
+        this._src = value;
+        if (imageResults && imageResults.get(value) === false) {
+          if (typeof this.onerror === "function") this.onerror(new Error("image failed"));
+          return;
+        }
+        if (typeof this.onload === "function") this.onload();
+      }
+      get src() {
+        return this._src || "";
+      }
+    },
+    Node: { TEXT_NODE: 3 },
     apiUrl(pathname) {
       return "https://echo.example.test:9443" + pathname;
     },
@@ -96,6 +115,29 @@ test("remote avatar prefers the mapped device avatar once the device id is known
     deviceId: "70ff47ce-0128-4d5f-a29d",
   });
 
+  context.updateAvatarDisplay("z-6826");
+
+  assert.equal(
+    avatar.image?.src,
+    "https://echo.example.test:9443/api/avatar/70ff47ce-0128-4d5f-a29d"
+  );
+});
+
+test("remote avatar keeps the last good image when a replacement fails to load", () => {
+  const badUrl = "https://echo.example.test:9443/api/avatar/bad-device";
+  const identityUrl = "https://echo.example.test:9443/api/avatar/z";
+  const { context, avatar } = loadParticipantsAvatar({
+    deviceId: "70ff47ce-0128-4d5f-a29d",
+    imageResults: new Map([[badUrl, false], [identityUrl, false]]),
+  });
+
+  context.updateAvatarDisplay("z-6826");
+  assert.equal(
+    avatar.image?.src,
+    "https://echo.example.test:9443/api/avatar/70ff47ce-0128-4d5f-a29d"
+  );
+
+  context.deviceIdByIdentity.set("z", "bad-device");
   context.updateAvatarDisplay("z-6826");
 
   assert.equal(

--- a/core/viewer/screen-share-adaptive.js
+++ b/core/viewer/screen-share-adaptive.js
@@ -670,6 +670,9 @@ function startInboundScreenStatsMonitor() {
         var displayStatus = typeof getEchoDisplayStatusSnapshot === "function"
           ? getEchoDisplayStatusSnapshot()
           : null;
+        var captureSource = typeof getCaptureSourceReportSnapshot === "function"
+          ? getCaptureSourceReportSnapshot()
+          : null;
         var nativePresenter = await resolveNativePresenterStatusForReport();
 
         // Fire the POST whenever we have ANYTHING to report — either receive-side
@@ -677,7 +680,7 @@ function startInboundScreenStatsMonitor() {
         // a Tauri publisher). Without this OR, a publisher alone in the room
         // would never report their own capture telemetry. Discovered live
         // 2026-04-08 during Phase 2 smoke test.
-        if (inboundArr2.length > 0 || captureHealth || displayStatus || nativePresenter) {
+        if (inboundArr2.length > 0 || captureHealth || captureSource || displayStatus || nativePresenter) {
           fetch(apiUrl("/api/client-stats-report"), {
             method: "POST",
             headers: {
@@ -690,6 +693,7 @@ function startInboundScreenStatsMonitor() {
               room: currentRoomName || "",
               inbound: inboundArr2,
               capture_health: captureHealth,
+              capture_source: captureSource,
               display_status: displayStatus,
               native_presenter: nativePresenter,
             }),

--- a/core/viewer/screen-share-native.js
+++ b/core/viewer/screen-share-native.js
@@ -26,9 +26,52 @@ function _captureSourceVisibilityToastMessage(status) {
   return status.warning + '. Keep the shared window visible while sharing.';
 }
 
+function _nativeCaptureModeLabel(mode) {
+  if (mode === 'desktop-dd') return 'Desktop Duplication';
+  if (mode === 'wgc-monitor') return 'Monitor Capture';
+  if (mode === 'wgc-game-monitor') return 'Fullscreen Game Capture';
+  return 'Window Capture';
+}
+
+function _stringOrNull(value) {
+  if (value === undefined || value === null || value === '') return null;
+  return String(value);
+}
+
+function buildCaptureSourceReport(source, captureRoute, publishProfile) {
+  if (!source) return null;
+  var sourceType = source.sourceType || source.source_type || null;
+  var monitorId = source.monitorId || source.monitor_id || null;
+  if (!monitorId && sourceType === 'monitor') monitorId = source.id;
+  return {
+    source_type: _stringOrNull(sourceType) || 'unknown',
+    source_id: _stringOrNull(source.id),
+    source_title: _stringOrNull(source.title),
+    capture_route: _stringOrNull(captureRoute),
+    publish_profile: _stringOrNull(publishProfile),
+    monitor_id: _stringOrNull(monitorId),
+    fullscreen_like: typeof source.fullscreenLike === 'boolean'
+      ? source.fullscreenLike
+      : (typeof source.fullscreen_like === 'boolean' ? source.fullscreen_like : null),
+  };
+}
+
+function setCaptureSourceReport(source, captureRoute, publishProfile) {
+  var report = buildCaptureSourceReport(source, captureRoute, publishProfile);
+  if (typeof window !== 'undefined') window._echoCaptureSourceReport = report;
+  return report;
+}
+
+function getCaptureSourceReportSnapshot() {
+  if (typeof window === 'undefined') return null;
+  return window._echoCaptureSourceReport || null;
+}
+
 function nativeAudioCaptureRequestForSource(source) {
   if (!source) return null;
-  if (source.sourceType === 'monitor') return null;
+  if (source.sourceType === 'monitor') {
+    return { mode: 'system-exclude-echo', pid: 0, toast: 'System audio streaming (Echo voice excluded)' };
+  }
   if ((source.sourceType === 'game' || source.sourceType === 'window') &&
       source.pid && source.pid > 0) {
     return {
@@ -125,6 +168,7 @@ async function _finalizeNativeCaptureStop(stopMessage) {
   window._echoNativeCaptureActive = false;
   window._echoNativeCaptureMode = null;
   window._echoNativeCaptureSource = null;
+  window._echoCaptureSourceReport = null;
   screenEnabled = false;
   _stopNativeCaptureStopListeners();
   _stopSourceVisibilityMonitor();
@@ -132,6 +176,91 @@ async function _finalizeNativeCaptureStop(stopMessage) {
   await stopNativeAudioCapture();
   renderPublishButtons();
   if (stopMessage && wasActive) showToast(stopMessage, 3000);
+}
+
+function _clearNativeScreenTilesForIdentity(identity) {
+  if (!identity) return;
+  var identities = [identity];
+  if (!identity.endsWith('$screen')) identities.push(identity + '$screen');
+
+  function removeTile(tile, trackSid) {
+    if (trackSid && typeof removeScreenTile === 'function') {
+      removeScreenTile(trackSid);
+    } else if (tile) {
+      try {
+        if (tile.classList && tile.classList.contains && tile.classList.contains('is-focused') &&
+            typeof screenGridEl !== 'undefined' && screenGridEl && screenGridEl.classList) {
+          screenGridEl.classList.remove('is-focused');
+        }
+        if (typeof tile.remove === 'function') tile.remove();
+      } catch (_) {}
+    }
+    if (trackSid && typeof unregisterScreenTrack === 'function') unregisterScreenTrack(trackSid);
+    if (trackSid && typeof screenTileBySid !== 'undefined' && screenTileBySid) screenTileBySid.delete(trackSid);
+    if (trackSid && typeof screenRecoveryAttempts !== 'undefined' && screenRecoveryAttempts) screenRecoveryAttempts.delete(trackSid);
+    if (trackSid && typeof screenResubscribeIntent !== 'undefined' && screenResubscribeIntent) screenResubscribeIntent.delete(trackSid);
+  }
+
+  identities.forEach(function(key) {
+    var tile = (typeof screenTileByIdentity !== 'undefined' && screenTileByIdentity)
+      ? screenTileByIdentity.get(key)
+      : null;
+    var tileSid = tile && tile.dataset ? tile.dataset.trackSid : null;
+    if (tile) removeTile(tile, tileSid);
+    if (typeof screenTileByIdentity !== 'undefined' && screenTileByIdentity) screenTileByIdentity.delete(key);
+    if (typeof hiddenScreens !== 'undefined' && hiddenScreens) hiddenScreens.delete(key);
+    if (typeof watchedScreens !== 'undefined' && watchedScreens) watchedScreens.delete(key);
+    if (typeof _pubBitrateControl !== 'undefined' && _pubBitrateControl) _pubBitrateControl.delete(key);
+
+    if (typeof participantCards !== 'undefined' && participantCards) {
+      var cardRef = participantCards.get(key);
+      if (cardRef && cardRef.watchToggleBtn) {
+        cardRef.watchToggleBtn.style.display = 'none';
+        cardRef.watchToggleBtn.textContent = 'Stop Watching';
+        if (cardRef.ovWatchClone) {
+          cardRef.ovWatchClone.style.display = 'none';
+          cardRef.ovWatchClone.textContent = 'Stop Watching';
+        }
+      }
+    }
+  });
+
+  if (typeof screenTrackMeta !== 'undefined' && screenTrackMeta && screenTrackMeta.forEach) {
+    var staleSids = [];
+    screenTrackMeta.forEach(function(meta, sid) {
+      if (meta && identities.indexOf(meta.identity) >= 0) staleSids.push(sid);
+    });
+    staleSids.forEach(function(sid) {
+      var tile = (typeof screenTileBySid !== 'undefined' && screenTileBySid) ? screenTileBySid.get(sid) : null;
+      removeTile(tile, sid);
+    });
+  }
+}
+
+async function _removeNativeScreenCompanion(identity, roomName) {
+  if (!identity || !roomName || !adminToken || typeof fetch !== 'function') return false;
+  var companionIdentity = identity.endsWith('$screen') ? identity : identity + '$screen';
+  var path = '/v1/rooms/' + encodeURIComponent(roomName) + '/kick/' + encodeURIComponent(companionIdentity);
+  var url = typeof apiUrl === 'function'
+    ? apiUrl(path)
+    : ((_echoServerUrl || '').replace(/\/$/, '') + path);
+  if (!url) return false;
+
+  try {
+    var resp = await fetch(url, {
+      method: 'POST',
+      headers: { Authorization: 'Bearer ' + adminToken },
+    });
+    if (!resp.ok && typeof debugLog === 'function') {
+      debugLog('[screen-share] companion cleanup returned HTTP ' + resp.status);
+    }
+    return resp.ok;
+  } catch (err) {
+    if (typeof debugLog === 'function') {
+      debugLog('[screen-share] companion cleanup failed: ' + (err.message || err));
+    }
+    return false;
+  }
 }
 
 async function _startNativeCaptureStopListeners() {
@@ -345,6 +474,8 @@ async function startScreenShareManual() {
       }
       screenEnabled = true;
       window._echoNativeCaptureActive = true;
+      var nativePublishProfile = source.sourceType === 'game' ? 'game' : 'desktop';
+      setCaptureSourceReport(source, window._echoNativeCaptureMode, nativePublishProfile);
       _startSourceVisibilityMonitor(source);
       try {
         _startQualityWarnListener();
@@ -352,15 +483,20 @@ async function startScreenShareManual() {
         debugLog('[screen-share] quality warning listener failed: ' + (qualityWarnErr.message || qualityWarnErr));
       }
       renderPublishButtons();
-      var modeLabel = window._echoNativeCaptureMode === 'desktop-dd' ? 'Desktop Duplication' : 'Window Capture';
+      var modeLabel = _nativeCaptureModeLabel(window._echoNativeCaptureMode);
       showToast('Screen sharing started (' + modeLabel + ')', 4000);
 
       // Immediately start WASAPI per-process audio + publish pipeline using picker's PID
       var audioRequest = nativeAudioCaptureRequestForSource(source);
       if (audioRequest) {
-        var audioLabel = audioRequest.mode === 'system' ? 'system loopback' : 'PID ' + audioRequest.pid;
+        var audioLabel = audioRequest.mode === 'system-exclude-echo'
+          ? 'system loopback excluding Echo'
+          : (audioRequest.mode === 'system' ? 'system loopback' : 'PID ' + audioRequest.pid);
         debugLog('[audio] auto-starting native audio capture+publish for ' + audioLabel);
-        startNativeAudioCapture(audioRequest.pid, { system: audioRequest.mode === 'system' }).then(function() {
+        startNativeAudioCapture(audioRequest.pid, {
+          system: audioRequest.mode === 'system',
+          systemExcludeEcho: audioRequest.mode === 'system-exclude-echo',
+        }).then(function() {
           debugLog('[audio] native audio pipeline started for ' + audioLabel);
           showToast(audioRequest.toast, 3000);
         }).catch(function(e) {
@@ -408,6 +544,11 @@ async function startScreenShareManual() {
     const settings = videoMst.getSettings();
     debugLog("Screen capture actual FPS: " + (settings.frameRate || "unknown") +
       ", resolution: " + settings.width + "x" + settings.height);
+    setCaptureSourceReport({
+      sourceType: "browser",
+      id: "browser-picker",
+      title: settings.displaySurface || videoMst.label || "Browser picker",
+    }, "browser", "desktop");
 
     // Set content hint for smooth motion (gaming/video)
     videoMst.contentHint = "motion";
@@ -799,6 +940,7 @@ async function startScreenShareManual() {
             ice_local_type: lType !== "?" ? lType : null,
             ice_remote_type: rType !== "?" ? rType : null,
             simulcast_layers: layers.length,
+            capture_source: getCaptureSourceReportSnapshot(),
           };
 
           // Report stats to admin dashboard (apiUrl handles native vs browser path)
@@ -817,6 +959,7 @@ async function startScreenShareManual() {
                 ice_local_type: lType !== "?" ? lType : null,
                 ice_remote_type: rType !== "?" ? rType : null,
                 simulcast_layers: layers.length,
+                capture_source: getCaptureSourceReportSnapshot(),
               }),
             }).catch(() => {});
           }
@@ -1074,12 +1217,16 @@ async function stopScreenShareManual() {
     var stopCommand = window._echoNativeCaptureMode === 'desktop-dd'
       ? 'stop_desktop_capture'
       : 'stop_screen_share';
+    var localIdentity = room && room.localParticipant ? room.localParticipant.identity : null;
+    var roomName = currentRoomName || 'main';
     _stopNativeCaptureStopListeners();
     try {
       await tauriInvoke(stopCommand);
     } catch (e) {
       console.error('[screen-share] native stop error:', e);
     }
+    _clearNativeScreenTilesForIdentity(localIdentity);
+    await _removeNativeScreenCompanion(localIdentity, roomName);
     await _finalizeNativeCaptureStop(null);
     return; // Don't fall through to browser path
   }
@@ -1115,6 +1262,7 @@ async function stopScreenShareManual() {
   _bweKickAttempted = false;
   _highPausedTicks = 0;
   _latestOutboundBwe = 0;
+  window._echoCaptureSourceReport = null;
   // Clean up publisher-side bitrate cap state
   _bitrateCaps.clear();
   _currentAppliedCap = null;
@@ -1148,6 +1296,13 @@ async function stopScreenShareManual() {
 }
 
 // ---------- Native per-process audio capture (Tauri client only) ----------
+
+var _nativeAudioActive = false;
+var _nativeAudioCtx = null;
+var _nativeAudioWorklet = null;
+var _nativeAudioDest = null;
+var _nativeAudioTrack = null;
+var _nativeAudioUnlisten = null;
 
 var _nativeAudioWorkletCode = [
   "class NativeAudioProcessor extends AudioWorkletProcessor {",
@@ -1362,6 +1517,7 @@ async function startNativeAudioCapture(pid, opts) {
   var trackSource = opts.source || LK.Track.Source.ScreenShareAudio;
   var trackName = opts.name || undefined;
   var useSystemLoopback = !!opts.system;
+  var useSystemExcludeEcho = !!opts.systemExcludeEcho;
 
   // Create AudioContext — DON'T hardcode sample rate, let it match system default
   // WASAPI will report its actual format and we adapt
@@ -1466,7 +1622,10 @@ async function startNativeAudioCapture(pid, opts) {
   };
 
   // Start the WASAPI capture on Rust side
-  if (useSystemLoopback) {
+  if (useSystemExcludeEcho) {
+    await tauriInvoke("start_system_audio_capture_excluding_echo");
+    debugLog("[native-audio] WASAPI started for system loopback excluding Echo playback");
+  } else if (useSystemLoopback) {
     await tauriInvoke("start_system_audio_capture");
     debugLog("[native-audio] WASAPI started for system loopback");
   } else {

--- a/core/viewer/screen-share-native.test.js
+++ b/core/viewer/screen-share-native.test.js
@@ -6,6 +6,7 @@ const vm = require("node:vm");
 
 function loadScreenShareNative() {
   const calls = [];
+  const fetches = [];
   const context = {
     window: { __ECHO_NATIVE__: true },
     _nativeCaptureStopUnlisten: null,
@@ -40,6 +41,19 @@ function loadScreenShareNative() {
       return null;
     },
     tauriListen: undefined,
+    document: {
+      body: { appendChild() {} },
+      createElement() {
+        return { style: {}, classList: { add() {}, remove() {} } };
+      },
+      getElementById() {
+        return null;
+      },
+    },
+    fetch: async (url, opts) => {
+      fetches.push({ url: String(url), opts: opts || {} });
+      return { ok: true, status: 200 };
+    },
     debugLog() {},
     showToast() {},
     renderPublishButtons() {},
@@ -63,7 +77,7 @@ function loadScreenShareNative() {
   vm.createContext(context);
   const code = fs.readFileSync(path.join(__dirname, "screen-share-native.js"), "utf8");
   vm.runInContext(code, context, { filename: "screen-share-native.js" });
-  return { context, calls };
+  return { context, calls, fetches };
 }
 
 function loadNativeAudioProcessor(code) {
@@ -245,7 +259,7 @@ test("source visibility monitor is only enabled for native window-like sources",
   );
 });
 
-test("native audio capture request avoids system loopback for monitor shares", () => {
+test("monitor audio capture requests system audio with Echo playback excluded", () => {
   const { context } = loadScreenShareNative();
 
   assert.equal(
@@ -256,14 +270,109 @@ test("native audio capture request avoids system loopback for monitor shares", (
     JSON.stringify(context.nativeAudioCaptureRequestForSource({ sourceType: "game", pid: 5678 })),
     JSON.stringify({ mode: "process", pid: 5678, toast: "Game audio streaming" })
   );
-  assert.equal(
-    context.nativeAudioCaptureRequestForSource({ sourceType: "monitor", pid: 0 }),
-    null
-  );
+  const request = context.nativeAudioCaptureRequestForSource({ sourceType: "monitor", pid: 0 });
+  assert.equal(request.mode, "system-exclude-echo");
+  assert.equal(request.pid, 0);
   assert.equal(
     context.nativeAudioCaptureRequestForSource({ sourceType: "window", pid: 0 }),
     null
   );
+});
+
+test("native audio capture uses the Echo-excluding system command for monitor audio", async () => {
+  const { context, calls } = loadScreenShareNative();
+
+  context.hasTauriIPC = () => true;
+  context.getLiveKitClient = () => ({
+    Track: { Source: { ScreenShareAudio: "screen_share_audio" } },
+    LocalAudioTrack: class {
+      constructor(mediaStreamTrack) {
+        this.mediaStreamTrack = mediaStreamTrack;
+      }
+    },
+  });
+  context.AudioContext = class {
+    constructor() {
+      this.state = "running";
+      this.sampleRate = 48000;
+      this.audioWorklet = { addModule: async () => {} };
+    }
+    createMediaStreamDestination() {
+      return { stream: { getAudioTracks: () => [{ enabled: true, muted: false, readyState: "live" }] } };
+    }
+    async resume() {}
+    async close() {}
+  };
+  context.AudioWorkletNode = class {
+    constructor() {
+      this.port = { postMessage() {} };
+    }
+    connect() {}
+    disconnect() {}
+  };
+  context.Blob = Blob;
+  context.URL = {
+    createObjectURL: () => "blob:native-audio",
+    revokeObjectURL() {},
+  };
+  context.tauriListen = async () => () => {};
+  context.room.localParticipant.publishTrack = async () => {};
+
+  await context.startNativeAudioCapture(0, { systemExcludeEcho: true });
+
+  assert.equal(
+    calls.some((call) => call.command === "start_system_audio_capture_excluding_echo"),
+    true
+  );
+  assert.equal(
+    calls.some((call) => call.command === "start_system_audio_capture"),
+    false
+  );
+});
+
+test("native stop clears local screen tile and removes the screen companion", async () => {
+  const { context, calls, fetches } = loadScreenShareNative();
+  let removed = false;
+  let unregisteredSid = null;
+  const tile = {
+    dataset: { trackSid: "TR_SCREEN" },
+    classList: { contains: () => false },
+    remove() { removed = true; },
+  };
+  context.window._echoNativeCaptureActive = true;
+  context.window._echoNativeCaptureMode = "wgc-monitor";
+  context.screenEnabled = true;
+  context.screenTileByIdentity = new Map([["Sam", tile]]);
+  context.screenTileBySid = new Map([["TR_SCREEN", tile]]);
+  context.screenTrackMeta = new Map([["TR_SCREEN", { identity: "Sam" }]]);
+  context.screenRecoveryAttempts = new Map([["TR_SCREEN", 1]]);
+  context.screenResubscribeIntent = new Map([["TR_SCREEN", 1]]);
+  context.hiddenScreens = new Set(["Sam"]);
+  context.watchedScreens = new Set(["Sam"]);
+  context._pubBitrateControl = new Map([["Sam", {}]]);
+  context.removeScreenTile = (sid) => {
+    assert.equal(sid, "TR_SCREEN");
+    removed = true;
+    context.screenTileBySid.delete(sid);
+  };
+  context.unregisterScreenTrack = (sid) => {
+    unregisteredSid = sid;
+    context.screenTrackMeta.delete(sid);
+  };
+
+  await context.stopScreenShareManual();
+
+  assert.equal(calls.some((call) => call.command === "stop_screen_share"), true);
+  assert.equal(removed, true);
+  assert.equal(unregisteredSid, "TR_SCREEN");
+  assert.equal(context.screenTileByIdentity.has("Sam"), false);
+  assert.equal(context.hiddenScreens.has("Sam"), false);
+  assert.equal(context.watchedScreens.has("Sam"), false);
+  assert.equal(context._pubBitrateControl.has("Sam"), false);
+  assert.equal(fetches.length, 1);
+  assert.match(fetches[0].url, /\/v1\/rooms\/main\/kick\/Sam%24screen$/);
+  assert.equal(fetches[0].opts.method, "POST");
+  assert.equal(fetches[0].opts.headers.Authorization, "Bearer admin-token");
 });
 
 test("native audio worklet downmixes multichannel WASAPI frames to stereo", () => {


### PR DESCRIPTION
﻿## Summary
- Add Windows system-audio capture for entire-monitor shares that excludes the Echo playback process tree, so Echo voice is blocked while other system audio can still be shared.
- Clear native screen-share UI state on stop and remove the hidden `$screen` companion publisher when possible.
- Add capture-source diagnostics so admin tooling can tell whether someone shared a game/window/monitor/browser picker and which native route was used.
- Stabilize avatar replacement and uploaded enter/exit chime lookup across stable device IDs and visible identity fallback keys.
- Prepare desktop/control package metadata for 0.6.29.

## User-facing impact
- [x] User-visible behavior changed
- [ ] No user-visible behavior change

## Release impact
- [ ] Server-only
- [ ] Desktop binary required
- [x] Both

## Repro + validation evidence
Before:
1. Entire-monitor share could send Echo voice audio back into the stream.
2. Native screen-share stop could leave the local/remote screen tile stuck until another share cycled.
3. Avatar replacement failures could blank the avatar, and uploaded chimes could miss due device/identity key mismatch or suspended chime audio context.

After:
1. Monitor audio uses `start_system_audio_capture_excluding_echo`; older clients without that command fail closed instead of using unsafe raw loopback.
2. Native stop clears local screen tiles and kicks the hidden screen companion when the viewer has the admin token.
3. Admin stats carry `capture_source` for source type, route, profile, monitor id, and fullscreen-like state.
4. Avatars preload candidates and keep the last good image; chimes use stable device and identity fallback keys.

## Verification commands run
- [x] `node --test core/viewer/*.test.js` (106/106 pass)
- [x] `cargo check -p echo-core-client -p echo-core-control`
- [x] `cargo test -p echo-core-client audio_capture::tests` (7/7 pass)
- [x] `cargo test -p echo-core-control admin::tests` (2/2 pass)
- [x] `rustfmt --edition 2021 --check core/client/src/audio_capture.rs core/client/src/audio_capture_stub.rs core/client/src/main.rs core/control/src/admin.rs`
- [x] `git diff --cached --check`

## Risk
- [x] Medium

Native audio capture and screen companion cleanup touch live media state. Full monitor-audio behavior requires the 0.6.29 desktop binary plus the viewer/control changes.

## Rollback plan
Revert this PR and redeploy viewer/control. Do not update `core/deploy/latest.json` until the signed desktop release manifest exists and has been verified.
