### PR TITLE
Sync v0.6.30 updater manifest

### DIFF
--- a/core/deploy/latest.json
+++ b/core/deploy/latest.json
@@ -1,11 +1,11 @@
 {
     "platforms":  {
                       "windows-x86_64":  {
-                                             "signature":  "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVSQ3ByNFJuZlpjMEpxcTR6ODhNVlNwcUZlaEVGd1RXeGxkVFVxTzdSMHJjR1FIZDdscHhHVlVmTzFrZ0w0YUtYc2tOcHp3ZmJLMVhHdDdTN3JlYk1saE4reXh1M0VJekFjPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzgyNTkxNjQ3CWZpbGU6RWNobyBDaGFtYmVyXzAuNi4yOV94NjQtc2V0dXAuZXhlClJzTS9aMFFCZWFQejJkdXQ2RlVxaituZzZtV2pRV0NlS0k1ZE9MZDZveFFNZVp2VTErbEIycWVTakhqNjd2M1B5a3J6N0RJaWF6NjRIZ0x3YXFvbEJBPT0K",
-                                             "url":  "https://github.com/SamWatson86/echo-chamber/releases/download/v0.6.29/Echo.Chamber_0.6.29_x64-setup.exe"
+                                             "signature":  "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVSQ3ByNFJuZlpjMEpvQnVOaXpOdFRJWjRLQkJMUWhuaGUrRjlHVENKU210MVF4Q0RCU1RldkNic1FEdHF5Sys1UGx4RkNqaW14OTBCMmJmTjZMbWxXbjlYMEI2d0p1UkFjPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzg0MTM3NDEzCWZpbGU6RWNobyBDaGFtYmVyXzAuNi4zMF94NjQtc2V0dXAuZXhlCjRHdkFxMGVrb1JuS2hSVWcwaWQrNzdXSFJnYUF0SHZYcUs2Qi9WUU4zdGd5cmhVQnJvQ0swa25hOUgrTVlaR2FGb0VUWTBiamxTbFdrZVROYnJDdUJRPT0K",
+                                             "url":  "https://github.com/SamWatson86/echo-chamber/releases/download/v0.6.30/Echo.Chamber_0.6.30_x64-setup.exe"
                                          }
                   },
-    "pub_date":  "2026-06-27T20:20:47Z",
-    "version":  "0.6.29",
-    "notes":  "Echo Chamber v0.6.29"
+    "pub_date":  "2026-07-15T17:43:33Z",
+    "version":  "0.6.30",
+    "notes":  "Echo Chamber v0.6.30"
 }


### PR DESCRIPTION
## Summary

- sync the signed updater manifest from the published v0.6.30 GitHub Release
- point Windows clients at the verified v0.6.30 NSIS installer and signature

## Verification

- manifest version is 0.6.30
- Windows URL targets the v0.6.30 GitHub Release asset
- updater signature is present
- `git diff --check` passes

## Release impact

Updater metadata only. The v0.6.30 server/viewer and Spotify source-host desktop have already been deployed and validated; this PR does not restart production.