### PR TITLE
Harden Spotify Jam takeover and add shared Stop Music

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.6.31
+
+- Experience: The source PC can allow or deny Echo's Spotify takeover, mute Jam monitoring locally, and set an independent local Jam volume without changing what listeners hear.
+- Control: Jam participants can use Stop Music to pause Spotify while keeping the Jam, queue, listeners, and source connection ready to resume; host-only End Jam still performs the full teardown.
+- Reliability: Echo temporarily routes only Spotify into VB-CABLE while a Jam is active and restores Spotify's previous output when the Jam ends, takeover is disabled, or the source recovers from an interruption.
+- Release: Desktop and control package versions are bumped to 0.6.31.
+
 ## 0.6.30
 
 - Fix: Spotify Jam audio now comes from one explicitly provisioned Echo desktop running beside Spotify in the interactive Windows session, eliminating the Windows service/session-0 silence failure and the VB-CABLE routing requirement.

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -1304,7 +1304,7 @@ dependencies = [
 
 [[package]]
 name = "echo-core-client"
-version = "0.6.30"
+version = "0.6.31"
 dependencies = [
  "base64 0.22.1",
  "futures-util",
@@ -1326,7 +1326,7 @@ dependencies = [
 
 [[package]]
 name = "echo-core-control"
-version = "0.6.30"
+version = "0.6.31"
 dependencies = [
  "argon2",
  "axum",

--- a/core/client/Cargo.toml
+++ b/core/client/Cargo.toml
@@ -46,6 +46,8 @@ features = [
     "Win32_Security",
     "Win32_System_Registry",
     "Win32_System_Threading",
+    "Win32_System_WinRT",
+    "Win32_Storage_Packaging_Appx",
     "Win32_Storage_Xps",
     "Win32_UI_WindowsAndMessaging",
     "Win32_Graphics_Direct3D_Fxc",

--- a/core/client/Cargo.toml
+++ b/core/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "echo-core-client"
-version = "0.6.30"
+version = "0.6.31"
 edition = "2021"
 description = "Echo Chamber native desktop client"
 

--- a/core/client/README.md
+++ b/core/client/README.md
@@ -15,8 +15,8 @@ target the host app's Spotify Connect device.
 The source PC also needs:
 
 - the current Echo Desktop Windows binary;
-- the Spotify desktop app, signed in and visible as the server's exact bound
-  Spotify Connect device;
+- the Microsoft Store build of Spotify Desktop, signed in and visible as the
+  server's exact bound Spotify Connect device;
 - VB-CABLE installed with the playback endpoint named exactly
   `CABLE Input (VB-Audio Virtual Cable)`; and
 - a trusted HTTPS connection to the current Echo control-plane server.
@@ -57,7 +57,8 @@ control the same native settings:
 When an allowed Jam becomes active, Echo temporarily routes only the Spotify
 desktop app to the exact `CABLE Input (VB-Audio Virtual Cable)` endpoint. Echo
 does not change the Windows system-default output or reroute other apps. It
-captures the cable signal and uploads protocol-v3, generation-fenced audio for
+captures Spotify's process tree through Windows process loopback and uploads
+protocol-v3, generation-fenced audio for
 the server to relay. With local monitoring off, Echo mutes only its local relay;
 with monitoring on, the relay plays through Echo's selected output at the saved
 Jam Volume.
@@ -68,6 +69,24 @@ route, and audio sockets remain ready. Disabling local takeover, the last-
 listener empty timeout, and full Jam teardown are different lifecycle events.
 Those paths pause the bound Spotify device first, then release the temporary
 Spotify-only cable route.
+
+Echo records the exact prior Spotify route before takeover. Echo also serializes
+the complete journal-and-policy transaction across local Echo processes so an
+older recovery cannot undo a newer takeover. An exact-generation source
+teardown command restores it immediately. Turning local Allow off advertises the
+source unavailable first and uses a three-second local restore fallback if the
+server never sends that command. An unexpected socket or capture failure keeps
+Spotify on the silent route for 36 seconds before restoring, covering
+heartbeat, watchdog, and server pause timeouts. App exit waits up to 16 seconds
+for that exact teardown command; on timeout it leaves the route journaled and
+silent. A forced kill does the same implicitly. Startup recovery retains that
+silent route until the exact journal owner has been continuously observed dead
+for 36 seconds, then restores
+the recorded route (or Windows Default if the old endpoint no longer exists).
+After a reboot, logoff, or Fast User Switch, the old journal session ID is
+diagnostic only: recovery accepts the current Spotify process only when it is
+in Echo's current Windows session and its Store package family and app ID still
+match the journal.
 
 ## Release boundary
 

--- a/core/client/README.md
+++ b/core/client/README.md
@@ -12,6 +12,15 @@ Echo's Spotify OAuth connection must authorize the same Premium account that is
 signed into that desktop app; a different controlling account cannot see or
 target the host app's Spotify Connect device.
 
+The source PC also needs:
+
+- the current Echo Desktop Windows binary;
+- the Spotify desktop app, signed in and visible as the server's exact bound
+  Spotify Connect device;
+- VB-CABLE installed with the playback endpoint named exactly
+  `CABLE Input (VB-Audio Virtual Cable)`; and
+- a trusted HTTPS connection to the current Echo control-plane server.
+
 Create `config.json` beside the Echo client executable:
 
 ```json
@@ -33,3 +42,38 @@ The `server` URL is also the Jam source's secure WebSocket destination. Use the
 normal Echo hostname whose TLS certificate matches that hostname and is trusted
 by Windows. Do not substitute a raw IP address or `127.0.0.1` unless the
 certificate is valid and trusted for that exact address.
+
+## Source-PC controls and routing
+
+On the configured source PC, Echo shows a **Spotify Jam on this PC** card on the
+login portal before Echo Connect and again inside the Jam panel. The two copies
+control the same native settings:
+
+- **Allow Echo Jam to use Spotify on this PC** enables local takeover. Merely
+  turning it on does not change any audio route while no Jam is active.
+- **Hear Jam on this PC** enables Echo's synchronized local Jam relay. Its level
+  uses the independent Jam Volume setting and still obeys Mute All.
+
+When an allowed Jam becomes active, Echo temporarily routes only the Spotify
+desktop app to the exact `CABLE Input (VB-Audio Virtual Cable)` endpoint. Echo
+does not change the Windows system-default output or reroute other apps. It
+captures the cable signal and uploads protocol-v3, generation-fenced audio for
+the server to relay. With local monitoring off, Echo mutes only its local relay;
+with monitoring on, the relay plays through Echo's selected output at the saved
+Jam Volume.
+
+**Stop Music** pauses the exact Spotify device already bound by the server. It
+does not transfer playback and does not end the Jam: listeners, queue, capture,
+route, and audio sockets remain ready. Disabling local takeover, the last-
+listener empty timeout, and full Jam teardown are different lifecycle events.
+Those paths pause the bound Spotify device first, then release the temporary
+Spotify-only cable route.
+
+## Release boundary
+
+Protocol v3 is a coordinated desktop-and-server change. Deploy the control
+plane and its complete server-served viewer snapshot, and install the matching
+Echo Desktop binary on the configured Spotify source PC. Ordinary listener PCs
+do not receive Jam-source credentials and do not need the source binary; they
+receive the updated viewer from the server. Do not run a protocol-v3 server
+against an older source client or publish only part of the viewer bundle.

--- a/core/client/src/jam_source.rs
+++ b/core/client/src/jam_source.rs
@@ -8,22 +8,53 @@ use crate::audio_capture::{
     find_spotify_root_pid, start_owned_process_capture, validate_spotify_root_pid,
     OwnedProcessCapture, ProcessCaptureEvent,
 };
+use crate::spotify_output_route::{
+    SpotifyOutputRouteLease, SpotifyOutputRouter, StartupRecoveryOutcome,
+    DEFAULT_SPOTIFY_ROUTE_TARGET,
+};
 use futures_util::{SinkExt, StreamExt};
 use serde::{Deserialize, Serialize};
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
+use std::ffi::OsString;
+use std::fs::{self, OpenOptions};
+use std::io::{ErrorKind, Write};
+use std::os::windows::ffi::OsStrExt;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
+use tokio::sync::watch;
 use tokio_tungstenite::tungstenite::client::IntoClientRequest;
 use tokio_tungstenite::tungstenite::http::header::{AUTHORIZATION, USER_AGENT};
 use tokio_tungstenite::tungstenite::http::HeaderValue;
 use tokio_tungstenite::tungstenite::Message;
+use windows::core::PWSTR;
+use windows::Win32::Foundation::{
+    CloseHandle, ERROR_INSUFFICIENT_BUFFER, ERROR_SUCCESS, HANDLE, WIN32_ERROR,
+};
+use windows::Win32::Storage::Packaging::Appx::{GetApplicationUserModelId, GetPackageFamilyName};
+use windows::Win32::System::Threading::{OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION};
 
-const PROTOCOL_VERSION: u8 = 2;
+const PROTOCOL_VERSION: u8 = 3;
 const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(5);
 const SHUTDOWN_POLL_INTERVAL: Duration = Duration::from_millis(250);
 const WEBSOCKET_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 const WEBSOCKET_SEND_TIMEOUT: Duration = Duration::from_secs(5);
 const MAX_RECONNECT_DELAY_SECS: u64 = 30;
+const ROUTE_JOURNAL_FILE_NAME: &str = "jam-source-route-journal.json";
+const AMBIGUOUS_DISCONNECT_ROUTE_RELEASE_GRACE: Duration = Duration::from_secs(36);
+const TAKEOVER_DISABLE_FALLBACK: Duration = Duration::from_secs(3);
+const SHUTDOWN_STOP_ACK_TIMEOUT: Duration = Duration::from_secs(16);
+const SPOTIFY_STORE_PACKAGE_PREFIX: &str = "SpotifyAB.SpotifyMusic_";
+const SPOTIFY_STORE_APP_SUFFIX: &str = "!Spotify";
+const MOVEFILE_REPLACE_EXISTING: u32 = 0x1;
+const MOVEFILE_WRITE_THROUGH: u32 = 0x8;
+
+static PREFERENCE_TEMP_SEQUENCE: AtomicU64 = AtomicU64::new(1);
+
+#[link(name = "kernel32")]
+extern "system" {
+    fn MoveFileExW(existing_file_name: *const u16, new_file_name: *const u16, flags: u32) -> i32;
+}
 
 fn log_jam_source(message: &str) {
     eprintln!("{}", message);
@@ -36,6 +67,12 @@ pub struct JamSourceConfig {
     pub id: String,
     #[serde(default)]
     pub token: String,
+    #[serde(default = "default_silent_output_name")]
+    pub silent_output_name: String,
+}
+
+fn default_silent_output_name() -> String {
+    DEFAULT_SPOTIFY_ROUTE_TARGET.to_string()
 }
 
 impl JamSourceConfig {
@@ -46,37 +83,458 @@ impl JamSourceConfig {
         if self.token.trim().is_empty() {
             return Err("jam_source.token cannot be empty".to_string());
         }
+        if self.silent_output_name.trim().is_empty() {
+            return Err("jam_source.silent_output_name cannot be empty".to_string());
+        }
         Ok(())
+    }
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq)]
+struct JamSourceLocalPreferences {
+    #[serde(default = "default_takeover_enabled")]
+    takeover_enabled: bool,
+    #[serde(default)]
+    monitor_enabled: bool,
+}
+
+fn default_takeover_enabled() -> bool {
+    // A jam_source block is an explicit provisioning decision. Preserve the
+    // pre-toggle behavior on upgrade while still letting this PC revoke access.
+    true
+}
+
+impl Default for JamSourceLocalPreferences {
+    fn default() -> Self {
+        Self {
+            takeover_enabled: default_takeover_enabled(),
+            monitor_enabled: false,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+pub struct JamSourceLocalControlSnapshot {
+    pub is_source_host: bool,
+    pub takeover_enabled: bool,
+    pub monitor_enabled: bool,
+    pub takeover_active: bool,
+    pub agent_running: bool,
+    pub target_device_name: String,
+    pub last_error: Option<String>,
+}
+
+struct JamSourceLocalControlInner {
+    configured: bool,
+    target_device_name: String,
+    settings_path: PathBuf,
+    preferences: Mutex<JamSourceLocalPreferences>,
+    preferences_tx: watch::Sender<JamSourceLocalPreferences>,
+    takeover_active: AtomicBool,
+    agent_running: AtomicBool,
+    preference_error: Mutex<Option<String>>,
+    last_error: Mutex<Option<String>>,
+}
+
+/// Local-only source consent and monitoring preferences.
+///
+/// This state is reachable only through Tauri IPC on the configured source
+/// installation. It is deliberately not exposed through an HTTP endpoint.
+#[derive(Clone)]
+pub struct JamSourceLocalControl {
+    inner: Arc<JamSourceLocalControlInner>,
+}
+
+impl JamSourceLocalControl {
+    pub fn load(config: Option<&JamSourceConfig>, settings_path: PathBuf) -> Self {
+        let configured = config.is_some();
+        let target_device_name = config
+            .map(|config| config.silent_output_name.trim().to_string())
+            .unwrap_or_default();
+        let (preferences, preference_error) = if configured {
+            match load_local_preferences(&settings_path) {
+                Ok(Some(preferences)) => (preferences, None),
+                Ok(None) => (JamSourceLocalPreferences::default(), None),
+                Err(error) => (
+                    JamSourceLocalPreferences {
+                        takeover_enabled: false,
+                        monitor_enabled: false,
+                    },
+                    Some(error),
+                ),
+            }
+        } else {
+            (
+                JamSourceLocalPreferences {
+                    takeover_enabled: false,
+                    monitor_enabled: false,
+                },
+                None,
+            )
+        };
+        let (preferences_tx, _) = watch::channel(preferences);
+        Self {
+            inner: Arc::new(JamSourceLocalControlInner {
+                configured,
+                target_device_name,
+                settings_path,
+                preferences: Mutex::new(preferences),
+                preferences_tx,
+                takeover_active: AtomicBool::new(false),
+                agent_running: AtomicBool::new(false),
+                preference_error: Mutex::new(preference_error),
+                last_error: Mutex::new(None),
+            }),
+        }
+    }
+
+    pub fn is_source_host(&self) -> bool {
+        self.inner.configured
+    }
+
+    pub fn snapshot(&self) -> JamSourceLocalControlSnapshot {
+        let preferences = *self
+            .inner
+            .preferences
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let preference_error = self
+            .inner
+            .preference_error
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone();
+        let runtime_error = self
+            .inner
+            .last_error
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone();
+        JamSourceLocalControlSnapshot {
+            is_source_host: self.inner.configured,
+            takeover_enabled: preferences.takeover_enabled,
+            monitor_enabled: preferences.monitor_enabled,
+            takeover_active: self.inner.takeover_active.load(Ordering::Acquire),
+            agent_running: self.inner.agent_running.load(Ordering::Acquire),
+            target_device_name: self.inner.target_device_name.clone(),
+            last_error: preference_error.or(runtime_error),
+        }
+    }
+
+    pub fn set_takeover_enabled(
+        &self,
+        enabled: bool,
+    ) -> Result<JamSourceLocalControlSnapshot, String> {
+        self.update_preferences(|preferences| preferences.takeover_enabled = enabled)?;
+        Ok(self.snapshot())
+    }
+
+    pub fn set_monitor_enabled(
+        &self,
+        enabled: bool,
+    ) -> Result<JamSourceLocalControlSnapshot, String> {
+        self.update_preferences(|preferences| preferences.monitor_enabled = enabled)?;
+        Ok(self.snapshot())
+    }
+
+    fn update_preferences(
+        &self,
+        update: impl FnOnce(&mut JamSourceLocalPreferences),
+    ) -> Result<(), String> {
+        if !self.inner.configured {
+            return Err("This Echo installation is not the Jam source host".to_string());
+        }
+        let next = {
+            let mut preferences = self
+                .inner
+                .preferences
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            let mut candidate = *preferences;
+            update(&mut candidate);
+            if let Err(error) = persist_local_preferences(&self.inner.settings_path, &candidate) {
+                *self
+                    .inner
+                    .preference_error
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(error.clone());
+                return Err(error);
+            }
+            *preferences = candidate;
+            candidate
+        };
+        *self
+            .inner
+            .preference_error
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = None;
+        self.inner.preferences_tx.send_replace(next);
+        Ok(())
+    }
+
+    fn subscribe(&self) -> watch::Receiver<JamSourceLocalPreferences> {
+        self.inner.preferences_tx.subscribe()
+    }
+
+    fn route_journal_path(&self) -> PathBuf {
+        self.inner
+            .settings_path
+            .parent()
+            .map(|directory| directory.join(ROUTE_JOURNAL_FILE_NAME))
+            .unwrap_or_else(|| PathBuf::from(ROUTE_JOURNAL_FILE_NAME))
+    }
+
+    fn preference_error(&self) -> Option<String> {
+        self.inner
+            .preference_error
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone()
+    }
+
+    fn set_agent_running(&self, running: bool) {
+        self.inner.agent_running.store(running, Ordering::Release);
+        if !running {
+            self.set_takeover_active(false);
+        }
+    }
+
+    fn set_takeover_active(&self, active: bool) {
+        self.inner.takeover_active.store(active, Ordering::Release);
+    }
+
+    fn set_last_error(&self, error: Option<String>) {
+        *self
+            .inner
+            .last_error
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = error;
+    }
+}
+
+fn load_local_preferences(path: &Path) -> Result<Option<JamSourceLocalPreferences>, String> {
+    let contents = match fs::read_to_string(path) {
+        Ok(contents) => contents,
+        Err(error) if error.kind() == ErrorKind::NotFound => return Ok(None),
+        Err(error) => {
+            return Err(format!(
+                "Could not read Jam source settings '{}': {}. Jam sharing was disabled for safety",
+                path.display(),
+                error
+            ))
+        }
+    };
+    serde_json::from_str(contents.trim_start_matches('\u{FEFF}'))
+        .map(Some)
+        .map_err(|error| {
+            format!(
+                "Could not parse Jam source settings '{}': {}. Jam sharing was disabled for safety",
+                path.display(),
+                error
+            )
+        })
+}
+
+fn persist_local_preferences(
+    path: &Path,
+    preferences: &JamSourceLocalPreferences,
+) -> Result<(), String> {
+    if let Some(parent) = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    {
+        fs::create_dir_all(parent).map_err(|error| {
+            format!(
+                "Could not create Jam source settings directory '{}': {}",
+                parent.display(),
+                error
+            )
+        })?;
+    }
+    let json = serde_json::to_string_pretty(preferences)
+        .map_err(|error| format!("Could not serialize Jam source settings: {}", error))?;
+    let temporary_path = preference_temporary_path(path)?;
+    let result = (|| {
+        let mut file = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&temporary_path)
+            .map_err(|error| {
+                format!(
+                    "Could not create temporary Jam source settings '{}': {}",
+                    temporary_path.display(),
+                    error
+                )
+            })?;
+        file.write_all(format!("{}\n", json).as_bytes())
+            .map_err(|error| {
+                format!(
+                    "Could not write temporary Jam source settings '{}': {}",
+                    temporary_path.display(),
+                    error
+                )
+            })?;
+        file.sync_all().map_err(|error| {
+            format!(
+                "Could not flush temporary Jam source settings '{}': {}",
+                temporary_path.display(),
+                error
+            )
+        })?;
+        drop(file);
+        replace_file_atomically(&temporary_path, path)
+    })();
+    if result.is_err() {
+        let _ = fs::remove_file(&temporary_path);
+    }
+    result
+}
+
+fn preference_temporary_path(path: &Path) -> Result<PathBuf, String> {
+    let file_name = path
+        .file_name()
+        .ok_or_else(|| "Jam source settings path has no file name".to_string())?;
+    let sequence = PREFERENCE_TEMP_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+    let mut temporary_name = OsString::from(".");
+    temporary_name.push(file_name);
+    temporary_name.push(format!(".tmp-{}-{sequence}", std::process::id()));
+    Ok(path.with_file_name(temporary_name))
+}
+
+fn replace_file_atomically(temporary_path: &Path, destination: &Path) -> Result<(), String> {
+    let temporary_wide = temporary_path
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect::<Vec<_>>();
+    let destination_wide = destination
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect::<Vec<_>>();
+    let replaced = unsafe {
+        MoveFileExW(
+            temporary_wide.as_ptr(),
+            destination_wide.as_ptr(),
+            MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
+        )
+    };
+    if replaced != 0 {
+        Ok(())
+    } else {
+        Err(format!(
+            "Could not atomically save Jam source settings '{}': {}",
+            destination.display(),
+            std::io::Error::last_os_error()
+        ))
     }
 }
 
 pub struct JamSourceAgent {
     shutdown: Arc<AtomicBool>,
-    task: tauri::async_runtime::JoinHandle<()>,
+    shutdown_complete: Arc<AtomicBool>,
+    task: Mutex<Option<tauri::async_runtime::JoinHandle<()>>>,
+    control: JamSourceLocalControl,
+}
+
+pub struct JamSourceShutdown {
+    task: Option<tauri::async_runtime::JoinHandle<()>>,
+    complete: Arc<AtomicBool>,
+}
+
+impl JamSourceShutdown {
+    pub async fn wait(self) {
+        if let Some(task) = self.task {
+            let _ = task.await;
+            self.complete.store(true, Ordering::Release);
+            return;
+        }
+        while !self.complete.load(Ordering::Acquire) {
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+    }
 }
 
 impl JamSourceAgent {
-    pub fn start(server: String, config: JamSourceConfig) -> Result<Self, String> {
-        config.validate()?;
-        let endpoint = build_source_ws_url(&server, &config.id)?;
+    pub fn start(
+        server: String,
+        config: JamSourceConfig,
+        control: JamSourceLocalControl,
+    ) -> Result<Self, String> {
+        if let Err(error) = config.validate() {
+            control.set_last_error(Some(error.clone()));
+            return Err(error);
+        }
+        if !control.is_source_host() {
+            let error = "Jam source local control is not configured".to_string();
+            control.set_last_error(Some(error.clone()));
+            return Err(error);
+        }
+        let router = SpotifyOutputRouter::new(control.route_journal_path()).map_err(|error| {
+            control.set_last_error(Some(error.clone()));
+            error
+        })?;
+        let endpoint = build_source_ws_url(&server, &config.id).map_err(|error| {
+            control.set_last_error(Some(error.clone()));
+            error
+        })?;
         let shutdown = Arc::new(AtomicBool::new(false));
+        let shutdown_complete = Arc::new(AtomicBool::new(false));
         let task_shutdown = shutdown.clone();
+        let task_shutdown_complete = shutdown_complete.clone();
+        let task_control = control.clone();
+        control.set_agent_running(true);
         let task = tauri::async_runtime::spawn(async move {
-            run_agent(endpoint, config, task_shutdown).await;
+            run_agent(
+                endpoint,
+                config,
+                task_shutdown,
+                task_control.clone(),
+                router,
+            )
+            .await;
+            task_control.set_agent_running(false);
+            task_shutdown_complete.store(true, Ordering::Release);
         });
 
-        Ok(Self { shutdown, task })
+        Ok(Self {
+            shutdown,
+            shutdown_complete,
+            task: Mutex::new(Some(task)),
+            control,
+        })
     }
 
-    pub fn stop(&self) {
+    pub fn begin_shutdown(&self) -> JamSourceShutdown {
         self.shutdown.store(true, Ordering::SeqCst);
+        let task = self
+            .task
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .take();
+        JamSourceShutdown {
+            task,
+            complete: self.shutdown_complete.clone(),
+        }
+    }
+
+    pub fn shutdown_complete(&self) -> bool {
+        self.shutdown_complete.load(Ordering::Acquire)
     }
 }
 
 impl Drop for JamSourceAgent {
     fn drop(&mut self) {
         self.shutdown.store(true, Ordering::SeqCst);
-        self.task.abort();
+        self.control.set_agent_running(false);
+        if let Some(task) = self
+            .task
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .take()
+        {
+            task.abort();
+        }
     }
 }
 
@@ -91,6 +549,11 @@ enum ServerCommand {
 #[derive(Debug, Serialize)]
 #[serde(tag = "type", rename_all = "lowercase")]
 enum SourceMessage<'a> {
+    Availability {
+        enabled: bool,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        error: Option<&'a str>,
+    },
     Format {
         generation: u64,
         sample_rate: u32,
@@ -114,9 +577,34 @@ enum SourceMessage<'a> {
 
 struct ActiveCapture {
     generation: u64,
-    pid: u32,
     _handle: OwnedProcessCapture,
     events: tokio::sync::mpsc::Receiver<ProcessCaptureEvent>,
+}
+
+struct ActiveTakeover {
+    generation: u64,
+    route: SpotifyOutputRouteLease,
+    capture: Option<ActiveCapture>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ActiveConnectionExitPolicy {
+    PreserveJournal,
+    RestoreAfter(Duration),
+}
+
+fn active_connection_exit_policy(preserve_active_route: bool) -> ActiveConnectionExitPolicy {
+    if preserve_active_route {
+        ActiveConnectionExitPolicy::PreserveJournal
+    } else {
+        ActiveConnectionExitPolicy::RestoreAfter(AMBIGUOUS_DISCONNECT_ROUTE_RELEASE_GRACE)
+    }
+}
+
+impl ActiveTakeover {
+    fn pid(&self) -> u32 {
+        self.route.info().spotify_pid
+    }
 }
 
 #[derive(Default)]
@@ -183,19 +671,50 @@ impl ConnectionAttemptState {
     }
 }
 
-async fn run_agent(endpoint: String, config: JamSourceConfig, shutdown: Arc<AtomicBool>) {
+async fn run_agent(
+    endpoint: String,
+    config: JamSourceConfig,
+    shutdown: Arc<AtomicBool>,
+    control: JamSourceLocalControl,
+    router: SpotifyOutputRouter,
+) {
     let mut reconnect_delay_secs = 1_u64;
 
     while !shutdown.load(Ordering::SeqCst) {
+        if let Err(error) = recover_local_spotify_route(&router) {
+            control.set_last_error(Some(error.clone()));
+            log_jam_source(&format!(
+                "[jam-source] local Spotify route recovery blocked connection: {}",
+                error
+            ));
+            if wait_or_shutdown(Duration::from_secs(1), &shutdown).await {
+                break;
+            }
+            continue;
+        }
         let mut attempt = ConnectionAttemptState::default();
-        let result = run_connection(&endpoint, &config, &shutdown, &mut attempt).await;
+        let result = run_connection(
+            &endpoint,
+            &config,
+            &shutdown,
+            &mut attempt,
+            &control,
+            &router,
+        )
+        .await;
+        control.set_takeover_active(false);
         reconnect_delay_secs = attempt.retry_delay_secs(reconnect_delay_secs);
 
         match result {
             Ok(()) => {
-                log_jam_source("[jam-source] connection closed; reconnecting");
+                if !shutdown.load(Ordering::SeqCst) {
+                    let error = "Jam source connection closed; reconnecting".to_string();
+                    control.set_last_error(Some(error));
+                    log_jam_source("[jam-source] connection closed; reconnecting");
+                }
             }
             Err(error) => {
+                control.set_last_error(Some(format!("Jam source connection failed: {error}")));
                 log_jam_source(&format!(
                     "[jam-source] connection failed: {}; retrying in {}s",
                     error, reconnect_delay_secs
@@ -209,6 +728,7 @@ async fn run_agent(endpoint: String, config: JamSourceConfig, shutdown: Arc<Atom
         reconnect_delay_secs = next_reconnect_delay(reconnect_delay_secs);
     }
 
+    control.set_takeover_active(false);
     log_jam_source("[jam-source] agent stopped");
 }
 
@@ -217,6 +737,8 @@ async fn run_connection(
     config: &JamSourceConfig,
     shutdown: &AtomicBool,
     attempt: &mut ConnectionAttemptState,
+    control: &JamSourceLocalControl,
+    router: &SpotifyOutputRouter,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let mut request = endpoint.into_client_request()?;
     request.headers_mut().insert(
@@ -232,17 +754,18 @@ async fn run_connection(
         ))?,
     );
 
-    let connect_result = tokio::time::timeout(
-        WEBSOCKET_CONNECT_TIMEOUT,
-        tokio_tungstenite::connect_async(request),
-    )
-    .await
-    .map_err(|_| {
-        reconnect_error(format!(
-            "WebSocket connection timed out after {}s",
-            WEBSOCKET_CONNECT_TIMEOUT.as_secs()
-        ))
-    })?;
+    let connect_result = tokio::select! {
+        result = tokio::time::timeout(
+            WEBSOCKET_CONNECT_TIMEOUT,
+            tokio_tungstenite::connect_async(request),
+        ) => result.map_err(|_| {
+            reconnect_error(format!(
+                "WebSocket connection timed out after {}s",
+                WEBSOCKET_CONNECT_TIMEOUT.as_secs()
+            ))
+        })?,
+        _ = wait_for_shutdown(shutdown) => return Ok(()),
+    };
     let (socket, _) = connect_result?;
     attempt.mark_websocket_established();
     log_jam_source(&format!(
@@ -250,16 +773,36 @@ async fn run_connection(
         config.id
     ));
     let (mut writer, mut reader) = socket.split();
+    let mut preferences_rx = control.subscribe();
+    let (mut source_enabled, mut availability_error) = evaluate_local_availability(
+        router,
+        config,
+        preferences_rx.borrow().takeover_enabled,
+        control.preference_error(),
+    );
+    send_source_message(
+        &mut writer,
+        &SourceMessage::Availability {
+            enabled: source_enabled,
+            error: availability_error.as_deref(),
+        },
+    )
+    .await?;
+    control.set_last_error(availability_error.clone());
     let mut heartbeat = tokio::time::interval(HEARTBEAT_INTERVAL);
     heartbeat.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
     let mut shutdown_poll = tokio::time::interval(SHUTDOWN_POLL_INTERVAL);
     shutdown_poll.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
-    let mut active: Option<ActiveCapture> = None;
+    let mut active: Option<ActiveTakeover> = None;
     let mut generation_fence = GenerationFence::default();
+    let mut disable_fallback_deadline = None;
+    let mut shutdown_stop_deadline = None;
+    let mut preserve_active_route = false;
 
-    loop {
-        tokio::select! {
+    let loop_result: Result<(), Box<dyn std::error::Error + Send + Sync>> = async {
+        loop {
+            tokio::select! {
             incoming = reader.next() => {
                 match incoming {
                     Some(Ok(Message::Text(text))) => {
@@ -269,7 +812,7 @@ async fn run_connection(
                                 send_source_message(
                                     &mut writer,
                                     &SourceMessage::Error {
-                                        generation: active.as_ref().map(|capture| capture.generation).unwrap_or(0),
+                                        generation: active.as_ref().map(|takeover| takeover.generation).unwrap_or(0),
                                         message: &error,
                                     },
                                 ).await?;
@@ -279,17 +822,44 @@ async fn run_connection(
 
                         match command {
                             ServerCommand::Start { generation } => {
+                                if !source_enabled || !preferences_rx.borrow().takeover_enabled {
+                                    let error = availability_error
+                                        .as_deref()
+                                        .unwrap_or("Jam sharing is turned off on this source PC");
+                                    send_source_message(
+                                        &mut writer,
+                                        &SourceMessage::Error {
+                                            generation,
+                                            message: error,
+                                        },
+                                    ).await?;
+                                    continue;
+                                }
                                 if !generation_fence.accept_start(
                                     generation,
-                                    active.as_ref().map(|capture| capture.generation),
+                                    active.as_ref().map(|takeover| takeover.generation),
                                 ) {
                                     continue;
                                 }
+                                disable_fallback_deadline = None;
 
-                                active.take();
-                                match start_spotify_capture(generation) {
-                                    Ok(capture) => active = Some(capture),
+                                if let Some(previous) = active.take() {
+                                    if let Err(error) = stop_spotify_takeover(previous) {
+                                        log_jam_source(&format!(
+                                            "[jam-source] prior Spotify route restore failed: {}",
+                                            error
+                                        ));
+                                    }
+                                }
+                                match start_spotify_takeover(router, config, generation) {
+                                    Ok(takeover) => {
+                                        control.set_takeover_active(true);
+                                        control.set_last_error(None);
+                                        active = Some(takeover);
+                                    }
                                     Err(error) => {
+                                        control.set_takeover_active(false);
+                                        control.set_last_error(Some(error.clone()));
                                         send_source_message(
                                             &mut writer,
                                             &SourceMessage::Error {
@@ -302,25 +872,52 @@ async fn run_connection(
                                 }
                             }
                             ServerCommand::Stop { generation } => {
-                                if !generation_fence.accept_stop(generation) {
+                                let stop_accepted = generation_fence.accept_stop(generation);
+                                disable_fallback_deadline = disable_fallback_deadline_after_stop(
+                                    disable_fallback_deadline,
+                                    stop_accepted,
+                                );
+                                if !stop_accepted {
                                     continue;
                                 }
+                                let acknowledged_shutdown = shutdown_stop_deadline.is_some()
+                                    && active
+                                        .as_ref()
+                                        .map(|takeover| takeover.generation == generation)
+                                        .unwrap_or(false);
                                 if active
                                     .as_ref()
-                                    .map(|capture| capture.generation <= generation)
+                                    .map(|takeover| takeover.generation <= generation)
                                     .unwrap_or(false)
                                 {
                                     log_jam_source(&format!(
                                         "[jam-source] stopping generation {}",
                                         generation
                                     ));
-                                    active.take();
+                                    if let Some(takeover) = active.take() {
+                                        if let Err(error) = stop_spotify_takeover(takeover) {
+                                            control.set_last_error(Some(error.clone()));
+                                            log_jam_source(&format!(
+                                                "[jam-source] Spotify route restore failed: {}",
+                                                error
+                                            ));
+                                        }
+                                    }
+                                    control.set_takeover_active(false);
+                                }
+                                if acknowledged_shutdown {
+                                    shutdown_stop_deadline = None;
+                                    send_ws_message(&mut writer, Message::Close(None)).await?;
+                                    break;
                                 }
                             }
                             ServerCommand::Restart { generation } => {
+                                if shutdown_stop_deadline.is_some() {
+                                    continue;
+                                }
                                 if !generation_fence.accept_restart(
                                     generation,
-                                    active.as_ref().map(|capture| capture.generation),
+                                    active.as_ref().map(|takeover| takeover.generation),
                                 ) {
                                     continue;
                                 }
@@ -328,7 +925,10 @@ async fn run_connection(
                                 // Drop the old handle before acknowledging. Messages sent
                                 // before `restarting` belong to the old capture; messages
                                 // after it belong to the replacement on this ordered socket.
-                                active.take();
+                                let Some(takeover) = active.as_mut() else {
+                                    continue;
+                                };
+                                takeover.capture.take();
                                 log_jam_source(&format!(
                                     "[jam-source] restarting stalled capture generation {}",
                                     generation
@@ -338,9 +938,15 @@ async fn run_connection(
                                     &SourceMessage::Restarting { generation },
                                 ).await?;
 
-                                match start_spotify_capture(generation) {
-                                    Ok(capture) => active = Some(capture),
+                                match restart_spotify_capture(takeover) {
+                                    Ok(capture) => {
+                                        control.set_takeover_active(true);
+                                        control.set_last_error(None);
+                                        takeover.capture = Some(capture);
+                                    }
                                     Err(error) => {
+                                        control.set_takeover_active(false);
+                                        control.set_last_error(Some(error.clone()));
                                         send_source_message(
                                             &mut writer,
                                             &SourceMessage::Error {
@@ -362,20 +968,62 @@ async fn run_connection(
                     Some(Err(error)) => return Err(error.into()),
                 }
             }
+            changed = preferences_rx.changed() => {
+                if changed.is_err() {
+                    break;
+                }
+                let takeover_enabled = preferences_rx.borrow().takeover_enabled;
+                if takeover_enabled {
+                    disable_fallback_deadline = None;
+                }
+                if shutdown_stop_deadline.is_some() {
+                    continue;
+                }
+                let (next_enabled, next_error) = if active.is_some() {
+                    (takeover_enabled, None)
+                } else {
+                    evaluate_local_availability(
+                        router,
+                        config,
+                        takeover_enabled,
+                        control.preference_error(),
+                    )
+                };
+                if next_enabled != source_enabled || next_error != availability_error {
+                    source_enabled = next_enabled;
+                    availability_error = next_error;
+                    control.set_last_error(availability_error.clone());
+                    send_source_message(
+                        &mut writer,
+                        &SourceMessage::Availability {
+                            enabled: source_enabled,
+                            error: availability_error.as_deref(),
+                        },
+                    ).await?;
+                }
+                // Arm only after Availability(false) was successfully written.
+                // Repeated monitor preference notifications must not extend it.
+                disable_fallback_deadline = next_disable_fallback_deadline(
+                    disable_fallback_deadline,
+                    takeover_enabled,
+                    active.is_some(),
+                    tokio::time::Instant::now(),
+                );
+            }
             capture_event = next_capture_event(&mut active) => {
                 let Some((generation, event)) = capture_event else {
-                    if let Some(capture) = active.take() {
+                    if let Some(takeover) = active.as_ref() {
                         let message = "Spotify audio capture event channel closed";
                         send_source_message(
                             &mut writer,
                             &SourceMessage::Error {
-                                generation: capture.generation,
+                                generation: takeover.generation,
                                 message,
                             },
                         ).await?;
                         return Err(reconnect_error(format!(
                             "generation {} {}",
-                            capture.generation, message
+                            takeover.generation, message
                         )));
                     }
                     continue;
@@ -431,7 +1079,7 @@ async fn run_connection(
             _ = heartbeat.tick() => {
                 if let Some((generation, pid)) = active
                     .as_ref()
-                    .map(|capture| (capture.generation, capture.pid))
+                    .map(|takeover| (takeover.generation, takeover.pid()))
                 {
                     if let Err(error) = validate_spotify_root_pid(pid) {
                         send_source_message(
@@ -446,35 +1094,360 @@ async fn run_connection(
                             generation, pid, error
                         )));
                     }
+                } else {
+                    let (next_enabled, next_error) = evaluate_local_availability(
+                        router,
+                        config,
+                        preferences_rx.borrow().takeover_enabled,
+                        control.preference_error(),
+                    );
+                    if next_enabled != source_enabled || next_error != availability_error {
+                        source_enabled = next_enabled;
+                        availability_error = next_error;
+                        control.set_last_error(availability_error.clone());
+                        send_source_message(
+                            &mut writer,
+                            &SourceMessage::Availability {
+                                enabled: source_enabled,
+                                error: availability_error.as_deref(),
+                            },
+                        ).await?;
+                    }
                 }
                 send_source_message(
                     &mut writer,
                     &SourceMessage::Heartbeat {
-                        generation: active.as_ref().map(|capture| capture.generation).unwrap_or(0),
+                        generation: active.as_ref().map(|takeover| takeover.generation).unwrap_or(0),
                     },
                 ).await?;
             }
             _ = shutdown_poll.tick() => {
-                if shutdown.load(Ordering::SeqCst) {
-                    send_ws_message(&mut writer, Message::Close(None)).await?;
-                    break;
+                if shutdown.load(Ordering::SeqCst) && shutdown_stop_deadline.is_none() {
+                    source_enabled = false;
+                    availability_error = None;
+                    disable_fallback_deadline = None;
+                    send_source_message(
+                        &mut writer,
+                        &SourceMessage::Availability {
+                            enabled: false,
+                            error: None,
+                        },
+                    ).await?;
+                    if let Some(generation) = active.as_ref().map(|takeover| takeover.generation) {
+                        shutdown_stop_deadline = Some(
+                            tokio::time::Instant::now() + SHUTDOWN_STOP_ACK_TIMEOUT
+                        );
+                        log_jam_source(&format!(
+                            "[jam-source] shutdown waiting for generation {} Stop",
+                            generation
+                        ));
+                    } else {
+                        send_ws_message(&mut writer, Message::Close(None)).await?;
+                        break;
+                    }
+                }
+            }
+            _ = wait_for_optional_deadline(disable_fallback_deadline), if disable_fallback_deadline.is_some() => {
+                disable_fallback_deadline = None;
+                if !preferences_rx.borrow().takeover_enabled {
+                    if let Some(takeover) = active.take() {
+                        log_jam_source(&format!(
+                            "[jam-source] local disable fallback stopping generation {} after {}ms",
+                            takeover.generation,
+                            TAKEOVER_DISABLE_FALLBACK.as_millis()
+                        ));
+                        if let Err(error) = stop_spotify_takeover(takeover) {
+                            control.set_last_error(Some(error.clone()));
+                            log_jam_source(&format!(
+                                "[jam-source] local disable fallback could not restore Spotify: {}",
+                                error
+                            ));
+                        }
+                        control.set_takeover_active(false);
+                    }
+                }
+            }
+            _ = wait_for_optional_deadline(shutdown_stop_deadline), if shutdown_stop_deadline.is_some() => {
+                shutdown_stop_deadline = None;
+                preserve_active_route = active.is_some();
+                break;
+            }
+            }
+        }
+        Ok(())
+    }
+    .await;
+
+    // Close the socket before the release grace so the control plane observes
+    // disconnect and has its full pause timeout before Spotify can be audible.
+    drop(writer);
+    drop(reader);
+
+    let mut cleanup_error = None;
+    if let Some(takeover) = active.take() {
+        match active_connection_exit_policy(preserve_active_route) {
+            ActiveConnectionExitPolicy::PreserveJournal => {
+                log_jam_source(&format!(
+                    "[jam-source] shutdown timed out waiting for generation {} Stop; preserving the Spotify route journal",
+                    takeover.generation
+                ));
+                // Process exit is imminent. Leaking the lease deliberately prevents
+                // its synchronous Drop restore; next launch recovers the journal.
+                std::mem::forget(takeover);
+            }
+            ActiveConnectionExitPolicy::RestoreAfter(delay) => {
+                log_jam_source(&format!(
+                    "[jam-source] connection ended with generation {} active; holding the silent route for up to {}s before restore",
+                    takeover.generation,
+                    delay.as_secs()
+                ));
+                let restore_after_delay = wait_for_ambiguous_connection_release(
+                    delay,
+                    shutdown,
+                    &mut preferences_rx,
+                    disable_fallback_deadline,
+                )
+                .await;
+                if restore_after_delay {
+                    if let Err(error) = stop_spotify_takeover(takeover) {
+                        control.set_last_error(Some(error.clone()));
+                        log_jam_source(&format!(
+                            "[jam-source] Spotify route restore failed while closing connection: {}",
+                            error
+                        ));
+                        cleanup_error = Some(error);
+                    }
+                } else {
+                    log_jam_source(&format!(
+                        "[jam-source] exit requested during release grace for generation {}; preserving the Spotify route journal",
+                        takeover.generation
+                    ));
+                    std::mem::forget(takeover);
                 }
             }
         }
     }
+    control.set_takeover_active(false);
+    match (loop_result, cleanup_error) {
+        (Err(error), _) => Err(error),
+        (Ok(()), Some(error)) => Err(reconnect_error(error)),
+        (Ok(()), None) => Ok(()),
+    }
+}
 
-    // Dropping the owned handle stops only Jam capture before reconnecting.
-    active.take();
+fn evaluate_local_availability(
+    router: &SpotifyOutputRouter,
+    config: &JamSourceConfig,
+    takeover_enabled: bool,
+    preference_error: Option<String>,
+) -> (bool, Option<String>) {
+    evaluate_local_availability_with(
+        takeover_enabled,
+        preference_error,
+        || recover_local_spotify_route(router),
+        || {
+            let pid = find_spotify_root_pid()?;
+            validate_store_spotify_root_pid(pid)?;
+            router
+                .validate_target(config.silent_output_name.trim())
+                .map(|_| ())
+                .map_err(|error| format!("Jam silent output is unavailable: {}", error))
+        },
+    )
+}
+
+fn evaluate_local_availability_with(
+    takeover_enabled: bool,
+    preference_error: Option<String>,
+    recover_route: impl FnOnce() -> Result<(), String>,
+    validate_readiness: impl FnOnce() -> Result<(), String>,
+) -> (bool, Option<String>) {
+    if let Err(error) = recover_route() {
+        return (false, Some(error));
+    }
+    if !takeover_enabled {
+        return (false, preference_error);
+    }
+    match validate_readiness() {
+        Ok(()) => (true, None),
+        Err(error) => (false, Some(error)),
+    }
+}
+
+fn recover_local_spotify_route(router: &SpotifyOutputRouter) -> Result<(), String> {
+    let current_spotify_pid = find_spotify_root_pid().ok();
+    let retry_report = router.restore_active(current_spotify_pid)?;
+    if !retry_report.restored_roles.is_empty()
+        || !retry_report.cleared_to_default_roles.is_empty()
+        || !retry_report.skipped_changed_roles.is_empty()
+    {
+        log_jam_source(&format!(
+            "[jam-source] retried Spotify route restoration: {:?}",
+            retry_report
+        ));
+    }
+    match router.recover_startup(current_spotify_pid)? {
+        StartupRecoveryOutcome::NoJournal => Ok(()),
+        StartupRecoveryOutcome::OwnerStillRunning { owner_pid } => Err(format!(
+            "Another Echo process (PID {}) still owns Spotify's Jam route",
+            owner_pid
+        )),
+        StartupRecoveryOutcome::Deferred {
+            owner_pid,
+            retry_after,
+        } => Err(format!(
+            "Waiting {}ms before recovering the Spotify route from stopped Echo PID {}",
+            retry_after.as_millis(),
+            owner_pid
+        )),
+        StartupRecoveryOutcome::SpotifyNotRunning { previous_pid } => Err(format!(
+            "Spotify must be opened once so Echo can recover its previous Jam route (old PID {})",
+            previous_pid
+        )),
+        StartupRecoveryOutcome::Restored(report) => {
+            log_jam_source(&format!(
+                "[jam-source] recovered prior Spotify route: {:?}",
+                report
+            ));
+            Ok(())
+        }
+    }
+}
+
+struct OwnedIdentityProcess(HANDLE);
+
+impl Drop for OwnedIdentityProcess {
+    fn drop(&mut self) {
+        unsafe {
+            let _ = CloseHandle(self.0);
+        }
+    }
+}
+
+fn validate_store_spotify_root_pid(pid: u32) -> Result<(), String> {
+    let process = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, pid) }
+        .map(OwnedIdentityProcess)
+        .map_err(|error| format!("Cannot inspect Spotify PID {}: {}", pid, error))?;
+    let package_family = read_process_app_model_string(
+        |length, buffer| unsafe { GetPackageFamilyName(process.0, length, buffer) },
+        "GetPackageFamilyName",
+    )?;
+    if !package_family
+        .get(..SPOTIFY_STORE_PACKAGE_PREFIX.len())
+        .map(|prefix| prefix.eq_ignore_ascii_case(SPOTIFY_STORE_PACKAGE_PREFIX))
+        .unwrap_or(false)
+    {
+        return Err(format!(
+            "Spotify PID {} is not the Microsoft Store Spotify app",
+            pid
+        ));
+    }
+    let application_user_model_id = read_process_app_model_string(
+        |length, buffer| unsafe { GetApplicationUserModelId(process.0, length, buffer) },
+        "GetApplicationUserModelId",
+    )?;
+    let expected_aumid = format!("{}{}", package_family, SPOTIFY_STORE_APP_SUFFIX);
+    if !application_user_model_id.eq_ignore_ascii_case(&expected_aumid) {
+        return Err(format!(
+            "Spotify PID {} has an unexpected Store application identity",
+            pid
+        ));
+    }
     Ok(())
 }
 
-fn start_spotify_capture(generation: u64) -> Result<ActiveCapture, String> {
+fn read_process_app_model_string(
+    mut call: impl FnMut(*mut u32, PWSTR) -> WIN32_ERROR,
+    operation: &str,
+) -> Result<String, String> {
+    let mut length = 0_u32;
+    let size_result = call(&mut length, PWSTR::null());
+    if size_result != ERROR_INSUFFICIENT_BUFFER || length == 0 {
+        return Err(format!(
+            "{} size query failed with Win32 error {}",
+            operation, size_result.0
+        ));
+    }
+
+    let mut buffer = vec![0_u16; length as usize];
+    let result = call(&mut length, PWSTR(buffer.as_mut_ptr()));
+    if result != ERROR_SUCCESS {
+        return Err(format!(
+            "{} failed with Win32 error {}",
+            operation, result.0
+        ));
+    }
+    let string_length = buffer
+        .iter()
+        .position(|character| *character == 0)
+        .unwrap_or(length as usize);
+    let value = String::from_utf16(&buffer[..string_length])
+        .map_err(|error| format!("{} returned invalid UTF-16: {}", operation, error))?;
+    if value.is_empty() {
+        Err(format!("{} returned an empty identity", operation))
+    } else {
+        Ok(value)
+    }
+}
+
+fn start_spotify_takeover(
+    router: &SpotifyOutputRouter,
+    config: &JamSourceConfig,
+    generation: u64,
+) -> Result<ActiveTakeover, String> {
     let pid = find_spotify_root_pid().map_err(|error| {
         format!(
             "generation {} could not bind Spotify: {}",
             generation, error
         )
     })?;
+    match router.recover_startup(Some(pid))? {
+        StartupRecoveryOutcome::NoJournal => {}
+        StartupRecoveryOutcome::Restored(report) => log_jam_source(&format!(
+            "[jam-source] generation {} recovered prior Spotify route: {:?}",
+            generation, report
+        )),
+        StartupRecoveryOutcome::OwnerStillRunning { owner_pid } => {
+            return Err(format!(
+                "generation {} cannot route Spotify because Echo PID {} still owns the previous route",
+                generation, owner_pid
+            ));
+        }
+        StartupRecoveryOutcome::Deferred {
+            owner_pid,
+            retry_after,
+        } => {
+            return Err(format!(
+                "generation {} is waiting {}ms before recovering the Spotify route from stopped Echo PID {}",
+                generation,
+                retry_after.as_millis(),
+                owner_pid
+            ));
+        }
+        StartupRecoveryOutcome::SpotifyNotRunning { previous_pid } => {
+            return Err(format!(
+                "generation {} could not recover Spotify route from old PID {}",
+                generation, previous_pid
+            ));
+        }
+    }
+    router.validate_target(config.silent_output_name.trim())?;
+    let route = router.acquire(pid, config.silent_output_name.trim())?;
+    log_jam_source(&format!(
+        "[jam-source] generation {} routed Spotify root PID {} to '{}'",
+        generation,
+        pid,
+        route.info().target.name
+    ));
+    let capture = start_spotify_capture_for_pid(generation, pid)?;
+    Ok(ActiveTakeover {
+        generation,
+        route,
+        capture: Some(capture),
+    })
+}
+
+fn start_spotify_capture_for_pid(generation: u64, pid: u32) -> Result<ActiveCapture, String> {
     let (handle, events) = start_owned_process_capture(pid).map_err(|error| {
         format!(
             "generation {} capture start failed for Spotify root PID {}: {}",
@@ -487,22 +1460,96 @@ fn start_spotify_capture(generation: u64) -> Result<ActiveCapture, String> {
     ));
     Ok(ActiveCapture {
         generation,
-        pid,
         _handle: handle,
         events,
     })
 }
 
+fn restart_spotify_capture(takeover: &ActiveTakeover) -> Result<ActiveCapture, String> {
+    let current_pid = find_spotify_root_pid().map_err(|error| {
+        format!(
+            "generation {} could not rebind Spotify capture: {}",
+            takeover.generation, error
+        )
+    })?;
+    if current_pid != takeover.pid() {
+        return Err(format!(
+            "generation {} Spotify root changed from PID {} to {}; reconnecting to recover its route",
+            takeover.generation,
+            takeover.pid(),
+            current_pid
+        ));
+    }
+    start_spotify_capture_for_pid(takeover.generation, current_pid)
+}
+
+fn stop_spotify_takeover(mut takeover: ActiveTakeover) -> Result<(), String> {
+    takeover.capture.take();
+    let routed_pid = takeover.pid();
+    let current_pid = find_spotify_root_pid().ok();
+    let report = match current_pid {
+        Some(pid) if pid != routed_pid => takeover.route.restore_for_spotify_pid(pid),
+        _ => takeover.route.restore(),
+    }?;
+    log_jam_source(&format!(
+        "[jam-source] generation {} restored Spotify output: {:?}",
+        takeover.generation, report
+    ));
+    Ok(())
+}
+
 async fn next_capture_event(
-    active: &mut Option<ActiveCapture>,
+    active: &mut Option<ActiveTakeover>,
 ) -> Option<(u64, ProcessCaptureEvent)> {
-    match active {
+    match active
+        .as_mut()
+        .and_then(|takeover| takeover.capture.as_mut())
+    {
         Some(capture) => capture
             .events
             .recv()
             .await
             .map(|event| (capture.generation, event)),
         None => std::future::pending().await,
+    }
+}
+
+async fn wait_for_ambiguous_connection_release(
+    transport_grace: Duration,
+    shutdown: &AtomicBool,
+    preferences: &mut watch::Receiver<JamSourceLocalPreferences>,
+    initial_disable_deadline: Option<tokio::time::Instant>,
+) -> bool {
+    let now = tokio::time::Instant::now();
+    let transport_deadline = now + transport_grace;
+    let mut disable_deadline = next_disable_fallback_deadline(
+        initial_disable_deadline,
+        preferences.borrow().takeover_enabled,
+        true,
+        now,
+    );
+    let mut preferences_open = true;
+
+    loop {
+        let release_deadline = disable_deadline
+            .map(|deadline| deadline.min(transport_deadline))
+            .unwrap_or(transport_deadline);
+        tokio::select! {
+            _ = tokio::time::sleep_until(release_deadline) => return true,
+            _ = wait_for_shutdown(shutdown) => return false,
+            changed = preferences.changed(), if preferences_open => {
+                if changed.is_err() {
+                    preferences_open = false;
+                    continue;
+                }
+                disable_deadline = next_disable_fallback_deadline(
+                    disable_deadline,
+                    preferences.borrow().takeover_enabled,
+                    true,
+                    tokio::time::Instant::now(),
+                );
+            }
+        }
     }
 }
 
@@ -558,6 +1605,43 @@ async fn wait_or_shutdown(duration: Duration, shutdown: &AtomicBool) -> bool {
                 }
             }
         }
+    }
+}
+
+async fn wait_for_shutdown(shutdown: &AtomicBool) {
+    while !shutdown.load(Ordering::SeqCst) {
+        tokio::time::sleep(SHUTDOWN_POLL_INTERVAL).await;
+    }
+}
+
+async fn wait_for_optional_deadline(deadline: Option<tokio::time::Instant>) {
+    match deadline {
+        Some(deadline) => tokio::time::sleep_until(deadline).await,
+        None => std::future::pending().await,
+    }
+}
+
+fn next_disable_fallback_deadline(
+    current: Option<tokio::time::Instant>,
+    takeover_enabled: bool,
+    active: bool,
+    now: tokio::time::Instant,
+) -> Option<tokio::time::Instant> {
+    if takeover_enabled || !active {
+        None
+    } else {
+        current.or(Some(now + TAKEOVER_DISABLE_FALLBACK))
+    }
+}
+
+fn disable_fallback_deadline_after_stop(
+    current: Option<tokio::time::Instant>,
+    stop_accepted: bool,
+) -> Option<tokio::time::Instant> {
+    if stop_accepted {
+        None
+    } else {
+        current
     }
 }
 
@@ -626,13 +1710,36 @@ fn percent_encode_component(value: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::cell::Cell;
+
+    fn source_config() -> JamSourceConfig {
+        JamSourceConfig {
+            id: "sam-pc".into(),
+            token: "secret".into(),
+            silent_output_name: default_silent_output_name(),
+        }
+    }
+
+    fn temporary_settings_path(test_name: &str) -> PathBuf {
+        let nonce = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir()
+            .join(format!(
+                "echo-jam-source-test-{}-{}",
+                std::process::id(),
+                nonce
+            ))
+            .join(format!("{}.json", test_name))
+    }
 
     #[test]
     fn builds_authenticated_source_endpoint_without_token_in_url() {
         let url = build_source_ws_url("https://echo.example:9443/", "SAM PC/source").unwrap();
         assert_eq!(
             url,
-            "wss://echo.example:9443/api/jam/source?source_id=SAM%20PC%2Fsource&protocol=2"
+            "wss://echo.example:9443/api/jam/source?source_id=SAM%20PC%2Fsource&protocol=3"
         );
         assert!(!url.contains("token"));
     }
@@ -684,16 +1791,275 @@ mod tests {
     fn source_config_rejects_missing_binding_values() {
         assert!(JamSourceConfig {
             id: "".into(),
-            token: "secret".into()
+            token: "secret".into(),
+            silent_output_name: default_silent_output_name(),
         }
         .validate()
         .is_err());
         assert!(JamSourceConfig {
             id: "sam-pc".into(),
-            token: "".into()
+            token: "".into(),
+            silent_output_name: default_silent_output_name(),
         }
         .validate()
         .is_err());
+        assert!(JamSourceConfig {
+            id: "sam-pc".into(),
+            token: "secret".into(),
+            silent_output_name: "".into(),
+        }
+        .validate()
+        .is_err());
+    }
+
+    #[test]
+    fn source_start_validation_error_is_latched_in_native_snapshot() {
+        let path = temporary_settings_path("invalid-source-start");
+        let control = JamSourceLocalControl::load(Some(&source_config()), path.clone());
+        let error = JamSourceAgent::start(
+            "https://echo.invalid".to_string(),
+            JamSourceConfig {
+                id: "sam-pc".to_string(),
+                token: String::new(),
+                silent_output_name: default_silent_output_name(),
+            },
+            control.clone(),
+        )
+        .err()
+        .expect("missing source token must reject startup");
+
+        assert!(error.contains("jam_source.token cannot be empty"));
+        assert_eq!(
+            control.snapshot().last_error.as_deref(),
+            Some(error.as_str())
+        );
+
+        let _ = std::fs::remove_dir_all(path.parent().unwrap());
+    }
+
+    #[test]
+    fn local_source_preferences_default_armed_and_persist_changes() {
+        let path = temporary_settings_path("preferences");
+        let control = JamSourceLocalControl::load(Some(&source_config()), path.clone());
+        assert_eq!(
+            control.snapshot(),
+            JamSourceLocalControlSnapshot {
+                is_source_host: true,
+                takeover_enabled: true,
+                monitor_enabled: false,
+                takeover_active: false,
+                agent_running: false,
+                target_device_name: DEFAULT_SPOTIFY_ROUTE_TARGET.to_string(),
+                last_error: None,
+            }
+        );
+
+        control.set_takeover_enabled(false).unwrap();
+        control.set_monitor_enabled(true).unwrap();
+        drop(control);
+
+        let reloaded = JamSourceLocalControl::load(Some(&source_config()), path.clone());
+        assert!(!reloaded.snapshot().takeover_enabled);
+        assert!(reloaded.snapshot().monitor_enabled);
+
+        let _ = std::fs::remove_file(&path);
+        if let Some(parent) = path.parent() {
+            let _ = std::fs::remove_dir(parent);
+        }
+    }
+
+    #[test]
+    fn corrupt_preferences_fail_closed_and_surface_the_error_until_repaired() {
+        let path = temporary_settings_path("corrupt-preferences");
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, br#"{"takeover_enabled": "#).unwrap();
+
+        let control = JamSourceLocalControl::load(Some(&source_config()), path.clone());
+        let snapshot = control.snapshot();
+        assert!(!snapshot.takeover_enabled);
+        assert!(!snapshot.monitor_enabled);
+        assert!(snapshot
+            .last_error
+            .as_deref()
+            .unwrap_or_default()
+            .contains("Could not parse Jam source settings"));
+
+        control.set_takeover_enabled(true).unwrap();
+        let repaired = control.snapshot();
+        assert!(repaired.takeover_enabled);
+        assert!(repaired.last_error.is_none());
+        assert!(load_local_preferences(&path).unwrap().is_some());
+
+        let _ = std::fs::remove_dir_all(path.parent().unwrap());
+    }
+
+    #[test]
+    fn unreadable_preferences_fail_closed_instead_of_using_upgrade_defaults() {
+        let path = temporary_settings_path("unreadable-preferences");
+        std::fs::create_dir_all(&path).unwrap();
+
+        let control = JamSourceLocalControl::load(Some(&source_config()), path.clone());
+        let snapshot = control.snapshot();
+        assert!(!snapshot.takeover_enabled);
+        assert!(snapshot
+            .last_error
+            .as_deref()
+            .unwrap_or_default()
+            .contains("Could not read Jam source settings"));
+
+        let _ = std::fs::remove_dir_all(path.parent().unwrap());
+    }
+
+    #[test]
+    fn failed_preference_write_does_not_mutate_memory_or_notify_watchers() {
+        let path = temporary_settings_path("failed-preference-write");
+        let control = JamSourceLocalControl::load(Some(&source_config()), path.clone());
+        let preferences_rx = control.subscribe();
+        assert!(control.snapshot().takeover_enabled);
+
+        // A directory at the destination makes the atomic replacement fail.
+        std::fs::create_dir_all(&path).unwrap();
+        let error = control.set_takeover_enabled(false).unwrap_err();
+        assert!(error.contains("Could not atomically save Jam source settings"));
+        assert!(control.snapshot().takeover_enabled);
+        assert!(!preferences_rx.has_changed().unwrap());
+        assert_eq!(
+            control.snapshot().last_error.as_deref(),
+            Some(error.as_str())
+        );
+
+        // Once the destination is writable again, a successful durable save
+        // clears the latched persistence error and publishes the preference.
+        std::fs::remove_dir(&path).unwrap();
+        control.set_takeover_enabled(false).unwrap();
+        assert!(!control.snapshot().takeover_enabled);
+        assert!(control.snapshot().last_error.is_none());
+        assert!(preferences_rx.has_changed().unwrap());
+
+        let _ = std::fs::remove_dir_all(path.parent().unwrap());
+    }
+
+    #[test]
+    fn disabled_availability_runs_recovery_but_skips_readiness_validation() {
+        let recovery_calls = Cell::new(0);
+        let validation_calls = Cell::new(0);
+        let result = evaluate_local_availability_with(
+            false,
+            Some("preferences are corrupt".to_string()),
+            || {
+                recovery_calls.set(recovery_calls.get() + 1);
+                Ok(())
+            },
+            || {
+                validation_calls.set(validation_calls.get() + 1);
+                Ok(())
+            },
+        );
+
+        assert_eq!(result, (false, Some("preferences are corrupt".to_string())));
+        assert_eq!(recovery_calls.get(), 1);
+        assert_eq!(validation_calls.get(), 0);
+    }
+
+    #[test]
+    fn recovery_failure_blocks_availability_even_when_takeover_is_disabled() {
+        let validation_calls = Cell::new(0);
+        let result = evaluate_local_availability_with(
+            false,
+            None,
+            || Err("route recovery failed".to_string()),
+            || {
+                validation_calls.set(validation_calls.get() + 1);
+                Ok(())
+            },
+        );
+
+        assert_eq!(result, (false, Some("route recovery failed".to_string())));
+        assert_eq!(validation_calls.get(), 0);
+    }
+
+    #[test]
+    fn disable_fallback_is_non_extending_and_clears_on_reenable_or_stop() {
+        let now = tokio::time::Instant::now();
+        let first = next_disable_fallback_deadline(None, false, true, now).unwrap();
+        assert_eq!(first, now + TAKEOVER_DISABLE_FALLBACK);
+
+        let repeated =
+            next_disable_fallback_deadline(Some(first), false, true, now + Duration::from_secs(1));
+        assert_eq!(repeated, Some(first));
+        assert_eq!(
+            next_disable_fallback_deadline(Some(first), true, true, now),
+            None
+        );
+        assert_eq!(
+            next_disable_fallback_deadline(Some(first), false, false, now),
+            None
+        );
+
+        assert_eq!(
+            disable_fallback_deadline_after_stop(Some(first), false),
+            Some(first)
+        );
+        assert_eq!(
+            disable_fallback_deadline_after_stop(Some(first), true),
+            None
+        );
+    }
+
+    #[test]
+    fn active_connection_exit_policy_never_restores_before_pause_timeout() {
+        assert!(SHUTDOWN_STOP_ACK_TIMEOUT >= Duration::from_secs(16));
+        assert_eq!(
+            active_connection_exit_policy(false),
+            ActiveConnectionExitPolicy::RestoreAfter(Duration::from_secs(36))
+        );
+        assert_eq!(
+            active_connection_exit_policy(true),
+            ActiveConnectionExitPolicy::PreserveJournal
+        );
+    }
+
+    #[tokio::test]
+    async fn ambiguous_release_honors_local_reclaim_and_shutdown_preservation() {
+        let (_preferences_tx, mut preferences_rx) = watch::channel(JamSourceLocalPreferences {
+            takeover_enabled: false,
+            monitor_enabled: false,
+        });
+        let shutdown = AtomicBool::new(false);
+        assert!(
+            wait_for_ambiguous_connection_release(
+                Duration::from_secs(36),
+                &shutdown,
+                &mut preferences_rx,
+                Some(tokio::time::Instant::now()),
+            )
+            .await
+        );
+
+        let (_preferences_tx, mut preferences_rx) = watch::channel(JamSourceLocalPreferences {
+            takeover_enabled: true,
+            monitor_enabled: false,
+        });
+        shutdown.store(true, Ordering::SeqCst);
+        assert!(
+            !wait_for_ambiguous_connection_release(
+                Duration::from_secs(36),
+                &shutdown,
+                &mut preferences_rx,
+                None,
+            )
+            .await
+        );
+    }
+
+    #[test]
+    fn unconfigured_install_cannot_enable_source_controls() {
+        let control = JamSourceLocalControl::load(None, temporary_settings_path("unconfigured"));
+        let snapshot = control.snapshot();
+        assert!(!snapshot.is_source_host);
+        assert!(!snapshot.takeover_enabled);
+        assert!(control.set_takeover_enabled(true).is_err());
+        assert!(control.set_monitor_enabled(true).is_err());
     }
 
     #[test]

--- a/core/client/src/main.rs
+++ b/core/client/src/main.rs
@@ -12,6 +12,8 @@ use audio_capture_stub as audio_capture;
 
 #[cfg(target_os = "windows")]
 mod screen_capture;
+#[cfg(target_os = "windows")]
+mod spotify_output_route;
 
 #[cfg(target_os = "windows")]
 mod audio_output;
@@ -38,7 +40,6 @@ use audio_output_stub as audio_output;
 
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use tauri::{Manager, WebviewUrl, WebviewWindowBuilder};
 use tauri_plugin_updater::UpdaterExt;
@@ -59,37 +60,6 @@ struct Config {
     #[cfg(target_os = "windows")]
     #[serde(default)]
     jam_source: Option<jam_source::JamSourceConfig>,
-}
-
-struct JamSourceHost(AtomicBool);
-
-impl JamSourceHost {
-    fn new() -> Self {
-        Self(AtomicBool::new(false))
-    }
-
-    fn is_active(&self) -> bool {
-        self.0.load(Ordering::Acquire)
-    }
-
-    fn set_active(&self, active: bool) {
-        self.0.store(active, Ordering::Release);
-    }
-}
-
-#[cfg(test)]
-mod jam_source_host_role_tests {
-    use super::JamSourceHost;
-
-    #[test]
-    fn source_host_role_is_false_until_agent_start_is_confirmed() {
-        let role = JamSourceHost::new();
-        assert!(!role.is_active());
-        role.set_active(true);
-        assert!(role.is_active());
-        role.set_active(false);
-        assert!(!role.is_active());
-    }
 }
 
 #[derive(Serialize)]
@@ -158,10 +128,7 @@ fn detect_windows_build_number() -> u32 {
 /// Load config.json from next to the executable.
 /// Falls back to defaults if missing or invalid.
 fn load_config() -> Config {
-    let config_path = std::env::current_exe()
-        .ok()
-        .and_then(|p| p.parent().map(|d| d.join("config.json")))
-        .unwrap_or_else(|| PathBuf::from("config.json"));
+    let config_path = executable_sibling_path("config.json");
 
     if config_path.exists() {
         match std::fs::read_to_string(&config_path) {
@@ -228,6 +195,13 @@ fn load_config() -> Config {
     }
 }
 
+fn executable_sibling_path(file_name: &str) -> PathBuf {
+    std::env::current_exe()
+        .ok()
+        .and_then(|path| path.parent().map(|directory| directory.join(file_name)))
+        .unwrap_or_else(|| PathBuf::from(file_name))
+}
+
 /// Clear webview cache when the app version changes (prevents stale content after update)
 fn clear_cache_on_upgrade(app: &tauri::App) {
     let version = env!("CARGO_PKG_VERSION");
@@ -287,9 +261,49 @@ fn get_control_url(server: tauri::State<'_, String>) -> String {
     server.to_string()
 }
 
+#[cfg(target_os = "windows")]
 #[tauri::command]
-fn is_jam_source_host(role: tauri::State<'_, JamSourceHost>) -> bool {
-    role.is_active()
+fn is_jam_source_host(control: tauri::State<'_, jam_source::JamSourceLocalControl>) -> bool {
+    control.is_source_host()
+}
+
+#[cfg(not(target_os = "windows"))]
+#[tauri::command]
+fn is_jam_source_host() -> bool {
+    false
+}
+
+#[cfg(target_os = "windows")]
+#[tauri::command]
+fn get_jam_source_local_control(
+    control: tauri::State<'_, jam_source::JamSourceLocalControl>,
+) -> jam_source::JamSourceLocalControlSnapshot {
+    control.snapshot()
+}
+
+#[cfg(target_os = "windows")]
+#[tauri::command]
+fn set_jam_source_takeover_enabled(
+    enabled: bool,
+    control: tauri::State<'_, jam_source::JamSourceLocalControl>,
+) -> Result<jam_source::JamSourceLocalControlSnapshot, String> {
+    control.set_takeover_enabled(enabled)
+}
+
+#[cfg(target_os = "windows")]
+#[tauri::command]
+fn set_jam_source_monitor_enabled(
+    enabled: bool,
+    control: tauri::State<'_, jam_source::JamSourceLocalControl>,
+) -> Result<jam_source::JamSourceLocalControlSnapshot, String> {
+    control.set_monitor_enabled(enabled)
+}
+
+#[cfg(target_os = "windows")]
+async fn shutdown_jam_source_agent(app: &tauri::AppHandle) {
+    if let Some(agent) = app.try_state::<jam_source::JamSourceAgent>() {
+        agent.begin_shutdown().wait().await;
+    }
 }
 
 #[tauri::command]
@@ -311,6 +325,8 @@ async fn check_for_updates(app: tauri::AppHandle) -> Result<String, String> {
             match update.download_and_install(|_, _| {}, || {}).await {
                 Ok(_) => {
                     eprintln!("[updater] manual update installed, restarting...");
+                    #[cfg(target_os = "windows")]
+                    shutdown_jam_source_agent(&app).await;
                     app.restart();
                     #[allow(unreachable_code)]
                     Ok(format!("Updated to v{}", version))
@@ -706,8 +722,7 @@ fn main() {
 
     let builder = tauri::Builder::default()
         .plugin(tauri_plugin_updater::Builder::new().build())
-        .manage(server)
-        .manage(JamSourceHost::new());
+        .manage(server);
 
     // capture_health module is Windows-only (DXGI + WGC capture paths).
     // Gate the state management so macOS builds compile.
@@ -721,6 +736,12 @@ fn main() {
             get_app_info,
             get_control_url,
             is_jam_source_host,
+            #[cfg(target_os = "windows")]
+            get_jam_source_local_control,
+            #[cfg(target_os = "windows")]
+            set_jam_source_takeover_enabled,
+            #[cfg(target_os = "windows")]
+            set_jam_source_monitor_enabled,
             toggle_fullscreen,
             set_always_on_top,
             open_external_url,
@@ -827,21 +848,62 @@ fn main() {
             // deliberately independent of viewer login/panels and owns a
             // separate WASAPI handle from screen-share audio.
             #[cfg(target_os = "windows")]
-            if let Some(source_config) = jam_source_config.clone() {
-                let source_server = app.state::<String>().inner().clone();
-                match jam_source::JamSourceAgent::start(source_server, source_config) {
-                    Ok(agent) => {
-                        app.manage(agent);
-                        app.state::<JamSourceHost>().set_active(true);
-                        eprintln!("[jam-source] native source agent started");
-                        file_debug_log::append("[jam-source] native source agent started");
+            {
+                let source_data_dir = match app.path().app_data_dir() {
+                    Ok(directory) => directory,
+                    Err(app_data_error) => {
+                        let fallback = std::env::var_os("LOCALAPPDATA")
+                            .filter(|path| !path.is_empty())
+                            .map(PathBuf::from)
+                            .map(|directory| directory.join("Echo Chamber"));
+                        match fallback {
+                            Some(directory) => {
+                                eprintln!(
+                                    "[jam-source] app data directory unavailable ({}); using durable fallback '{}'",
+                                    app_data_error,
+                                    directory.display()
+                                );
+                                directory
+                            }
+                            None if jam_source_config.is_some() => {
+                                let error = format!(
+                                    "Configured Jam source cannot resolve a durable settings/journal directory: {}",
+                                    app_data_error
+                                );
+                                eprintln!("[jam-source] {}", error);
+                                file_debug_log::append(&format!("[jam-source] {}", error));
+                                return Err(std::io::Error::other(error).into());
+                            }
+                            None => PathBuf::new(),
+                        }
                     }
-                    Err(error) => {
-                        eprintln!("[jam-source] source agent disabled: {}", error);
-                        file_debug_log::append(&format!(
-                            "[jam-source] source agent disabled: {}",
-                            error
-                        ));
+                };
+                let source_settings_path = source_data_dir.join("jam-source-local.json");
+                let source_control = jam_source::JamSourceLocalControl::load(
+                    jam_source_config.as_ref(),
+                    source_settings_path,
+                );
+                app.manage(source_control.clone());
+
+                if let Some(source_config) = jam_source_config.clone() {
+                    let source_server = app.state::<String>().inner().clone();
+                    match jam_source::JamSourceAgent::start(
+                        source_server,
+                        source_config,
+                        source_control,
+                    ) {
+                        Ok(agent) => {
+                            app.manage(agent);
+                            eprintln!("[jam-source] native source agent started");
+                            file_debug_log::append("[jam-source] native source agent started");
+                        }
+                        Err(error) => {
+                            eprintln!("[jam-source] source agent disabled: {}", error);
+                            file_debug_log::append(&format!(
+                                "[jam-source] source agent disabled: {}",
+                                error
+                            ));
+                        }
                     }
                 }
             }
@@ -923,6 +985,8 @@ fn main() {
                         {
                             Ok(_) => {
                                 eprintln!("[updater] install complete, restarting...");
+                                #[cfg(target_os = "windows")]
+                                shutdown_jam_source_agent(&handle).await;
                                 handle.restart();
                             }
                             Err(e) => eprintln!("[updater] install failed: {}", e),
@@ -939,14 +1003,18 @@ fn main() {
         .expect("Error while building Echo Chamber")
         .run(|app, event| {
             #[cfg(target_os = "windows")]
-            if matches!(
-                event,
-                tauri::RunEvent::ExitRequested { .. } | tauri::RunEvent::Exit
-            ) {
+            if let tauri::RunEvent::ExitRequested { api, code, .. } = event {
                 if let Some(agent) = app.try_state::<jam_source::JamSourceAgent>() {
-                    agent.stop();
+                    if !agent.shutdown_complete() {
+                        api.prevent_exit();
+                        let shutdown = agent.begin_shutdown();
+                        let handle = app.clone();
+                        tauri::async_runtime::spawn(async move {
+                            shutdown.wait().await;
+                            handle.exit(code.unwrap_or(0));
+                        });
+                    }
                 }
-                app.state::<JamSourceHost>().set_active(false);
             }
         });
 }

--- a/core/client/src/spotify_output_route.rs
+++ b/core/client/src/spotify_output_route.rs
@@ -1,0 +1,2434 @@
+//! Spotify-only Windows audio output routing for the Jam source host.
+//!
+//! Windows exposes its per-application output preference through the internal
+//! `Windows.Media.Internal.AudioPolicyConfig` WinRT factory. This module keeps
+//! that undocumented surface isolated on a dedicated MTA thread and wraps it in
+//! a transactional lease:
+//!
+//! 1. Resolve one exact, active render endpoint by friendly name.
+//! 2. Snapshot Spotify's role-specific persisted routes.
+//! 3. Durably journal the snapshot before changing either role.
+//! 4. Set and verify only Spotify's console and multimedia routes.
+//! 5. Restore only values that still point at Echo's target (compare-and-swap).
+//!
+//! It never changes the Windows system default endpoint.
+//! A forced process termination cannot run RAII cleanup; in that case the
+//! durable journal is recovered by `recover_startup` on the next Echo launch.
+
+use serde::{Deserialize, Serialize};
+use std::ffi::c_void;
+use std::fs::{self, OpenOptions};
+use std::io::{ErrorKind, Write};
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{mpsc, Arc, Mutex};
+use std::thread::{self, JoinHandle};
+use std::time::{Duration, Instant};
+
+use windows::core::{Interface, GUID, HRESULT, HSTRING, PROPVARIANT, PWSTR};
+use windows::Win32::Foundation::{
+    CloseHandle, ERROR_INSUFFICIENT_BUFFER, ERROR_SUCCESS, FILETIME, HANDLE, WAIT_ABANDONED,
+    WAIT_FAILED, WAIT_OBJECT_0, WAIT_TIMEOUT, WIN32_ERROR,
+};
+use windows::Win32::Media::Audio::{
+    eConsole, eMultimedia, eRender, ERole, IMMDevice, IMMDeviceEnumerator, MMDeviceEnumerator,
+    DEVICE_STATE_ACTIVE,
+};
+use windows::Win32::Storage::Packaging::Appx::{GetApplicationUserModelId, GetPackageFamilyName};
+use windows::Win32::System::Com::{CoCreateInstance, CoTaskMemFree, CLSCTX_ALL};
+use windows::Win32::System::RemoteDesktop::ProcessIdToSessionId;
+use windows::Win32::System::Threading::{
+    CreateMutexW, GetProcessTimes, OpenProcess, QueryFullProcessImageNameW, ReleaseMutex,
+    WaitForSingleObject, PROCESS_NAME_WIN32, PROCESS_QUERY_LIMITED_INFORMATION,
+};
+use windows::Win32::System::WinRT::{
+    RoGetActivationFactory, RoInitialize, RoUninitialize, RO_INIT_MULTITHREADED,
+};
+
+pub const DEFAULT_SPOTIFY_ROUTE_TARGET: &str = "CABLE Input (VB-Audio Virtual Cable)";
+
+const JOURNAL_VERSION: u32 = 2;
+const AUDIO_POLICY_RUNTIME_CLASS: &str = "Windows.Media.Internal.AudioPolicyConfig";
+const SPOTIFY_STORE_PACKAGE_PREFIX: &str = "SpotifyAB.SpotifyMusic_";
+const SPOTIFY_STORE_APP_SUFFIX: &str = "!Spotify";
+const HRESULT_FROM_ERROR_NOT_FOUND: HRESULT = HRESULT(0x8007_0490_u32 as i32);
+const DEAD_OWNER_RECOVERY_GRACE: Duration = Duration::from_secs(36);
+const ROUTE_TRANSACTION_MUTEX_NAME: &str = r"Local\EchoChamber.SpotifyOutputRoute.Transaction.v1";
+const ROUTE_TRANSACTION_MUTEX_WAIT: Duration = Duration::from_secs(5);
+const MMDEVAPI_INTERFACE_PREFIX: &str = r"\\?\SWD#MMDEVAPI#";
+const AUDIO_RENDER_INTERFACE_SUFFIX: &str = "#{e6327cad-dcec-4949-ae8a-991e976a79d2}";
+
+static TEMP_FILE_SEQUENCE: AtomicU64 = AtomicU64::new(1);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum PersistedEndpointGetResult {
+    Value,
+    NoOverride,
+}
+
+fn classify_persisted_endpoint_get_result(
+    result: HRESULT,
+) -> windows_core::Result<PersistedEndpointGetResult> {
+    if result == HRESULT_FROM_ERROR_NOT_FOUND {
+        Ok(PersistedEndpointGetResult::NoOverride)
+    } else {
+        result.ok()?;
+        Ok(PersistedEndpointGetResult::Value)
+    }
+}
+
+/// A successfully and uniquely resolved active render endpoint.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TargetEndpoint {
+    /// The raw MMDevice endpoint ID returned by `IMMDevice::GetId`.
+    pub id: String,
+    pub name: String,
+}
+
+/// The two application roles Echo changes for Spotify.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum RouteRole {
+    Console,
+    Multimedia,
+}
+
+impl RouteRole {
+    const ALL: [Self; 2] = [Self::Console, Self::Multimedia];
+
+    fn windows_role(self) -> ERole {
+        match self {
+            Self::Console => eConsole,
+            Self::Multimedia => eMultimedia,
+        }
+    }
+}
+
+/// What a compare-and-swap restoration did for each role.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct RestoreReport {
+    /// Roles restored to their exact pre-Echo value.
+    pub restored_roles: Vec<RouteRole>,
+    /// Roles whose recorded endpoint was unavailable and were safely cleared
+    /// to follow the Windows default instead of remaining trapped on CABLE.
+    pub cleared_to_default_roles: Vec<RouteRole>,
+    /// Roles left alone because another actor changed them after Echo took over.
+    pub skipped_changed_roles: Vec<RouteRole>,
+}
+
+/// Result of checking for a route journal left by an earlier Echo process.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum StartupRecoveryOutcome {
+    NoJournal,
+    /// Another Echo process still owns the journal, so recovery did not touch it.
+    OwnerStillRunning {
+        owner_pid: u32,
+    },
+    /// The exact journal owner was first observed dead less than the pause
+    /// safety window ago. The route and journal remain untouched for retry.
+    Deferred {
+        owner_pid: u32,
+        retry_after: Duration,
+    },
+    /// Spotify is not currently running. The journal remains for a later retry.
+    SpotifyNotRunning {
+        previous_pid: u32,
+    },
+    Restored(RestoreReport),
+}
+
+/// Read-only details about an active route lease.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SpotifyRouteInfo {
+    pub spotify_pid: u32,
+    pub target: TargetEndpoint,
+}
+
+/// Synchronous handle to the dedicated audio-policy MTA worker.
+///
+/// Cloning this handle is cheap. The final handle drop synchronously asks the
+/// worker to restore any active lease and then joins the worker thread.
+#[derive(Clone)]
+pub struct SpotifyOutputRouter {
+    inner: Arc<RouterInner>,
+}
+
+impl SpotifyOutputRouter {
+    /// Start the dedicated MTA worker.
+    ///
+    /// `journal_path` must be a local path owned by Echo (normally under the
+    /// Tauri app-data directory). A pre-existing journal is never overwritten.
+    pub fn new(journal_path: impl Into<PathBuf>) -> Result<Self, String> {
+        let journal_path = journal_path.into();
+        let (command_tx, command_rx) = mpsc::channel();
+        let (ready_tx, ready_rx) = mpsc::sync_channel(1);
+
+        let worker = thread::Builder::new()
+            .name("echo-spotify-audio-policy".to_string())
+            .spawn(move || worker_main(journal_path, command_rx, ready_tx))
+            .map_err(|error| format!("Cannot start Spotify audio-policy worker: {error}"))?;
+
+        match ready_rx.recv() {
+            Ok(Ok(())) => Ok(Self {
+                inner: Arc::new(RouterInner {
+                    command_tx,
+                    worker: Mutex::new(Some(worker)),
+                }),
+            }),
+            Ok(Err(error)) => {
+                let _ = worker.join();
+                Err(error)
+            }
+            Err(error) => {
+                let _ = worker.join();
+                Err(format!(
+                    "Spotify audio-policy worker exited during startup: {error}"
+                ))
+            }
+        }
+    }
+
+    /// Resolve `target_name` using an exact, case-sensitive friendly-name
+    /// match among active render endpoints. Zero or multiple matches are errors.
+    pub fn validate_target(
+        &self,
+        target_name: impl Into<String>,
+    ) -> Result<TargetEndpoint, String> {
+        let (reply_tx, reply_rx) = mpsc::sync_channel(1);
+        self.send(WorkerCommand::ValidateTarget {
+            target_name: target_name.into(),
+            reply: reply_tx,
+        })?;
+        recv_reply(reply_rx)
+    }
+
+    /// Recover a durable journal left by a dead Echo process.
+    ///
+    /// Pass the currently selected Spotify root PID when available. If it is
+    /// `None`, recovery uses the journaled PID only when that process still
+    /// exists. A live previous Echo owner always blocks recovery.
+    pub fn recover_startup(
+        &self,
+        current_spotify_root_pid: Option<u32>,
+    ) -> Result<StartupRecoveryOutcome, String> {
+        validate_optional_pid(current_spotify_root_pid)?;
+        let (reply_tx, reply_rx) = mpsc::sync_channel(1);
+        self.send(WorkerCommand::RecoverStartup {
+            current_spotify_root_pid,
+            reply: reply_tx,
+        })?;
+        recv_reply(reply_rx)
+    }
+
+    /// Route one Spotify root process to one exact active render endpoint.
+    ///
+    /// The returned lease owns restoration. Keep it alive across capture-only
+    /// restarts; restore or drop it only when the Jam route should end.
+    pub fn acquire(
+        &self,
+        spotify_root_pid: u32,
+        target_name: impl Into<String>,
+    ) -> Result<SpotifyOutputRouteLease, String> {
+        validate_pid(spotify_root_pid)?;
+        let (reply_tx, reply_rx) = mpsc::sync_channel(1);
+        self.send(WorkerCommand::Acquire {
+            spotify_root_pid,
+            target_name: target_name.into(),
+            reply: reply_tx,
+        })?;
+        let active = recv_reply(reply_rx)?;
+        Ok(SpotifyOutputRouteLease {
+            router: self.clone(),
+            lease_id: active.lease_id,
+            info: active.info,
+            active: true,
+        })
+    }
+
+    /// Synchronously restore whichever lease is active on this worker.
+    ///
+    /// `current_spotify_root_pid` supports Spotify process replacement. With
+    /// `None`, the journaled PID must still be running.
+    pub fn restore_active(
+        &self,
+        current_spotify_root_pid: Option<u32>,
+    ) -> Result<RestoreReport, String> {
+        validate_optional_pid(current_spotify_root_pid)?;
+        let (reply_tx, reply_rx) = mpsc::sync_channel(1);
+        self.send(WorkerCommand::RestoreActive {
+            current_spotify_root_pid,
+            reply: reply_tx,
+        })?;
+        recv_reply(reply_rx)
+    }
+
+    fn restore_lease(
+        &self,
+        lease_id: u64,
+        current_spotify_root_pid: Option<u32>,
+    ) -> Result<RestoreReport, String> {
+        validate_optional_pid(current_spotify_root_pid)?;
+        let (reply_tx, reply_rx) = mpsc::sync_channel(1);
+        self.send(WorkerCommand::RestoreLease {
+            lease_id,
+            current_spotify_root_pid,
+            reply: reply_tx,
+        })?;
+        recv_reply(reply_rx)
+    }
+
+    fn send(&self, command: WorkerCommand) -> Result<(), String> {
+        self.inner
+            .command_tx
+            .send(command)
+            .map_err(|_| "Spotify audio-policy worker is not running".to_string())
+    }
+}
+
+/// RAII ownership of Spotify's temporary per-application route.
+///
+/// A lease is intentionally not cloneable. `Drop` performs a synchronous,
+/// best-effort restoration through the MTA worker.
+pub struct SpotifyOutputRouteLease {
+    router: SpotifyOutputRouter,
+    lease_id: u64,
+    info: SpotifyRouteInfo,
+    active: bool,
+}
+
+impl SpotifyOutputRouteLease {
+    pub fn info(&self) -> &SpotifyRouteInfo {
+        &self.info
+    }
+
+    /// Restore using the originally routed Spotify PID.
+    pub fn restore(&mut self) -> Result<RestoreReport, String> {
+        self.restore_with_spotify_pid(None)
+    }
+
+    /// Restore using a newly selected live Spotify root PID.
+    pub fn restore_for_spotify_pid(
+        &mut self,
+        spotify_root_pid: u32,
+    ) -> Result<RestoreReport, String> {
+        validate_pid(spotify_root_pid)?;
+        self.restore_with_spotify_pid(Some(spotify_root_pid))
+    }
+
+    fn restore_with_spotify_pid(
+        &mut self,
+        spotify_root_pid: Option<u32>,
+    ) -> Result<RestoreReport, String> {
+        if !self.active {
+            return Ok(RestoreReport::default());
+        }
+        let report = self.router.restore_lease(self.lease_id, spotify_root_pid)?;
+        self.active = false;
+        Ok(report)
+    }
+}
+
+impl Drop for SpotifyOutputRouteLease {
+    fn drop(&mut self) {
+        if !self.active {
+            return;
+        }
+        match self.router.restore_lease(self.lease_id, None) {
+            Ok(_) => self.active = false,
+            Err(error) => {
+                eprintln!("[spotify-route] lease drop could not restore Spotify output: {error}")
+            }
+        }
+    }
+}
+
+struct RouterInner {
+    command_tx: mpsc::Sender<WorkerCommand>,
+    worker: Mutex<Option<JoinHandle<()>>>,
+}
+
+impl Drop for RouterInner {
+    fn drop(&mut self) {
+        let (reply_tx, reply_rx) = mpsc::sync_channel(1);
+        if self
+            .command_tx
+            .send(WorkerCommand::Shutdown { reply: reply_tx })
+            .is_ok()
+        {
+            if let Ok(Err(error)) = reply_rx.recv() {
+                eprintln!(
+                    "[spotify-route] worker shutdown could not restore Spotify output: {error}"
+                );
+            }
+        }
+
+        let worker = self.worker.get_mut().ok().and_then(Option::take);
+        if let Some(worker) = worker {
+            if worker.join().is_err() {
+                eprintln!("[spotify-route] audio-policy worker panicked");
+            }
+        }
+    }
+}
+
+fn validate_pid(pid: u32) -> Result<(), String> {
+    if pid == 0 {
+        Err("Spotify root PID cannot be zero".to_string())
+    } else {
+        Ok(())
+    }
+}
+
+fn validate_optional_pid(pid: Option<u32>) -> Result<(), String> {
+    match pid {
+        Some(pid) => validate_pid(pid),
+        None => Ok(()),
+    }
+}
+
+fn recv_reply<T>(receiver: mpsc::Receiver<Result<T, String>>) -> Result<T, String> {
+    receiver
+        .recv()
+        .map_err(|_| "Spotify audio-policy worker stopped before replying".to_string())?
+}
+
+enum WorkerCommand {
+    ValidateTarget {
+        target_name: String,
+        reply: mpsc::SyncSender<Result<TargetEndpoint, String>>,
+    },
+    RecoverStartup {
+        current_spotify_root_pid: Option<u32>,
+        reply: mpsc::SyncSender<Result<StartupRecoveryOutcome, String>>,
+    },
+    Acquire {
+        spotify_root_pid: u32,
+        target_name: String,
+        reply: mpsc::SyncSender<Result<ActiveRoute, String>>,
+    },
+    RestoreLease {
+        lease_id: u64,
+        current_spotify_root_pid: Option<u32>,
+        reply: mpsc::SyncSender<Result<RestoreReport, String>>,
+    },
+    RestoreActive {
+        current_spotify_root_pid: Option<u32>,
+        reply: mpsc::SyncSender<Result<RestoreReport, String>>,
+    },
+    Shutdown {
+        reply: mpsc::SyncSender<Result<(), String>>,
+    },
+}
+
+#[derive(Clone, Debug)]
+struct ActiveRoute {
+    lease_id: u64,
+    info: SpotifyRouteInfo,
+}
+
+fn worker_main(
+    journal_path: PathBuf,
+    command_rx: mpsc::Receiver<WorkerCommand>,
+    ready_tx: mpsc::SyncSender<Result<(), String>>,
+) {
+    if let Err(error) = unsafe { RoInitialize(RO_INIT_MULTITHREADED) } {
+        let _ = ready_tx.send(Err(format!(
+            "RoInitialize(RO_INIT_MULTITHREADED) failed: {error}"
+        )));
+        return;
+    }
+
+    let backend = match WindowsAudioPolicyBackend::new() {
+        Ok(backend) => backend,
+        Err(error) => {
+            let _ = ready_tx.send(Err(error));
+            unsafe { RoUninitialize() };
+            return;
+        }
+    };
+
+    let transaction_mutex = match RouteTransactionMutex::new() {
+        Ok(transaction_mutex) => transaction_mutex,
+        Err(error) => {
+            let _ = ready_tx.send(Err(error));
+            drop(backend);
+            unsafe { RoUninitialize() };
+            return;
+        }
+    };
+
+    let journal = FileJournalStore::new(journal_path);
+    let mut engine = RouteEngine::new(backend, journal);
+    let mut active: Option<ActiveRoute> = None;
+    let mut next_lease_id = 1_u64;
+
+    if ready_tx.send(Ok(())).is_err() {
+        drop(engine);
+        unsafe { RoUninitialize() };
+        return;
+    }
+
+    while let Ok(command) = command_rx.recv() {
+        match command {
+            WorkerCommand::ValidateTarget { target_name, reply } => {
+                let _ = reply.send(engine.validate_target(&target_name));
+            }
+            WorkerCommand::RecoverStartup {
+                current_spotify_root_pid,
+                reply,
+            } => {
+                let result = transaction_mutex.run(|| {
+                    if active.is_some() {
+                        Err("Cannot run startup recovery while a route lease is active".to_string())
+                    } else {
+                        engine.recover_startup(current_spotify_root_pid)
+                    }
+                });
+                let _ = reply.send(result);
+            }
+            WorkerCommand::Acquire {
+                spotify_root_pid,
+                target_name,
+                reply,
+            } => {
+                let result = transaction_mutex.run(|| {
+                    if active.is_some() {
+                        Err("A Spotify output route lease is already active".to_string())
+                    } else {
+                        engine
+                            .acquire(std::process::id(), spotify_root_pid, &target_name)
+                            .map(|info| {
+                                let route = ActiveRoute {
+                                    lease_id: next_lease_id,
+                                    info,
+                                };
+                                next_lease_id = next_lease_id.wrapping_add(1).max(1);
+                                active = Some(route.clone());
+                                route
+                            })
+                    }
+                });
+                let _ = reply.send(result);
+            }
+            WorkerCommand::RestoreLease {
+                lease_id,
+                current_spotify_root_pid,
+                reply,
+            } => {
+                let result = transaction_mutex.run(|| match active.as_ref() {
+                    Some(route) if route.lease_id == lease_id => {
+                        engine.restore_active(current_spotify_root_pid)
+                    }
+                    Some(_) => Err("Spotify output route lease is stale".to_string()),
+                    None => Ok(RestoreReport::default()),
+                });
+                if result.is_ok() && active.as_ref().map(|route| route.lease_id) == Some(lease_id) {
+                    active = None;
+                }
+                let _ = reply.send(result);
+            }
+            WorkerCommand::RestoreActive {
+                current_spotify_root_pid,
+                reply,
+            } => {
+                let result = transaction_mutex.run(|| {
+                    if active.is_some() {
+                        engine.restore_active(current_spotify_root_pid)
+                    } else {
+                        Ok(RestoreReport::default())
+                    }
+                });
+                if result.is_ok() {
+                    active = None;
+                }
+                let _ = reply.send(result);
+            }
+            WorkerCommand::Shutdown { reply } => {
+                let result = transaction_mutex.run(|| {
+                    if active.is_some() {
+                        engine.restore_active(None).map(|_| ())
+                    } else {
+                        Ok(())
+                    }
+                });
+                // Shutdown has made its one synchronous restoration attempt.
+                // A failure keeps the durable journal for startup recovery.
+                active = None;
+                let _ = reply.send(result);
+                break;
+            }
+        }
+    }
+
+    // A disconnected command channel must still make a best-effort restoration.
+    if active.is_some() {
+        if let Err(error) = transaction_mutex.run(|| engine.restore_active(None).map(|_| ())) {
+            eprintln!("[spotify-route] worker exit could not restore Spotify output: {error}");
+        }
+    }
+
+    drop(engine);
+    unsafe { RoUninitialize() };
+}
+
+/// Cross-process serialization for the complete journal + audio-policy
+/// transaction. Journal publication alone cannot protect against a stale
+/// recovery deleting or undoing a newer takeover that reused the same target.
+struct RouteTransactionMutex {
+    handle: HANDLE,
+}
+
+impl RouteTransactionMutex {
+    fn new() -> Result<Self, String> {
+        Self::open_named(ROUTE_TRANSACTION_MUTEX_NAME)
+    }
+
+    fn open_named(name: &str) -> Result<Self, String> {
+        let name = HSTRING::from(name);
+        let handle = unsafe { CreateMutexW(None, false, &name) }
+            .map_err(|error| format!("Cannot open Spotify route transaction mutex: {error}"))?;
+        Ok(Self { handle })
+    }
+
+    fn run<T>(&self, operation: impl FnOnce() -> Result<T, String>) -> Result<T, String> {
+        let _guard = self.lock_for(ROUTE_TRANSACTION_MUTEX_WAIT)?;
+        operation()
+    }
+
+    fn lock_for(&self, timeout: Duration) -> Result<RouteTransactionGuard<'_>, String> {
+        let timeout_ms = timeout.as_millis().min(u32::MAX as u128) as u32;
+        let wait = unsafe { WaitForSingleObject(self.handle, timeout_ms) };
+        if wait == WAIT_OBJECT_0 || wait == WAIT_ABANDONED {
+            Ok(RouteTransactionGuard { mutex: self })
+        } else if wait == WAIT_TIMEOUT {
+            Err(format!(
+                "Timed out after {}ms waiting for another Echo process to finish a Spotify route transaction",
+                timeout.as_millis()
+            ))
+        } else if wait == WAIT_FAILED {
+            Err(format!(
+                "Cannot wait for Spotify route transaction mutex: {}",
+                std::io::Error::last_os_error()
+            ))
+        } else {
+            Err(format!(
+                "Spotify route transaction mutex returned unexpected wait status {}",
+                wait.0
+            ))
+        }
+    }
+}
+
+impl Drop for RouteTransactionMutex {
+    fn drop(&mut self) {
+        if let Err(error) = unsafe { CloseHandle(self.handle) } {
+            eprintln!("[spotify-route] cannot close route transaction mutex: {error}");
+        }
+    }
+}
+
+struct RouteTransactionGuard<'a> {
+    mutex: &'a RouteTransactionMutex,
+}
+
+impl Drop for RouteTransactionGuard<'_> {
+    fn drop(&mut self) {
+        if let Err(error) = unsafe { ReleaseMutex(self.mutex.handle) } {
+            eprintln!("[spotify-route] cannot release route transaction mutex: {error}");
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+struct RouteJournal {
+    version: u32,
+    owner_pid: u32,
+    owner_started_at: u64,
+    spotify_pid: u32,
+    spotify_identity: SpotifyProcessIdentity,
+    target: JournalTarget,
+    previous: RoleRoutes,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+struct SpotifyProcessIdentity {
+    package_family: String,
+    application_user_model_id: String,
+    /// Diagnostic metadata for the session that created the journal. A later
+    /// Echo launch still independently requires Spotify to share its current
+    /// interactive session, but this historical value is not a stable app ID.
+    session_id: u32,
+}
+
+impl SpotifyProcessIdentity {
+    fn same_store_application_as(&self, other: &Self) -> bool {
+        self.package_family
+            .eq_ignore_ascii_case(&other.package_family)
+            && self
+                .application_user_model_id
+                .eq_ignore_ascii_case(&other.application_user_model_id)
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+struct JournalTarget {
+    endpoint_id: String,
+    endpoint_name: String,
+    policy_device_id: String,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+struct RoleRoutes {
+    console: Option<String>,
+    multimedia: Option<String>,
+}
+
+impl RoleRoutes {
+    fn get(&self, role: RouteRole) -> &Option<String> {
+        match role {
+            RouteRole::Console => &self.console,
+            RouteRole::Multimedia => &self.multimedia,
+        }
+    }
+}
+
+trait AudioPolicyBackend {
+    fn find_unique_active_render_endpoint(
+        &mut self,
+        target_name: &str,
+    ) -> Result<TargetEndpoint, String>;
+
+    fn get_persisted_route(
+        &mut self,
+        spotify_pid: u32,
+        role: RouteRole,
+    ) -> Result<Option<String>, String>;
+
+    fn set_persisted_route(
+        &mut self,
+        spotify_pid: u32,
+        role: RouteRole,
+        policy_device_id: Option<&str>,
+    ) -> Result<(), String>;
+
+    /// Returns the process creation timestamp, or `None` when the PID is not
+    /// running. The timestamp fences PID reuse during crash recovery.
+    fn process_started_at(&mut self, pid: u32) -> Result<Option<u64>, String>;
+
+    /// Validate that `pid` is the same-session Microsoft Store Spotify app and
+    /// return the stable package identity used to fence replacement PIDs.
+    fn spotify_process_identity(
+        &mut self,
+        pid: u32,
+    ) -> Result<Option<SpotifyProcessIdentity>, String>;
+}
+
+trait JournalStore {
+    fn load(&self) -> Result<Option<RouteJournal>, String>;
+    fn create(&mut self, journal: &RouteJournal) -> Result<(), String>;
+    fn remove(&mut self) -> Result<(), String>;
+}
+
+struct RouteEngine<B, J> {
+    backend: B,
+    journal: J,
+    pending_dead_owner: Option<DeadOwnerObservation>,
+}
+
+struct DeadOwnerObservation {
+    owner_pid: u32,
+    owner_started_at: u64,
+    first_observed_dead: Instant,
+}
+
+impl<B: AudioPolicyBackend, J: JournalStore> RouteEngine<B, J> {
+    fn new(backend: B, journal: J) -> Self {
+        Self {
+            backend,
+            journal,
+            pending_dead_owner: None,
+        }
+    }
+
+    fn validate_target(&mut self, target_name: &str) -> Result<TargetEndpoint, String> {
+        if target_name.is_empty() {
+            return Err("Spotify output target name cannot be empty".to_string());
+        }
+        self.backend.find_unique_active_render_endpoint(target_name)
+    }
+
+    fn acquire(
+        &mut self,
+        owner_pid: u32,
+        spotify_pid: u32,
+        target_name: &str,
+    ) -> Result<SpotifyRouteInfo, String> {
+        if self.journal.load()?.is_some() {
+            return Err(
+                "A Spotify route recovery journal already exists; recover it before acquiring a new route"
+                    .to_string(),
+            );
+        }
+        let owner_started_at = self
+            .backend
+            .process_started_at(owner_pid)?
+            .ok_or_else(|| format!("Echo owner PID {owner_pid} is not running"))?;
+        let spotify_identity = self
+            .backend
+            .spotify_process_identity(spotify_pid)?
+            .ok_or_else(|| format!("Spotify root PID {spotify_pid} is not running"))?;
+
+        let target = self.validate_target(target_name)?;
+        let policy_device_id = pack_render_policy_device_id(&target.id);
+        let previous = RoleRoutes {
+            console: self
+                .backend
+                .get_persisted_route(spotify_pid, RouteRole::Console)?,
+            multimedia: self
+                .backend
+                .get_persisted_route(spotify_pid, RouteRole::Multimedia)?,
+        };
+        let journal = RouteJournal {
+            version: JOURNAL_VERSION,
+            owner_pid,
+            owner_started_at,
+            spotify_pid,
+            spotify_identity,
+            target: JournalTarget {
+                endpoint_id: target.id.clone(),
+                endpoint_name: target.name.clone(),
+                policy_device_id: policy_device_id.clone(),
+            },
+            previous,
+        };
+
+        // This durable write must complete before the first policy mutation.
+        self.journal.create(&journal)?;
+
+        for role in RouteRole::ALL {
+            let apply_result = self
+                .ensure_spotify_identity(spotify_pid, &journal.spotify_identity)
+                .and_then(|_| {
+                    self.backend
+                        .set_persisted_route(spotify_pid, role, Some(&policy_device_id))
+                })
+                .and_then(|_| {
+                    let actual = self.backend.get_persisted_route(spotify_pid, role)?;
+                    if route_value_eq(&actual, &Some(policy_device_id.clone())) {
+                        Ok(())
+                    } else {
+                        Err(format!(
+                            "Spotify {role:?} route verification failed: expected {policy_device_id:?}, got {actual:?}"
+                        ))
+                    }
+                });
+
+            if let Err(apply_error) = apply_result {
+                let rollback_result = self.restore_journal(&journal, spotify_pid);
+                return match rollback_result {
+                    Ok(_) => Err(format!(
+                        "Could not apply Spotify {role:?} route: {apply_error}; partial changes were rolled back"
+                    )),
+                    Err(rollback_error) => Err(format!(
+                        "Could not apply Spotify {role:?} route: {apply_error}; rollback also failed: {rollback_error}"
+                    )),
+                };
+            }
+        }
+
+        Ok(SpotifyRouteInfo {
+            spotify_pid,
+            target,
+        })
+    }
+
+    fn recover_startup(
+        &mut self,
+        current_spotify_root_pid: Option<u32>,
+    ) -> Result<StartupRecoveryOutcome, String> {
+        let journal = match self.load_valid_journal() {
+            Ok(Some(journal)) => journal,
+            Ok(None) => {
+                self.pending_dead_owner = None;
+                return Ok(StartupRecoveryOutcome::NoJournal);
+            }
+            Err(error) => {
+                // An unreadable or invalid journal breaks the continuity of
+                // the dead-owner observation. Start a fresh safety window
+                // after the journal can be validated again.
+                self.pending_dead_owner = None;
+                return Err(error);
+            }
+        };
+
+        let owner_started_at = match self.backend.process_started_at(journal.owner_pid) {
+            Ok(owner_started_at) => owner_started_at,
+            Err(error) => {
+                // Unknown is not dead. A failed liveness probe must not count
+                // toward the continuously-dead recovery grace.
+                self.pending_dead_owner = None;
+                return Err(error);
+            }
+        };
+        if owner_started_at == Some(journal.owner_started_at) {
+            self.pending_dead_owner = None;
+            return Ok(StartupRecoveryOutcome::OwnerStillRunning {
+                owner_pid: journal.owner_pid,
+            });
+        }
+
+        let now = Instant::now();
+        let elapsed = match self.pending_dead_owner.as_ref() {
+            Some(pending)
+                if pending.owner_pid == journal.owner_pid
+                    && pending.owner_started_at == journal.owner_started_at =>
+            {
+                now.saturating_duration_since(pending.first_observed_dead)
+            }
+            _ => {
+                self.pending_dead_owner = Some(DeadOwnerObservation {
+                    owner_pid: journal.owner_pid,
+                    owner_started_at: journal.owner_started_at,
+                    first_observed_dead: now,
+                });
+                Duration::ZERO
+            }
+        };
+        if elapsed < DEAD_OWNER_RECOVERY_GRACE {
+            return Ok(StartupRecoveryOutcome::Deferred {
+                owner_pid: journal.owner_pid,
+                retry_after: DEAD_OWNER_RECOVERY_GRACE.saturating_sub(elapsed),
+            });
+        }
+
+        let Some(spotify_pid) = self.select_restore_pid(&journal, current_spotify_root_pid)? else {
+            return Ok(StartupRecoveryOutcome::SpotifyNotRunning {
+                previous_pid: journal.spotify_pid,
+            });
+        };
+
+        let report = self.restore_journal(&journal, spotify_pid)?;
+        self.pending_dead_owner = None;
+        Ok(StartupRecoveryOutcome::Restored(report))
+    }
+
+    fn restore_active(
+        &mut self,
+        current_spotify_root_pid: Option<u32>,
+    ) -> Result<RestoreReport, String> {
+        let journal = self.load_valid_journal()?.ok_or_else(|| {
+            "Active Spotify route has no recovery journal; refusing an unsafe restoration"
+                .to_string()
+        })?;
+        let spotify_pid = self
+            .select_restore_pid(&journal, current_spotify_root_pid)?
+            .ok_or_else(|| {
+                format!(
+                    "Spotify is not running; retained route journal for PID {}",
+                    journal.spotify_pid
+                )
+            })?;
+        self.restore_journal(&journal, spotify_pid)
+    }
+
+    fn select_restore_pid(
+        &mut self,
+        journal: &RouteJournal,
+        current_spotify_root_pid: Option<u32>,
+    ) -> Result<Option<u32>, String> {
+        let pid = current_spotify_root_pid.unwrap_or(journal.spotify_pid);
+        let Some(identity) = self.backend.spotify_process_identity(pid)? else {
+            return if current_spotify_root_pid.is_some() {
+                Err(format!("Current Spotify root PID {pid} is not running"))
+            } else {
+                Ok(None)
+            };
+        };
+        if !identity.same_store_application_as(&journal.spotify_identity) {
+            return Err(format!(
+                "PID {pid} is not the Store Spotify application recorded in Echo's route journal"
+            ));
+        }
+        Ok(Some(pid))
+    }
+
+    fn restore_journal(
+        &mut self,
+        journal: &RouteJournal,
+        spotify_pid: u32,
+    ) -> Result<RestoreReport, String> {
+        self.ensure_spotify_identity(spotify_pid, &journal.spotify_identity)?;
+        let mut report = RestoreReport::default();
+        let mut failures = Vec::new();
+        let target = Some(journal.target.policy_device_id.clone());
+
+        for role in RouteRole::ALL {
+            if let Err(error) = self.ensure_spotify_identity(spotify_pid, &journal.spotify_identity)
+            {
+                failures.push(format!("validate Spotify before {role:?}: {error}"));
+                continue;
+            }
+            let current = match self.backend.get_persisted_route(spotify_pid, role) {
+                Ok(current) => current,
+                Err(error) => {
+                    failures.push(format!("read {role:?}: {error}"));
+                    continue;
+                }
+            };
+
+            if !route_value_eq(&current, &target) {
+                report.skipped_changed_roles.push(role);
+                continue;
+            }
+
+            let previous = journal.previous.get(role);
+            let exact_restore = self
+                .backend
+                .set_persisted_route(spotify_pid, role, previous.as_deref())
+                .and_then(|_| {
+                    let actual = self.backend.get_persisted_route(spotify_pid, role)?;
+                    if route_value_eq(&actual, previous) {
+                        Ok(())
+                    } else {
+                        Err(format!("expected {previous:?}, got {actual:?}"))
+                    }
+                });
+
+            match exact_restore {
+                Ok(()) => report.restored_roles.push(role),
+                Err(exact_error) => {
+                    // A disconnected pre-Jam endpoint can reject restoration.
+                    // The safe degraded state is "follow Windows default", not
+                    // leaving Spotify silently pinned to Echo's CABLE target.
+                    let clear_result = self
+                        .backend
+                        .set_persisted_route(spotify_pid, role, None)
+                        .and_then(|_| {
+                            let actual = self.backend.get_persisted_route(spotify_pid, role)?;
+                            if actual.is_none() {
+                                Ok(())
+                            } else {
+                                Err(format!("expected None, got {actual:?}"))
+                            }
+                        });
+                    match clear_result {
+                        Ok(()) => report.cleared_to_default_roles.push(role),
+                        Err(clear_error) => failures.push(format!(
+                            "restore {role:?}: {exact_error}; clear-to-default fallback failed: {clear_error}"
+                        )),
+                    }
+                }
+            }
+        }
+
+        if failures.is_empty() {
+            self.journal.remove()?;
+            Ok(report)
+        } else {
+            Err(format!(
+                "Spotify output restoration incomplete (journal retained): {}",
+                failures.join("; ")
+            ))
+        }
+    }
+
+    fn ensure_spotify_identity(
+        &mut self,
+        pid: u32,
+        expected: &SpotifyProcessIdentity,
+    ) -> Result<(), String> {
+        let current = self
+            .backend
+            .spotify_process_identity(pid)?
+            .ok_or_else(|| format!("Spotify PID {pid} is no longer running"))?;
+        if current.same_store_application_as(expected) {
+            Ok(())
+        } else {
+            Err(format!(
+                "PID {pid} no longer identifies the Store Spotify app recorded in the route journal"
+            ))
+        }
+    }
+
+    fn load_valid_journal(&self) -> Result<Option<RouteJournal>, String> {
+        let Some(journal) = self.journal.load()? else {
+            return Ok(None);
+        };
+        if journal.version != JOURNAL_VERSION {
+            return Err(format!(
+                "Unsupported Spotify route journal version {} (expected {})",
+                journal.version, JOURNAL_VERSION
+            ));
+        }
+        if journal.owner_pid == 0 || journal.owner_started_at == 0 || journal.spotify_pid == 0 {
+            return Err(
+                "Spotify route journal contains an invalid owner/process identity".to_string(),
+            );
+        }
+        if journal.spotify_identity.package_family.is_empty()
+            || journal
+                .spotify_identity
+                .application_user_model_id
+                .is_empty()
+        {
+            return Err("Spotify route journal has an empty app identity".to_string());
+        }
+        let expected_aumid = format!(
+            "{}{}",
+            journal.spotify_identity.package_family, SPOTIFY_STORE_APP_SUFFIX
+        );
+        if !journal
+            .spotify_identity
+            .package_family
+            .get(..SPOTIFY_STORE_PACKAGE_PREFIX.len())
+            .map(|prefix| prefix.eq_ignore_ascii_case(SPOTIFY_STORE_PACKAGE_PREFIX))
+            .unwrap_or(false)
+            || !journal
+                .spotify_identity
+                .application_user_model_id
+                .eq_ignore_ascii_case(&expected_aumid)
+        {
+            return Err("Spotify route journal has an unexpected Store app identity".to_string());
+        }
+        let expected_policy_id = pack_render_policy_device_id(&journal.target.endpoint_id);
+        if journal.target.endpoint_id.is_empty()
+            || journal.target.endpoint_name.is_empty()
+            || !journal
+                .target
+                .policy_device_id
+                .eq_ignore_ascii_case(&expected_policy_id)
+        {
+            return Err("Spotify route journal has an invalid policy endpoint ID".to_string());
+        }
+        Ok(Some(journal))
+    }
+}
+
+fn route_value_eq(left: &Option<String>, right: &Option<String>) -> bool {
+    match (left, right) {
+        (None, None) => true,
+        (Some(left), Some(right)) => left.eq_ignore_ascii_case(right),
+        _ => false,
+    }
+}
+
+fn pack_render_policy_device_id(endpoint_id: &str) -> String {
+    format!("{MMDEVAPI_INTERFACE_PREFIX}{endpoint_id}{AUDIO_RENDER_INTERFACE_SUFFIX}")
+}
+
+struct FileJournalStore {
+    path: PathBuf,
+}
+
+impl FileJournalStore {
+    fn new(path: PathBuf) -> Self {
+        Self { path }
+    }
+
+    fn temporary_path(&self) -> Result<PathBuf, String> {
+        let file_name = self
+            .path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .ok_or_else(|| "Spotify route journal path has no valid file name".to_string())?;
+        let sequence = TEMP_FILE_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+        Ok(self.path.with_file_name(format!(
+            ".{file_name}.tmp-{}-{sequence}",
+            std::process::id()
+        )))
+    }
+}
+
+impl JournalStore for FileJournalStore {
+    fn load(&self) -> Result<Option<RouteJournal>, String> {
+        let bytes = match fs::read(&self.path) {
+            Ok(bytes) => bytes,
+            Err(error) if error.kind() == ErrorKind::NotFound => return Ok(None),
+            Err(error) => {
+                return Err(format!(
+                    "Cannot read Spotify route journal {}: {error}",
+                    self.path.display()
+                ))
+            }
+        };
+        serde_json::from_slice(&bytes).map(Some).map_err(|error| {
+            format!(
+                "Cannot parse Spotify route journal {}: {error}",
+                self.path.display()
+            )
+        })
+    }
+
+    fn create(&mut self, journal: &RouteJournal) -> Result<(), String> {
+        if self.path.exists() {
+            return Err(format!(
+                "Spotify route journal already exists at {}",
+                self.path.display()
+            ));
+        }
+        if let Some(parent) = self
+            .path
+            .parent()
+            .filter(|parent| !parent.as_os_str().is_empty())
+        {
+            fs::create_dir_all(parent).map_err(|error| {
+                format!(
+                    "Cannot create Spotify route journal directory {}: {error}",
+                    parent.display()
+                )
+            })?;
+        }
+
+        let bytes = serde_json::to_vec_pretty(journal)
+            .map_err(|error| format!("Cannot serialize Spotify route journal: {error}"))?;
+        let temporary_path = self.temporary_path()?;
+        let write_result = (|| {
+            let mut file = OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(&temporary_path)
+                .map_err(|error| {
+                    format!(
+                        "Cannot create temporary Spotify route journal {}: {error}",
+                        temporary_path.display()
+                    )
+                })?;
+            file.write_all(&bytes).map_err(|error| {
+                format!(
+                    "Cannot write temporary Spotify route journal {}: {error}",
+                    temporary_path.display()
+                )
+            })?;
+            file.sync_all().map_err(|error| {
+                format!(
+                    "Cannot flush temporary Spotify route journal {}: {error}",
+                    temporary_path.display()
+                )
+            })?;
+            drop(file);
+
+            // Publishing a hard link is atomic and fails when the destination
+            // already exists. Unlike `rename`, it cannot clobber a journal won
+            // concurrently by another Echo process. Both paths are on the same
+            // app-data volume by construction.
+            fs::hard_link(&temporary_path, &self.path).map_err(|error| {
+                format!(
+                    "Cannot exclusively publish Spotify route journal {}: {error}",
+                    self.path.display()
+                )
+            })?;
+            Ok(())
+        })();
+
+        // After a successful hard-link publication the temporary path is just
+        // a second name for the already-synced journal contents.
+        let _ = fs::remove_file(&temporary_path);
+        write_result
+    }
+
+    fn remove(&mut self) -> Result<(), String> {
+        match fs::remove_file(&self.path) {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(format!(
+                "Cannot remove Spotify route journal {}: {error}",
+                self.path.display()
+            )),
+        }
+    }
+}
+
+// The two interface variants have an identical IInspectable vtable and differ
+// only by IID. This is a call-only definition: Echo never implements it.
+#[repr(C)]
+pub struct AudioPolicyConfigFactoryVtable {
+    base: windows_core::IInspectable_Vtbl,
+    incomplete_01: unsafe extern "system" fn(*mut c_void) -> HRESULT,
+    incomplete_02: unsafe extern "system" fn(*mut c_void) -> HRESULT,
+    incomplete_03: unsafe extern "system" fn(*mut c_void) -> HRESULT,
+    incomplete_04: unsafe extern "system" fn(*mut c_void) -> HRESULT,
+    incomplete_05: unsafe extern "system" fn(*mut c_void) -> HRESULT,
+    incomplete_06: unsafe extern "system" fn(*mut c_void) -> HRESULT,
+    incomplete_07: unsafe extern "system" fn(*mut c_void) -> HRESULT,
+    incomplete_08: unsafe extern "system" fn(*mut c_void) -> HRESULT,
+    incomplete_09: unsafe extern "system" fn(*mut c_void) -> HRESULT,
+    incomplete_10: unsafe extern "system" fn(*mut c_void) -> HRESULT,
+    incomplete_11: unsafe extern "system" fn(*mut c_void) -> HRESULT,
+    incomplete_12: unsafe extern "system" fn(*mut c_void) -> HRESULT,
+    incomplete_13: unsafe extern "system" fn(*mut c_void) -> HRESULT,
+    incomplete_14: unsafe extern "system" fn(*mut c_void) -> HRESULT,
+    incomplete_15: unsafe extern "system" fn(*mut c_void) -> HRESULT,
+    incomplete_16: unsafe extern "system" fn(*mut c_void) -> HRESULT,
+    incomplete_17: unsafe extern "system" fn(*mut c_void) -> HRESULT,
+    incomplete_18: unsafe extern "system" fn(*mut c_void) -> HRESULT,
+    incomplete_19: unsafe extern "system" fn(*mut c_void) -> HRESULT,
+    set_persisted_default_audio_endpoint:
+        unsafe extern "system" fn(*mut c_void, u32, i32, i32, *mut c_void) -> HRESULT,
+    get_persisted_default_audio_endpoint:
+        unsafe extern "system" fn(*mut c_void, u32, i32, i32, *mut *mut c_void) -> HRESULT,
+    clear_all_persisted_application_default_endpoints:
+        unsafe extern "system" fn(*mut c_void) -> HRESULT,
+}
+
+windows_core::imp::define_interface!(
+    IAudioPolicyConfigFactory21H2,
+    AudioPolicyConfigFactoryVtable,
+    0xab3d4648_e242_459f_b02f_541c70306324
+);
+windows_core::imp::define_interface!(
+    IAudioPolicyConfigFactoryDownlevel,
+    AudioPolicyConfigFactoryVtable,
+    0x2a59116d_6c4f_45e0_a74f_707e3fef9258
+);
+
+macro_rules! impl_audio_policy_calls {
+    ($name:ident) => {
+        impl $name {
+            unsafe fn set_persisted_default_audio_endpoint(
+                &self,
+                process_id: u32,
+                flow: i32,
+                role: i32,
+                device_id: *mut c_void,
+            ) -> HRESULT {
+                (Interface::vtable(self).set_persisted_default_audio_endpoint)(
+                    Interface::as_raw(self),
+                    process_id,
+                    flow,
+                    role,
+                    device_id,
+                )
+            }
+
+            unsafe fn get_persisted_default_audio_endpoint(
+                &self,
+                process_id: u32,
+                flow: i32,
+                role: i32,
+                device_id: *mut *mut c_void,
+            ) -> HRESULT {
+                (Interface::vtable(self).get_persisted_default_audio_endpoint)(
+                    Interface::as_raw(self),
+                    process_id,
+                    flow,
+                    role,
+                    device_id,
+                )
+            }
+        }
+    };
+}
+
+impl_audio_policy_calls!(IAudioPolicyConfigFactory21H2);
+impl_audio_policy_calls!(IAudioPolicyConfigFactoryDownlevel);
+
+enum AudioPolicyFactory {
+    Windows11(IAudioPolicyConfigFactory21H2),
+    Downlevel(IAudioPolicyConfigFactoryDownlevel),
+}
+
+impl AudioPolicyFactory {
+    fn activate() -> Result<Self, String> {
+        let class_name = HSTRING::from(AUDIO_POLICY_RUNTIME_CLASS);
+        let windows_11 =
+            unsafe { RoGetActivationFactory::<IAudioPolicyConfigFactory21H2>(&class_name) };
+        match windows_11 {
+            Ok(factory) => Ok(Self::Windows11(factory)),
+            Err(windows_11_error) => unsafe {
+                RoGetActivationFactory::<IAudioPolicyConfigFactoryDownlevel>(&class_name)
+                    .map(Self::Downlevel)
+                    .map_err(|downlevel_error| {
+                        format!(
+                            "Cannot activate {AUDIO_POLICY_RUNTIME_CLASS}: Windows 11 interface failed ({windows_11_error}); downlevel fallback failed ({downlevel_error})"
+                        )
+                    })
+            },
+        }
+    }
+
+    fn set(&self, process_id: u32, role: ERole, device_id: Option<&str>) -> Result<(), String> {
+        let hstring = device_id.map(HSTRING::from);
+        let raw_hstring = hstring
+            .as_ref()
+            .map(|value| unsafe { std::mem::transmute_copy::<HSTRING, *mut c_void>(value) })
+            .unwrap_or(std::ptr::null_mut());
+        let result = unsafe {
+            match self {
+                Self::Windows11(factory) => factory.set_persisted_default_audio_endpoint(
+                    process_id,
+                    eRender.0,
+                    role.0,
+                    raw_hstring,
+                ),
+                Self::Downlevel(factory) => factory.set_persisted_default_audio_endpoint(
+                    process_id,
+                    eRender.0,
+                    role.0,
+                    raw_hstring,
+                ),
+            }
+        };
+        result.ok().map_err(|error| {
+            format!(
+                "SetPersistedDefaultAudioEndpoint(pid={process_id}, role={}) failed: {error}",
+                role.0
+            )
+        })
+    }
+
+    fn get(&self, process_id: u32, role: ERole) -> Result<Option<String>, String> {
+        let mut raw_hstring: *mut c_void = std::ptr::null_mut();
+        let result = unsafe {
+            match self {
+                Self::Windows11(factory) => factory.get_persisted_default_audio_endpoint(
+                    process_id,
+                    eRender.0,
+                    role.0,
+                    &mut raw_hstring,
+                ),
+                Self::Downlevel(factory) => factory.get_persisted_default_audio_endpoint(
+                    process_id,
+                    eRender.0,
+                    role.0,
+                    &mut raw_hstring,
+                ),
+            }
+        };
+        match classify_persisted_endpoint_get_result(result).map_err(|error| {
+            format!(
+                "GetPersistedDefaultAudioEndpoint(pid={process_id}, role={}) failed: {error}",
+                role.0
+            )
+        })? {
+            PersistedEndpointGetResult::NoOverride => return Ok(None),
+            PersistedEndpointGetResult::Value => {}
+        }
+
+        if raw_hstring.is_null() {
+            return Ok(None);
+        }
+        let value = unsafe { std::mem::transmute::<*mut c_void, HSTRING>(raw_hstring) };
+        if value.is_empty() {
+            Ok(None)
+        } else {
+            Ok(Some(value.to_string_lossy()))
+        }
+    }
+}
+
+struct WindowsAudioPolicyBackend {
+    factory: AudioPolicyFactory,
+}
+
+impl WindowsAudioPolicyBackend {
+    fn new() -> Result<Self, String> {
+        AudioPolicyFactory::activate().map(|factory| Self { factory })
+    }
+}
+
+impl AudioPolicyBackend for WindowsAudioPolicyBackend {
+    fn find_unique_active_render_endpoint(
+        &mut self,
+        target_name: &str,
+    ) -> Result<TargetEndpoint, String> {
+        enumerate_active_render_endpoints().and_then(|endpoints| {
+            let matches = endpoints
+                .iter()
+                .filter(|endpoint| endpoint.name == target_name)
+                .cloned()
+                .collect::<Vec<_>>();
+            match matches.as_slice() {
+                [endpoint] => Ok(endpoint.clone()),
+                [] => {
+                    let available = endpoints
+                        .iter()
+                        .map(|endpoint| endpoint.name.as_str())
+                        .collect::<Vec<_>>()
+                        .join(", ");
+                    Err(format!(
+                        "No active render endpoint exactly named {target_name:?}; active endpoints: [{available}]"
+                    ))
+                }
+                _ => Err(format!(
+                    "Multiple active render endpoints are exactly named {target_name:?}; refusing an ambiguous Spotify route"
+                )),
+            }
+        })
+    }
+
+    fn get_persisted_route(
+        &mut self,
+        spotify_pid: u32,
+        role: RouteRole,
+    ) -> Result<Option<String>, String> {
+        self.factory.get(spotify_pid, role.windows_role())
+    }
+
+    fn set_persisted_route(
+        &mut self,
+        spotify_pid: u32,
+        role: RouteRole,
+        policy_device_id: Option<&str>,
+    ) -> Result<(), String> {
+        self.factory
+            .set(spotify_pid, role.windows_role(), policy_device_id)
+    }
+
+    fn process_started_at(&mut self, pid: u32) -> Result<Option<u64>, String> {
+        let Some(process) = open_process_for_identity(pid)? else {
+            return Ok(None);
+        };
+        process_started_at(&process).map(Some)
+    }
+
+    fn spotify_process_identity(
+        &mut self,
+        pid: u32,
+    ) -> Result<Option<SpotifyProcessIdentity>, String> {
+        read_store_spotify_identity(pid)
+    }
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct PropertyKey {
+    fmtid: GUID,
+    pid: u32,
+}
+
+const PKEY_DEVICE_FRIENDLY_NAME: PropertyKey = PropertyKey {
+    fmtid: GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0),
+    pid: 14,
+};
+
+fn enumerate_active_render_endpoints() -> Result<Vec<TargetEndpoint>, String> {
+    unsafe {
+        let enumerator: IMMDeviceEnumerator =
+            CoCreateInstance(&MMDeviceEnumerator, None, CLSCTX_ALL)
+                .map_err(|error| format!("CoCreateInstance(MMDeviceEnumerator) failed: {error}"))?;
+        let collection = enumerator
+            .EnumAudioEndpoints(eRender, DEVICE_STATE_ACTIVE)
+            .map_err(|error| format!("EnumAudioEndpoints(eRender) failed: {error}"))?;
+        let count = collection
+            .GetCount()
+            .map_err(|error| format!("Audio endpoint GetCount failed: {error}"))?;
+        let mut endpoints = Vec::with_capacity(count as usize);
+
+        for index in 0..count {
+            let device = collection
+                .Item(index)
+                .map_err(|error| format!("Audio endpoint Item({index}) failed: {error}"))?;
+            let id_pointer = device
+                .GetId()
+                .map_err(|error| format!("Audio endpoint GetId({index}) failed: {error}"))?;
+            let id = id_pointer
+                .to_string()
+                .map_err(|error| format!("Audio endpoint ID {index} is invalid UTF-16: {error}"))?;
+            CoTaskMemFree(Some(id_pointer.0.cast()));
+            let name = get_device_friendly_name(&device).map_err(|error| {
+                format!("Cannot read friendly name for audio endpoint {id:?}: {error}")
+            })?;
+            endpoints.push(TargetEndpoint { id, name });
+        }
+
+        Ok(endpoints)
+    }
+}
+
+fn get_device_friendly_name(device: &IMMDevice) -> Result<String, String> {
+    unsafe {
+        let device_pointer = Interface::as_raw(device);
+        let device_vtable = *(device_pointer as *const *const usize);
+        let open_property_store: unsafe extern "system" fn(
+            *mut c_void,
+            i32,
+            *mut *mut c_void,
+        ) -> HRESULT = std::mem::transmute(*(device_vtable.add(4)));
+
+        let mut property_store: *mut c_void = std::ptr::null_mut();
+        let result = open_property_store(device_pointer, 0, &mut property_store);
+        result
+            .ok()
+            .map_err(|error| format!("IMMDevice::OpenPropertyStore failed: {error}"))?;
+        if property_store.is_null() {
+            return Err("IMMDevice::OpenPropertyStore returned a null store".to_string());
+        }
+
+        let store_vtable = *(property_store as *const *const usize);
+        let get_value: unsafe extern "system" fn(
+            *mut c_void,
+            *const PropertyKey,
+            *mut PROPVARIANT,
+        ) -> HRESULT = std::mem::transmute(*(store_vtable.add(5)));
+        let release: unsafe extern "system" fn(*mut c_void) -> u32 =
+            std::mem::transmute(*(store_vtable.add(2)));
+
+        let mut value = PROPVARIANT::new();
+        let result = get_value(property_store, &PKEY_DEVICE_FRIENDLY_NAME, &mut value);
+        release(property_store);
+        result
+            .ok()
+            .map_err(|error| format!("IPropertyStore::GetValue failed: {error}"))?;
+
+        let name = value.to_string();
+        if name.is_empty() {
+            Err("PKEY_Device_FriendlyName was empty".to_string())
+        } else {
+            Ok(name)
+        }
+    }
+}
+
+struct OwnedProcessHandle(HANDLE);
+
+impl Drop for OwnedProcessHandle {
+    fn drop(&mut self) {
+        unsafe {
+            let _ = CloseHandle(self.0);
+        }
+    }
+}
+
+fn open_process_for_identity(pid: u32) -> Result<Option<OwnedProcessHandle>, String> {
+    if pid == 0 {
+        return Ok(None);
+    }
+    unsafe {
+        match OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, pid) {
+            Ok(handle) => Ok(Some(OwnedProcessHandle(handle))),
+            Err(error) => {
+                // OpenProcess reports ERROR_INVALID_PARAMETER for a PID that
+                // no longer exists. Every other error is ambiguous (notably
+                // access denied) and must fail closed.
+                const HRESULT_FROM_ERROR_INVALID_PARAMETER: HRESULT =
+                    HRESULT(0x8007_0057_u32 as i32);
+                if error.code() == HRESULT_FROM_ERROR_INVALID_PARAMETER {
+                    Ok(None)
+                } else {
+                    Err(format!(
+                        "Cannot open process PID {pid} for identity validation: {error}"
+                    ))
+                }
+            }
+        }
+    }
+}
+
+fn process_started_at(process: &OwnedProcessHandle) -> Result<u64, String> {
+    unsafe {
+        let mut created = FILETIME::default();
+        let mut exited = FILETIME::default();
+        let mut kernel = FILETIME::default();
+        let mut user = FILETIME::default();
+        GetProcessTimes(process.0, &mut created, &mut exited, &mut kernel, &mut user)
+            .map_err(|error| format!("GetProcessTimes failed: {error}"))?;
+        Ok(((created.dwHighDateTime as u64) << 32) | created.dwLowDateTime as u64)
+    }
+}
+
+fn read_store_spotify_identity(pid: u32) -> Result<Option<SpotifyProcessIdentity>, String> {
+    let Some(process) = open_process_for_identity(pid)? else {
+        return Ok(None);
+    };
+
+    let executable_name = process_executable_name(&process)?;
+    if !executable_name.eq_ignore_ascii_case("Spotify.exe") {
+        return Err(format!(
+            "PID {pid} is {executable_name:?}, not Spotify.exe; refusing per-app routing"
+        ));
+    }
+
+    let package_family = read_app_model_string(
+        |length, buffer| unsafe { GetPackageFamilyName(process.0, length, buffer) },
+        "GetPackageFamilyName",
+    )?;
+    if !package_family
+        .get(..SPOTIFY_STORE_PACKAGE_PREFIX.len())
+        .map(|prefix| prefix.eq_ignore_ascii_case(SPOTIFY_STORE_PACKAGE_PREFIX))
+        .unwrap_or(false)
+    {
+        return Err(format!(
+            "PID {pid} has unexpected package family {package_family:?}; expected Microsoft Store Spotify"
+        ));
+    }
+
+    let application_user_model_id = read_app_model_string(
+        |length, buffer| unsafe { GetApplicationUserModelId(process.0, length, buffer) },
+        "GetApplicationUserModelId",
+    )?;
+    let expected_aumid = format!("{package_family}{SPOTIFY_STORE_APP_SUFFIX}");
+    if !application_user_model_id.eq_ignore_ascii_case(&expected_aumid) {
+        return Err(format!(
+            "PID {pid} has unexpected Spotify application ID {application_user_model_id:?}"
+        ));
+    }
+
+    let current_session = process_session_id(std::process::id())?;
+    let spotify_session = process_session_id(pid)?;
+    if current_session != spotify_session {
+        return Err(format!(
+            "Spotify PID {pid} is in Windows session {spotify_session}, but Echo is in session {current_session}"
+        ));
+    }
+
+    Ok(Some(SpotifyProcessIdentity {
+        package_family,
+        application_user_model_id,
+        session_id: spotify_session,
+    }))
+}
+
+fn process_executable_name(process: &OwnedProcessHandle) -> Result<String, String> {
+    let mut buffer = vec![0_u16; 32_768];
+    let mut length = buffer.len() as u32;
+    unsafe {
+        QueryFullProcessImageNameW(
+            process.0,
+            PROCESS_NAME_WIN32,
+            PWSTR(buffer.as_mut_ptr()),
+            &mut length,
+        )
+        .map_err(|error| format!("QueryFullProcessImageNameW failed: {error}"))?;
+    }
+    let path = String::from_utf16_lossy(&buffer[..length as usize]);
+    path.rsplit(['\\', '/'])
+        .next()
+        .filter(|name| !name.is_empty())
+        .map(ToOwned::to_owned)
+        .ok_or_else(|| format!("Process executable path {path:?} has no file name"))
+}
+
+fn read_app_model_string(
+    mut call: impl FnMut(*mut u32, PWSTR) -> WIN32_ERROR,
+    operation: &str,
+) -> Result<String, String> {
+    let mut length = 0_u32;
+    let size_result = call(&mut length, PWSTR::null());
+    if size_result != ERROR_INSUFFICIENT_BUFFER || length == 0 {
+        return Err(format!(
+            "{operation} size query failed with Win32 error {}",
+            size_result.0
+        ));
+    }
+
+    let mut buffer = vec![0_u16; length as usize];
+    let result = call(&mut length, PWSTR(buffer.as_mut_ptr()));
+    if result != ERROR_SUCCESS {
+        return Err(format!("{operation} failed with Win32 error {}", result.0));
+    }
+    let string_length = buffer
+        .iter()
+        .position(|character| *character == 0)
+        .unwrap_or(length as usize);
+    let value = String::from_utf16(&buffer[..string_length])
+        .map_err(|error| format!("{operation} returned invalid UTF-16: {error}"))?;
+    if value.is_empty() {
+        Err(format!("{operation} returned an empty identity"))
+    } else {
+        Ok(value)
+    }
+}
+
+fn process_session_id(pid: u32) -> Result<u32, String> {
+    let mut session_id = 0_u32;
+    unsafe {
+        ProcessIdToSessionId(pid, &mut session_id)
+            .map_err(|error| format!("Cannot determine Windows session for PID {pid}: {error}"))?;
+    }
+    Ok(session_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::{HashMap, HashSet};
+    use std::sync::{Arc, Mutex};
+
+    const PID: u32 = 4242;
+    const OWNER_PID: u32 = 9001;
+    const OWNER_STARTED_AT: u64 = 100;
+    const SPOTIFY_STARTED_AT: u64 = 200;
+    const TARGET_NAME: &str = DEFAULT_SPOTIFY_ROUTE_TARGET;
+    const TARGET_ID: &str = "{0.0.0.00000000}.{CABLE}";
+    const OLD_CONSOLE: &str = "old-console";
+    const OLD_MULTIMEDIA: &str = "old-multimedia";
+
+    #[test]
+    fn persisted_endpoint_not_found_means_no_per_app_override() {
+        assert_eq!(
+            classify_persisted_endpoint_get_result(HRESULT_FROM_ERROR_NOT_FOUND).unwrap(),
+            PersistedEndpointGetResult::NoOverride
+        );
+        assert_eq!(
+            classify_persisted_endpoint_get_result(HRESULT(0)).unwrap(),
+            PersistedEndpointGetResult::Value
+        );
+        assert!(classify_persisted_endpoint_get_result(HRESULT(0x8000_4005_u32 as i32)).is_err());
+    }
+
+    #[test]
+    fn route_transaction_mutex_serializes_independent_threads() {
+        let sequence = TEMP_FILE_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+        let name = format!(
+            r"Local\EchoChamber.SpotifyOutputRoute.Test.{}.{sequence}",
+            std::process::id()
+        );
+        let first = RouteTransactionMutex::open_named(&name).unwrap();
+        let held = first.lock_for(Duration::from_secs(1)).unwrap();
+
+        let competing_name = name.clone();
+        let error = std::thread::spawn(move || {
+            let competing = RouteTransactionMutex::open_named(&competing_name).unwrap();
+            competing
+                .lock_for(Duration::from_millis(25))
+                .err()
+                .expect("a second thread must not enter the held transaction")
+        })
+        .join()
+        .unwrap();
+        assert!(error.contains("Timed out"));
+
+        drop(held);
+        let after_release = RouteTransactionMutex::open_named(&name).unwrap();
+        let _guard = after_release.lock_for(Duration::from_secs(1)).unwrap();
+    }
+
+    #[test]
+    fn recorded_session_is_audit_only_for_the_same_store_application() {
+        let expected = spotify_identity();
+        let mut other_session = expected.clone();
+        other_session.session_id += 1;
+        let mut other_package = expected.clone();
+        other_package.package_family = "Different.Package_family".to_string();
+        let mut other_aumid = expected.clone();
+        other_aumid.application_user_model_id = "Different.Package_family!Different".to_string();
+
+        assert!(expected.same_store_application_as(&expected));
+        assert!(expected.same_store_application_as(&other_session));
+        assert!(!expected.same_store_application_as(&other_package));
+        assert!(!expected.same_store_application_as(&other_aumid));
+    }
+
+    #[derive(Clone, Debug, PartialEq, Eq)]
+    enum Event {
+        JournalCreated,
+        Set(RouteRole, Option<String>),
+        JournalRemoved,
+    }
+
+    #[derive(Default)]
+    struct FakeBackend {
+        endpoints: Vec<TargetEndpoint>,
+        routes: HashMap<(u32, RouteRole), Option<String>>,
+        process_starts: HashMap<u32, u64>,
+        spotify_identities: HashMap<u32, SpotifyProcessIdentity>,
+        fail_set_role: Option<RouteRole>,
+        fail_set_values: HashSet<(RouteRole, Option<String>)>,
+        fail_process_start_once: bool,
+        events: Arc<Mutex<Vec<Event>>>,
+    }
+
+    impl FakeBackend {
+        fn with_target() -> Self {
+            Self {
+                endpoints: vec![TargetEndpoint {
+                    id: TARGET_ID.to_string(),
+                    name: TARGET_NAME.to_string(),
+                }],
+                process_starts: HashMap::from([
+                    (OWNER_PID, OWNER_STARTED_AT),
+                    (PID, SPOTIFY_STARTED_AT),
+                ]),
+                spotify_identities: HashMap::from([(PID, spotify_identity())]),
+                ..Default::default()
+            }
+        }
+
+        fn route(&self, pid: u32, role: RouteRole) -> Option<String> {
+            self.routes.get(&(pid, role)).cloned().flatten()
+        }
+    }
+
+    impl AudioPolicyBackend for FakeBackend {
+        fn find_unique_active_render_endpoint(
+            &mut self,
+            target_name: &str,
+        ) -> Result<TargetEndpoint, String> {
+            let matches = self
+                .endpoints
+                .iter()
+                .filter(|endpoint| endpoint.name == target_name)
+                .cloned()
+                .collect::<Vec<_>>();
+            match matches.as_slice() {
+                [endpoint] => Ok(endpoint.clone()),
+                [] => Err("missing target".to_string()),
+                _ => Err("ambiguous target".to_string()),
+            }
+        }
+
+        fn get_persisted_route(
+            &mut self,
+            spotify_pid: u32,
+            role: RouteRole,
+        ) -> Result<Option<String>, String> {
+            Ok(self.routes.get(&(spotify_pid, role)).cloned().flatten())
+        }
+
+        fn set_persisted_route(
+            &mut self,
+            spotify_pid: u32,
+            role: RouteRole,
+            policy_device_id: Option<&str>,
+        ) -> Result<(), String> {
+            self.events
+                .lock()
+                .unwrap()
+                .push(Event::Set(role, policy_device_id.map(ToOwned::to_owned)));
+            if self.fail_set_role == Some(role) {
+                self.fail_set_role = None;
+                return Err("injected set failure".to_string());
+            }
+            let requested = policy_device_id.map(ToOwned::to_owned);
+            if self.fail_set_values.remove(&(role, requested.clone())) {
+                return Err("injected value-specific set failure".to_string());
+            }
+            self.routes.insert((spotify_pid, role), requested);
+            Ok(())
+        }
+
+        fn process_started_at(&mut self, pid: u32) -> Result<Option<u64>, String> {
+            if self.fail_process_start_once {
+                self.fail_process_start_once = false;
+                return Err("injected process liveness failure".to_string());
+            }
+            Ok(self.process_starts.get(&pid).copied())
+        }
+
+        fn spotify_process_identity(
+            &mut self,
+            pid: u32,
+        ) -> Result<Option<SpotifyProcessIdentity>, String> {
+            if !self.process_starts.contains_key(&pid) {
+                return Ok(None);
+            }
+            Ok(self.spotify_identities.get(&pid).cloned())
+        }
+    }
+
+    fn spotify_identity() -> SpotifyProcessIdentity {
+        SpotifyProcessIdentity {
+            package_family: "SpotifyAB.SpotifyMusic_zpdnekdrzrea0".to_string(),
+            application_user_model_id: "SpotifyAB.SpotifyMusic_zpdnekdrzrea0!Spotify".to_string(),
+            session_id: 1,
+        }
+    }
+
+    #[derive(Default)]
+    struct MemoryJournal {
+        value: Option<RouteJournal>,
+        events: Arc<Mutex<Vec<Event>>>,
+    }
+
+    impl JournalStore for MemoryJournal {
+        fn load(&self) -> Result<Option<RouteJournal>, String> {
+            Ok(self.value.clone())
+        }
+
+        fn create(&mut self, journal: &RouteJournal) -> Result<(), String> {
+            if self.value.is_some() {
+                return Err("journal exists".to_string());
+            }
+            self.events.lock().unwrap().push(Event::JournalCreated);
+            self.value = Some(journal.clone());
+            Ok(())
+        }
+
+        fn remove(&mut self) -> Result<(), String> {
+            self.events.lock().unwrap().push(Event::JournalRemoved);
+            self.value = None;
+            Ok(())
+        }
+    }
+
+    fn engine_with_routes(
+        console: Option<&str>,
+        multimedia: Option<&str>,
+    ) -> RouteEngine<FakeBackend, MemoryJournal> {
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let mut backend = FakeBackend::with_target();
+        backend.events = events.clone();
+        backend
+            .routes
+            .insert((PID, RouteRole::Console), console.map(ToOwned::to_owned));
+        backend.routes.insert(
+            (PID, RouteRole::Multimedia),
+            multimedia.map(ToOwned::to_owned),
+        );
+        let journal = MemoryJournal {
+            value: None,
+            events,
+        };
+        RouteEngine::new(backend, journal)
+    }
+
+    fn observe_dead_owner_and_age_grace(
+        engine: &mut RouteEngine<FakeBackend, MemoryJournal>,
+        current_spotify_pid: Option<u32>,
+    ) {
+        let outcome = engine
+            .recover_startup(current_spotify_pid)
+            .expect("first dead-owner observation should defer");
+        assert!(matches!(
+            outcome,
+            StartupRecoveryOutcome::Deferred {
+                owner_pid: OWNER_PID,
+                ..
+            }
+        ));
+        engine
+            .pending_dead_owner
+            .as_mut()
+            .expect("deferred recovery should record the owner")
+            .first_observed_dead = Instant::now() - DEAD_OWNER_RECOVERY_GRACE;
+    }
+
+    #[test]
+    fn target_resolution_fails_closed_for_missing_or_ambiguous_name() {
+        let mut missing = RouteEngine::new(FakeBackend::default(), MemoryJournal::default());
+        assert_eq!(
+            missing.validate_target(TARGET_NAME).unwrap_err(),
+            "missing target"
+        );
+
+        let endpoint = TargetEndpoint {
+            id: TARGET_ID.to_string(),
+            name: TARGET_NAME.to_string(),
+        };
+        let ambiguous_backend = FakeBackend {
+            endpoints: vec![endpoint.clone(), endpoint],
+            ..Default::default()
+        };
+        let mut ambiguous = RouteEngine::new(ambiguous_backend, MemoryJournal::default());
+        assert_eq!(
+            ambiguous.validate_target(TARGET_NAME).unwrap_err(),
+            "ambiguous target"
+        );
+    }
+
+    #[test]
+    fn acquire_journals_before_mutation_and_routes_both_roles() {
+        let mut engine = engine_with_routes(Some(OLD_CONSOLE), Some(OLD_MULTIMEDIA));
+        let info = engine
+            .acquire(OWNER_PID, PID, TARGET_NAME)
+            .expect("route should apply");
+        let target = pack_render_policy_device_id(TARGET_ID);
+
+        assert_eq!(info.spotify_pid, PID);
+        assert_eq!(
+            engine.backend.route(PID, RouteRole::Console),
+            Some(target.clone())
+        );
+        assert_eq!(
+            engine.backend.route(PID, RouteRole::Multimedia),
+            Some(target.clone())
+        );
+        let events = engine.backend.events.lock().unwrap().clone();
+        assert_eq!(events.first(), Some(&Event::JournalCreated));
+        assert_eq!(
+            engine.journal.value.as_ref().unwrap().previous,
+            RoleRoutes {
+                console: Some(OLD_CONSOLE.to_string()),
+                multimedia: Some(OLD_MULTIMEDIA.to_string()),
+            }
+        );
+    }
+
+    #[test]
+    fn partial_apply_failure_rolls_back_and_removes_journal() {
+        let mut engine = engine_with_routes(Some(OLD_CONSOLE), Some(OLD_MULTIMEDIA));
+        engine.backend.fail_set_role = Some(RouteRole::Multimedia);
+
+        let error = engine
+            .acquire(OWNER_PID, PID, TARGET_NAME)
+            .expect_err("second role should fail");
+
+        assert!(error.contains("partial changes were rolled back"));
+        assert_eq!(
+            engine.backend.route(PID, RouteRole::Console),
+            Some(OLD_CONSOLE.to_string())
+        );
+        assert_eq!(
+            engine.backend.route(PID, RouteRole::Multimedia),
+            Some(OLD_MULTIMEDIA.to_string())
+        );
+        assert!(engine.journal.value.is_none());
+    }
+
+    #[test]
+    fn restore_preserves_none_and_role_specific_previous_values() {
+        let mut engine = engine_with_routes(None, Some(OLD_MULTIMEDIA));
+        engine
+            .acquire(OWNER_PID, PID, TARGET_NAME)
+            .expect("route should apply");
+
+        let report = engine.restore_active(None).expect("route should restore");
+
+        assert_eq!(
+            report.restored_roles,
+            vec![RouteRole::Console, RouteRole::Multimedia]
+        );
+        assert_eq!(engine.backend.route(PID, RouteRole::Console), None);
+        assert_eq!(
+            engine.backend.route(PID, RouteRole::Multimedia),
+            Some(OLD_MULTIMEDIA.to_string())
+        );
+        assert!(engine.journal.value.is_none());
+    }
+
+    #[test]
+    fn restore_is_compare_and_swap_and_does_not_overwrite_user_change() {
+        let mut engine = engine_with_routes(Some(OLD_CONSOLE), Some(OLD_MULTIMEDIA));
+        engine
+            .acquire(OWNER_PID, PID, TARGET_NAME)
+            .expect("route should apply");
+        engine.backend.routes.insert(
+            (PID, RouteRole::Console),
+            Some("user-selected-route".to_string()),
+        );
+
+        let report = engine.restore_active(None).expect("route should restore");
+
+        assert_eq!(report.restored_roles, vec![RouteRole::Multimedia]);
+        assert_eq!(report.skipped_changed_roles, vec![RouteRole::Console]);
+        assert_eq!(
+            engine.backend.route(PID, RouteRole::Console),
+            Some("user-selected-route".to_string())
+        );
+        assert_eq!(
+            engine.backend.route(PID, RouteRole::Multimedia),
+            Some(OLD_MULTIMEDIA.to_string())
+        );
+    }
+
+    #[test]
+    fn unavailable_previous_endpoint_clears_to_default_instead_of_leaving_cable() {
+        let mut engine = engine_with_routes(Some(OLD_CONSOLE), Some(OLD_MULTIMEDIA));
+        engine
+            .acquire(OWNER_PID, PID, TARGET_NAME)
+            .expect("route should apply");
+        engine
+            .backend
+            .fail_set_values
+            .insert((RouteRole::Console, Some(OLD_CONSOLE.to_string())));
+
+        let report = engine
+            .restore_active(None)
+            .expect("fallback should restore");
+
+        assert_eq!(report.restored_roles, vec![RouteRole::Multimedia]);
+        assert_eq!(report.cleared_to_default_roles, vec![RouteRole::Console]);
+        assert_eq!(engine.backend.route(PID, RouteRole::Console), None);
+        assert_eq!(
+            engine.backend.route(PID, RouteRole::Multimedia),
+            Some(OLD_MULTIMEDIA.to_string())
+        );
+        assert!(engine.journal.value.is_none());
+    }
+
+    #[test]
+    fn startup_recovery_defers_while_previous_owner_is_running() {
+        let mut engine = engine_with_routes(Some(OLD_CONSOLE), Some(OLD_MULTIMEDIA));
+        engine
+            .acquire(OWNER_PID, PID, TARGET_NAME)
+            .expect("route should apply");
+
+        let outcome = engine
+            .recover_startup(Some(PID))
+            .expect("live owner should be a non-error outcome");
+
+        assert_eq!(
+            outcome,
+            StartupRecoveryOutcome::OwnerStillRunning {
+                owner_pid: OWNER_PID
+            }
+        );
+        assert!(engine.journal.value.is_some());
+    }
+
+    #[test]
+    fn failed_owner_liveness_probe_resets_the_dead_owner_grace() {
+        let mut engine = engine_with_routes(Some(OLD_CONSOLE), Some(OLD_MULTIMEDIA));
+        engine
+            .acquire(OWNER_PID, PID, TARGET_NAME)
+            .expect("route should apply");
+        engine.backend.process_starts.remove(&OWNER_PID);
+
+        let first = engine
+            .recover_startup(Some(PID))
+            .expect("first dead-owner observation should defer");
+        assert!(matches!(first, StartupRecoveryOutcome::Deferred { .. }));
+        engine
+            .pending_dead_owner
+            .as_mut()
+            .expect("deferred recovery should record the owner")
+            .first_observed_dead = Instant::now() - DEAD_OWNER_RECOVERY_GRACE;
+
+        engine.backend.fail_process_start_once = true;
+        assert!(engine.recover_startup(Some(PID)).is_err());
+        assert!(engine.pending_dead_owner.is_none());
+
+        let after_unknown = engine
+            .recover_startup(Some(PID))
+            .expect("confirmed dead owner should begin a fresh grace");
+        assert!(matches!(
+            after_unknown,
+            StartupRecoveryOutcome::Deferred {
+                owner_pid: OWNER_PID,
+                retry_after
+            } if retry_after > Duration::from_secs(35)
+        ));
+        assert!(engine.journal.value.is_some());
+    }
+
+    #[test]
+    fn startup_recovery_uses_current_spotify_after_process_and_session_replacement() {
+        let replacement_pid = 5151;
+        let mut engine = engine_with_routes(Some(OLD_CONSOLE), Some(OLD_MULTIMEDIA));
+        engine
+            .acquire(OWNER_PID, PID, TARGET_NAME)
+            .expect("route should apply");
+        let target = pack_render_policy_device_id(TARGET_ID);
+        engine.backend.process_starts.remove(&OWNER_PID);
+        engine.backend.process_starts.remove(&PID);
+        engine
+            .backend
+            .process_starts
+            .insert(replacement_pid, SPOTIFY_STARTED_AT + 1);
+        let mut replacement_identity = spotify_identity();
+        replacement_identity.session_id += 1;
+        engine
+            .backend
+            .spotify_identities
+            .insert(replacement_pid, replacement_identity);
+        engine
+            .backend
+            .routes
+            .insert((replacement_pid, RouteRole::Console), Some(target.clone()));
+        engine
+            .backend
+            .routes
+            .insert((replacement_pid, RouteRole::Multimedia), Some(target));
+
+        let mutation_count_before_recovery = engine.backend.events.lock().unwrap().len();
+        let first_outcome = engine
+            .recover_startup(Some(replacement_pid))
+            .expect("first dead-owner observation should defer");
+        assert!(matches!(
+            first_outcome,
+            StartupRecoveryOutcome::Deferred {
+                owner_pid: OWNER_PID,
+                ..
+            }
+        ));
+        assert!(engine.journal.value.is_some());
+        assert_eq!(
+            engine.backend.events.lock().unwrap().len(),
+            mutation_count_before_recovery,
+            "deferred recovery must not mutate either route"
+        );
+        engine
+            .pending_dead_owner
+            .as_mut()
+            .expect("deferred recovery should record the owner")
+            .first_observed_dead = Instant::now() - DEAD_OWNER_RECOVERY_GRACE;
+
+        let outcome = engine
+            .recover_startup(Some(replacement_pid))
+            .expect("aged dead-owner observation should recover");
+
+        assert_eq!(
+            outcome,
+            StartupRecoveryOutcome::Restored(RestoreReport {
+                restored_roles: vec![RouteRole::Console, RouteRole::Multimedia],
+                cleared_to_default_roles: Vec::new(),
+                skipped_changed_roles: Vec::new(),
+            })
+        );
+        assert_eq!(
+            engine.backend.route(replacement_pid, RouteRole::Console),
+            Some(OLD_CONSOLE.to_string())
+        );
+        assert_eq!(
+            engine.backend.route(replacement_pid, RouteRole::Multimedia),
+            Some(OLD_MULTIMEDIA.to_string())
+        );
+        assert!(engine.journal.value.is_none());
+    }
+
+    #[test]
+    fn reused_owner_pid_does_not_block_crash_recovery() {
+        let mut engine = engine_with_routes(Some(OLD_CONSOLE), Some(OLD_MULTIMEDIA));
+        engine
+            .acquire(OWNER_PID, PID, TARGET_NAME)
+            .expect("route should apply");
+        engine
+            .backend
+            .process_starts
+            .insert(OWNER_PID, OWNER_STARTED_AT + 1);
+
+        observe_dead_owner_and_age_grace(&mut engine, Some(PID));
+        let outcome = engine
+            .recover_startup(Some(PID))
+            .expect("reused owner PID should be treated as stale");
+
+        assert!(matches!(outcome, StartupRecoveryOutcome::Restored(_)));
+        assert!(engine.journal.value.is_none());
+    }
+
+    #[test]
+    fn replacement_pid_with_different_app_identity_is_rejected_and_journal_is_retained() {
+        let replacement_pid = 6262;
+        let mut engine = engine_with_routes(Some(OLD_CONSOLE), Some(OLD_MULTIMEDIA));
+        engine
+            .acquire(OWNER_PID, PID, TARGET_NAME)
+            .expect("route should apply");
+        engine.backend.process_starts.remove(&OWNER_PID);
+        engine
+            .backend
+            .process_starts
+            .insert(replacement_pid, SPOTIFY_STARTED_AT + 1);
+        let mut different_identity = spotify_identity();
+        different_identity.application_user_model_id =
+            "Different.Package_family!Different".to_string();
+        engine
+            .backend
+            .spotify_identities
+            .insert(replacement_pid, different_identity);
+
+        observe_dead_owner_and_age_grace(&mut engine, Some(replacement_pid));
+        let error = engine
+            .recover_startup(Some(replacement_pid))
+            .expect_err("unrelated replacement PID must fail closed");
+
+        assert!(error.contains("not the Store Spotify application"));
+        assert!(engine.journal.value.is_some());
+    }
+
+    #[test]
+    fn journal_publication_is_exclusive_under_concurrent_creators() {
+        use std::sync::Barrier;
+
+        let sequence = TEMP_FILE_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+        let directory = std::env::temp_dir().join(format!(
+            "echo-spotify-journal-race-{}-{sequence}",
+            std::process::id()
+        ));
+        fs::create_dir(&directory).expect("unique test directory should be created");
+        let path = directory.join("route.json");
+
+        let mut source = engine_with_routes(Some(OLD_CONSOLE), Some(OLD_MULTIMEDIA));
+        source
+            .acquire(OWNER_PID, PID, TARGET_NAME)
+            .expect("sample journal should be created");
+        let journal = source.journal.value.clone().unwrap();
+        let barrier = Arc::new(Barrier::new(2));
+
+        let handles = (0..2)
+            .map(|_| {
+                let path = path.clone();
+                let journal = journal.clone();
+                let barrier = barrier.clone();
+                std::thread::spawn(move || {
+                    let mut store = FileJournalStore::new(path);
+                    barrier.wait();
+                    store.create(&journal)
+                })
+            })
+            .collect::<Vec<_>>();
+        let results = handles
+            .into_iter()
+            .map(|handle| handle.join().expect("journal writer should not panic"))
+            .collect::<Vec<_>>();
+
+        assert_eq!(results.iter().filter(|result| result.is_ok()).count(), 1);
+        assert_eq!(results.iter().filter(|result| result.is_err()).count(), 1);
+        let published = FileJournalStore::new(path.clone())
+            .load()
+            .expect("published journal should parse")
+            .expect("published journal should exist");
+        assert_eq!(published, journal);
+
+        fs::remove_file(&path).expect("published journal should be removable");
+        fs::remove_dir(&directory).expect("empty test directory should be removable");
+    }
+
+    /// Manual integration test. It is both ignored and environment guarded
+    /// because it temporarily changes the running Spotify app's route.
+    #[test]
+    #[ignore = "set ECHO_SPOTIFY_ROUTE_TEST_PID to a live Spotify root PID to run"]
+    fn windows_spotify_route_round_trip() {
+        let Ok(pid) = std::env::var("ECHO_SPOTIFY_ROUTE_TEST_PID") else {
+            return;
+        };
+        let pid = pid
+            .parse::<u32>()
+            .expect("ECHO_SPOTIFY_ROUTE_TEST_PID must be a PID");
+        let journal_path = std::env::temp_dir().join(format!(
+            "echo-spotify-route-integration-{}-{pid}.json",
+            std::process::id()
+        ));
+        assert!(
+            !journal_path.exists(),
+            "refusing to overwrite existing integration-test journal {}",
+            journal_path.display()
+        );
+
+        let system_default_before = current_default_render_endpoint_id();
+        let router = SpotifyOutputRouter::new(&journal_path).expect("worker should start");
+        let target = router
+            .validate_target(DEFAULT_SPOTIFY_ROUTE_TARGET)
+            .expect("CABLE Input must resolve uniquely");
+        let mut lease = router
+            .acquire(pid, DEFAULT_SPOTIFY_ROUTE_TARGET)
+            .expect("Spotify route should apply");
+        assert_eq!(lease.info().target, target);
+        let report = lease.restore().expect("Spotify route should restore");
+        assert_eq!(
+            report.restored_roles,
+            vec![RouteRole::Console, RouteRole::Multimedia]
+        );
+        assert_eq!(
+            current_default_render_endpoint_id(),
+            system_default_before,
+            "Spotify-only routing must never change the Windows default endpoint"
+        );
+        assert!(!journal_path.exists());
+    }
+
+    fn current_default_render_endpoint_id() -> String {
+        use windows::Win32::System::Com::{CoInitializeEx, CoUninitialize, COINIT_MULTITHREADED};
+
+        unsafe {
+            CoInitializeEx(None, COINIT_MULTITHREADED)
+                .ok()
+                .expect("integration-test COM initialization should succeed");
+            let result = (|| {
+                let enumerator: IMMDeviceEnumerator =
+                    CoCreateInstance(&MMDeviceEnumerator, None, CLSCTX_ALL)
+                        .expect("default endpoint enumerator should be created");
+                let device = enumerator
+                    .GetDefaultAudioEndpoint(eRender, eMultimedia)
+                    .expect("default render endpoint should exist");
+                let id_pointer = device.GetId().expect("default endpoint should have an ID");
+                let id = id_pointer
+                    .to_string()
+                    .expect("default endpoint ID should be valid UTF-16");
+                CoTaskMemFree(Some(id_pointer.0.cast()));
+                id
+            })();
+            CoUninitialize();
+            result
+        }
+    }
+}

--- a/core/client/tauri.conf.json
+++ b/core/client/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "Echo Chamber",
-  "version": "0.6.30",
+  "version": "0.6.31",
   "identifier": "com.echochamber.app",
   "build": {
     "frontendDist": "../viewer"

--- a/core/control/Cargo.toml
+++ b/core/control/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "echo-core-control"
-version = "0.6.30"
+version = "0.6.31"
 edition = "2021"
 
 [dependencies]

--- a/core/control/src/jam_bot.rs
+++ b/core/control/src/jam_bot.rs
@@ -87,11 +87,28 @@ impl JamBot {
                     source.stop(generation).await;
                     return Err(format!("Jam source error: {}", message));
                 }
-                SourceEvent::Disconnected => {
-                    warn!(
-                        "[jam-bot] source disconnected during startup generation={}; waiting for reconnect",
-                        generation
-                    );
+                SourceEvent::AvailabilityChanged {
+                    enabled: false,
+                    generation: event_generation,
+                    error,
+                } if event_generation.is_none() || event_generation == Some(generation) => {
+                    source.stop(generation).await;
+                    return Err(match error {
+                        Some(error) => format!("Jam source was disabled during startup: {error}"),
+                        None => "Jam source was disabled during startup".to_string(),
+                    });
+                }
+                SourceEvent::Disconnected {
+                    generation: event_generation,
+                } if event_generation.is_none() || event_generation == Some(generation) => {
+                    source.stop(generation).await;
+                    return Err("Jam source disconnected during startup".to_string());
+                }
+                SourceEvent::ConnectionReplaced {
+                    generation: event_generation,
+                } if event_generation.is_none() || event_generation == Some(generation) => {
+                    source.stop(generation).await;
+                    return Err("Jam source connection was replaced during startup".to_string());
                 }
                 _ => {}
             }
@@ -183,13 +200,41 @@ async fn broadcast_loop(
                 healthy.store(false, Ordering::Release);
                 accum.clear();
             }
-            Ok(SourceEvent::Disconnected) => {
+            Ok(SourceEvent::AvailabilityChanged {
+                enabled: false,
+                generation: event_generation,
+                error,
+            }) if event_generation.is_none() || event_generation == Some(generation) => {
+                if let Some(error) = error {
+                    warn!(
+                        "[jam-bot] source disabled generation={}: {}",
+                        generation, error
+                    );
+                } else {
+                    warn!("[jam-bot] source disabled generation={}", generation);
+                }
+                healthy.store(false, Ordering::Release);
+                accum.clear();
+            }
+            Ok(SourceEvent::Disconnected {
+                generation: event_generation,
+            }) if event_generation.is_none() || event_generation == Some(generation) => {
                 warn!("[jam-bot] source disconnected generation={}", generation);
                 healthy.store(false, Ordering::Release);
                 accum.clear();
             }
             Ok(SourceEvent::Connected) => {
                 warn!("[jam-bot] source reconnecting generation={}", generation);
+                healthy.store(false, Ordering::Release);
+                accum.clear();
+            }
+            Ok(SourceEvent::ConnectionReplaced {
+                generation: event_generation,
+            }) if event_generation.is_none() || event_generation == Some(generation) => {
+                warn!(
+                    "[jam-bot] source connection replaced generation={}",
+                    generation
+                );
                 healthy.store(false, Ordering::Release);
                 accum.clear();
             }
@@ -353,10 +398,60 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn startup_waits_for_reconnect_and_replayed_start() {
+    async fn disabled_source_marks_an_active_relay_unhealthy() {
+        let (source_tx, source_rx) = broadcast::channel(16);
+        let (audio_tx, _audio_rx) = broadcast::channel(16);
+        let healthy = Arc::new(AtomicBool::new(true));
+        let task = tokio::spawn(broadcast_loop(9, audio_tx, source_rx, healthy.clone()));
+
+        source_tx
+            .send(SourceEvent::AvailabilityChanged {
+                enabled: false,
+                generation: Some(9),
+                error: Some("Local Jam source is turned off".to_string()),
+            })
+            .unwrap();
+        tokio::task::yield_now().await;
+        assert!(!healthy.load(Ordering::Acquire));
+        task.abort();
+    }
+
+    #[tokio::test]
+    async fn startup_fails_immediately_if_the_source_becomes_disabled() {
+        let source = JamSourceRegistry::new(true);
+        let (command_tx, mut command_rx) = tokio::sync::mpsc::unbounded_channel();
+        let connection_id = source.test_register(command_tx).await;
+        source.test_availability(connection_id, true, None).await;
+        let start_source = source.clone();
+        let start_task =
+            tokio::spawn(
+                async move { JamBot::start(30, start_source, Duration::from_secs(30)).await },
+            );
+        command_rx.recv().await.expect("initial start command");
+
+        source
+            .test_availability(connection_id, false, Some("Local Jam source is turned off"))
+            .await;
+        let result = tokio::time::timeout(Duration::from_secs(1), start_task)
+            .await
+            .expect("startup should fail without waiting for its timeout")
+            .expect("startup task");
+        let error = match result {
+            Ok(_) => panic!("disabled source must fail startup"),
+            Err(error) => error,
+        };
+        assert_eq!(
+            error,
+            "Jam source was disabled during startup: Local Jam source is turned off"
+        );
+    }
+
+    #[tokio::test]
+    async fn startup_fails_immediately_if_the_source_disconnects() {
         let source = JamSourceRegistry::new(true);
         let (first_tx, mut first_rx) = tokio::sync::mpsc::unbounded_channel();
         let first_connection = source.test_register(first_tx).await;
+        source.test_availability(first_connection, true, None).await;
         let start_source = source.clone();
         let start_task =
             tokio::spawn(
@@ -365,17 +460,10 @@ mod tests {
 
         first_rx.recv().await.expect("initial start command");
         source.test_unregister(first_connection).await;
-
-        let (second_tx, mut second_rx) = tokio::sync::mpsc::unbounded_channel();
-        let second_connection = source.test_register(second_tx).await;
-        second_rx.recv().await.expect("replayed start command");
-        source.test_ready(second_connection, 31).await;
-
-        let bot = start_task
-            .await
-            .expect("startup task")
-            .expect("startup recovered");
-        assert!(bot.is_healthy());
-        bot.stop().await;
+        let error = match start_task.await.expect("startup task") {
+            Ok(_) => panic!("disconnected startup must fail closed"),
+            Err(error) => error,
+        };
+        assert_eq!(error, "Jam source disconnected during startup");
     }
 }

--- a/core/control/src/jam_session.rs
+++ b/core/control/src/jam_session.rs
@@ -15,9 +15,15 @@ use serde::{Deserialize, Serialize};
 use std::{
     collections::HashMap,
     fs,
+    future::Future,
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 use tracing::{info, warn};
+
+const SPOTIFY_RELEASE_PAUSE_TIMEOUT: Duration = Duration::from_secs(15);
+const SPOTIFY_START_BIND_TIMEOUT: Duration = Duration::from_secs(15);
+const SPOTIFY_RECOVERY_OPERATION_TIMEOUT: Duration = Duration::from_secs(15);
+const SOURCE_START_RECHECK_INTERVAL: Duration = Duration::from_millis(100);
 
 // ── Structs ──────────────────────────────────────────────────────────────
 
@@ -591,17 +597,6 @@ async fn spotify_response_error(
 
 // ── Jam Session endpoints ────────────────────────────────────────────────
 
-/// Stop the jam audio bot if it's running.
-pub(crate) async fn stop_jam_bot(state: &AppState) -> bool {
-    let bot = state.jam_bot.lock().await.take();
-    if let Some(bot) = bot {
-        bot.stop().await;
-        true
-    } else {
-        false
-    }
-}
-
 pub(crate) fn clear_active_jam_state(jam: &mut JamState) {
     jam.active = false;
     jam.starting = false;
@@ -615,6 +610,209 @@ pub(crate) fn clear_active_jam_state(jam: &mut JamState) {
     jam.spotify_device_name = None;
     jam.spotify_is_playing = false;
     jam.audio_expected_since = None;
+}
+
+#[derive(Clone, Copy)]
+enum JamEndCondition {
+    Active,
+    ActiveOrStarting,
+    NoListeners,
+}
+
+fn jam_end_condition_matches(jam: &JamState, generation: u64, condition: JamEndCondition) -> bool {
+    if jam.generation != generation {
+        return false;
+    }
+    match condition {
+        JamEndCondition::Active => jam.active,
+        JamEndCondition::ActiveOrStarting => jam.active || jam.starting,
+        JamEndCondition::NoListeners => jam.active && jam.listeners.is_empty(),
+    }
+}
+
+fn bound_spotify_device(jam: &JamState, generation: u64) -> Option<SpotifyDevice> {
+    if jam.generation != generation {
+        return None;
+    }
+    Some(SpotifyDevice {
+        id: jam.spotify_device_id.clone()?,
+        name: jam.spotify_device_name.clone().unwrap_or_default(),
+    })
+}
+
+async fn pause_bound_spotify_before_release(
+    state: &AppState,
+    generation: u64,
+    device: Option<&SpotifyDevice>,
+) {
+    let Some(device) = device else {
+        return;
+    };
+    match tokio::time::timeout(
+        SPOTIFY_RELEASE_PAUSE_TIMEOUT,
+        pause_spotify_playback_on_device(state, device),
+    )
+    .await
+    {
+        Ok(Ok(())) => {}
+        Ok(Err((_, error))) => {
+            // Teardown must still release a wedged source. This is best-effort,
+            // but the attempt always precedes the source release command.
+            warn!(
+                "Jam generation {} could not pause Spotify before source release: {}",
+                generation, error
+            );
+        }
+        Err(_) => {
+            warn!(
+                "Jam generation {} Spotify pause exceeded the {}s source-release deadline",
+                generation,
+                SPOTIFY_RELEASE_PAUSE_TIMEOUT.as_secs()
+            );
+        }
+    }
+}
+
+/// End one exact Jam generation while the caller holds `jam_lifecycle`.
+/// Spotify is paused before the native source receives Stop, so restoring its
+/// prior per-app output route does not normally make Jam audio erupt locally.
+async fn end_jam_generation_locked(
+    state: &AppState,
+    generation: u64,
+    condition: JamEndCondition,
+    reason: &str,
+    final_error: Option<String>,
+) -> bool {
+    let device = {
+        let jam = state.jam.lock().unwrap_or_else(|e| e.into_inner());
+        if !jam_end_condition_matches(&jam, generation, condition) {
+            return false;
+        }
+        bound_spotify_device(&jam, generation)
+    };
+
+    pause_bound_spotify_before_release(state, generation, device.as_ref()).await;
+
+    let ended = {
+        let mut jam = state.jam.lock().unwrap_or_else(|e| e.into_inner());
+        if !jam_end_condition_matches(&jam, generation, condition) {
+            false
+        } else {
+            clear_active_jam_state(&mut jam);
+            jam.last_error = final_error;
+            true
+        }
+    };
+    if !ended {
+        return false;
+    }
+
+    let bot = {
+        let mut guard = state.jam_bot.lock().await;
+        if guard.as_ref().map(|bot| bot.generation()) == Some(generation) {
+            guard.take()
+        } else {
+            None
+        }
+    };
+    if let Some(bot) = bot {
+        bot.stop().await;
+    } else {
+        state.jam_source.stop(generation).await;
+    }
+    info!("Jam generation {} ended ({})", generation, reason);
+    true
+}
+
+pub(crate) async fn end_jam_for_source_unavailable(
+    state: &AppState,
+    generation: u64,
+    reason: String,
+) -> bool {
+    let _lifecycle = state.jam_lifecycle.lock().await;
+    end_jam_generation_locked(
+        state,
+        generation,
+        JamEndCondition::ActiveOrStarting,
+        "source unavailable",
+        Some(reason),
+    )
+    .await
+}
+
+fn active_jam_source_watchdog_error(
+    source: &crate::jam_source::JamSourceSnapshot,
+    generation: u64,
+) -> Option<String> {
+    let unavailable = !source.connected
+        || !source.availability_known
+        || !source.enabled
+        || source.status == "error"
+        || source.generation != Some(generation);
+    if !unavailable {
+        return None;
+    }
+
+    source.error.clone().or_else(|| {
+        if source.generation != Some(generation) {
+            Some(format!(
+                "Jam source lost the active generation binding (expected {}, source {:?})",
+                generation, source.generation
+            ))
+        } else {
+            Some(format!(
+                "Jam source became unavailable (status: {})",
+                source.status
+            ))
+        }
+    })
+}
+
+/// Redundant lifecycle reconciliation for a missed source event.
+///
+/// The source registry clears its desired generation when a connection is
+/// replaced, disconnected, or disabled. Therefore the watchdog must derive the
+/// exact teardown generation from the active Jam rather than relying on the
+/// snapshot to retain it. Starting Jams are intentionally excluded: startup has
+/// a normal pre-source binding window and its own source-loss guard.
+pub(crate) async fn end_active_jam_if_source_unhealthy(state: &AppState) -> bool {
+    let _lifecycle = state.jam_lifecycle.lock().await;
+    let generation = {
+        let jam = state.jam.lock().unwrap_or_else(|e| e.into_inner());
+        if !jam.active {
+            return false;
+        }
+        jam.generation
+    };
+    let source = state.jam_source.snapshot().await;
+    let Some(reason) = active_jam_source_watchdog_error(&source, generation) else {
+        return false;
+    };
+
+    end_jam_generation_locked(
+        state,
+        generation,
+        JamEndCondition::Active,
+        "source watchdog reconciliation",
+        Some(reason),
+    )
+    .await
+}
+
+pub(crate) async fn end_jam_if_still_empty(
+    state: &AppState,
+    generation: u64,
+    reason: &'static str,
+) -> bool {
+    let _lifecycle = state.jam_lifecycle.lock().await;
+    end_jam_generation_locked(
+        state,
+        generation,
+        JamEndCondition::NoListeners,
+        reason,
+        None,
+    )
+    .await
 }
 
 fn apply_revoked_participant_bindings(
@@ -642,7 +840,6 @@ fn apply_revoked_participant_bindings(
 
     if host_revoked {
         let generation = jam.generation;
-        clear_active_jam_state(jam);
         (Some(generation), None)
     } else {
         let auto_end = (jam.active && jam.listeners.is_empty()).then_some(jam.generation);
@@ -670,28 +867,16 @@ pub(crate) async fn reconcile_revoked_participant_bindings(
             "Jam generation {} ended because its host binding was revoked ({})",
             generation, reason
         );
-        let bot = {
-            let mut guard = state.jam_bot.lock().await;
-            if guard.as_ref().map(|bot| bot.generation()) == Some(generation) {
-                guard.take()
-            } else {
-                None
-            }
-        };
-        if let Some(bot) = bot {
-            bot.stop().await;
-        } else {
-            state.jam_source.stop(generation).await;
-        }
-    } else if let Some(generation) = auto_end_generation {
-        schedule_jam_auto_end(
-            state.jam.clone(),
-            state.jam_bot.clone(),
-            state.jam_source.clone(),
-            state.jam_lifecycle.clone(),
+        end_jam_generation_locked(
+            state,
             generation,
+            JamEndCondition::Active,
             reason,
-        );
+            Some("Jam host authorization was revoked".to_string()),
+        )
+        .await;
+    } else if let Some(generation) = auto_end_generation {
+        schedule_jam_auto_end(state.clone(), generation, reason);
     }
 }
 
@@ -725,6 +910,66 @@ fn jam_start_response(generation: u64, device: &SpotifyDevice) -> serde_json::Va
     })
 }
 
+fn jam_source_start_preflight(
+    source: &crate::jam_source::JamSourceSnapshot,
+) -> Result<(), (StatusCode, String)> {
+    let message = if !source.configured {
+        Some("Jam source is not configured".to_string())
+    } else if !source.connected {
+        Some(
+            source
+                .error
+                .clone()
+                .unwrap_or_else(|| "Configured Jam source is offline".to_string()),
+        )
+    } else if !source.availability_known {
+        Some("Jam source availability is still negotiating".to_string())
+    } else if !source.enabled {
+        Some(
+            source
+                .error
+                .clone()
+                .unwrap_or_else(|| "Jam sharing is turned off on the source PC".to_string()),
+        )
+    } else if source.status == "error" {
+        Some(
+            source
+                .error
+                .clone()
+                .unwrap_or_else(|| "Jam source is unavailable".to_string()),
+        )
+    } else {
+        None
+    };
+    match message {
+        Some(message) => Err((StatusCode::SERVICE_UNAVAILABLE, message)),
+        None => Ok(()),
+    }
+}
+
+fn jam_source_ready_for_generation(
+    source: &crate::jam_source::JamSourceSnapshot,
+    generation: u64,
+) -> bool {
+    jam_source_start_preflight(source).is_ok()
+        && source.ready
+        && source.generation == Some(generation)
+}
+
+async fn wait_for_source_start_loss(state: &AppState, generation: u64) -> String {
+    let mut interval = tokio::time::interval(SOURCE_START_RECHECK_INTERVAL);
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    loop {
+        interval.tick().await;
+        let source = state.jam_source.snapshot().await;
+        if !jam_source_ready_for_generation(&source, generation) {
+            return source
+                .error
+                .unwrap_or_else(|| "Jam source changed during Spotify startup".to_string());
+        }
+    }
+}
+
 pub(crate) async fn jam_start(
     State(state): State<AppState>,
     headers: HeaderMap,
@@ -741,6 +986,9 @@ pub(crate) async fn jam_start(
         .ok_or((StatusCode::UNAUTHORIZED, String::new()))?;
     let actor_identity = actor.sub;
     let _lifecycle = state.jam_lifecycle.lock().await;
+
+    let source_before_start = state.jam_source.snapshot().await;
+    jam_source_start_preflight(&source_before_start)?;
 
     let generation = {
         let mut jam = state.jam.lock().unwrap_or_else(|e| e.into_inner());
@@ -784,14 +1032,62 @@ pub(crate) async fn jam_start(
         }
     };
 
-    let spotify_is_playing = match bind_spotify_playback_to_device(&state, &device).await {
+    // Ready means the source PC has both acquired its silent per-app route and
+    // opened process capture. Recheck immediately before Spotify transfer so a
+    // local Off toggle cannot race playback onto the PC speakers.
+    let source_before_transfer = state.jam_source.snapshot().await;
+    if let Err(error) = jam_source_start_preflight(&source_before_transfer) {
+        bot.stop().await;
+        fail_jam_start(&state, generation, &error.1);
+        return Err(error);
+    }
+    if !jam_source_ready_for_generation(&source_before_transfer, generation) {
+        let error = "Jam source changed before Spotify playback could be transferred".to_string();
+        bot.stop().await;
+        fail_jam_start(&state, generation, &error);
+        return Err((StatusCode::SERVICE_UNAVAILABLE, error));
+    }
+
+    let spotify_bind = tokio::select! {
+        result = tokio::time::timeout(
+            SPOTIFY_START_BIND_TIMEOUT,
+            bind_spotify_playback_to_device(&state, &device),
+        ) => match result {
+            Ok(result) => result,
+            Err(_) => Err((
+                StatusCode::SERVICE_UNAVAILABLE,
+                format!(
+                    "Spotify startup exceeded the {}s safety deadline",
+                    SPOTIFY_START_BIND_TIMEOUT.as_secs()
+                ),
+            )),
+        },
+        reason = wait_for_source_start_loss(&state, generation) => Err((
+            StatusCode::SERVICE_UNAVAILABLE,
+            reason,
+        )),
+    };
+    let spotify_is_playing = match spotify_bind {
         Ok(is_playing) => is_playing,
         Err(error) => {
+            // The transfer request may have reached Spotify before a timeout
+            // or source-loss cancellation. Pause the exact target before the
+            // source route is released.
+            pause_bound_spotify_before_release(&state, generation, Some(&device)).await;
             bot.stop().await;
             fail_jam_start(&state, generation, &error.1);
             return Err(error);
         }
     };
+
+    let source_after_transfer = state.jam_source.snapshot().await;
+    if !jam_source_ready_for_generation(&source_after_transfer, generation) || !bot.is_healthy() {
+        let error = "Jam source changed while Spotify playback was transferring".to_string();
+        pause_bound_spotify_before_release(&state, generation, Some(&device)).await;
+        bot.stop().await;
+        fail_jam_start(&state, generation, &error);
+        return Err((StatusCode::SERVICE_UNAVAILABLE, error));
+    }
     *state.jam_bot.lock().await = Some(bot);
     info!(
         "Jam audio bot started successfully generation={}",
@@ -827,6 +1123,7 @@ pub(crate) async fn jam_start(
         }
     };
     if !activated {
+        pause_bound_spotify_before_release(&state, generation, Some(&device)).await;
         if let Some(bot) = state.jam_bot.lock().await.take() {
             bot.stop().await;
         }
@@ -970,27 +1267,87 @@ async fn ensure_jam_recovery_controls_ready(state: &AppState) -> Result<u64, (St
     Ok(generation)
 }
 
-fn observe_spotify_playback(jam: &mut JamState, generation: u64, is_playing: bool) -> bool {
-    if !jam.active || jam.generation != generation {
-        return false;
+async fn wait_for_jam_recovery_controls_loss(
+    state: &AppState,
+    generation: u64,
+) -> (StatusCode, String) {
+    let mut interval = tokio::time::interval(SOURCE_START_RECHECK_INTERVAL);
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    loop {
+        interval.tick().await;
+        match ensure_jam_recovery_controls_ready(state).await {
+            Ok(current_generation) if current_generation == generation => {}
+            Ok(_) => {
+                return (
+                    StatusCode::CONFLICT,
+                    "Jam generation changed during Spotify control".to_string(),
+                );
+            }
+            Err(error) => return error,
+        }
     }
-    jam.spotify_is_playing = is_playing;
-    if is_playing {
-        jam.audio_expected_since
-            .get_or_insert_with(std::time::Instant::now);
-    } else {
-        jam.audio_expected_since = None;
+}
+
+/// Run a playback-changing Spotify operation only while the exact Jam source
+/// generation remains safe. Cancellation is ambiguous because Spotify may have
+/// accepted a request before the HTTP future was dropped, so every safety exit
+/// pauses the exact bound device before the desktop may restore its old route.
+async fn run_guarded_spotify_recovery_operation<T, F>(
+    state: &AppState,
+    generation: u64,
+    device: &SpotifyDevice,
+    operation_name: &str,
+    operation: F,
+) -> Result<T, (StatusCode, String)>
+where
+    F: Future<Output = Result<T, (StatusCode, String)>>,
+{
+    let guarded_result: Result<Result<T, (StatusCode, String)>, (StatusCode, String)> = tokio::select! {
+        result = tokio::time::timeout(SPOTIFY_RECOVERY_OPERATION_TIMEOUT, operation) => {
+            match result {
+                Ok(result) => Ok(result),
+                Err(_) => Err((
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    format!(
+                        "{} exceeded the {}s source-safety deadline",
+                        operation_name,
+                        SPOTIFY_RECOVERY_OPERATION_TIMEOUT.as_secs(),
+                    ),
+                )),
+            }
+        }
+        error = wait_for_jam_recovery_controls_loss(state, generation) => Err(error),
+    };
+
+    match guarded_result {
+        Err(safety_error) => {
+            pause_bound_spotify_before_release(state, generation, Some(device)).await;
+            Err(safety_error)
+        }
+        Ok(operation_result) => match ensure_jam_recovery_controls_ready(state).await {
+            Ok(current_generation) if current_generation == generation => operation_result,
+            Ok(_) => {
+                pause_bound_spotify_before_release(state, generation, Some(device)).await;
+                Err((
+                    StatusCode::CONFLICT,
+                    "Jam generation changed during Spotify control".to_string(),
+                ))
+            }
+            Err(error) => {
+                pause_bound_spotify_before_release(state, generation, Some(device)).await;
+                Err(error)
+            }
+        },
     }
-    true
 }
 
 fn apply_spotify_pause_result(jam: &mut JamState, generation: u64, device: &SpotifyDevice) -> bool {
-    if !active_generation_matches(jam, generation) {
+    if !active_generation_matches(jam, generation)
+        || jam.spotify_device_id.as_deref() != Some(device.id.as_str())
+    {
         return false;
     }
 
-    jam.spotify_device_id = Some(device.id.clone());
-    jam.spotify_device_name = Some(device.name.clone());
     jam.spotify_is_playing = false;
     jam.audio_expected_since = None;
     jam.last_error = None;
@@ -1029,7 +1386,7 @@ pub(crate) async fn jam_stop(
     let _lifecycle = state.jam_lifecycle.lock().await;
 
     let generation = {
-        let mut jam = state.jam.lock().unwrap_or_else(|e| e.into_inner());
+        let jam = state.jam.lock().unwrap_or_else(|e| e.into_inner());
 
         if !active_generation_matches(&jam, payload.generation) {
             return Err(StatusCode::CONFLICT);
@@ -1044,14 +1401,20 @@ pub(crate) async fn jam_stop(
             return Err(StatusCode::FORBIDDEN);
         }
 
-        clear_active_jam_state(&mut jam);
         info!("Jam session stopped by {}", &actor_identity);
         payload.generation
     };
 
-    // Stop the audio bot
-    if !stop_jam_bot(&state).await {
-        state.jam_source.stop(generation).await;
+    if !end_jam_generation_locked(
+        &state,
+        generation,
+        JamEndCondition::Active,
+        "host ended Jam",
+        None,
+    )
+    .await
+    {
+        return Err(StatusCode::CONFLICT);
     }
 
     Ok(Json(serde_json::json!({ "ok": true })))
@@ -1273,6 +1636,8 @@ pub(crate) async fn jam_state(
         "jam_protocol_version": crate::jam_source::JAM_SOURCE_PROTOCOL_VERSION,
         "source_status": source_status,
         "source_error": source_error,
+        "source_availability_known": source.availability_known,
+        "source_enabled": source.enabled,
         "source_last_frame_ms": source.last_frame_ms,
         "source_peak": source.peak,
         "source_ready": source.ready,
@@ -1356,70 +1721,81 @@ pub(crate) async fn jam_queue_add(
     if generation != payload.generation {
         return Err((StatusCode::CONFLICT, "Jam generation changed".to_string()));
     }
-    let device = resolve_spotify_device(&state).await?;
+    let device = {
+        let jam = state.jam.lock().unwrap_or_else(|e| e.into_inner());
+        bound_spotify_device(&jam, generation).ok_or((
+            StatusCode::SERVICE_UNAVAILABLE,
+            "The active Jam has no bound Spotify device".to_string(),
+        ))?
+    };
 
-    let playback_response = spotify_api_request(
+    run_guarded_spotify_recovery_operation(
         &state,
-        reqwest::Method::GET,
-        "https://api.spotify.com/v1/me/player",
-        None,
+        generation,
+        &device,
+        "Queueing a Spotify track",
+        async {
+            let playback_response = spotify_api_request(
+                &state,
+                reqwest::Method::GET,
+                "https://api.spotify.com/v1/me/player",
+                None,
+            )
+            .await?;
+            let should_queue = if playback_response.status() == reqwest::StatusCode::NO_CONTENT {
+                false
+            } else if playback_response.status().is_success() {
+                let playback: serde_json::Value =
+                    playback_response.json().await.map_err(|error| {
+                        (
+                            StatusCode::BAD_GATEWAY,
+                            format!("Spotify playback response was invalid: {}", error),
+                        )
+                    })?;
+                playback["is_playing"].as_bool().unwrap_or(false)
+                    && playback["device"]["id"].as_str() == Some(device.id.as_str())
+            } else {
+                return Err(
+                    spotify_response_error(playback_response, "Read Spotify playback").await,
+                );
+            };
+
+            if should_queue {
+                let queue_url = format!(
+                    "https://api.spotify.com/v1/me/player/queue?uri={}&device_id={}",
+                    urlencoded(&payload.spotify_uri),
+                    urlencoded(&device.id),
+                );
+                let response =
+                    spotify_api_request(&state, reqwest::Method::POST, &queue_url, None).await?;
+                if !response.status().is_success() {
+                    return Err(spotify_response_error(response, "Queue Spotify track").await);
+                }
+                info!(
+                    "Track queued on configured Spotify device: {}",
+                    payload.spotify_uri
+                );
+            } else {
+                let play_url = format!(
+                    "https://api.spotify.com/v1/me/player/play?device_id={}",
+                    urlencoded(&device.id)
+                );
+                let play_body = serde_json::json!({ "uris": [payload.spotify_uri] });
+                let response =
+                    spotify_api_request(&state, reqwest::Method::PUT, &play_url, Some(play_body))
+                        .await?;
+                if !response.status().is_success() {
+                    return Err(spotify_response_error(response, "Start Spotify track").await);
+                }
+                info!(
+                    "Track started on configured Spotify device: {}",
+                    payload.spotify_uri
+                );
+            }
+            Ok(())
+        },
     )
     .await?;
-    let should_queue = if playback_response.status() == reqwest::StatusCode::NO_CONTENT {
-        false
-    } else if playback_response.status().is_success() {
-        let playback: serde_json::Value = playback_response.json().await.map_err(|error| {
-            (
-                StatusCode::BAD_GATEWAY,
-                format!("Spotify playback response was invalid: {}", error),
-            )
-        })?;
-        playback["is_playing"].as_bool().unwrap_or(false)
-            && playback["device"]["id"].as_str() == Some(device.id.as_str())
-    } else {
-        return Err(spotify_response_error(playback_response, "Read Spotify playback").await);
-    };
-    {
-        let mut jam = state.jam.lock().unwrap_or_else(|e| e.into_inner());
-        if !observe_spotify_playback(&mut jam, generation, should_queue) {
-            return Err((
-                StatusCode::CONFLICT,
-                "Jam changed during Spotify request".to_string(),
-            ));
-        }
-    }
-    ensure_jam_recovery_controls_ready(&state).await?;
-
-    if should_queue {
-        let queue_url = format!(
-            "https://api.spotify.com/v1/me/player/queue?uri={}&device_id={}",
-            urlencoded(&payload.spotify_uri),
-            urlencoded(&device.id),
-        );
-        let response = spotify_api_request(&state, reqwest::Method::POST, &queue_url, None).await?;
-        if !response.status().is_success() {
-            return Err(spotify_response_error(response, "Queue Spotify track").await);
-        }
-        info!(
-            "Track queued on configured Spotify device: {}",
-            payload.spotify_uri
-        );
-    } else {
-        let play_url = format!(
-            "https://api.spotify.com/v1/me/player/play?device_id={}",
-            urlencoded(&device.id)
-        );
-        let play_body = serde_json::json!({ "uris": [payload.spotify_uri] });
-        let response =
-            spotify_api_request(&state, reqwest::Method::PUT, &play_url, Some(play_body)).await?;
-        if !response.status().is_success() {
-            return Err(spotify_response_error(response, "Start Spotify track").await);
-        }
-        info!(
-            "Track started on configured Spotify device: {}",
-            payload.spotify_uri
-        );
-    }
 
     let track = QueuedTrack {
         spotify_uri: payload.spotify_uri,
@@ -1429,14 +1805,29 @@ pub(crate) async fn jam_queue_add(
         duration_ms: payload.duration_ms,
         added_by,
     };
-    let mut jam = state.jam.lock().unwrap_or_else(|e| e.into_inner());
-    jam.spotify_device_id = Some(device.id);
-    jam.spotify_device_name = Some(device.name);
-    jam.spotify_is_playing = true;
-    jam.audio_expected_since = Some(std::time::Instant::now());
-    jam.last_error = None;
-    jam.queue.push(track);
-    jam.now_playing = None;
+    let applied = {
+        let mut jam = state.jam.lock().unwrap_or_else(|e| e.into_inner());
+        if !active_generation_matches(&jam, generation)
+            || jam.spotify_device_id.as_deref() != Some(device.id.as_str())
+        {
+            false
+        } else {
+            jam.spotify_device_name = Some(device.name.clone());
+            jam.spotify_is_playing = true;
+            jam.audio_expected_since = Some(std::time::Instant::now());
+            jam.last_error = None;
+            jam.queue.push(track);
+            jam.now_playing = None;
+            true
+        }
+    };
+    if !applied {
+        pause_bound_spotify_before_release(&state, generation, Some(&device)).await;
+        return Err((
+            StatusCode::CONFLICT,
+            "Jam changed while queueing the Spotify track".to_string(),
+        ));
+    }
     Ok(Json(serde_json::json!({ "ok": true })))
 }
 
@@ -1448,18 +1839,25 @@ pub(crate) async fn jam_stop_playback(
     ensure_admin(&state, &headers).map_err(|status| (status, String::new()))?;
     ensure_jam_participant(&state, &headers, None).map_err(|status| (status, String::new()))?;
 
+    // Fence the Spotify observation used by /api/jam/state. Otherwise an
+    // older in-flight GET can arrive after this pause and incorrectly mark
+    // playback as running again for the same generation and device.
+    let _refresh = state.jam_state_refresh.lock().await;
+
     // Serialize against start/end/queue/skip/leave. Capture health is
     // deliberately not consulted: Spotify playback can and should be stopped
     // even when the Jam source is stalled or offline.
     let _lifecycle = state.jam_lifecycle.lock().await;
-    {
+    let device = {
         let jam = state.jam.lock().unwrap_or_else(|e| e.into_inner());
         if !active_generation_matches(&jam, payload.generation) {
             return Err((StatusCode::CONFLICT, "Jam generation changed".to_string()));
         }
-    }
-
-    let device = resolve_spotify_device(&state).await?;
+        bound_spotify_device(&jam, payload.generation).ok_or((
+            StatusCode::SERVICE_UNAVAILABLE,
+            "The active Jam has no bound Spotify device".to_string(),
+        ))?
+    };
     pause_spotify_playback_on_device(&state, &device).await?;
 
     let mut jam = state.jam.lock().unwrap_or_else(|e| e.into_inner());
@@ -1492,34 +1890,56 @@ pub(crate) async fn jam_skip(
     if generation != payload.generation {
         return Err((StatusCode::CONFLICT, "Jam generation changed".to_string()));
     }
-    let device = resolve_spotify_device(&state).await?;
-    let spotify_is_playing = bind_spotify_playback_to_device(&state, &device).await?;
-    {
-        let mut jam = state.jam.lock().unwrap_or_else(|e| e.into_inner());
-        if !observe_spotify_playback(&mut jam, generation, spotify_is_playing) {
-            return Err((
-                StatusCode::CONFLICT,
-                "Jam changed during Spotify request".to_string(),
-            ));
-        }
-    }
-    ensure_jam_recovery_controls_ready(&state).await?;
-    let next_url = format!(
-        "https://api.spotify.com/v1/me/player/next?device_id={}",
-        urlencoded(&device.id)
-    );
-    let response = spotify_api_request(&state, reqwest::Method::POST, &next_url, None).await?;
-    if !response.status().is_success() {
-        return Err(spotify_response_error(response, "Skip Spotify track").await);
-    }
+    let device = {
+        let jam = state.jam.lock().unwrap_or_else(|e| e.into_inner());
+        bound_spotify_device(&jam, generation).ok_or((
+            StatusCode::SERVICE_UNAVAILABLE,
+            "The active Jam has no bound Spotify device".to_string(),
+        ))?
+    };
+    let spotify_is_playing = run_guarded_spotify_recovery_operation(
+        &state,
+        generation,
+        &device,
+        "Skipping a Spotify track",
+        async {
+            let spotify_is_playing = bind_spotify_playback_to_device(&state, &device).await?;
+            let next_url = format!(
+                "https://api.spotify.com/v1/me/player/next?device_id={}",
+                urlencoded(&device.id)
+            );
+            let response =
+                spotify_api_request(&state, reqwest::Method::POST, &next_url, None).await?;
+            if !response.status().is_success() {
+                return Err(spotify_response_error(response, "Skip Spotify track").await);
+            }
+            Ok(spotify_is_playing)
+        },
+    )
+    .await?;
 
-    let mut jam = state.jam.lock().unwrap_or_else(|e| e.into_inner());
-    jam.spotify_device_id = Some(device.id);
-    jam.spotify_device_name = Some(device.name);
-    jam.spotify_is_playing = spotify_is_playing;
-    jam.audio_expected_since = spotify_is_playing.then(std::time::Instant::now);
-    jam.last_error = None;
-    jam.now_playing = None;
+    let applied = {
+        let mut jam = state.jam.lock().unwrap_or_else(|e| e.into_inner());
+        if !active_generation_matches(&jam, generation)
+            || jam.spotify_device_id.as_deref() != Some(device.id.as_str())
+        {
+            false
+        } else {
+            jam.spotify_device_name = Some(device.name.clone());
+            jam.spotify_is_playing = spotify_is_playing;
+            jam.audio_expected_since = spotify_is_playing.then(std::time::Instant::now);
+            jam.last_error = None;
+            jam.now_playing = None;
+            true
+        }
+    };
+    if !applied {
+        pause_bound_spotify_before_release(&state, generation, Some(&device)).await;
+        return Err((
+            StatusCode::CONFLICT,
+            "Jam changed while skipping the Spotify track".to_string(),
+        ));
+    }
     Ok(Json(serde_json::json!({ "ok": true })))
 }
 
@@ -1600,14 +2020,7 @@ pub(crate) async fn jam_leave(
     };
 
     if let Some(generation) = auto_end_generation {
-        schedule_jam_auto_end(
-            state.jam.clone(),
-            state.jam_bot.clone(),
-            state.jam_source.clone(),
-            state.jam_lifecycle.clone(),
-            generation,
-            "listener left",
-        );
+        schedule_jam_auto_end(state.clone(), generation, "listener left");
     }
 
     Ok(Json(serde_json::json!({ "ok": true })))
@@ -1636,7 +2049,10 @@ pub(crate) async fn jam_audio_ws(
 
 fn listener_protocol_is_current(params: &std::collections::HashMap<String, String>) -> bool {
     params.len() == 2
-        && params.get("jam_protocol_version").map(String::as_str) == Some("2")
+        && params
+            .get("jam_protocol_version")
+            .and_then(|value| value.parse::<u8>().ok())
+            == Some(crate::jam_source::JAM_SOURCE_PROTOCOL_VERSION)
         && params.contains_key("generation")
 }
 
@@ -1947,6 +2363,29 @@ mod tests {
         }
     }
 
+    fn source_snapshot(
+        connected: bool,
+        availability_known: bool,
+        enabled: bool,
+        status: &str,
+    ) -> crate::jam_source::JamSourceSnapshot {
+        crate::jam_source::JamSourceSnapshot {
+            configured: true,
+            connected,
+            availability_known,
+            enabled,
+            status: status.to_string(),
+            error: None,
+            generation: None,
+            ready: false,
+            pid: None,
+            sample_rate: None,
+            channels: None,
+            last_frame_ms: None,
+            peak: 0.0,
+        }
+    }
+
     fn now_playing(is_playing: bool) -> NowPlayingInfo {
         NowPlayingInfo {
             name: "Current track".to_string(),
@@ -1977,6 +2416,89 @@ mod tests {
         assert!(!jam.active);
         assert!(jam.host_identity.is_empty());
         assert!(jam.listeners.is_empty());
+    }
+
+    #[test]
+    fn jam_start_fails_closed_until_the_source_pc_is_explicitly_armed() {
+        let negotiating = source_snapshot(true, false, false, "negotiating");
+        assert_eq!(
+            jam_source_start_preflight(&negotiating).unwrap_err().1,
+            "Jam source availability is still negotiating"
+        );
+
+        let disabled = source_snapshot(true, true, false, "disabled");
+        assert_eq!(
+            jam_source_start_preflight(&disabled).unwrap_err().1,
+            "Jam sharing is turned off on the source PC"
+        );
+
+        let armed = source_snapshot(true, true, true, "ready");
+        assert!(jam_source_start_preflight(&armed).is_ok());
+        assert!(!jam_source_ready_for_generation(&armed, 12));
+
+        let mut exact_ready = armed.clone();
+        exact_ready.ready = true;
+        exact_ready.generation = Some(12);
+        assert!(jam_source_ready_for_generation(&exact_ready, 12));
+        assert!(!jam_source_ready_for_generation(&exact_ready, 13));
+
+        exact_ready.connected = false;
+        assert!(!jam_source_ready_for_generation(&exact_ready, 12));
+    }
+
+    #[test]
+    fn source_watchdog_recovers_when_registry_generation_was_cleared() {
+        let source = source_snapshot(true, true, true, "ready");
+        let error = active_jam_source_watchdog_error(&source, 42)
+            .expect("an active Jam cannot survive a cleared source generation");
+        assert!(error.contains("expected 42"));
+    }
+
+    #[test]
+    fn source_watchdog_allows_exact_generation_restart_but_rejects_terminal_error() {
+        let mut source = source_snapshot(true, true, true, "starting");
+        source.generation = Some(42);
+        assert!(active_jam_source_watchdog_error(&source, 42).is_none());
+
+        source.status = "error".to_string();
+        source.error = Some("capture failed".to_string());
+        assert_eq!(
+            active_jam_source_watchdog_error(&source, 42).as_deref(),
+            Some("capture failed")
+        );
+    }
+
+    #[test]
+    fn jam_teardown_conditions_are_generation_fenced() {
+        let mut jam = JamState {
+            active: true,
+            generation: 12,
+            ..JamState::default()
+        };
+        assert!(jam_end_condition_matches(&jam, 12, JamEndCondition::Active));
+        assert!(!jam_end_condition_matches(
+            &jam,
+            11,
+            JamEndCondition::Active
+        ));
+        assert!(jam_end_condition_matches(
+            &jam,
+            12,
+            JamEndCondition::NoListeners
+        ));
+        jam.listeners.insert("sam".into(), "binding".into());
+        assert!(!jam_end_condition_matches(
+            &jam,
+            12,
+            JamEndCondition::NoListeners
+        ));
+        jam.active = false;
+        jam.starting = true;
+        assert!(jam_end_condition_matches(
+            &jam,
+            12,
+            JamEndCondition::ActiveOrStarting
+        ));
     }
 
     #[test]
@@ -2042,12 +2564,20 @@ mod tests {
             queue: vec![queued_track("spotify:track:one")],
             now_playing: Some(now_playing(true)),
             listeners,
+            spotify_device_id: Some("device-a".to_string()),
+            spotify_device_name: Some("Echo PC".to_string()),
             spotify_is_playing: true,
             audio_expected_since: Some(std::time::Instant::now()),
             last_error: Some("old capture warning".to_string()),
             ..JamState::default()
         };
 
+        assert!(!apply_spotify_pause_result(
+            &mut jam,
+            42,
+            &spotify_device("different-device", "Other PC")
+        ));
+        assert!(jam.spotify_is_playing);
         assert!(apply_spotify_pause_result(
             &mut jam,
             42,
@@ -2146,13 +2676,16 @@ mod tests {
     }
 
     #[test]
-    fn listener_audio_requires_protocol_v2() {
+    fn listener_audio_requires_current_protocol() {
         let mut params = std::collections::HashMap::new();
         assert!(!listener_protocol_is_current(&params));
         params.insert("generation".to_string(), "9".to_string());
         params.insert("jam_protocol_version".to_string(), "1".to_string());
         assert!(!listener_protocol_is_current(&params));
-        params.insert("jam_protocol_version".to_string(), "2".to_string());
+        params.insert(
+            "jam_protocol_version".to_string(),
+            crate::jam_source::JAM_SOURCE_PROTOCOL_VERSION.to_string(),
+        );
         assert!(listener_protocol_is_current(&params));
         params.insert("identity".to_string(), "must-not-be-in-url".to_string());
         assert!(!listener_protocol_is_current(&params));
@@ -2286,7 +2819,7 @@ mod tests {
     }
 
     #[test]
-    fn revoking_the_exact_host_binding_ends_the_generation() {
+    fn revoking_the_exact_host_binding_requests_generation_teardown() {
         let mut jam = JamState {
             active: true,
             generation: 9,
@@ -2306,8 +2839,10 @@ mod tests {
         );
 
         assert_eq!(result, (Some(9), None));
-        assert!(!jam.active);
-        assert!(jam.host_identity.is_empty());
+        // Session teardown is asynchronous because Spotify must be paused
+        // before the source PC restores its output route.
+        assert!(jam.active);
+        assert_eq!(jam.host_identity, "host-1111");
         assert!(jam.listeners.is_empty());
         assert!(jam.audio_connections.is_empty());
     }

--- a/core/control/src/jam_session.rs
+++ b/core/control/src/jam_session.rs
@@ -539,6 +539,32 @@ async fn bind_spotify_playback_to_device(
     Ok(was_playing)
 }
 
+fn spotify_pause_url(device_id: &str) -> String {
+    format!(
+        "https://api.spotify.com/v1/me/player/pause?device_id={}",
+        urlencoded(device_id)
+    )
+}
+
+async fn pause_spotify_playback_on_device(
+    state: &AppState,
+    device: &SpotifyDevice,
+) -> Result<(), (StatusCode, String)> {
+    // Stop Music must never transfer playback. Resolve the configured device,
+    // then address Spotify's pause endpoint for that device directly.
+    let response = spotify_api_request(
+        state,
+        reqwest::Method::PUT,
+        &spotify_pause_url(&device.id),
+        None,
+    )
+    .await?;
+    if !response.status().is_success() {
+        return Err(spotify_response_error(response, "Stop Spotify playback").await);
+    }
+    Ok(())
+}
+
 async fn spotify_response_error(
     response: reqwest::Response,
     operation: &str,
@@ -958,6 +984,23 @@ fn observe_spotify_playback(jam: &mut JamState, generation: u64, is_playing: boo
     true
 }
 
+fn apply_spotify_pause_result(jam: &mut JamState, generation: u64, device: &SpotifyDevice) -> bool {
+    if !active_generation_matches(jam, generation) {
+        return false;
+    }
+
+    jam.spotify_device_id = Some(device.id.clone());
+    jam.spotify_device_name = Some(device.name.clone());
+    jam.spotify_is_playing = false;
+    jam.audio_expected_since = None;
+    jam.last_error = None;
+    if let Some(now_playing) = jam.now_playing.as_mut() {
+        now_playing.is_playing = false;
+        now_playing.fetched_at = Some(std::time::Instant::now());
+    }
+    true
+}
+
 fn jam_stop_authorized(jam: &JamState, identity: &str, participant_auth_id: &str) -> bool {
     !identity.trim().is_empty()
         && !jam.host_identity.is_empty()
@@ -1223,6 +1266,8 @@ pub(crate) async fn jam_state(
         "spotify_connected": spotify_connected,
         "spotify_device_id": spotify_device_id,
         "spotify_device_name": spotify_device_name,
+        "spotify_is_playing": spotify_is_playing,
+        "playback_stop_supported": true,
         "bot_connected": bot_connected,
         "last_error": last_error,
         "jam_protocol_version": crate::jam_source::JAM_SOURCE_PROTOCOL_VERSION,
@@ -1393,6 +1438,46 @@ pub(crate) async fn jam_queue_add(
     jam.queue.push(track);
     jam.now_playing = None;
     Ok(Json(serde_json::json!({ "ok": true })))
+}
+
+pub(crate) async fn jam_stop_playback(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Json(payload): Json<JamGenerationRequest>,
+) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
+    ensure_admin(&state, &headers).map_err(|status| (status, String::new()))?;
+    ensure_jam_participant(&state, &headers, None).map_err(|status| (status, String::new()))?;
+
+    // Serialize against start/end/queue/skip/leave. Capture health is
+    // deliberately not consulted: Spotify playback can and should be stopped
+    // even when the Jam source is stalled or offline.
+    let _lifecycle = state.jam_lifecycle.lock().await;
+    {
+        let jam = state.jam.lock().unwrap_or_else(|e| e.into_inner());
+        if !active_generation_matches(&jam, payload.generation) {
+            return Err((StatusCode::CONFLICT, "Jam generation changed".to_string()));
+        }
+    }
+
+    let device = resolve_spotify_device(&state).await?;
+    pause_spotify_playback_on_device(&state, &device).await?;
+
+    let mut jam = state.jam.lock().unwrap_or_else(|e| e.into_inner());
+    if !apply_spotify_pause_result(&mut jam, payload.generation, &device) {
+        return Err((
+            StatusCode::CONFLICT,
+            "Jam changed while Spotify playback was stopping".to_string(),
+        ));
+    }
+    info!(
+        "Jam music stopped on configured Spotify device '{}' for generation {}",
+        device.name, payload.generation
+    );
+    Ok(Json(serde_json::json!({
+        "ok": true,
+        "generation": payload.generation,
+        "spotify_device_name": device.name,
+    })))
 }
 
 pub(crate) async fn jam_skip(
@@ -1862,6 +1947,18 @@ mod tests {
         }
     }
 
+    fn now_playing(is_playing: bool) -> NowPlayingInfo {
+        NowPlayingInfo {
+            name: "Current track".to_string(),
+            artist: "Current artist".to_string(),
+            album_art_url: String::new(),
+            duration_ms: 120_000,
+            progress_ms: 15_000,
+            is_playing,
+            fetched_at: None,
+        }
+    }
+
     #[test]
     fn failed_bot_start_does_not_activate_jam() {
         let mut jam = JamState {
@@ -1923,6 +2020,87 @@ mod tests {
         assert!(!jam_stop_authorized(&jam, "sam-7475", "binding-b"));
         assert!(!jam_stop_authorized(&jam, "", "binding-a"));
         assert!(!jam_stop_authorized(&jam, "other-1234", "binding-a"));
+    }
+
+    #[test]
+    fn spotify_pause_targets_only_the_encoded_device() {
+        assert_eq!(
+            spotify_pause_url("device id/+"),
+            "https://api.spotify.com/v1/me/player/pause?device_id=device%20id%2F%2B"
+        );
+    }
+
+    #[test]
+    fn playback_stop_preserves_the_active_jam_and_marks_music_paused() {
+        let mut listeners = HashMap::new();
+        listeners.insert("sam-7475".to_string(), "binding-a".to_string());
+        let mut jam = JamState {
+            active: true,
+            generation: 42,
+            host_identity: "sam-7475".to_string(),
+            host_participant_auth_id: "binding-a".to_string(),
+            queue: vec![queued_track("spotify:track:one")],
+            now_playing: Some(now_playing(true)),
+            listeners,
+            spotify_is_playing: true,
+            audio_expected_since: Some(std::time::Instant::now()),
+            last_error: Some("old capture warning".to_string()),
+            ..JamState::default()
+        };
+
+        assert!(apply_spotify_pause_result(
+            &mut jam,
+            42,
+            &spotify_device("device-a", "Echo PC")
+        ));
+
+        assert!(jam.active);
+        assert_eq!(jam.generation, 42);
+        assert_eq!(jam.host_identity, "sam-7475");
+        assert_eq!(
+            jam.listeners.get("sam-7475").map(String::as_str),
+            Some("binding-a")
+        );
+        assert_eq!(jam.queue.len(), 1);
+        assert_eq!(jam.queue[0].spotify_uri, "spotify:track:one");
+        assert_eq!(jam.spotify_device_id.as_deref(), Some("device-a"));
+        assert_eq!(jam.spotify_device_name.as_deref(), Some("Echo PC"));
+        assert!(!jam.spotify_is_playing);
+        assert!(jam.audio_expected_since.is_none());
+        assert!(jam.last_error.is_none());
+        assert_eq!(
+            jam.now_playing.as_ref().map(|track| track.is_playing),
+            Some(false)
+        );
+        assert!(jam
+            .now_playing
+            .as_ref()
+            .and_then(|track| track.fetched_at)
+            .is_some());
+    }
+
+    #[test]
+    fn stale_playback_stop_cannot_mutate_a_newer_generation() {
+        let mut jam = JamState {
+            active: true,
+            generation: 43,
+            spotify_is_playing: true,
+            now_playing: Some(now_playing(true)),
+            ..JamState::default()
+        };
+
+        assert!(!apply_spotify_pause_result(
+            &mut jam,
+            42,
+            &spotify_device("stale-device", "Stale Echo PC")
+        ));
+        assert_eq!(jam.generation, 43);
+        assert!(jam.spotify_is_playing);
+        assert!(jam.spotify_device_id.is_none());
+        assert_eq!(
+            jam.now_playing.as_ref().map(|track| track.is_playing),
+            Some(true)
+        );
     }
 
     #[test]

--- a/core/control/src/jam_source.rs
+++ b/core/control/src/jam_source.rs
@@ -16,7 +16,7 @@ use tracing::{info, warn};
 
 use crate::AppState;
 
-pub(crate) const JAM_SOURCE_PROTOCOL_VERSION: u8 = 2;
+pub(crate) const JAM_SOURCE_PROTOCOL_VERSION: u8 = 3;
 pub(crate) const AUDIBLE_PEAK_THRESHOLD: f32 = 0.0005;
 const MAX_AUDIO_MESSAGE_BYTES: usize = 4 * 1024 * 1024;
 const SOURCE_ACTIVITY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
@@ -26,7 +26,17 @@ const CAPTURE_RESTART_DEBOUNCE: std::time::Duration = std::time::Duration::from_
 #[derive(Clone, Debug)]
 pub(crate) enum SourceEvent {
     Connected,
-    Disconnected,
+    ConnectionReplaced {
+        generation: Option<u64>,
+    },
+    Disconnected {
+        generation: Option<u64>,
+    },
+    AvailabilityChanged {
+        enabled: bool,
+        generation: Option<u64>,
+        error: Option<String>,
+    },
     Format {
         generation: u64,
         sample_rate: u32,
@@ -55,6 +65,8 @@ pub(crate) enum SourceEvent {
 pub(crate) struct JamSourceSnapshot {
     pub(crate) configured: bool,
     pub(crate) connected: bool,
+    pub(crate) availability_known: bool,
+    pub(crate) enabled: bool,
     pub(crate) status: String,
     pub(crate) error: Option<String>,
     pub(crate) generation: Option<u64>,
@@ -73,6 +85,8 @@ struct ConnectedSource {
 
 struct SourceInner {
     connection: Option<ConnectedSource>,
+    availability_known: bool,
+    enabled: bool,
     desired_generation: Option<u64>,
     ready_generation: Option<u64>,
     format_generation: Option<u64>,
@@ -94,6 +108,8 @@ impl Default for SourceInner {
     fn default() -> Self {
         Self {
             connection: None,
+            availability_known: false,
+            enabled: false,
             desired_generation: None,
             ready_generation: None,
             format_generation: None,
@@ -162,6 +178,12 @@ impl JamSourceRegistry {
         {
             return Err("Configured Jam source heartbeat is stale".to_string());
         }
+        if !inner.availability_known {
+            return Err("Jam source availability is still negotiating".to_string());
+        }
+        if !inner.enabled {
+            return Err("Jam source is disabled on the source PC".to_string());
+        }
         command_tx
             .send(Message::Text(message))
             .map_err(|_| "Configured Jam source disconnected".to_string())?;
@@ -199,12 +221,17 @@ impl JamSourceRegistry {
             inner.sample_rate = None;
             inner.channels = None;
             inner.pid = None;
-            inner.status = if inner.connection.is_some() {
-                "ready".to_string()
-            } else if self.configured {
-                "offline".to_string()
-            } else {
+            inner.error = None;
+            inner.status = if !self.configured {
                 "unconfigured".to_string()
+            } else if inner.connection.is_none() {
+                "offline".to_string()
+            } else if !inner.availability_known {
+                "negotiating".to_string()
+            } else if inner.enabled {
+                "ready".to_string()
+            } else {
+                "disabled".to_string()
             };
             inner.ready_at = None;
             inner.last_frame_at = None;
@@ -223,6 +250,8 @@ impl JamSourceRegistry {
         let mut inner = self.inner.lock().await;
         if inner.desired_generation != Some(generation)
             || inner.ready_generation != Some(generation)
+            || !inner.availability_known
+            || !inner.enabled
             || !capture_packets_stalled(&inner)
             || inner
                 .last_activity_at
@@ -273,6 +302,10 @@ impl JamSourceRegistry {
             "unconfigured".to_string()
         } else if inner.connection.is_none() || activity_stale {
             "offline".to_string()
+        } else if !inner.availability_known {
+            "negotiating".to_string()
+        } else if !inner.enabled {
+            "disabled".to_string()
         } else if inner.error.is_some() {
             "error".to_string()
         } else if inner.desired_generation.is_some()
@@ -302,6 +335,8 @@ impl JamSourceRegistry {
         JamSourceSnapshot {
             configured: self.configured,
             connected: inner.connection.is_some() && !activity_stale,
+            availability_known: inner.availability_known,
+            enabled: inner.enabled,
             status,
             error: if activity_stale {
                 Some("Jam source heartbeat timed out".to_string())
@@ -310,6 +345,8 @@ impl JamSourceRegistry {
             },
             generation: inner.desired_generation,
             ready: !activity_stale
+                && inner.availability_known
+                && inner.enabled
                 && inner.desired_generation.is_some()
                 && inner.ready_generation == inner.desired_generation,
             pid: inner.pid,
@@ -322,18 +359,22 @@ impl JamSourceRegistry {
 
     async fn register(&self, command_tx: mpsc::UnboundedSender<Message>) -> u64 {
         let connection_id = self.next_connection_id.fetch_add(1, Ordering::Relaxed);
-        let replay_tx = command_tx.clone();
-        let (old, desired_generation) = {
+        let (old, replaced_generation) = {
             let mut inner = self.inner.lock().await;
             let old = inner.connection.replace(ConnectedSource {
                 connection_id,
                 command_tx,
             });
-            let desired_generation = inner.desired_generation;
-            inner.status = if desired_generation.is_some() {
-                "starting".to_string()
+            let replaced_generation = old.as_ref().and(inner.desired_generation);
+            if replaced_generation.is_some() {
+                inner.desired_generation = None;
+            }
+            inner.availability_known = false;
+            inner.enabled = false;
+            inner.status = if self.configured {
+                "negotiating".to_string()
             } else {
-                "ready".to_string()
+                "unconfigured".to_string()
             };
             inner.error = None;
             inner.ready_generation = None;
@@ -347,22 +388,23 @@ impl JamSourceRegistry {
             inner.last_audible_at = None;
             inner.restart_pending_generation = None;
             inner.last_restart = None;
-            (old, desired_generation)
+            inner.peak = 0.0;
+            (old, replaced_generation)
         };
-        if let Some(old) = old {
+        let event = if let Some(old) = old {
             let _ = old.command_tx.send(Message::Close(None));
-        }
-        if let Some(generation) = desired_generation {
-            let _ = replay_tx.send(Message::Text(
-                serde_json::json!({ "type": "start", "generation": generation }).to_string(),
-            ));
-        }
-        let _ = self.events.send(SourceEvent::Connected);
+            SourceEvent::ConnectionReplaced {
+                generation: replaced_generation,
+            }
+        } else {
+            SourceEvent::Connected
+        };
+        let _ = self.events.send(event);
         connection_id
     }
 
     async fn unregister(&self, connection_id: u64) {
-        let removed = {
+        let (removed, generation) = {
             let mut inner = self.inner.lock().await;
             if inner
                 .connection
@@ -370,24 +412,35 @@ impl JamSourceRegistry {
                 .map(|connection| connection.connection_id)
                 == Some(connection_id)
             {
+                let generation = inner.desired_generation;
                 inner.connection = None;
+                inner.desired_generation = None;
+                inner.availability_known = false;
+                inner.enabled = false;
                 inner.ready_generation = None;
+                inner.format_generation = None;
+                inner.sample_rate = None;
+                inner.channels = None;
+                inner.pid = None;
                 inner.ready_at = None;
                 inner.last_activity_at = None;
+                inner.last_frame_at = None;
+                inner.last_audible_at = None;
                 inner.restart_pending_generation = None;
                 inner.last_restart = None;
+                inner.peak = 0.0;
                 inner.status = if self.configured {
                     "offline".to_string()
                 } else {
                     "unconfigured".to_string()
                 };
-                true
+                (true, generation)
             } else {
-                false
+                (false, None)
             }
         };
         if removed {
-            let _ = self.events.send(SourceEvent::Disconnected);
+            let _ = self.events.send(SourceEvent::Disconnected { generation });
         }
     }
 
@@ -402,14 +455,19 @@ impl JamSourceRegistry {
     }
 
     #[cfg(test)]
-    pub(crate) async fn test_ready(&self, connection_id: u64, generation: u64) {
+    pub(crate) async fn test_availability(
+        &self,
+        connection_id: u64,
+        enabled: bool,
+        error: Option<&str>,
+    ) {
         handle_text(
             self,
             connection_id,
             &serde_json::json!({
-                "type": "ready",
-                "generation": generation,
-                "pid": 123,
+                "type": "availability",
+                "enabled": enabled,
+                "error": error,
             })
             .to_string(),
         )
@@ -437,6 +495,10 @@ pub(crate) struct JamSourceQuery {
 #[derive(Deserialize)]
 #[serde(tag = "type", rename_all = "lowercase")]
 enum SourceTextMessage {
+    Availability {
+        enabled: bool,
+        error: Option<String>,
+    },
     Format {
         generation: u64,
         sample_rate: u32,
@@ -494,7 +556,7 @@ async fn source_socket(socket: WebSocket, registry: JamSourceRegistry) {
     let (command_tx, mut command_rx) = mpsc::unbounded_channel();
     let connection_id = registry.register(command_tx).await;
     info!(
-        "[jam-source] protocol v2 source connected id={}",
+        "[jam-source] protocol v3 source connected id={}",
         connection_id
     );
 
@@ -539,12 +601,72 @@ async fn handle_text(registry: &JamSourceRegistry, connection_id: u64, text: &st
         return;
     }
     match message {
+        SourceTextMessage::Availability { enabled, error } => {
+            inner.last_activity_at = Some(Instant::now());
+            inner.availability_known = true;
+            inner.enabled = enabled;
+            let error = error
+                .map(|message| message.chars().take(500).collect::<String>())
+                .filter(|message| !message.trim().is_empty());
+            if enabled {
+                inner.error = None;
+                inner.status = if inner.desired_generation.is_some() {
+                    "starting".to_string()
+                } else {
+                    "ready".to_string()
+                };
+                if let Some(generation) = inner.desired_generation {
+                    if let Some(command_tx) = inner
+                        .connection
+                        .as_ref()
+                        .map(|connection| connection.command_tx.clone())
+                    {
+                        let _ = command_tx.send(Message::Text(
+                            serde_json::json!({
+                                "type": "start",
+                                "generation": generation,
+                            })
+                            .to_string(),
+                        ));
+                    }
+                }
+            } else {
+                let prior_generation = inner.desired_generation;
+                inner.desired_generation = None;
+                inner.ready_generation = None;
+                inner.format_generation = None;
+                inner.sample_rate = None;
+                inner.channels = None;
+                inner.pid = None;
+                inner.status = "disabled".to_string();
+                inner.error = error.clone();
+                inner.ready_at = None;
+                inner.last_frame_at = None;
+                inner.last_audible_at = None;
+                inner.restart_pending_generation = None;
+                inner.last_restart = None;
+                inner.peak = 0.0;
+                let _ = registry.events.send(SourceEvent::AvailabilityChanged {
+                    enabled,
+                    generation: prior_generation,
+                    error,
+                });
+                return;
+            }
+            let _ = registry.events.send(SourceEvent::AvailabilityChanged {
+                enabled,
+                generation: inner.desired_generation,
+                error: None,
+            });
+        }
         SourceTextMessage::Format {
             generation,
             sample_rate,
             channels,
         } => {
-            if inner.desired_generation != Some(generation)
+            if !inner.availability_known
+                || !inner.enabled
+                || inner.desired_generation != Some(generation)
                 || !(8_000..=192_000).contains(&sample_rate)
                 || !(1..=8).contains(&channels)
             {
@@ -561,7 +683,10 @@ async fn handle_text(registry: &JamSourceRegistry, connection_id: u64, text: &st
             });
         }
         SourceTextMessage::Ready { generation, pid } => {
-            if inner.desired_generation != Some(generation) {
+            if !inner.availability_known
+                || !inner.enabled
+                || inner.desired_generation != Some(generation)
+            {
                 return;
             }
             inner.last_activity_at = Some(Instant::now());
@@ -579,7 +704,10 @@ async fn handle_text(registry: &JamSourceRegistry, connection_id: u64, text: &st
             generation,
             message,
         } => {
-            if inner.desired_generation != Some(generation) {
+            if !inner.availability_known
+                || !inner.enabled
+                || inner.desired_generation != Some(generation)
+            {
                 return;
             }
             inner.last_activity_at = Some(Instant::now());
@@ -604,7 +732,9 @@ async fn handle_text(registry: &JamSourceRegistry, connection_id: u64, text: &st
             inner.last_activity_at = Some(Instant::now());
         }
         SourceTextMessage::Restarting { generation } => {
-            if inner.desired_generation != Some(generation)
+            if !inner.availability_known
+                || !inner.enabled
+                || inner.desired_generation != Some(generation)
                 || inner.restart_pending_generation != Some(generation)
             {
                 return;
@@ -644,7 +774,9 @@ async fn handle_audio(registry: &JamSourceRegistry, connection_id: u64, bytes: &
     {
         return;
     }
-    if inner.desired_generation != Some(generation)
+    if !inner.availability_known
+        || !inner.enabled
+        || inner.desired_generation != Some(generation)
         || inner.ready_generation != Some(generation)
         || inner.format_generation != Some(generation)
     {
@@ -701,6 +833,15 @@ fn constant_time_eq(left: &[u8], right: &[u8]) -> bool {
 mod tests {
     use super::*;
 
+    async fn arm(registry: &JamSourceRegistry, connection_id: u64) {
+        handle_text(
+            registry,
+            connection_id,
+            r#"{"type":"availability","enabled":true}"#,
+        )
+        .await;
+    }
+
     #[test]
     fn source_token_comparison_requires_exact_match() {
         assert!(constant_time_eq(b"source-secret", b"source-secret"));
@@ -709,10 +850,225 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn new_connection_fails_closed_while_availability_is_negotiating() {
+        let registry = JamSourceRegistry::new(true);
+        let (command_tx, mut command_rx) = mpsc::unbounded_channel();
+        registry.register(command_tx).await;
+
+        let snapshot = registry.snapshot().await;
+        assert!(snapshot.connected);
+        assert!(!snapshot.availability_known);
+        assert!(!snapshot.enabled);
+        assert_eq!(snapshot.status, "negotiating");
+        assert_eq!(
+            registry.start(1).await.unwrap_err(),
+            "Jam source availability is still negotiating"
+        );
+        assert!(command_rx.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn disabled_source_rejects_start_with_a_clear_diagnostic() {
+        let registry = JamSourceRegistry::new(true);
+        let (command_tx, mut command_rx) = mpsc::unbounded_channel();
+        let connection_id = registry.register(command_tx).await;
+        handle_text(
+            &registry,
+            connection_id,
+            r#"{"type":"availability","enabled":false,"error":"Local Jam source is turned off"}"#,
+        )
+        .await;
+
+        let snapshot = registry.snapshot().await;
+        assert!(snapshot.availability_known);
+        assert!(!snapshot.enabled);
+        assert_eq!(snapshot.status, "disabled");
+        assert_eq!(
+            snapshot.error.as_deref(),
+            Some("Local Jam source is turned off")
+        );
+        assert_eq!(
+            registry.start(2).await.unwrap_err(),
+            "Jam source is disabled on the source PC"
+        );
+        assert!(command_rx.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn availability_true_arms_an_idle_source() {
+        let registry = JamSourceRegistry::new(true);
+        let (command_tx, mut command_rx) = mpsc::unbounded_channel();
+        let connection_id = registry.register(command_tx).await;
+        arm(&registry, connection_id).await;
+
+        let snapshot = registry.snapshot().await;
+        assert!(snapshot.availability_known);
+        assert!(snapshot.enabled);
+        assert_eq!(snapshot.status, "ready");
+        registry.start(3).await.expect("enabled source starts");
+        let Message::Text(command) = command_rx.recv().await.expect("start command") else {
+            panic!("expected start text command");
+        };
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(&command).unwrap(),
+            serde_json::json!({ "type": "start", "generation": 3 })
+        );
+    }
+
+    #[tokio::test]
+    async fn disabling_clears_capture_state_and_emits_the_prior_generation() {
+        let registry = JamSourceRegistry::new(true);
+        let (command_tx, mut command_rx) = mpsc::unbounded_channel();
+        let connection_id = registry.register(command_tx).await;
+        arm(&registry, connection_id).await;
+        registry.start(4).await.expect("enabled source starts");
+        command_rx.recv().await.expect("start command");
+        {
+            let mut inner = registry.inner.lock().await;
+            inner.ready_generation = Some(4);
+            inner.format_generation = Some(4);
+            inner.sample_rate = Some(48_000);
+            inner.channels = Some(2);
+            inner.pid = Some(123);
+            inner.ready_at = Some(Instant::now());
+            inner.last_frame_at = Some(Instant::now());
+            inner.last_audible_at = Some(Instant::now());
+            inner.restart_pending_generation = Some(4);
+            inner.last_restart = Some((4, Instant::now()));
+            inner.peak = 0.75;
+        }
+        let mut events = registry.subscribe();
+
+        handle_text(
+            &registry,
+            connection_id,
+            r#"{"type":"availability","enabled":false,"error":"Local source disabled"}"#,
+        )
+        .await;
+
+        let event = events.recv().await.expect("availability event");
+        match event {
+            SourceEvent::AvailabilityChanged {
+                enabled,
+                generation,
+                error,
+            } => {
+                assert!(!enabled);
+                assert_eq!(generation, Some(4));
+                assert_eq!(error.as_deref(), Some("Local source disabled"));
+            }
+            other => panic!("unexpected event: {other:?}"),
+        }
+        let snapshot = registry.snapshot().await;
+        assert_eq!(snapshot.status, "disabled");
+        assert_eq!(snapshot.generation, None);
+        assert!(!snapshot.ready);
+        assert_eq!(snapshot.pid, None);
+        assert_eq!(snapshot.sample_rate, None);
+        assert_eq!(snapshot.channels, None);
+        assert_eq!(snapshot.last_frame_ms, None);
+        assert_eq!(snapshot.peak, 0.0);
+    }
+
+    #[tokio::test]
+    async fn superseded_connection_cannot_arm_or_replay_capture() {
+        let registry = JamSourceRegistry::new(true);
+        let (old_tx, mut old_rx) = mpsc::unbounded_channel();
+        let old_connection_id = registry.register(old_tx).await;
+        arm(&registry, old_connection_id).await;
+        registry.start(5).await.expect("enabled source starts");
+        old_rx.recv().await.expect("initial start command");
+
+        let (new_tx, mut new_rx) = mpsc::unbounded_channel();
+        let new_connection_id = registry.register(new_tx).await;
+        assert!(new_rx.try_recv().is_err());
+        handle_text(
+            &registry,
+            old_connection_id,
+            r#"{"type":"availability","enabled":true}"#,
+        )
+        .await;
+        let snapshot = registry.snapshot().await;
+        assert_eq!(snapshot.status, "negotiating");
+        assert!(!snapshot.availability_known);
+        assert!(!snapshot.enabled);
+        assert!(new_rx.try_recv().is_err());
+
+        arm(&registry, new_connection_id).await;
+        assert!(new_rx.try_recv().is_err());
+
+        handle_text(
+            &registry,
+            old_connection_id,
+            r#"{"type":"availability","enabled":false,"error":"stale disable"}"#,
+        )
+        .await;
+        let snapshot = registry.snapshot().await;
+        assert!(snapshot.enabled);
+        assert_eq!(snapshot.generation, None);
+        assert_eq!(snapshot.status, "ready");
+        assert!(snapshot.error.is_none());
+    }
+
+    #[tokio::test]
+    async fn capture_reports_cannot_bypass_availability_negotiation() {
+        let registry = JamSourceRegistry::new(true);
+        registry.inner.lock().await.desired_generation = Some(8);
+        let (command_tx, mut command_rx) = mpsc::unbounded_channel();
+        let connection_id = registry.register(command_tx).await;
+
+        handle_text(
+            &registry,
+            connection_id,
+            r#"{"type":"format","generation":8,"sample_rate":48000,"channels":2}"#,
+        )
+        .await;
+        handle_text(
+            &registry,
+            connection_id,
+            r#"{"type":"ready","generation":8,"pid":123}"#,
+        )
+        .await;
+
+        let snapshot = registry.snapshot().await;
+        assert_eq!(snapshot.status, "negotiating");
+        assert!(!snapshot.ready);
+        assert_eq!(snapshot.pid, None);
+        assert_eq!(snapshot.sample_rate, None);
+        assert_eq!(snapshot.channels, None);
+        assert!(command_rx.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn stop_returns_to_ready_only_while_the_source_is_enabled() {
+        let registry = JamSourceRegistry::new(true);
+        let (command_tx, mut command_rx) = mpsc::unbounded_channel();
+        let connection_id = registry.register(command_tx).await;
+        arm(&registry, connection_id).await;
+        registry.start(6).await.expect("enabled source starts");
+        command_rx.recv().await.expect("start command");
+        registry.stop(6).await;
+        command_rx.recv().await.expect("stop command");
+        assert_eq!(registry.snapshot().await.status, "ready");
+
+        registry.start(7).await.expect("enabled source restarts");
+        command_rx.recv().await.expect("second start command");
+        handle_text(
+            &registry,
+            connection_id,
+            r#"{"type":"availability","enabled":false}"#,
+        )
+        .await;
+        registry.stop(7).await;
+        assert_eq!(registry.snapshot().await.status, "disabled");
+    }
+
+    #[tokio::test]
     async fn stale_generation_audio_is_ignored() {
         let registry = JamSourceRegistry::new(true);
         let (command_tx, _command_rx) = mpsc::unbounded_channel();
         let connection_id = registry.register(command_tx).await;
+        arm(&registry, connection_id).await;
         {
             let mut inner = registry.inner.lock().await;
             inner.desired_generation = Some(8);
@@ -735,6 +1091,7 @@ mod tests {
         let registry = JamSourceRegistry::new(true);
         let (command_tx, _command_rx) = mpsc::unbounded_channel();
         let connection_id = registry.register(command_tx).await;
+        arm(&registry, connection_id).await;
         {
             let mut inner = registry.inner.lock().await;
             inner.desired_generation = Some(9);
@@ -754,17 +1111,64 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn reconnect_replays_current_generation_start() {
+    async fn reconnect_does_not_replay_a_disconnected_generation() {
         let registry = JamSourceRegistry::new(true);
-        registry.inner.lock().await.desired_generation = Some(44);
+        let (first_tx, mut first_rx) = mpsc::unbounded_channel();
+        let first_connection = registry.register(first_tx).await;
+        arm(&registry, first_connection).await;
+        registry.start(44).await.expect("source starts");
+        first_rx.recv().await.expect("start command");
+        registry.unregister(first_connection).await;
+
         let (command_tx, mut command_rx) = mpsc::unbounded_channel();
-        registry.register(command_tx).await;
-        let message = command_rx.recv().await.expect("replayed start command");
-        let Message::Text(text) = message else {
-            panic!("expected text command");
-        };
-        assert!(text.contains("\"type\":\"start\""));
-        assert!(text.contains("\"generation\":44"));
+        let connection_id = registry.register(command_tx).await;
+
+        arm(&registry, connection_id).await;
+        assert!(command_rx.try_recv().is_err());
+        let snapshot = registry.snapshot().await;
+        assert_eq!(snapshot.generation, None);
+        assert_eq!(snapshot.status, "ready");
+    }
+
+    #[tokio::test]
+    async fn disconnect_event_is_fenced_to_the_connection_generation() {
+        let registry = JamSourceRegistry::new(true);
+        let (command_tx, mut command_rx) = mpsc::unbounded_channel();
+        let connection_id = registry.register(command_tx).await;
+        arm(&registry, connection_id).await;
+        registry.start(45).await.expect("source starts");
+        command_rx.recv().await.expect("start command");
+        let mut events = registry.subscribe();
+
+        registry.unregister(connection_id).await;
+
+        match events.recv().await.expect("disconnect event") {
+            SourceEvent::Disconnected { generation } => {
+                assert_eq!(generation, Some(45));
+            }
+            other => panic!("unexpected event: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn replacement_event_is_fenced_to_the_superseded_generation() {
+        let registry = JamSourceRegistry::new(true);
+        let (first_tx, mut first_rx) = mpsc::unbounded_channel();
+        let first_connection = registry.register(first_tx).await;
+        arm(&registry, first_connection).await;
+        registry.start(46).await.expect("source starts");
+        first_rx.recv().await.expect("start command");
+        let mut events = registry.subscribe();
+        let (replacement_tx, _replacement_rx) = mpsc::unbounded_channel();
+
+        registry.register(replacement_tx).await;
+
+        match events.recv().await.expect("replacement event") {
+            SourceEvent::ConnectionReplaced { generation } => {
+                assert_eq!(generation, Some(46));
+            }
+            other => panic!("unexpected event: {other:?}"),
+        }
     }
 
     #[tokio::test]
@@ -772,6 +1176,7 @@ mod tests {
         let registry = JamSourceRegistry::new(true);
         let (command_tx, mut command_rx) = mpsc::unbounded_channel();
         let connection_id = registry.register(command_tx).await;
+        arm(&registry, connection_id).await;
         {
             let mut inner = registry.inner.lock().await;
             inner.desired_generation = Some(45);
@@ -835,7 +1240,8 @@ mod tests {
     async fn ready_capture_without_any_packets_eventually_becomes_stalled() {
         let registry = JamSourceRegistry::new(true);
         let (command_tx, _command_rx) = mpsc::unbounded_channel();
-        registry.register(command_tx).await;
+        let connection_id = registry.register(command_tx).await;
+        arm(&registry, connection_id).await;
         {
             let mut inner = registry.inner.lock().await;
             inner.desired_generation = Some(46);
@@ -852,7 +1258,8 @@ mod tests {
     async fn old_frame_health_becomes_stalled() {
         let registry = JamSourceRegistry::new(true);
         let (command_tx, _command_rx) = mpsc::unbounded_channel();
-        registry.register(command_tx).await;
+        let connection_id = registry.register(command_tx).await;
+        arm(&registry, connection_id).await;
         {
             let mut inner = registry.inner.lock().await;
             inner.desired_generation = Some(3);
@@ -867,7 +1274,8 @@ mod tests {
     async fn recent_frames_without_recent_audible_signal_are_silent() {
         let registry = JamSourceRegistry::new(true);
         let (command_tx, _command_rx) = mpsc::unbounded_channel();
-        registry.register(command_tx).await;
+        let connection_id = registry.register(command_tx).await;
+        arm(&registry, connection_id).await;
         {
             let mut inner = registry.inner.lock().await;
             inner.desired_generation = Some(4);
@@ -882,7 +1290,8 @@ mod tests {
     async fn stale_heartbeat_is_offline_and_start_is_rejected() {
         let registry = JamSourceRegistry::new(true);
         let (command_tx, _command_rx) = mpsc::unbounded_channel();
-        registry.register(command_tx).await;
+        let connection_id = registry.register(command_tx).await;
+        arm(&registry, connection_id).await;
         registry.inner.lock().await.last_activity_at =
             Some(Instant::now() - SOURCE_ACTIVITY_TIMEOUT - std::time::Duration::from_secs(1));
 
@@ -901,6 +1310,7 @@ mod tests {
         let registry = JamSourceRegistry::new(true);
         let (command_tx, _command_rx) = mpsc::unbounded_channel();
         let connection_id = registry.register(command_tx).await;
+        arm(&registry, connection_id).await;
         {
             let mut inner = registry.inner.lock().await;
             inner.desired_generation = Some(12);
@@ -934,7 +1344,8 @@ mod tests {
         let (old_tx, _old_rx) = mpsc::unbounded_channel();
         let old_connection_id = registry.register(old_tx).await;
         let (new_tx, _new_rx) = mpsc::unbounded_channel();
-        registry.register(new_tx).await;
+        let new_connection_id = registry.register(new_tx).await;
+        arm(&registry, new_connection_id).await;
         registry.inner.lock().await.desired_generation = Some(17);
 
         handle_text(
@@ -952,6 +1363,7 @@ mod tests {
         let registry = JamSourceRegistry::new(true);
         let (command_tx, _command_rx) = mpsc::unbounded_channel();
         let connection_id = registry.register(command_tx).await;
+        arm(&registry, connection_id).await;
         registry.inner.lock().await.desired_generation = Some(21);
 
         handle_text(

--- a/core/control/src/main.rs
+++ b/core/control/src/main.rs
@@ -519,6 +519,7 @@ async fn main() {
         .route("/api/jam/state", get(jam_state))
         .route("/api/jam/search", post(jam_search))
         .route("/api/jam/queue", post(jam_queue_add))
+        .route("/api/jam/playback/stop", post(jam_stop_playback))
         .route("/api/jam/skip", post(jam_skip))
         .route("/api/jam/join", post(jam_join))
         .route("/api/jam/leave", post(jam_leave))

--- a/core/control/src/main.rs
+++ b/core/control/src/main.rs
@@ -327,6 +327,76 @@ async fn main() {
         login_attempts: Arc::new(Mutex::new(HashMap::new())),
     };
 
+    // Local source consent is authoritative. Turning Jam sharing off on the
+    // source PC pauses the bound Spotify device, ends only the current
+    // generation, and then releases the native per-app output route. A source
+    // disconnect fails closed immediately: the desktop deliberately delays
+    // local route release long enough for this pause-first teardown to run.
+    {
+        let source_event_state = state.clone();
+        let mut source_events = state.jam_source.subscribe();
+        tokio::spawn(async move {
+            let mut health_watchdog = tokio::time::interval(Duration::from_secs(5));
+            health_watchdog.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+            loop {
+                tokio::select! {
+                    event = source_events.recv() => match event {
+                        Ok(SourceEvent::AvailabilityChanged {
+                            enabled: false,
+                            generation: Some(generation),
+                            error,
+                        }) => {
+                            let reason = error.unwrap_or_else(|| {
+                                "Jam sharing was turned off on the source PC".to_string()
+                            });
+                            end_jam_for_source_unavailable(&source_event_state, generation, reason)
+                                .await;
+                        }
+                        Ok(SourceEvent::Error {
+                            generation,
+                            message,
+                        }) => {
+                            end_jam_for_source_unavailable(
+                                &source_event_state,
+                                generation,
+                                format!("Jam source failed: {message}"),
+                            )
+                            .await;
+                        }
+                        Ok(SourceEvent::Disconnected {
+                            generation: Some(generation),
+                        }) => {
+                            end_jam_for_source_unavailable(
+                                &source_event_state,
+                                generation,
+                                "Jam source disconnected from the source PC".to_string(),
+                            )
+                            .await;
+                        }
+                        Ok(SourceEvent::ConnectionReplaced {
+                            generation: Some(generation),
+                        }) => {
+                            end_jam_for_source_unavailable(
+                                &source_event_state,
+                                generation,
+                                "Jam source connection was replaced".to_string(),
+                            )
+                            .await;
+                        }
+                        Ok(_) => {}
+                        Err(tokio::sync::broadcast::error::RecvError::Lagged(count)) => {
+                            warn!("Jam source lifecycle watcher lagged by {} event(s)", count);
+                        }
+                        Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+                    },
+                    _ = health_watchdog.tick() => {
+                        end_active_jam_if_source_unhealthy(&source_event_state).await;
+                    }
+                }
+            }
+        });
+    }
+
     // Background task: clean up stale participants (no heartbeat for 20s)
     {
         let participants = state.participants.clone();
@@ -335,9 +405,7 @@ async fn main() {
         let client_stats = state.client_stats.clone();
         let session_log_dir = state.session_log_dir.clone();
         let jam_for_cleanup = state.jam.clone();
-        let jam_bot_for_cleanup = state.jam_bot.clone();
-        let jam_source_for_cleanup = state.jam_source.clone();
-        let jam_lifecycle_for_cleanup = state.jam_lifecycle.clone();
+        let state_for_cleanup = state.clone();
         tokio::spawn(async move {
             loop {
                 tokio::time::sleep(Duration::from_secs(10)).await;
@@ -381,14 +449,7 @@ async fn main() {
                     append_session_event(&session_log_dir, &event);
                 }
                 if let Some(generation) = auto_end_generation {
-                    schedule_jam_auto_end(
-                        jam_for_cleanup.clone(),
-                        jam_bot_for_cleanup.clone(),
-                        jam_source_for_cleanup.clone(),
-                        jam_lifecycle_for_cleanup.clone(),
-                        generation,
-                        "stale cleanup",
-                    );
+                    schedule_jam_auto_end(state_for_cleanup.clone(), generation, "stale cleanup");
                 }
             }
         });

--- a/core/control/src/rooms.rs
+++ b/core/control/src/rooms.rs
@@ -1,6 +1,5 @@
 use crate::auth::*;
 use crate::config::*;
-use crate::jam_bot;
 use crate::{epoch_days_to_date, AppState, JamState, ParticipantEntry};
 
 use axum::{
@@ -13,7 +12,6 @@ use serde::{Deserialize, Serialize};
 use std::{
     collections::HashMap,
     fs,
-    sync::{Arc, Mutex},
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 use tracing::{error, info};
@@ -291,14 +289,7 @@ pub(crate) async fn participant_leave(
         (jam.active && jam.listeners.is_empty()).then_some(jam.generation)
     };
     if let Some(generation) = auto_end_generation {
-        schedule_jam_auto_end(
-            state.jam.clone(),
-            state.jam_bot.clone(),
-            state.jam_source.clone(),
-            state.jam_lifecycle.clone(),
-            generation,
-            "participant left",
-        );
+        schedule_jam_auto_end(state.clone(), generation, "participant left");
     }
 
     Ok(StatusCode::NO_CONTENT)
@@ -725,46 +716,20 @@ fn jam_auto_end_matches(jam: &JamState, generation: u64) -> bool {
     jam.active && jam.generation == generation && jam.listeners.is_empty()
 }
 
-pub(crate) fn schedule_jam_auto_end(
-    jam_state: Arc<Mutex<JamState>>,
-    jam_bot: Arc<tokio::sync::Mutex<Option<jam_bot::JamBot>>>,
-    jam_source: crate::jam_source::JamSourceRegistry,
-    jam_lifecycle: Arc<tokio::sync::Mutex<()>>,
-    generation: u64,
-    reason: &'static str,
-) {
+pub(crate) fn schedule_jam_auto_end(state: AppState, generation: u64, reason: &'static str) {
     tokio::spawn(async move {
         info!("Jam auto-end ({}): no listeners, waiting 30s...", reason);
         tokio::time::sleep(Duration::from_secs(30)).await;
-        let _lifecycle = jam_lifecycle.lock().await;
-        let should_stop = {
-            let mut jam = jam_state.lock().unwrap_or_else(|e| e.into_inner());
-            if jam_auto_end_matches(&jam, generation) {
-                crate::jam_session::clear_active_jam_state(&mut jam);
-                info!("Jam auto-ended ({}): no listeners for 30s", reason);
-                true
-            } else {
-                info!(
-                    "Jam auto-end cancelled: {} listeners now",
-                    jam.listeners.len()
-                );
-                false
-            }
-        };
-        if should_stop {
-            let bot = {
-                let mut guard = jam_bot.lock().await;
-                if guard.as_ref().map(|bot| bot.generation()) == Some(generation) {
-                    guard.take()
-                } else {
-                    None
-                }
-            };
-            if let Some(bot) = bot {
-                bot.stop().await;
-            } else {
-                jam_source.stop(generation).await;
-            }
+        if crate::jam_session::end_jam_if_still_empty(&state, generation, reason).await {
+            info!("Jam auto-ended ({}): no listeners for 30s", reason);
+        } else {
+            let listener_count = state
+                .jam
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .listeners
+                .len();
+            info!("Jam auto-end cancelled: {} listeners now", listener_count);
         }
     });
 }

--- a/core/deploy/test-viewer-runtime-lib.ps1
+++ b/core/deploy/test-viewer-runtime-lib.ps1
@@ -29,8 +29,8 @@ try {
     foreach ($requiredFile in $requiredFiles) {
         Set-Content -LiteralPath (Join-Path $source $requiredFile) -Value ("fixture-" + $requiredFile) -NoNewline
     }
-    Set-Content -LiteralPath (Join-Path $source "jam.js") -Value 'var JAM_PROTOCOL_VERSION = 2;' -NoNewline
-    Set-Content -LiteralPath (Join-Path $source "jam-session-state.js") -Value 'state-v2' -NoNewline
+    Set-Content -LiteralPath (Join-Path $source "jam.js") -Value 'var JAM_PROTOCOL_VERSION = 3;' -NoNewline
+    Set-Content -LiteralPath (Join-Path $source "jam-session-state.js") -Value 'state-v3' -NoNewline
     New-Item -ItemType Directory -Path (Join-Path $source "assets") | Out-Null
     Set-Content -LiteralPath (Join-Path $source "assets\tone.bin") -Value 'audio' -NoNewline
 

--- a/core/docs/AUDIO_PIPELINE.md
+++ b/core/docs/AUDIO_PIPELINE.md
@@ -98,19 +98,22 @@ that preference while idle does not change Spotify, the system default, or any
 application route.
 
 For an active, generation-scoped Jam, the source temporarily assigns only the
-Spotify desktop app to the exact `CABLE Input (VB-Audio Virtual Cable)` playback
-endpoint. It never changes the Windows system-default output and does not route
-other applications through the cable. Echo captures the paired VB-CABLE signal,
-reports its format/readiness, and uploads float32 PCM independently of the
-viewer window, screen sharing, microphone state, and room media state.
+Microsoft Store Spotify desktop app to the exact
+`CABLE Input (VB-Audio Virtual Cable)` playback endpoint. It never changes the
+Windows system-default output and does not route other applications through
+the cable. Separately, Echo opens Windows process-
+loopback capture for Spotify's process tree, reports its format/readiness, and
+uploads float32 PCM independently of the selected endpoint, viewer window,
+screen sharing, microphone state, and room media state.
 
 ```text
 [Spotify desktop app]
+  |-- temporary per-app route (active Jam only)
+  |     `-> [CABLE Input (silent local sink; not the capture source)]
   |
-  v temporary per-app route (active Jam only)
-[CABLE Input (VB-Audio Virtual Cable)]
-  |
-  v paired VB-CABLE capture endpoint
+  `-- Windows process-loopback capture
+        |
+        v
 [Echo Desktop Jam source - float32 PCM]
   |
   v authenticated protocol-v3 /api/jam/source, fenced by generation
@@ -121,8 +124,9 @@ viewer window, screen sharing, microphone state, and room media state.
 ```
 
 `core/control/src/jam_source.rs` authenticates the single configured source,
-fences messages by connection and generation, measures source health, and
-replays the current `start` command after a reconnect. `JamBot` in
+fences messages by connection and generation, and measures source health. An
+active Jam fails closed and pauses playback when the source disconnects or its
+heartbeat becomes stale. `JamBot` in
 `core/control/src/jam_bot.rs` only normalizes uploaded PCM to 48 kHz stereo
 20 ms frames and relays it to listeners over `/api/jam/audio`.
 
@@ -132,9 +136,9 @@ Spotify is playing, the control plane independently reports live, silent, or
 stalled audio based on received frames and measured peak level.
 
 If packet delivery stalls while Spotify is expected to be audible, the control
-plane sends a generation-fenced, debounced `restart` command. The source drops
-only the Jam-owned cable capture handle, acknowledges the ordered restart
-boundary, and opens a replacement capture. Existing listener sockets stay
+plane sends a generation-fenced, debounced `restart` command. The source keeps
+the temporary Spotify route, drops only its Jam-owned process-loopback handle,
+acknowledges the ordered restart boundary, and opens a replacement capture. Existing listener sockets stay
 connected and resume after the replacement reports ready.
 
 The source PC's **Hear Jam on this PC** switch controls the same synchronized
@@ -146,12 +150,29 @@ avoid doubled direct Spotify and relayed audio.
 
 **Stop Music** uses Spotify's pause API against the exact device already bound
 for the Jam. It performs no transfer and preserves the active generation,
-listeners, queue, cable capture/route, and listener sockets. By contrast,
+listeners, queue, process capture/route, and listener sockets. By contrast,
 turning local takeover off, the empty-listener timeout, and full teardown pause
 that bound device first and then release the temporary Spotify-only route.
 
-The source PC requires Spotify Desktop, the matching Echo Desktop source
-binary, VB-CABLE with the exact playback endpoint above, and matching source
+Before takeover, Echo durably journals Spotify's exact prior per-app route. A
+per-session Windows mutex serializes each complete journal-and-policy
+transaction across Echo processes, preventing a stale recovery from touching a
+newer takeover. An exact-generation source teardown command restores
+immediately. Local takeover Off first advertises unavailable and has a
+three-second local restore fallback. An unexpected source socket/capture
+failure retains the silent route for 36
+seconds before restore, covering heartbeat, watchdog, and bounded server-pause
+latency. App exit waits up to 16 seconds for that exact teardown command and
+otherwise preserves the silent route plus journal. A forced kill also leaves
+that journal. Startup recovery restores only after the exact journal owner has
+been continuously
+observed dead for 36 seconds. The recorded Windows session ID is audit metadata,
+not a stable recovery identity: after reboot, logoff, or Fast User Switch, Echo
+can recover through the current same-session Spotify process only when its
+Microsoft Store package family and AUMID match the journal.
+
+The source PC requires the Microsoft Store Spotify Desktop app, the matching
+Echo Desktop source binary, VB-CABLE with the exact playback endpoint above, and matching source
 credentials on a reachable protocol-v3 server. The server/control plane and
 its complete viewer snapshot are the server-side half of the release; the
 configured source PC is the desktop-binary half. Deploy them together.

--- a/core/docs/AUDIO_PIPELINE.md
+++ b/core/docs/AUDIO_PIPELINE.md
@@ -91,11 +91,34 @@ plane must never attempt WASAPI capture: services run in session 0 and cannot
 reliably capture a user's Spotify process or audio session.
 
 The dedicated client source in `core/client/src/jam_source.rs` connects to
-`/api/jam/source` using Jam source protocol v2 and separate source credentials.
-On a generation-scoped `start` command it finds the Spotify root process,
-starts an independently owned WASAPI process-loopback capture, and reports its
-format and readiness before uploading float32 PCM. This capture is independent
-of the viewer window, screen sharing, microphone state, and room media state.
+`/api/jam/source` using Jam source protocol v3 and separate source credentials.
+Its local takeover preference is exposed by the source-only **Allow Echo Jam to
+use Spotify on this PC** switch, which is available before Echo login. Enabling
+that preference while idle does not change Spotify, the system default, or any
+application route.
+
+For an active, generation-scoped Jam, the source temporarily assigns only the
+Spotify desktop app to the exact `CABLE Input (VB-Audio Virtual Cable)` playback
+endpoint. It never changes the Windows system-default output and does not route
+other applications through the cable. Echo captures the paired VB-CABLE signal,
+reports its format/readiness, and uploads float32 PCM independently of the
+viewer window, screen sharing, microphone state, and room media state.
+
+```text
+[Spotify desktop app]
+  |
+  v temporary per-app route (active Jam only)
+[CABLE Input (VB-Audio Virtual Cable)]
+  |
+  v paired VB-CABLE capture endpoint
+[Echo Desktop Jam source - float32 PCM]
+  |
+  v authenticated protocol-v3 /api/jam/source, fenced by generation
+[control jam_source -> JamBot normalization]
+  |
+  v 48 kHz stereo, 20 ms frames over /api/jam/audio
+[listener Web Audio gain -> selected Echo output]
+```
 
 `core/control/src/jam_source.rs` authenticates the single configured source,
 fences messages by connection and generation, measures source health, and
@@ -110,13 +133,28 @@ stalled audio based on received frames and measured peak level.
 
 If packet delivery stalls while Spotify is expected to be audible, the control
 plane sends a generation-fenced, debounced `restart` command. The source drops
-only the Jam-owned WASAPI handle, acknowledges the ordered restart boundary,
-and opens a replacement capture. Existing listener sockets stay connected and
-resume after the replacement reports ready.
+only the Jam-owned cable capture handle, acknowledges the ordered restart
+boundary, and opens a replacement capture. Existing listener sockets stay
+connected and resume after the replacement reports ready.
 
-Jam audio does not depend on WebRTC microphone publishing or VB-Cable.
+The source PC's **Hear Jam on this PC** switch controls the same synchronized
+relay heard by other listeners. It does not restore direct Spotify playback.
+The relay uses its own Jam Volume and still obeys room-wide Mute All. If native
+takeover is active and monitoring is off, only this local relay gain is zero;
+the saved Jam Volume is unchanged. A legacy source-host path remains muted to
+avoid doubled direct Spotify and relayed audio.
 
-WASAPI output device switching (`set_audio_output_device`) was removed because changing the system-wide default is too dangerous. WebView2's `setSinkId` is a silent no-op.
+**Stop Music** uses Spotify's pause API against the exact device already bound
+for the Jam. It performs no transfer and preserves the active generation,
+listeners, queue, cable capture/route, and listener sockets. By contrast,
+turning local takeover off, the empty-listener timeout, and full teardown pause
+that bound device first and then release the temporary Spotify-only route.
+
+The source PC requires Spotify Desktop, the matching Echo Desktop source
+binary, VB-CABLE with the exact playback endpoint above, and matching source
+credentials on a reachable protocol-v3 server. The server/control plane and
+its complete viewer snapshot are the server-side half of the release; the
+configured source PC is the desktop-binary half. Deploy them together.
 
 ## Platform Stubs
 

--- a/core/docs/CONTROL_MODULES.md
+++ b/core/docs/CONTROL_MODULES.md
@@ -129,6 +129,7 @@ POST /api/jam/stop                → jam_stop
 GET  /api/jam/state               → jam_state
 POST /api/jam/search              → jam_search
 POST /api/jam/queue               → jam_queue_add
+POST /api/jam/playback/stop       → jam_stop_playback
 POST /api/jam/skip                → jam_skip
 POST /api/jam/join                → jam_join
 POST /api/jam/leave               → jam_leave
@@ -150,6 +151,14 @@ There is one control-plane-wide Echo Jam, not one Jam per user, link, or room. A
 authenticated Echo participant can start it, join it, search, add tracks, and skip through
 Echo's Jam UI. Listener accounts do not need Spotify accounts; the only Spotify login is the
 configured Premium host account used by Echo OAuth and Spotify desktop on the source PC.
+
+`Stop Music` is a shared playback control with the same participant authorization as queue and
+skip. It calls Spotify's pause endpoint for the exact configured source device without
+transferring playback, then marks playback paused while preserving the active Jam generation,
+listeners, queue, source capture, and audio sockets. It remains available when capture health is
+degraded because Spotify playback control is independent of PCM delivery. The older
+`POST /api/jam/stop` lifecycle endpoint remains exact-host-binding-only: it ends the Jam and
+stops capture, but it does not control Spotify playback.
 
 ### Admin API
 ```

--- a/core/docs/CONTROL_MODULES.md
+++ b/core/docs/CONTROL_MODULES.md
@@ -164,13 +164,14 @@ The configured source PC exposes **Allow Echo Jam to use Spotify on this PC**
 on the login portal before Echo Connect and in the Jam panel. Enabling it while
 idle changes only the stored native preference: Spotify and all Windows routes
 remain untouched. During an active Jam, Echo Desktop temporarily routes only
-Spotify to the exact `CABLE Input (VB-Audio Virtual Cable)` endpoint, captures
-the paired cable signal, and relays it to the control plane. It never changes
+Microsoft Store Spotify to the exact `CABLE Input (VB-Audio Virtual Cable)` endpoint as a silent
+local sink, captures Spotify independently through Windows process loopback,
+and relays that PCM to the control plane. It never changes
 the system-default output. **Hear Jam on this PC** enables the synchronized
 local relay through Echo's normal selected output and independent Jam Volume.
 
 `Stop Music` is a shared playback control with the same participant authorization as queue and
-skip. It calls Spotify's pause endpoint for the exact configured source device without
+skip. It calls Spotify's pause endpoint for the exact device ID already bound to the active Jam without
 transferring playback, then marks playback paused while preserving the active Jam generation,
 listeners, queue, source capture/route, and audio sockets. It remains available when capture
 health is degraded because Spotify playback control is independent of PCM delivery. Turning
@@ -182,8 +183,8 @@ and routing. It is not the shared Stop Music action.
 
 Protocol v3 has a coordinated release boundary. The control plane and complete
 server-served viewer snapshot are deployed together; the configured source PC
-also needs the matching Echo Desktop Windows binary, Spotify Desktop in the
-same interactive session, VB-CABLE, matching source credentials, and the same
+also needs the matching Echo Desktop Windows binary, Microsoft Store Spotify
+Desktop in the same interactive session, VB-CABLE, matching source credentials, and the same
 Premium account authorized by Echo OAuth. Ordinary listeners need neither a
 Spotify account nor Jam-source credentials.
 

--- a/core/docs/CONTROL_MODULES.md
+++ b/core/docs/CONTROL_MODULES.md
@@ -18,7 +18,7 @@ The control plane is an Axum HTTPS server. It handles auth, room management, par
 | `chat` | `chat.rs` | Chat message save/delete/history, file upload, upload serve |
 | `soundboard` | `soundboard.rs` | Sound file upload/list/serve per room, per-room limits |
 | `jam_session` | `jam_session.rs` | Spotify OAuth, now-playing state, queue management, join/leave, host controls |
-| `jam_source` | `jam_source.rs` | Authenticated protocol-v2 WebSocket source, generation fencing, and source health |
+| `jam_source` | `jam_source.rs` | Authenticated protocol-v3 WebSocket source, generation fencing, takeover availability, and source health |
 | `jam_bot` | `jam_bot.rs` | Normalizes source PCM and relays 48 kHz stereo frames to Jam listeners |
 
 ## AppState
@@ -134,13 +134,13 @@ POST /api/jam/skip                → jam_skip
 POST /api/jam/join                → jam_join
 POST /api/jam/leave               → jam_leave
 GET  /api/jam/audio               → jam_audio_ws (WebSocket)
-GET  /api/jam/source              → jam_source_ws (authenticated protocol-v2 WebSocket)
+GET  /api/jam/source              → jam_source_ws (authenticated protocol-v3 WebSocket)
 ```
 
 Spotify configuration and Jam state reads use the shared admin token. Jam mutations also
 require the caller's bound LiveKit token in `X-Echo-Participant-Token`; host and listener
 rights store both the exact identity and binding ID. The Jam audio WebSocket query contains
-only `jam_protocol_version=2` and the active `generation`; it rejects extra query fields.
+only `jam_protocol_version=3` and the active `generation`; it rejects extra query fields.
 Its first frame (within five seconds) must be
 `{"type":"auth","token":"<bound LiveKit JWT>"}`. The server derives the identity and
 binding from that token, verifies active Jam membership, replies `{"type":"ready"}`, and
@@ -152,13 +152,40 @@ authenticated Echo participant can start it, join it, search, add tracks, and sk
 Echo's Jam UI. Listener accounts do not need Spotify accounts; the only Spotify login is the
 configured Premium host account used by Echo OAuth and Spotify desktop on the source PC.
 
+Jam state protocol v3 exposes `source_enabled` and
+`source_availability_known` in addition to source health. `disabled` means the
+source PC's local takeover preference is off; `negotiating` means the desktop
+source is preparing the Spotify route/capture boundary. The viewer requires
+availability to be explicitly known, enabled, and capture-ready before Start
+Jam is enabled. Missing fields fail closed instead of guessing that the source
+is usable.
+
+The configured source PC exposes **Allow Echo Jam to use Spotify on this PC**
+on the login portal before Echo Connect and in the Jam panel. Enabling it while
+idle changes only the stored native preference: Spotify and all Windows routes
+remain untouched. During an active Jam, Echo Desktop temporarily routes only
+Spotify to the exact `CABLE Input (VB-Audio Virtual Cable)` endpoint, captures
+the paired cable signal, and relays it to the control plane. It never changes
+the system-default output. **Hear Jam on this PC** enables the synchronized
+local relay through Echo's normal selected output and independent Jam Volume.
+
 `Stop Music` is a shared playback control with the same participant authorization as queue and
 skip. It calls Spotify's pause endpoint for the exact configured source device without
 transferring playback, then marks playback paused while preserving the active Jam generation,
-listeners, queue, source capture, and audio sockets. It remains available when capture health is
-degraded because Spotify playback control is independent of PCM delivery. The older
+listeners, queue, source capture/route, and audio sockets. It remains available when capture
+health is degraded because Spotify playback control is independent of PCM delivery. Turning
+the source PC's Allow switch off, the empty-listener timeout, and full teardown instead pause
+that exact device first, then release the temporary Spotify-only route. The older
 `POST /api/jam/stop` lifecycle endpoint remains exact-host-binding-only: it ends the Jam and
-stops capture, but it does not control Spotify playback.
+clears listeners/queue, and drives the source teardown that pauses playback and releases capture
+and routing. It is not the shared Stop Music action.
+
+Protocol v3 has a coordinated release boundary. The control plane and complete
+server-served viewer snapshot are deployed together; the configured source PC
+also needs the matching Echo Desktop Windows binary, Spotify Desktop in the
+same interactive session, VB-CABLE, matching source credentials, and the same
+Premium account authorized by Echo OAuth. Ordinary listeners need neither a
+Spotify account nor Jam-source credentials.
 
 ### Admin API
 ```

--- a/core/viewer/changelog.js
+++ b/core/viewer/changelog.js
@@ -8,6 +8,15 @@
 
 var ECHO_CHANGELOG = [
   {
+    version: "v0.6.31",
+    title: "Jam Source Controls",
+    notes: [
+      "The Spotify source PC can allow or deny Jam takeover, mute its own Jam monitoring, and set a local volume without changing what listeners hear.",
+      "Stop Music now pauses Spotify while keeping the Jam and queue ready to resume; End Jam still closes the session completely.",
+      "Echo restores Spotify's previous Windows output when the Jam ends or takeover is turned off."
+    ]
+  },
+  {
     version: "v0.6.28",
     title: "Stable Game Streaming",
     notes: [

--- a/core/viewer/index.html
+++ b/core/viewer/index.html
@@ -43,6 +43,38 @@
         <!-- Online users -->
         <div id="online-users" class="online-users"></div>
 
+        <!-- Native source-PC controls are revealed only on the configured Spotify PC. -->
+        <section class="jam-source-local-card jam-source-local-card-portal hidden" data-jam-source-local-card hidden aria-label="Spotify Jam controls for this PC">
+          <div class="jam-source-local-heading">
+            <div>
+              <div class="jam-source-local-title">Spotify Jam on this PC</div>
+              <div class="jam-source-local-status" data-jam-source-local-status role="status" aria-live="polite">Checking this PC…</div>
+            </div>
+            <span class="jam-source-local-badge">Source PC</span>
+          </div>
+          <label class="jam-source-local-switch-row">
+            <span class="jam-source-local-copy">
+              <strong>Allow Echo Jam to use Spotify on this PC</strong>
+              <small>Lets Echo control the configured Spotify desktop device while a Jam is active.</small>
+            </span>
+            <span class="jam-source-local-switch">
+              <input type="checkbox" role="switch" data-jam-source-takeover-toggle aria-label="Allow Echo Jam to use Spotify on this PC" />
+              <span aria-hidden="true"></span>
+            </span>
+          </label>
+          <label class="jam-source-local-switch-row">
+            <span class="jam-source-local-copy">
+              <strong>Hear Jam on this PC</strong>
+              <small>Plays Echo's synced Jam audio here; Jam Volume still controls how loud it is.</small>
+            </span>
+            <span class="jam-source-local-switch">
+              <input type="checkbox" role="switch" data-jam-source-monitor-toggle aria-label="Hear Jam on this PC" />
+              <span aria-hidden="true"></span>
+            </span>
+          </label>
+          <div class="jam-source-local-error hidden" data-jam-source-local-error role="alert"></div>
+        </section>
+
         <!-- Login form -->
         <div class="portal-form">
           <div class="connect-main">
@@ -354,6 +386,36 @@
             <span id="jam-spotify-status" class="jam-spotify-status">Not Connected</span>
             <button id="jam-connect-spotify" type="button" class="jam-connect-btn">Connect Spotify</button>
           </div>
+          <section class="jam-source-local-card hidden" data-jam-source-local-card hidden aria-label="Spotify Jam controls for this PC">
+            <div class="jam-source-local-heading">
+              <div>
+                <div class="jam-source-local-title">Spotify Jam on this PC</div>
+                <div class="jam-source-local-status" data-jam-source-local-status role="status" aria-live="polite">Checking this PC…</div>
+              </div>
+              <span class="jam-source-local-badge">Source PC</span>
+            </div>
+            <label class="jam-source-local-switch-row">
+              <span class="jam-source-local-copy">
+                <strong>Allow Echo Jam to use Spotify on this PC</strong>
+                <small>Lets Echo control the configured Spotify desktop device while a Jam is active.</small>
+              </span>
+              <span class="jam-source-local-switch">
+                <input type="checkbox" role="switch" data-jam-source-takeover-toggle aria-label="Allow Echo Jam to use Spotify on this PC" />
+                <span aria-hidden="true"></span>
+              </span>
+            </label>
+            <label class="jam-source-local-switch-row">
+              <span class="jam-source-local-copy">
+                <strong>Hear Jam on this PC</strong>
+                <small>Plays Echo's synced Jam audio here; Jam Volume still controls how loud it is.</small>
+              </span>
+              <span class="jam-source-local-switch">
+                <input type="checkbox" role="switch" data-jam-source-monitor-toggle aria-label="Hear Jam on this PC" />
+                <span aria-hidden="true"></span>
+              </span>
+            </label>
+            <div class="jam-source-local-error hidden" data-jam-source-local-error role="alert"></div>
+          </section>
           <div id="jam-host-controls" class="jam-host-controls" style="display:none">
             <button id="jam-start-btn" type="button" class="jam-start-btn">Start Jam</button>
             <button id="jam-stop-btn" type="button" class="jam-stop-btn" style="display:none" title="Stops Spotify playback for everyone; the Jam stays open">Stop Music</button>

--- a/core/viewer/index.html
+++ b/core/viewer/index.html
@@ -356,7 +356,7 @@
           </div>
           <div id="jam-host-controls" class="jam-host-controls" style="display:none">
             <button id="jam-start-btn" type="button" class="jam-start-btn">Start Jam</button>
-            <button id="jam-stop-btn" type="button" class="jam-stop-btn" style="display:none">End Jam</button>
+            <button id="jam-stop-btn" type="button" class="jam-stop-btn" style="display:none" title="Stops Spotify playback for everyone; the Jam stays open">Stop Music</button>
             <button id="jam-skip-btn" type="button" class="jam-skip-btn" style="display:none">Skip</button>
           </div>
           <div id="jam-now-playing" class="jam-now-playing">

--- a/core/viewer/index.html
+++ b/core/viewer/index.html
@@ -65,7 +65,7 @@
           <label class="jam-source-local-switch-row">
             <span class="jam-source-local-copy">
               <strong>Hear Jam on this PC</strong>
-              <small>Plays Echo's synced Jam audio here; Jam Volume still controls how loud it is.</small>
+              <small>When this Echo client joins the Jam, Jam Volume controls how loud it is here.</small>
             </span>
             <span class="jam-source-local-switch">
               <input type="checkbox" role="switch" data-jam-source-monitor-toggle aria-label="Hear Jam on this PC" />
@@ -407,7 +407,7 @@
             <label class="jam-source-local-switch-row">
               <span class="jam-source-local-copy">
                 <strong>Hear Jam on this PC</strong>
-                <small>Plays Echo's synced Jam audio here; Jam Volume still controls how loud it is.</small>
+                <small>When this Echo client joins the Jam, Jam Volume controls how loud it is here.</small>
               </span>
               <span class="jam-source-local-switch">
                 <input type="checkbox" role="switch" data-jam-source-monitor-toggle aria-label="Hear Jam on this PC" />
@@ -418,7 +418,8 @@
           </section>
           <div id="jam-host-controls" class="jam-host-controls" style="display:none">
             <button id="jam-start-btn" type="button" class="jam-start-btn">Start Jam</button>
-            <button id="jam-stop-btn" type="button" class="jam-stop-btn" style="display:none" title="Stops Spotify playback for everyone; the Jam stays open">Stop Music</button>
+            <button id="jam-stop-music-btn" type="button" class="jam-stop-btn" style="display:none" title="Stops Spotify playback for everyone; the Jam stays open">Stop Music</button>
+            <button id="jam-end-btn" type="button" class="jam-end-btn" style="display:none" title="Ends the Jam for everyone and clears its queue">End Jam</button>
             <button id="jam-skip-btn" type="button" class="jam-skip-btn" style="display:none">Skip</button>
           </div>
           <div id="jam-now-playing" class="jam-now-playing">

--- a/core/viewer/jam-session-state.js
+++ b/core/viewer/jam-session-state.js
@@ -246,11 +246,10 @@
       // available against the current source so they can recover Spotify playback.
       canJoin: compatible && active && sourceReady,
       canControl: compatible && active && sourceControlReady,
-      // Stopping Spotify playback does not depend on capture health. Keep the
-      // action available during source stalls/errors while music is still
-      // reported as playing on the configured Spotify device.
-      canStopPlayback: compatible && active && spotifyConnected &&
-        playbackStopSupported && spotifyIsPlaying,
+      // Stopping Spotify playback does not depend on capture health or a fresh
+      // playback observation. Pause is idempotent and exact-device fenced, so
+      // keep this emergency control available for the whole active Jam.
+      canStopPlayback: compatible && active && spotifyConnected && playbackStopSupported,
       canConfigure: compatible,
     };
   }

--- a/core/viewer/jam-session-state.js
+++ b/core/viewer/jam-session-state.js
@@ -149,6 +149,8 @@
       (input.source_ready === true || ["ready", "live", "silent", "stalled"].includes(sourceStatus));
     const active = input.active === true;
     const spotifyConnected = input.spotify_connected === true;
+    const spotifyIsPlaying = input.spotify_is_playing === true;
+    const playbackStopSupported = input.playback_stop_supported === true;
     const sourceError = typeof input.source_error === "string" ? input.source_error.trim() : "";
 
     let sourceTone = "waiting";
@@ -196,6 +198,8 @@
       compatibilityMessage,
       active,
       spotifyConnected,
+      spotifyIsPlaying,
+      playbackStopSupported,
       sourceStatus,
       sourceReady,
       sourceControlReady,
@@ -209,6 +213,11 @@
       // available against the current source so they can recover Spotify playback.
       canJoin: compatible && active && sourceReady,
       canControl: compatible && active && sourceControlReady,
+      // Stopping Spotify playback does not depend on capture health. Keep the
+      // action available during source stalls/errors while music is still
+      // reported as playing on the configured Spotify device.
+      canStopPlayback: compatible && active && spotifyConnected &&
+        playbackStopSupported && spotifyIsPlaying,
       canConfigure: compatible,
     };
   }

--- a/core/viewer/jam-session-state.js
+++ b/core/viewer/jam-session-state.js
@@ -5,7 +5,7 @@
     root.EchoJamSessionState = factory();
   }
 })(typeof globalThis !== "undefined" ? globalThis : this, function () {
-  const JAM_PROTOCOL_VERSION = 2;
+  const JAM_PROTOCOL_VERSION = 3;
 
   function normalizeSourceStatus(value) {
     const status = String(value || "unknown").trim().toLowerCase();
@@ -61,8 +61,12 @@
     };
   }
 
-  function shouldMuteLocalRelay(isSourceHost, listenerJoined) {
-    return isSourceHost === true && listenerJoined !== false;
+  function shouldMuteLocalRelay(isSourceHost, listenerJoined, takeoverActive, monitorEnabled) {
+    if (isSourceHost !== true || listenerJoined === false) return false;
+    // The legacy source-host path remains muted to prevent a doubled local
+    // Spotify + Echo relay. Native takeover may explicitly opt into the relay
+    // as the source PC's monitor without changing the user's Jam volume.
+    return takeoverActive !== true || monitorEnabled !== true;
   }
 
   function effectiveJamGain(volumePercent, roomAudioMuted) {
@@ -70,6 +74,19 @@
     const volume = Number(volumePercent);
     if (!Number.isFinite(volume)) return 0;
     return Math.max(0, Math.min(100, volume)) / 100;
+  }
+
+  function effectiveJamRelayGain(volumePercent, roomAudioMuted, localControl) {
+    const local = localControl && typeof localControl === "object" ? localControl : {};
+    if (shouldMuteLocalRelay(
+      local.is_source_host === true,
+      true,
+      local.takeover_active === true,
+      local.monitor_enabled === true
+    )) {
+      return 0;
+    }
+    return effectiveJamGain(volumePercent, roomAudioMuted);
   }
 
   function buildJamAudioSocketQuery(protocolVersion, generation) {
@@ -139,13 +156,17 @@
       : Number(rawProtocol);
     const compatible = Number.isFinite(actualProtocol) && actualProtocol === JAM_PROTOCOL_VERSION;
     const sourceStatus = normalizeSourceStatus(input.source_status);
-    const sourceUnavailable = ["offline", "unconfigured", "error", "failed"].includes(sourceStatus);
-    const sourceReady = sourceStatus !== "stalled" && !sourceUnavailable &&
+    const sourceEnabled = input.source_enabled === true;
+    const sourceAvailabilityKnown = input.source_availability_known === true;
+    const sourceUnavailable = ["disabled", "offline", "unconfigured", "error", "failed"].includes(sourceStatus);
+    const sourceReady = sourceAvailabilityKnown && sourceEnabled &&
+      sourceStatus !== "negotiating" && sourceStatus !== "stalled" && !sourceUnavailable &&
       (input.source_ready === true || ["ready", "live", "silent"].includes(sourceStatus));
     // A stalled source is still the configured, generation-current source. Keep
     // queue/skip available so users can recover Spotify playback, while joining
     // and opening new audio sockets remain fail-closed until PCM is healthy.
-    const sourceControlReady = !sourceUnavailable &&
+    const sourceControlReady = sourceAvailabilityKnown && sourceEnabled &&
+      sourceStatus !== "negotiating" && !sourceUnavailable &&
       (input.source_ready === true || ["ready", "live", "silent", "stalled"].includes(sourceStatus));
     const active = input.active === true;
     const spotifyConnected = input.spotify_connected === true;
@@ -155,7 +176,17 @@
 
     let sourceTone = "waiting";
     let sourceMessage = "Host source status is unavailable";
-    if (sourceStatus === "ready" || (sourceReady && sourceStatus === "unknown")) {
+    if (sourceStatus === "disabled") {
+      sourceTone = "warning";
+      sourceMessage = "Echo Jam is disabled on the Spotify PC";
+    } else if (sourceStatus === "negotiating") {
+      sourceMessage = "Echo is preparing Spotify control on the source PC…";
+    } else if (!sourceAvailabilityKnown) {
+      sourceMessage = "Checking Spotify control on the source PC…";
+    } else if (!sourceEnabled) {
+      sourceTone = "warning";
+      sourceMessage = "Echo Jam is disabled on the Spotify PC";
+    } else if (sourceStatus === "ready" || (sourceReady && sourceStatus === "unknown")) {
       sourceTone = "ready";
       sourceMessage = "Host source is online";
     } else if (sourceStatus === "live") {
@@ -200,6 +231,8 @@
       spotifyConnected,
       spotifyIsPlaying,
       playbackStopSupported,
+      sourceEnabled,
+      sourceAvailabilityKnown,
       sourceStatus,
       sourceReady,
       sourceControlReady,
@@ -380,6 +413,7 @@
     buildJamAudioSocketQuery,
     evaluateJamContract,
     effectiveJamGain,
+    effectiveJamRelayGain,
     parseJamAudioControlMessage,
     planAudioFrame,
     shouldApplyBannerResponse,

--- a/core/viewer/jam-session-state.test.js
+++ b/core/viewer/jam-session-state.test.js
@@ -262,7 +262,7 @@ test("Stop Music remains available when capture fails but Spotify is playing", (
   }
 });
 
-test("Stop Music is capability, generation-state, and playback gated", () => {
+test("Stop Music is capability and generation-state gated, not observation gated", () => {
   const base = {
     jam_protocol_version: 3,
     spotify_connected: true,
@@ -275,7 +275,7 @@ test("Stop Music is capability, generation-state, and playback gated", () => {
   assert.equal(evaluateJamContract(base).canStopPlayback, true);
   assert.equal(evaluateJamContract({ ...base, active: false }).canStopPlayback, false);
   assert.equal(evaluateJamContract({ ...base, spotify_connected: false }).canStopPlayback, false);
-  assert.equal(evaluateJamContract({ ...base, spotify_is_playing: false }).canStopPlayback, false);
+  assert.equal(evaluateJamContract({ ...base, spotify_is_playing: false }).canStopPlayback, true);
   assert.equal(evaluateJamContract({ ...base, playback_stop_supported: false }).canStopPlayback, false);
   assert.equal(evaluateJamContract({ ...base, jam_protocol_version: 1 }).canStopPlayback, false);
 });

--- a/core/viewer/jam-session-state.test.js
+++ b/core/viewer/jam-session-state.test.js
@@ -168,6 +168,38 @@ test("an active degraded Jam fails closed while its source recovers", () => {
   assert.equal(contract.canControl, false);
 });
 
+test("Stop Music remains available when capture fails but Spotify is playing", () => {
+  for (const source_status of ["offline", "error", "failed", "stalled"]) {
+    const contract = evaluateJamContract({
+      jam_protocol_version: 2,
+      spotify_connected: true,
+      spotify_is_playing: true,
+      playback_stop_supported: true,
+      active: true,
+      source_status,
+    });
+    assert.equal(contract.canStopPlayback, true, source_status);
+  }
+});
+
+test("Stop Music is capability, generation-state, and playback gated", () => {
+  const base = {
+    jam_protocol_version: 2,
+    spotify_connected: true,
+    spotify_is_playing: true,
+    playback_stop_supported: true,
+    active: true,
+    source_status: "live",
+  };
+
+  assert.equal(evaluateJamContract(base).canStopPlayback, true);
+  assert.equal(evaluateJamContract({ ...base, active: false }).canStopPlayback, false);
+  assert.equal(evaluateJamContract({ ...base, spotify_connected: false }).canStopPlayback, false);
+  assert.equal(evaluateJamContract({ ...base, spotify_is_playing: false }).canStopPlayback, false);
+  assert.equal(evaluateJamContract({ ...base, playback_stop_supported: false }).canStopPlayback, false);
+  assert.equal(evaluateJamContract({ ...base, jam_protocol_version: 1 }).canStopPlayback, false);
+});
+
 test("an active healthy Jam permits join and control actions", () => {
   const contract = evaluateJamContract({
     jam_protocol_version: 2,

--- a/core/viewer/jam-session-state.test.js
+++ b/core/viewer/jam-session-state.test.js
@@ -6,6 +6,7 @@ const {
   createLatestRequestGate,
   createJamSessionState,
   effectiveJamGain,
+  effectiveJamRelayGain,
   evaluateJamContract,
   parseJamAudioControlMessage,
   planAudioFrame,
@@ -24,22 +25,48 @@ test("only the newest concurrent Jam state request may update the viewer", () =>
   assert.equal(gate.isCurrent(newer), true);
 });
 
-test("the Spotify source host mutes its relayed copy after auto-join", () => {
-  assert.equal(shouldMuteLocalRelay(true, true), true);
+test("the Spotify source host relay follows takeover and monitor state", () => {
+  assert.equal(shouldMuteLocalRelay(true, true, false, false), true);
+  assert.equal(shouldMuteLocalRelay(true, true, true, false), true);
+  assert.equal(shouldMuteLocalRelay(true, true, true, true), false);
   assert.equal(shouldMuteLocalRelay(true, false), false);
   assert.equal(shouldMuteLocalRelay(false, true), false);
 });
 
+test("source-PC monitor policy preserves independent Jam volume and global mute", () => {
+  assert.equal(effectiveJamRelayGain(50, false, { is_source_host: false }), 0.5);
+  assert.equal(effectiveJamRelayGain(50, false, {
+    is_source_host: true,
+    takeover_active: false,
+    monitor_enabled: true,
+  }), 0);
+  assert.equal(effectiveJamRelayGain(50, false, {
+    is_source_host: true,
+    takeover_active: true,
+    monitor_enabled: false,
+  }), 0);
+  assert.equal(effectiveJamRelayGain(50, false, {
+    is_source_host: true,
+    takeover_active: true,
+    monitor_enabled: true,
+  }), 0.5);
+  assert.equal(effectiveJamRelayGain(50, true, {
+    is_source_host: true,
+    takeover_active: true,
+    monitor_enabled: true,
+  }), 0);
+});
+
 test("Jam audio socket query contains protocol and generation only", () => {
-  const query = buildJamAudioSocketQuery(2, 41);
+  const query = buildJamAudioSocketQuery(3, 41);
   const params = new URLSearchParams(query);
 
   assert.deepEqual(Array.from(params.keys()), ["jam_protocol_version", "generation"]);
-  assert.equal(params.get("jam_protocol_version"), "2");
+  assert.equal(params.get("jam_protocol_version"), "3");
   assert.equal(params.get("generation"), "41");
   assert.equal(query.includes("token"), false);
   assert.equal(query.includes("identity"), false);
-  assert.throws(() => buildJamAudioSocketQuery(2, null), /Invalid Jam generation/);
+  assert.throws(() => buildJamAudioSocketQuery(3, null), /Invalid Jam generation/);
 });
 
 test("Jam audio is connected only after the explicit ready control frame", () => {
@@ -73,8 +100,8 @@ test("banner response cannot overwrite state after full polling starts", () => {
   assert.equal(shouldApplyBannerResponse(false, false), false);
 });
 
-test("Jam protocol v2 rejects missing and mismatched server contracts", () => {
-  assert.equal(JAM_PROTOCOL_VERSION, 2);
+test("Jam protocol v3 rejects missing and mismatched server contracts", () => {
+  assert.equal(JAM_PROTOCOL_VERSION, 3);
 
   const missing = evaluateJamContract({ source_status: "ready" });
   assert.equal(missing.compatible, false);
@@ -84,13 +111,15 @@ test("Jam protocol v2 rejects missing and mismatched server contracts", () => {
   const mismatched = evaluateJamContract({ jam_protocol_version: 1, source_status: "ready" });
   assert.equal(mismatched.compatible, false);
   assert.equal(mismatched.actualProtocol, 1);
-  assert.match(mismatched.compatibilityMessage, /viewer v2, server v1/);
+  assert.match(mismatched.compatibilityMessage, /viewer v3, server v1/);
 });
 
 test("ready, live, and silent sources are capture-ready for a new Jam", () => {
   for (const source_status of ["ready", "live", "silent"]) {
     const contract = evaluateJamContract({
-      jam_protocol_version: 2,
+      jam_protocol_version: 3,
+      source_enabled: true,
+      source_availability_known: true,
       spotify_connected: true,
       active: false,
       source_status,
@@ -102,18 +131,61 @@ test("ready, live, and silent sources are capture-ready for a new Jam", () => {
   }
 
   assert.equal(evaluateJamContract({
-    jam_protocol_version: 2,
+    jam_protocol_version: 3,
+    source_enabled: true,
+    source_availability_known: true,
     source_status: "ready",
   }).sourceMessage, "Host source is online");
   assert.equal(evaluateJamContract({
-    jam_protocol_version: 2,
+    jam_protocol_version: 3,
+    source_enabled: true,
+    source_availability_known: true,
     source_status: "live",
   }).sourceMessage, "Host source audio is live");
 });
 
+test("Start Jam fails closed until source availability is known and enabled", () => {
+  const base = {
+    jam_protocol_version: 3,
+    spotify_connected: true,
+    active: false,
+    source_status: "ready",
+  };
+
+  const missing = evaluateJamContract(base);
+  assert.equal(missing.sourceAvailabilityKnown, false);
+  assert.equal(missing.sourceEnabled, false);
+  assert.equal(missing.canStart, false);
+  assert.match(missing.sourceMessage, /Checking Spotify control/);
+
+  const unknown = evaluateJamContract({ ...base, source_enabled: true });
+  assert.equal(unknown.canStart, false);
+
+  const disabled = evaluateJamContract({
+    ...base,
+    source_availability_known: true,
+    source_enabled: false,
+    source_status: "disabled",
+  });
+  assert.equal(disabled.canStart, false);
+  assert.equal(disabled.sourceTone, "warning");
+  assert.match(disabled.sourceMessage, /disabled on the Spotify PC/);
+
+  const negotiating = evaluateJamContract({
+    ...base,
+    source_availability_known: true,
+    source_enabled: true,
+    source_status: "negotiating",
+  });
+  assert.equal(negotiating.canStart, false);
+  assert.match(negotiating.sourceMessage, /preparing Spotify control/);
+});
+
 test("offline and failed sources block start and preserve their diagnostic", () => {
   const offline = evaluateJamContract({
-    jam_protocol_version: 2,
+    jam_protocol_version: 3,
+    source_enabled: true,
+    source_availability_known: true,
     spotify_connected: true,
     source_status: "offline",
     source_error: "Configured source disconnected",
@@ -123,7 +195,9 @@ test("offline and failed sources block start and preserve their diagnostic", () 
   assert.equal(offline.sourceMessage, "Configured source disconnected");
 
   const failed = evaluateJamContract({
-    jam_protocol_version: 2,
+    jam_protocol_version: 3,
+    source_enabled: true,
+    source_availability_known: true,
     spotify_connected: true,
     source_status: "error",
     source_error: "Spotify capture helper exited",
@@ -134,7 +208,9 @@ test("offline and failed sources block start and preserve their diagnostic", () 
 
 test("a stalled source keeps queue and skip recovery controls but blocks new listeners", () => {
   const stalled = evaluateJamContract({
-    jam_protocol_version: 2,
+    jam_protocol_version: 3,
+    source_enabled: true,
+    source_availability_known: true,
     spotify_connected: true,
     active: true,
     source_status: "stalled",
@@ -148,7 +224,9 @@ test("a stalled source keeps queue and skip recovery controls but blocks new lis
   assert.equal(stalled.sourceMessage, "Spotify is playing but Echo audio has stalled");
 
   const stalledWithDiagnostic = evaluateJamContract({
-    jam_protocol_version: 2,
+    jam_protocol_version: 3,
+    source_enabled: true,
+    source_availability_known: true,
     source_status: "stalled",
     source_error: "Host capture stopped delivering frames",
   });
@@ -157,7 +235,9 @@ test("a stalled source keeps queue and skip recovery controls but blocks new lis
 
 test("an active degraded Jam fails closed while its source recovers", () => {
   const contract = evaluateJamContract({
-    jam_protocol_version: 2,
+    jam_protocol_version: 3,
+    source_enabled: true,
+    source_availability_known: true,
     spotify_connected: true,
     active: true,
     source_status: "offline",
@@ -171,7 +251,7 @@ test("an active degraded Jam fails closed while its source recovers", () => {
 test("Stop Music remains available when capture fails but Spotify is playing", () => {
   for (const source_status of ["offline", "error", "failed", "stalled"]) {
     const contract = evaluateJamContract({
-      jam_protocol_version: 2,
+      jam_protocol_version: 3,
       spotify_connected: true,
       spotify_is_playing: true,
       playback_stop_supported: true,
@@ -184,7 +264,7 @@ test("Stop Music remains available when capture fails but Spotify is playing", (
 
 test("Stop Music is capability, generation-state, and playback gated", () => {
   const base = {
-    jam_protocol_version: 2,
+    jam_protocol_version: 3,
     spotify_connected: true,
     spotify_is_playing: true,
     playback_stop_supported: true,
@@ -202,7 +282,9 @@ test("Stop Music is capability, generation-state, and playback gated", () => {
 
 test("an active healthy Jam permits join and control actions", () => {
   const contract = evaluateJamContract({
-    jam_protocol_version: 2,
+    jam_protocol_version: 3,
+    source_enabled: true,
+    source_availability_known: true,
     spotify_connected: true,
     active: true,
     source_status: "live",
@@ -215,7 +297,9 @@ test("an active healthy Jam permits join and control actions", () => {
 
 test("explicit source_ready can confirm a source before its status label catches up", () => {
   const contract = evaluateJamContract({
-    jam_protocol_version: 2,
+    jam_protocol_version: 3,
+    source_enabled: true,
+    source_availability_known: true,
     spotify_connected: true,
     source_status: "starting",
     source_ready: true,

--- a/core/viewer/jam-source-local-control.test.js
+++ b/core/viewer/jam-source-local-control.test.js
@@ -1,0 +1,61 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const viewerDir = __dirname;
+const jamSource = fs.readFileSync(path.join(viewerDir, "jam.js"), "utf8");
+const indexSource = fs.readFileSync(path.join(viewerDir, "index.html"), "utf8");
+
+function functionSource(name, nextName) {
+  const start = jamSource.indexOf(`function ${name}(`);
+  const asyncStart = jamSource.indexOf(`async function ${name}(`);
+  const actualStart = start === -1 ? asyncStart : start;
+  const next = jamSource.indexOf(`function ${nextName}(`, actualStart + 1);
+  const asyncNext = jamSource.indexOf(`async function ${nextName}(`, actualStart + 1);
+  const actualNext = [next, asyncNext].filter((value) => value !== -1).sort((a, b) => a - b)[0];
+  assert.notEqual(actualStart, -1, `${name} is present`);
+  assert.notEqual(actualNext, undefined, `${nextName} follows ${name}`);
+  return jamSource.slice(actualStart, actualNext);
+}
+
+test("source-PC switches appear in synchronized portal and Jam cards", () => {
+  assert.equal((indexSource.match(/data-jam-source-local-card/g) || []).length, 2);
+  assert.equal((indexSource.match(/>Allow Echo Jam to use Spotify on this PC</g) || []).length, 2);
+  assert.equal((indexSource.match(/>Hear Jam on this PC</g) || []).length, 2);
+  assert.equal((indexSource.match(/data-jam-source-takeover-toggle/g) || []).length, 2);
+  assert.equal((indexSource.match(/data-jam-source-monitor-toggle/g) || []).length, 2);
+  assert.ok(
+    indexSource.indexOf("data-jam-source-local-card") < indexSource.indexOf('<div class="portal-form">'),
+    "the source-PC controls are available before Echo Connect",
+  );
+});
+
+test("source-PC controls boot before login and refresh with Jam polling", () => {
+  assert.match(jamSource, /DOMContentLoaded", initJamSourceLocalControlUi/);
+  assert.match(jamSource, /else\s*{\s*initJamSourceLocalControlUi\(\);\s*}/);
+
+  const refresh = functionSource("refreshJamSourceLocalControl", "setJamSourceLocalControl");
+  assert.match(refresh, /tauriInvoke\("get_jam_source_local_control"\)/);
+
+  const poll = functionSource("fetchJamState", "renderJamPanel");
+  assert.match(poll, /refreshJamSourceLocalControl\(\)/);
+});
+
+test("both source-PC settings use their native IPC setters", () => {
+  const setter = functionSource("setJamSourceLocalControl", "bindJamSourceLocalControls");
+  assert.match(setter, /set_jam_source_takeover_enabled/);
+  assert.match(setter, /set_jam_source_monitor_enabled/);
+  assert.match(setter, /tauriInvoke\(command,\s*{ enabled: enabled === true }\)/);
+});
+
+test("source relay muting never overwrites the independent Jam volume", () => {
+  const mute = functionSource("muteSourceHostRelayIfNeeded", "evaluateJamServerContract");
+  assert.match(mute, /applyJamRelayGain\(\)/);
+  assert.doesNotMatch(mute, /_jamVolume\s*=/);
+  assert.doesNotMatch(mute, /jam-volume-slider/);
+
+  const routingHook = functionSource("installJamRelayAudioRoutingHook", "refreshJamSourceLocalControl");
+  assert.match(routingHook, /originalSetRoomAudioMutedState\(next\)/);
+  assert.match(routingHook, /applyJamRelayGain\(\)/);
+});

--- a/core/viewer/jam-source-local-control.test.js
+++ b/core/viewer/jam-source-local-control.test.js
@@ -40,6 +40,9 @@ test("source-PC controls boot before login and refresh with Jam polling", () => 
 
   const poll = functionSource("fetchJamState", "renderJamPanel");
   assert.match(poll, /refreshJamSourceLocalControl\(\)/);
+
+  const init = functionSource("initJamSourceLocalControlUi", "detectJamSourceHost");
+  assert.match(init, /setInterval\(refreshJamSourceLocalControl, 2000\)/);
 });
 
 test("both source-PC settings use their native IPC setters", () => {

--- a/core/viewer/jam-stop-music.test.js
+++ b/core/viewer/jam-stop-music.test.js
@@ -1,0 +1,32 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const viewerDir = __dirname;
+const jamSource = fs.readFileSync(path.join(viewerDir, "jam.js"), "utf8");
+const indexSource = fs.readFileSync(path.join(viewerDir, "index.html"), "utf8");
+
+function functionSource(name, nextName) {
+  const start = jamSource.indexOf(`async function ${name}(`);
+  const end = jamSource.indexOf(`async function ${nextName}(`, start + 1);
+  assert.notEqual(start, -1, `${name} is present`);
+  assert.notEqual(end, -1, `${nextName} follows ${name}`);
+  return jamSource.slice(start, end);
+}
+
+test("Stop Music is a distinct red playback control", () => {
+  assert.match(indexSource, /id="jam-stop-btn"[^>]*class="jam-stop-btn"[^>]*>Stop Music<\/button>/);
+  assert.match(indexSource, /Stops Spotify playback for everyone; the Jam stays open/);
+});
+
+test("Stop Music never tears down Jam membership or listener audio", () => {
+  const handler = functionSource("stopJamPlayback", "skipTrack");
+
+  assert.match(handler, /\/api\/jam\/playback\/stop/);
+  assert.match(handler, /jam-playback-stopped/);
+  assert.doesNotMatch(handler, /\/api\/jam\/stop["']/);
+  assert.doesNotMatch(handler, /stopJamAudioStream/);
+  assert.doesNotMatch(handler, /leaveSucceeded/);
+  assert.doesNotMatch(handler, /_jamListeningGeneration\s*=\s*null/);
+});

--- a/core/viewer/jam-stop-music.test.js
+++ b/core/viewer/jam-stop-music.test.js
@@ -16,12 +16,12 @@ function functionSource(name, nextName) {
 }
 
 test("Stop Music is a distinct red playback control", () => {
-  assert.match(indexSource, /id="jam-stop-btn"[^>]*class="jam-stop-btn"[^>]*>Stop Music<\/button>/);
+  assert.match(indexSource, /id="jam-stop-music-btn"[^>]*class="jam-stop-btn"[^>]*>Stop Music<\/button>/);
   assert.match(indexSource, /Stops Spotify playback for everyone; the Jam stays open/);
 });
 
 test("Stop Music never tears down Jam membership or listener audio", () => {
-  const handler = functionSource("stopJamPlayback", "skipTrack");
+  const handler = functionSource("stopJamPlayback", "endJam");
 
   assert.match(handler, /\/api\/jam\/playback\/stop/);
   assert.match(handler, /jam-playback-stopped/);
@@ -29,4 +29,14 @@ test("Stop Music never tears down Jam membership or listener audio", () => {
   assert.doesNotMatch(handler, /stopJamAudioStream/);
   assert.doesNotMatch(handler, /leaveSucceeded/);
   assert.doesNotMatch(handler, /_jamListeningGeneration\s*=\s*null/);
+});
+
+test("host-only End Jam remains distinct from shared Stop Music", () => {
+  assert.match(indexSource, /id="jam-end-btn"[^>]*class="jam-end-btn"[^>]*>End Jam<\/button>/);
+  const handler = functionSource("endJam", "skipTrack");
+
+  assert.match(handler, /\/api\/jam\/stop/);
+  assert.match(handler, /stopJamAudioStream/);
+  assert.match(handler, /_jamListeningGeneration\s*=\s*null/);
+  assert.match(jamSource, /_jamState\.host_identity\s*===\s*identity/);
 });

--- a/core/viewer/jam.css
+++ b/core/viewer/jam.css
@@ -318,6 +318,23 @@
   background: #dc2626;
 }
 
+.jam-end-btn {
+  padding: 8px 14px;
+  font-size: 13px;
+  font-weight: 600;
+  background: transparent;
+  color: #f87171;
+  border: 1px solid rgba(248, 113, 113, 0.65);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: var(--transition);
+}
+
+.jam-end-btn:hover {
+  background: rgba(239, 68, 68, 0.14);
+  border-color: #f87171;
+}
+
 .jam-skip-btn {
   padding: 8px 14px;
   font-size: 13px;

--- a/core/viewer/jam.css
+++ b/core/viewer/jam.css
@@ -115,6 +115,170 @@
   background: #1ed760;
 }
 
+/* --- Source-PC Local Control --- */
+.jam-source-local-card {
+  display: grid;
+  gap: 10px;
+  padding: 12px;
+  text-align: left;
+  background: rgba(15, 23, 42, calc(0.62 * var(--ui-bg-alpha, 1)));
+  border: 1px solid rgba(29, 185, 84, 0.34);
+  border-radius: var(--radius);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+}
+
+.jam-source-local-card.hidden,
+.jam-source-local-card[hidden] {
+  display: none;
+}
+
+.portal .jam-source-local-card-portal {
+  position: relative;
+  z-index: 1;
+  width: min(100%, 420px);
+  box-sizing: border-box;
+  margin: 0 0 18px;
+}
+
+.jam-source-local-heading,
+.jam-source-local-switch-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+}
+
+.jam-source-local-title {
+  color: var(--text);
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.jam-source-local-status {
+  margin-top: 2px;
+  color: var(--muted);
+  font-size: 11px;
+  line-height: 1.35;
+}
+
+.jam-source-local-status.ready {
+  color: #4ade80;
+}
+
+.jam-source-local-status.warning {
+  color: #fbbf24;
+}
+
+.jam-source-local-badge {
+  flex: 0 0 auto;
+  padding: 3px 7px;
+  color: #86efac;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  background: rgba(29, 185, 84, 0.14);
+  border: 1px solid rgba(29, 185, 84, 0.3);
+  border-radius: 999px;
+}
+
+.jam-source-local-switch-row {
+  padding-top: 10px;
+  border-top: 1px solid rgba(148, 163, 184, 0.1);
+  cursor: pointer;
+}
+
+.jam-source-local-switch-row:has(input:disabled) {
+  cursor: wait;
+  opacity: 0.65;
+}
+
+.jam-source-local-copy {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+
+.jam-source-local-copy strong {
+  color: var(--text);
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1.35;
+}
+
+.jam-source-local-copy small {
+  color: var(--muted);
+  font-size: 10px;
+  line-height: 1.35;
+}
+
+.jam-source-local-switch {
+  position: relative;
+  flex: 0 0 auto;
+  width: 38px;
+  height: 22px;
+}
+
+.jam-source-local-switch input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+}
+
+.jam-source-local-switch > span {
+  position: absolute;
+  inset: 0;
+  background: rgba(148, 163, 184, 0.28);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: 999px;
+  transition: 160ms ease;
+}
+
+.jam-source-local-switch > span::after {
+  content: "";
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 14px;
+  height: 14px;
+  background: #f8fafc;
+  border-radius: 50%;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.35);
+  transition: 160ms ease;
+}
+
+.jam-source-local-switch input:checked + span {
+  background: #1db954;
+  border-color: #1ed760;
+}
+
+.jam-source-local-switch input:checked + span::after {
+  transform: translateX(16px);
+}
+
+.jam-source-local-switch input:focus-visible + span {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.jam-source-local-error {
+  padding: 7px 9px;
+  color: #fecaca;
+  font-size: 11px;
+  line-height: 1.35;
+  background: rgba(239, 68, 68, 0.12);
+  border: 1px solid rgba(239, 68, 68, 0.25);
+  border-radius: var(--radius-sm);
+}
+
+.jam-source-local-error.hidden {
+  display: none;
+}
+
 /* --- Host Controls --- */
 .jam-host-controls {
   display: flex;

--- a/core/viewer/jam.js
+++ b/core/viewer/jam.js
@@ -97,6 +97,8 @@ function evaluateJamServerContract(state) {
     compatibilityMessage: "Jam viewer assets are incomplete — reopen Echo after the server update",
     active: false,
     spotifyConnected: false,
+    spotifyIsPlaying: false,
+    playbackStopSupported: false,
     sourceStatus: "unknown",
     sourceReady: false,
     sourceTone: "error",
@@ -107,6 +109,7 @@ function evaluateJamServerContract(state) {
     canStart: false,
     canJoin: false,
     canControl: false,
+    canStopPlayback: false,
     canConfigure: false,
   };
 }
@@ -177,6 +180,20 @@ function jamActionAllowed(action) {
     }
     return true;
   }
+  if (action === "stopPlayback") {
+    if (!contract.canStopPlayback) {
+      var message = !contract.playbackStopSupported
+        ? "Stop Music is unavailable — reopen Echo after the server update"
+        : !contract.active
+          ? "No active Jam is running"
+          : !contract.spotifyConnected
+            ? "Spotify is not connected"
+            : "Music is already stopped";
+      showJamError(message);
+      return false;
+    }
+    return true;
+  }
   return contract.canControl;
 }
 
@@ -184,6 +201,7 @@ function applyJamContractToControls() {
   var contract = _jamContract || evaluateJamServerContract(null);
   var connectBtn = document.getElementById("jam-connect-spotify");
   var startBtn = document.getElementById("jam-start-btn");
+  var stopBtn = document.getElementById("jam-stop-btn");
   var skipBtn = document.getElementById("jam-skip-btn");
   var searchInput = document.getElementById("jam-search-input");
   var searchSection = document.getElementById("jam-search-section");
@@ -199,6 +217,18 @@ function applyJamContractToControls() {
         : !contract.spotifyConnected
           ? "Connect Spotify first"
           : contract.sourceMessage;
+  }
+  if (stopBtn) {
+    stopBtn.disabled = !contract.canStopPlayback;
+    stopBtn.title = contract.canStopPlayback
+      ? "Stops Spotify playback for everyone; the Jam stays open"
+      : !contract.playbackStopSupported
+        ? "Stop Music is unavailable until the server update is complete"
+        : !contract.active
+          ? "No active Jam is running"
+          : !contract.spotifyConnected
+            ? "Spotify is not connected"
+            : "Music is already stopped";
   }
   if (skipBtn) skipBtn.disabled = !contract.canControl || !contract.active;
   if (searchInput) searchInput.disabled = !contract.canControl;
@@ -550,44 +580,52 @@ async function startJam() {
   }
 }
 
-async function stopJam() {
+async function stopJamPlayback() {
+  var stopBtn = document.getElementById("jam-stop-btn");
   try {
-    if (!jamActionAllowed("control")) return;
-    var identity = room && room.localParticipant ? room.localParticipant.identity : "";
-    var stopResp = await fetch(apiUrl("/api/jam/stop"), {
+    if (!jamActionAllowed("stopPlayback")) return;
+    if (stopBtn) {
+      stopBtn.disabled = true;
+      stopBtn.textContent = "Stopping...";
+    }
+    var stopResp = await fetch(apiUrl("/api/jam/playback/stop"), {
       method: "POST",
       headers: jamActorHeaders(),
-      body: JSON.stringify({ identity: identity, generation: _jamState && _jamState.generation })
+      body: JSON.stringify({ generation: _jamState && _jamState.generation })
     });
     if (!stopResp.ok) {
-      if (stopResp.status === 403) {
-        showJamError("Only the host can end the Jam");
-        return;
-      }
-      showJamError("Stop failed: " + stopResp.status);
+      var stopError = (await stopResp.text()).trim();
+      showJamError("Stop Music failed" + (stopError
+        ? ": " + stopError
+        : " (status " + stopResp.status + ")"));
       return;
     }
 
-    if (_jamSessionState && _jamSessionState.leaveSucceeded) {
-      _jamSessionState.leaveSucceeded();
-      syncJamButtonsFromState();
+    if (_jamState) {
+      _jamState.spotify_is_playing = false;
+      if (_jamState.now_playing) _jamState.now_playing.is_playing = false;
+      _jamContract = evaluateJamServerContract(_jamState);
+      renderJamPanel();
+      updateNowPlayingBanner(_jamState);
     }
-    _jamListeningGeneration = null;
-    // Stop audio stream
-    stopJamAudioStream();
+    showJamToast("Music stopped. The Jam is still open.");
 
-    // Broadcast jam-stopped
+    // Prompt other viewers to refresh immediately without resetting their
+    // listener intent or closing the generation-scoped audio socket.
     try {
-      var msg = JSON.stringify({ type: "jam-stopped" });
+      var msg = JSON.stringify({ type: "jam-playback-stopped" });
       room.localParticipant.publishData(new TextEncoder().encode(msg), { reliable: true });
     } catch (e) {
       debugLog("[jam] data broadcast error: " + e);
     }
 
-    fetchJamState();
+    await fetchJamState();
   } catch (e) {
-    showJamError("Stop jam error: " + e.message);
-    debugLog("[jam] stopJam error: " + e);
+    showJamError("Stop Music failed: " + e.message);
+    debugLog("[jam] stopJamPlayback error: " + e);
+  } finally {
+    if (stopBtn) stopBtn.textContent = "Stop Music";
+    applyJamContractToControls();
   }
 }
 
@@ -878,8 +916,10 @@ function renderJamPanel() {
     startBtn.style.display = _jamState.active ? "none" : "";
     startBtn.disabled = !contract.canStart;
   }
-  // End Jam is hidden — jam auto-ends when all listeners leave (30s timeout)
-  if (stopBtn) stopBtn.style.display = "none";
+  if (stopBtn) {
+    stopBtn.style.display = _jamState.active && contract.playbackStopSupported ? "" : "none";
+    stopBtn.disabled = !contract.canStopPlayback;
+  }
   if (skipBtn) {
     skipBtn.style.display = _jamState.active ? "" : "none";
     skipBtn.disabled = !contract.canControl;
@@ -1287,6 +1327,15 @@ function handleJamDataMessage(payload) {
     playJamStartChime();
     startBannerPolling();
     fetchJamState();
+  } else if (payload.type === "jam-playback-stopped") {
+    if (_jamState) {
+      _jamState.spotify_is_playing = false;
+      if (_jamState.now_playing) _jamState.now_playing.is_playing = false;
+      _jamContract = evaluateJamServerContract(_jamState);
+      renderJamPanel();
+      updateNowPlayingBanner(_jamState);
+    }
+    fetchJamState();
   } else if (payload.type === "jam-stopped") {
     resetLocalJamListening();
     syncJamButtonsFromState();
@@ -1320,7 +1369,7 @@ function initJam() {
   if (startBtn) startBtn.onclick = startJam;
 
   var stopBtn = document.getElementById("jam-stop-btn");
-  if (stopBtn) stopBtn.onclick = stopJam;
+  if (stopBtn) stopBtn.onclick = stopJamPlayback;
 
   var skipBtn = document.getElementById("jam-skip-btn");
   if (skipBtn) skipBtn.onclick = skipTrack;

--- a/core/viewer/jam.js
+++ b/core/viewer/jam.js
@@ -20,11 +20,16 @@ var _jamGainNode = null;       // GainNode for volume control
 var _jamNextPlayTime = 0;      // next scheduled buffer start time
 var _jamReconnectTimer = null;
 var _jamRejoinPromise = null;
-var JAM_PROTOCOL_VERSION = 2;
+var JAM_PROTOCOL_VERSION = 3;
 var _jamContract = null;
 var _jamListeningGeneration = null;
 var _jamIsSourceHost = null;
-var _jamSourceHostPromise = null;
+var _jamSourceLocalControl = null;
+var _jamSourceLocalControlPromise = null;
+var _jamSourceLocalControlPending = false;
+var _jamSourceLocalControlLegacy = false;
+var _jamSourceLocalControlsBound = false;
+var _jamRelayMuteNoticeShown = false;
 var _jamStateRequestGate = (window.EchoJamSessionState && window.EchoJamSessionState.createLatestRequestGate)
   ? window.EchoJamSessionState.createLatestRequestGate()
   : (function() {
@@ -46,41 +51,227 @@ function jamActorHeaders(participantToken) {
   };
 }
 
-async function detectJamSourceHost() {
-  if (_jamIsSourceHost !== null) return _jamIsSourceHost;
-  if (_jamSourceHostPromise) return _jamSourceHostPromise;
-  if (typeof tauriInvoke !== "function" || typeof hasTauriIPC !== "function" || !hasTauriIPC()) {
-    _jamIsSourceHost = false;
-    return false;
+function normalizeJamSourceLocalControl(value) {
+  var input = value && typeof value === "object" ? value : {};
+  return {
+    is_source_host: input.is_source_host === true,
+    takeover_enabled: input.takeover_enabled === true,
+    monitor_enabled: input.monitor_enabled === true,
+    takeover_active: input.takeover_active === true,
+    agent_running: input.agent_running === true,
+    target_device_name: typeof input.target_device_name === "string" ? input.target_device_name.trim() : "",
+    last_error: typeof input.last_error === "string" ? input.last_error.trim() : ""
+  };
+}
+
+function jamSourceLocalErrorMessage(error) {
+  if (error && typeof error.message === "string" && error.message.trim()) return error.message.trim();
+  var message = String(error || "Unknown native control error").trim();
+  return message || "Unknown native control error";
+}
+
+function renderJamSourceLocalControl() {
+  var state = _jamSourceLocalControl;
+  var isSourceHost = !!state && state.is_source_host === true;
+  var status = "Checking this PC…";
+  var tone = "";
+
+  if (isSourceHost) {
+    var device = state.target_device_name || "Spotify on this PC";
+    if (_jamSourceLocalControlPending) {
+      status = "Saving this PC's Jam settings…";
+    } else if (_jamSourceLocalControlLegacy) {
+      status = "Echo update required for local Spotify controls";
+      tone = "warning";
+    } else if (!state.takeover_enabled) {
+      status = "Spotify control is off";
+      tone = "warning";
+    } else if (state.takeover_active) {
+      status = "Echo is using " + device + (state.monitor_enabled ? " · local Jam audio is on" : " · local Jam audio is off");
+      tone = "ready";
+    } else if (!state.agent_running) {
+      status = "Spotify control is starting…";
+    } else {
+      status = "Ready to use " + device + " when the Jam starts";
+      tone = "ready";
+    }
   }
-  _jamSourceHostPromise = tauriInvoke("is_jam_source_host")
-    .then(function(isSourceHost) {
-      _jamIsSourceHost = isSourceHost === true;
-      return _jamIsSourceHost;
+
+  document.querySelectorAll("[data-jam-source-local-card]").forEach(function(card) {
+    card.hidden = !isSourceHost;
+    card.classList.toggle("hidden", !isSourceHost);
+  });
+  document.querySelectorAll("[data-jam-source-local-status]").forEach(function(el) {
+    el.textContent = status;
+    el.className = "jam-source-local-status" + (tone ? " " + tone : "");
+  });
+  document.querySelectorAll("[data-jam-source-takeover-toggle]").forEach(function(input) {
+    input.checked = isSourceHost && state.takeover_enabled === true;
+    input.disabled = !isSourceHost || _jamSourceLocalControlPending || _jamSourceLocalControlLegacy;
+  });
+  document.querySelectorAll("[data-jam-source-monitor-toggle]").forEach(function(input) {
+    input.checked = isSourceHost && state.monitor_enabled === true;
+    input.disabled = !isSourceHost || _jamSourceLocalControlPending || _jamSourceLocalControlLegacy;
+  });
+  document.querySelectorAll("[data-jam-source-local-error]").forEach(function(el) {
+    var error = isSourceHost && state.last_error ? state.last_error : "";
+    el.textContent = error;
+    el.classList.toggle("hidden", !error);
+  });
+}
+
+function currentJamRelayGain() {
+  var roomMuted = typeof roomAudioMuted !== "undefined" && roomAudioMuted;
+  var localControl = _jamSourceLocalControl || {
+    is_source_host: _jamIsSourceHost === true,
+    takeover_active: false,
+    monitor_enabled: false
+  };
+  if (window.EchoJamSessionState &&
+      typeof window.EchoJamSessionState.effectiveJamRelayGain === "function") {
+    return window.EchoJamSessionState.effectiveJamRelayGain(_jamVolume, roomMuted, localControl);
+  }
+  if (localControl.is_source_host === true &&
+      !(localControl.takeover_active === true && localControl.monitor_enabled === true)) {
+    return 0;
+  }
+  return roomMuted ? 0 : (_jamVolume / 100);
+}
+
+function applyJamRelayGain() {
+  if (_jamGainNode) _jamGainNode.gain.value = currentJamRelayGain();
+}
+
+function installJamRelayAudioRoutingHook() {
+  if (typeof setRoomAudioMutedState !== "function" || setRoomAudioMutedState._jamSourceRelayAware) return;
+  var originalSetRoomAudioMutedState = setRoomAudioMutedState;
+  setRoomAudioMutedState = function(next) {
+    var result = originalSetRoomAudioMutedState(next);
+    // audio-routing.js owns the room-wide mute toggle. Re-apply the local
+    // source monitor policy synchronously after it updates the shared gain.
+    applyJamRelayGain();
+    return result;
+  };
+  setRoomAudioMutedState._jamSourceRelayAware = true;
+}
+
+async function refreshJamSourceLocalControl(allowDuringMutation) {
+  if (_jamSourceLocalControlPending && allowDuringMutation !== true) return _jamSourceLocalControl;
+  if (_jamSourceLocalControlPromise) return _jamSourceLocalControlPromise;
+  if (typeof tauriInvoke !== "function" || typeof hasTauriIPC !== "function" || !hasTauriIPC()) {
+    _jamSourceLocalControl = normalizeJamSourceLocalControl(null);
+    _jamIsSourceHost = false;
+    _jamSourceLocalControlLegacy = false;
+    renderJamSourceLocalControl();
+    applyJamRelayGain();
+    return _jamSourceLocalControl;
+  }
+
+  _jamSourceLocalControlPromise = tauriInvoke("get_jam_source_local_control")
+    .then(function(value) {
+      _jamSourceLocalControl = normalizeJamSourceLocalControl(value);
+      _jamIsSourceHost = _jamSourceLocalControl.is_source_host;
+      _jamSourceLocalControlLegacy = false;
+      return _jamSourceLocalControl;
     })
-    .catch(function(e) {
-      _jamIsSourceHost = false;
-      debugLog("[jam] could not determine native Jam source role: " + e);
-      return false;
+    .catch(async function(error) {
+      // A mixed desktop/viewer rollout must retain the old doubled-audio
+      // protection even though the new switches cannot be used yet.
+      var isSourceHost = false;
+      try {
+        isSourceHost = await tauriInvoke("is_jam_source_host") === true;
+      } catch (_) {}
+      _jamSourceLocalControl = normalizeJamSourceLocalControl({
+        is_source_host: isSourceHost,
+        last_error: isSourceHost ? "Update Echo to enable the source-PC Spotify controls." : ""
+      });
+      _jamIsSourceHost = isSourceHost;
+      _jamSourceLocalControlLegacy = true;
+      debugLog("[jam] could not read native source-PC controls: " + jamSourceLocalErrorMessage(error));
+      return _jamSourceLocalControl;
     })
-    .finally(function() { _jamSourceHostPromise = null; });
-  return _jamSourceHostPromise;
+    .finally(function() {
+      _jamSourceLocalControlPromise = null;
+      renderJamSourceLocalControl();
+      applyJamRelayGain();
+    });
+  return _jamSourceLocalControlPromise;
+}
+
+async function setJamSourceLocalControl(setting, enabled) {
+  if (!_jamSourceLocalControl || !_jamSourceLocalControl.is_source_host || _jamSourceLocalControlPending) return;
+  if (_jamSourceLocalControlPromise) await _jamSourceLocalControlPromise;
+  var command = setting === "takeover"
+    ? "set_jam_source_takeover_enabled"
+    : "set_jam_source_monitor_enabled";
+  var field = setting === "takeover" ? "takeover_enabled" : "monitor_enabled";
+  var previous = _jamSourceLocalControl[field] === true;
+  _jamSourceLocalControlPending = true;
+  _jamSourceLocalControl[field] = enabled === true;
+  _jamSourceLocalControl.last_error = "";
+  renderJamSourceLocalControl();
+  applyJamRelayGain();
+
+  try {
+    await tauriInvoke(command, { enabled: enabled === true });
+    await refreshJamSourceLocalControl(true);
+  } catch (error) {
+    _jamSourceLocalControl[field] = previous;
+    _jamSourceLocalControl.last_error = jamSourceLocalErrorMessage(error);
+    debugLog("[jam] source-PC setting failed: " + _jamSourceLocalControl.last_error);
+  } finally {
+    _jamSourceLocalControlPending = false;
+    renderJamSourceLocalControl();
+    applyJamRelayGain();
+  }
+}
+
+function bindJamSourceLocalControls() {
+  if (_jamSourceLocalControlsBound) return;
+  _jamSourceLocalControlsBound = true;
+  document.querySelectorAll("[data-jam-source-takeover-toggle]").forEach(function(input) {
+    input.addEventListener("change", function() {
+      setJamSourceLocalControl("takeover", input.checked);
+    });
+  });
+  document.querySelectorAll("[data-jam-source-monitor-toggle]").forEach(function(input) {
+    input.addEventListener("change", function() {
+      setJamSourceLocalControl("monitor", input.checked);
+    });
+  });
+}
+
+function initJamSourceLocalControlUi() {
+  installJamRelayAudioRoutingHook();
+  bindJamSourceLocalControls();
+  refreshJamSourceLocalControl();
+}
+
+async function detectJamSourceHost() {
+  var state = await refreshJamSourceLocalControl();
+  return !!state && state.is_source_host === true;
 }
 
 function muteSourceHostRelayIfNeeded(listenerJoined) {
   var shouldMute = window.EchoJamSessionState &&
     typeof window.EchoJamSessionState.shouldMuteLocalRelay === "function"
-    ? window.EchoJamSessionState.shouldMuteLocalRelay(_jamIsSourceHost, listenerJoined)
+    ? window.EchoJamSessionState.shouldMuteLocalRelay(
+        _jamIsSourceHost,
+        listenerJoined,
+        !!_jamSourceLocalControl && _jamSourceLocalControl.takeover_active,
+        !!_jamSourceLocalControl && _jamSourceLocalControl.monitor_enabled
+      )
     : _jamIsSourceHost === true && listenerJoined !== false;
-  if (!shouldMute) return;
-
-  _jamVolume = 0;
-  var volumeInput = document.getElementById("jam-volume-slider");
-  var volumeLabel = document.getElementById("jam-volume-value");
-  if (volumeInput) volumeInput.value = "0";
-  if (volumeLabel) volumeLabel.textContent = "0%";
-  if (_jamGainNode) _jamGainNode.gain.value = 0;
-  showJamToast("Local Jam relay muted - Spotify is already playing on this PC");
+  applyJamRelayGain();
+  if (!shouldMute) {
+    _jamRelayMuteNoticeShown = false;
+    return;
+  }
+  if (_jamRelayMuteNoticeShown) return;
+  _jamRelayMuteNoticeShown = true;
+  showJamToast(_jamSourceLocalControl && _jamSourceLocalControl.takeover_active
+    ? "Local Jam audio is off — enable Hear Jam on this PC to listen here"
+    : "Local Jam relay muted — Spotify is already playing on this PC");
 }
 
 function evaluateJamServerContract(state) {
@@ -99,8 +290,11 @@ function evaluateJamServerContract(state) {
     spotifyConnected: false,
     spotifyIsPlaying: false,
     playbackStopSupported: false,
+    sourceEnabled: false,
+    sourceAvailabilityKnown: false,
     sourceStatus: "unknown",
     sourceReady: false,
+    sourceControlReady: false,
     sourceTone: "error",
     sourceMessage: "Host source status is unavailable",
     sourceError: "",
@@ -569,7 +763,7 @@ async function startJam() {
     }
 
     // Host is auto-joined as listener — start audio stream
-    // The start endpoint does not return the full v2 state contract. Refresh it
+    // The start endpoint does not return the full v3 state contract. Refresh it
     // before opening audio so the connection never uses stale inactive state.
     // If this refresh fails, a later successful poll resumes the pending stream.
     await fetchJamState();
@@ -774,8 +968,8 @@ async function joinJam() {
       _jamSessionState.joinAccepted();
       syncJamButtonsFromState();
     }
-    // The configured source host already hears Spotify directly. This applies
-    // both when it starts the Jam and when it joins a Jam started elsewhere.
+    // Keep legacy source hosts from hearing a doubled relay. Native takeover
+    // may explicitly enable this synced relay as the source PC's monitor.
     muteSourceHostRelayIfNeeded(true);
     // Start receiving audio via WebSocket
     startJamAudioStream();
@@ -846,6 +1040,9 @@ async function leaveJam() {
 // ──────────────────────────────────────────
 
 async function fetchJamState() {
+  // Native source state is local to this PC and intentionally independent of
+  // room/login state. Refresh it alongside each server Jam poll.
+  refreshJamSourceLocalControl();
   var requestId = _jamStateRequestGate.begin();
   try {
     var resp = await fetch(apiUrl("/api/jam/state"), {
@@ -1068,13 +1265,7 @@ function startJamAudioStream() {
     if (!_jamAudioCtx) {
       _jamAudioCtx = new (window.AudioContext || window.webkitAudioContext)({ sampleRate: 48000 });
       _jamGainNode = _jamAudioCtx.createGain();
-      _jamGainNode.gain.value = window.EchoJamSessionState &&
-        typeof window.EchoJamSessionState.effectiveJamGain === "function"
-        ? window.EchoJamSessionState.effectiveJamGain(
-            _jamVolume,
-            typeof roomAudioMuted !== "undefined" && roomAudioMuted
-          )
-        : ((typeof roomAudioMuted !== "undefined" && roomAudioMuted) ? 0 : (_jamVolume / 100));
+      _jamGainNode.gain.value = currentJamRelayGain();
 
       var speakerSelect = document.getElementById("speaker-select");
       if (speakerSelect && speakerSelect.value && typeof _jamAudioCtx.setSinkId === "function") {
@@ -1244,12 +1435,9 @@ function onJamVolumeChange(e) {
   _jamVolume = parseInt(e.target.value, 10);
   var label = document.getElementById("jam-volume-value");
   if (label) label.textContent = _jamVolume + "%";
-  if (_jamGainNode) {
-    // Preserve global Mute All semantics even when the local jam volume slider moves.
-    _jamGainNode.gain.value = (typeof roomAudioMuted !== "undefined" && roomAudioMuted)
-      ? 0
-      : (_jamVolume / 100);
-  }
+  // Preserve both global Mute All and the source-PC monitor policy while the
+  // user adjusts their independent Jam volume.
+  applyJamRelayGain();
 }
 
 // ──────────────────────────────────────────
@@ -1355,7 +1543,7 @@ function initJam() {
   // Full polling owns Jam state once the panel initializes. Cancel the
   // lightweight banner loop before issuing the first ordered full-state fetch.
   stopBannerPolling();
-  detectJamSourceHost();
+  refreshJamSourceLocalControl();
   _jamContract = unavailableJamContract("Checking Jam server and host source…");
 
   // Wire up event listeners
@@ -1412,8 +1600,6 @@ function cleanupJam() {
   _jamState = null;
   _jamContract = null;
   _jamListeningGeneration = null;
-  _jamIsSourceHost = null;
-  _jamSourceHostPromise = null;
   _jamInited = false;
   clearJamReconnectTimer();
   if (_jamSessionState && _jamSessionState.leaveSucceeded) {
@@ -1510,4 +1696,12 @@ function stopBannerPolling() {
     clearInterval(_bannerPollTimer);
     _bannerPollTimer = null;
   }
+}
+
+// Source-PC settings must be available on the login portal before Echo
+// Connect, so this boot path deliberately does not depend on initJam().
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", initJamSourceLocalControlUi, { once: true });
+} else {
+  initJamSourceLocalControlUi();
 }

--- a/core/viewer/jam.js
+++ b/core/viewer/jam.js
@@ -29,6 +29,7 @@ var _jamSourceLocalControlPromise = null;
 var _jamSourceLocalControlPending = false;
 var _jamSourceLocalControlLegacy = false;
 var _jamSourceLocalControlsBound = false;
+var _jamSourceLocalPollTimer = null;
 var _jamRelayMuteNoticeShown = false;
 var _jamStateRequestGate = (window.EchoJamSessionState && window.EchoJamSessionState.createLatestRequestGate)
   ? window.EchoJamSessionState.createLatestRequestGate()
@@ -83,11 +84,14 @@ function renderJamSourceLocalControl() {
     } else if (_jamSourceLocalControlLegacy) {
       status = "Echo update required for local Spotify controls";
       tone = "warning";
+    } else if (state.takeover_active && !state.takeover_enabled) {
+      status = "Stopping the Jam and returning Spotify to this PC...";
+      tone = "warning";
     } else if (!state.takeover_enabled) {
       status = "Spotify control is off";
       tone = "warning";
     } else if (state.takeover_active) {
-      status = "Echo is using " + device + (state.monitor_enabled ? " · local Jam audio is on" : " · local Jam audio is off");
+      status = "Echo is using " + device + (state.monitor_enabled ? " · local Jam monitor is enabled" : " · local Jam monitor is off");
       tone = "ready";
     } else if (!state.agent_running) {
       status = "Spotify control is starting…";
@@ -244,7 +248,14 @@ function bindJamSourceLocalControls() {
 function initJamSourceLocalControlUi() {
   installJamRelayAudioRoutingHook();
   bindJamSourceLocalControls();
-  refreshJamSourceLocalControl();
+  var initialControl = refreshJamSourceLocalControl();
+  // This PC can be taken over while the viewer is sitting at the login portal.
+  // Keep the local-only status truthful without depending on Echo room polling.
+  Promise.resolve(initialControl).then(function(state) {
+    if (state && state.is_source_host && !_jamSourceLocalPollTimer) {
+      _jamSourceLocalPollTimer = setInterval(refreshJamSourceLocalControl, 2000);
+    }
+  });
 }
 
 async function detectJamSourceHost() {
@@ -382,8 +393,15 @@ function jamActionAllowed(action) {
           ? "No active Jam is running"
           : !contract.spotifyConnected
             ? "Spotify is not connected"
-            : "Music is already stopped";
+            : "Stop Music is unavailable";
       showJamError(message);
+      return false;
+    }
+    return true;
+  }
+  if (action === "end") {
+    if (!contract.active) {
+      showJamError("No active Jam is running");
       return false;
     }
     return true;
@@ -395,7 +413,8 @@ function applyJamContractToControls() {
   var contract = _jamContract || evaluateJamServerContract(null);
   var connectBtn = document.getElementById("jam-connect-spotify");
   var startBtn = document.getElementById("jam-start-btn");
-  var stopBtn = document.getElementById("jam-stop-btn");
+  var stopBtn = document.getElementById("jam-stop-music-btn");
+  var endBtn = document.getElementById("jam-end-btn");
   var skipBtn = document.getElementById("jam-skip-btn");
   var searchInput = document.getElementById("jam-search-input");
   var searchSection = document.getElementById("jam-search-section");
@@ -422,7 +441,13 @@ function applyJamContractToControls() {
           ? "No active Jam is running"
           : !contract.spotifyConnected
             ? "Spotify is not connected"
-            : "Music is already stopped";
+            : "Stop Music is unavailable";
+  }
+  if (endBtn) {
+    endBtn.disabled = !contract.compatible || !contract.active;
+    endBtn.title = contract.compatible
+      ? "Ends the Jam for everyone and clears its queue"
+      : contract.compatibilityMessage;
   }
   if (skipBtn) skipBtn.disabled = !contract.canControl || !contract.active;
   if (searchInput) searchInput.disabled = !contract.canControl;
@@ -775,7 +800,7 @@ async function startJam() {
 }
 
 async function stopJamPlayback() {
-  var stopBtn = document.getElementById("jam-stop-btn");
+  var stopBtn = document.getElementById("jam-stop-music-btn");
   try {
     if (!jamActionAllowed("stopPlayback")) return;
     if (stopBtn) {
@@ -820,6 +845,50 @@ async function stopJamPlayback() {
   } finally {
     if (stopBtn) stopBtn.textContent = "Stop Music";
     applyJamContractToControls();
+  }
+}
+
+async function endJam() {
+  try {
+    if (!jamActionAllowed("end")) return;
+    var identity = room && room.localParticipant ? room.localParticipant.identity : "";
+    var response = await fetch(apiUrl("/api/jam/stop"), {
+      method: "POST",
+      headers: jamActorHeaders(),
+      body: JSON.stringify({
+        identity: identity,
+        generation: _jamState && _jamState.generation
+      })
+    });
+    if (!response.ok) {
+      if (response.status === 403) {
+        showJamError("Only the participant who started this Jam can end it");
+      } else {
+        var detail = (await response.text()).trim();
+        showJamError("End Jam failed" + (detail
+          ? ": " + detail
+          : " (status " + response.status + ")"));
+      }
+      return;
+    }
+
+    if (_jamSessionState && _jamSessionState.leaveSucceeded) {
+      _jamSessionState.leaveSucceeded();
+      syncJamButtonsFromState();
+    }
+    _jamListeningGeneration = null;
+    stopJamAudioStream();
+    try {
+      var message = JSON.stringify({ type: "jam-stopped" });
+      room.localParticipant.publishData(new TextEncoder().encode(message), { reliable: true });
+    } catch (error) {
+      debugLog("[jam] data broadcast error: " + error);
+    }
+    showJamToast("Jam ended.");
+    await fetchJamState();
+  } catch (error) {
+    showJamError("End Jam failed: " + error.message);
+    debugLog("[jam] endJam error: " + error);
   }
 }
 
@@ -1107,7 +1176,8 @@ function renderJamPanel() {
   var myBase = idBase(identity);
 
   var startBtn = document.getElementById("jam-start-btn");
-  var stopBtn = document.getElementById("jam-stop-btn");
+  var stopBtn = document.getElementById("jam-stop-music-btn");
+  var endBtn = document.getElementById("jam-end-btn");
   var skipBtn = document.getElementById("jam-skip-btn");
   if (startBtn) {
     startBtn.style.display = _jamState.active ? "none" : "";
@@ -1116,6 +1186,11 @@ function renderJamPanel() {
   if (stopBtn) {
     stopBtn.style.display = _jamState.active && contract.playbackStopSupported ? "" : "none";
     stopBtn.disabled = !contract.canStopPlayback;
+  }
+  if (endBtn) {
+    var isExactHost = !!identity && _jamState.host_identity === identity;
+    endBtn.style.display = _jamState.active && isExactHost ? "" : "none";
+    endBtn.disabled = !contract.compatible;
   }
   if (skipBtn) {
     skipBtn.style.display = _jamState.active ? "" : "none";
@@ -1556,8 +1631,11 @@ function initJam() {
   var startBtn = document.getElementById("jam-start-btn");
   if (startBtn) startBtn.onclick = startJam;
 
-  var stopBtn = document.getElementById("jam-stop-btn");
+  var stopBtn = document.getElementById("jam-stop-music-btn");
   if (stopBtn) stopBtn.onclick = stopJamPlayback;
+
+  var endBtn = document.getElementById("jam-end-btn");
+  if (endBtn) endBtn.onclick = endJam;
 
   var skipBtn = document.getElementById("jam-skip-btn");
   if (skipBtn) skipBtn.onclick = skipTrack;

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -54,9 +54,11 @@ powershell -ExecutionPolicy Bypass -File .\core\stop-core.ps1
 ## Spotify Jam source
 
 Jam audio comes from one explicitly provisioned Echo desktop client, not from
-the Windows service. The source client and `Spotify.exe` must stay open in the
-same interactive Windows session. Echo's Spotify OAuth connection must use the
-same Premium account signed into that Spotify desktop app.
+the Windows service. The source client and the Microsoft Store build of
+`Spotify.exe` must stay open in the same interactive Windows session. Echo's
+Spotify OAuth connection must use the same Premium account signed into that
+Spotify desktop app. VB-CABLE must expose the exact playback endpoint
+`CABLE Input (VB-Audio Virtual Cable)`.
 
 Configure the control environment with a unique source ID, a long random source
 token, and an exact unique Spotify Connect device name. The name is the stable
@@ -77,22 +79,24 @@ credentials to listener clients. Set its `server` URL to the normal Echo
 hostname that matches a Windows-trusted TLS certificate; a raw IP or
 `127.0.0.1` will not work with a certificate issued only for the public
 hostname. After starting Spotify and Echo, `/api/jam/state`
-should report protocol 2 and source status `ready` while the source is idle.
+should report protocol 3, `source_availability_known: true`,
+`source_enabled: true`, and source status `ready` while the source is idle.
 Once the Jam is active, source status should be `ready` while Spotify is paused
 or warming up and `live` while audible playback is flowing.
 
 Echo exposes one global shared Jam at a time. Any authenticated Echo user can
-start it, join it, search, add songs, and skip from Echo's Jam panel. Those users
+start it, join it, search, add songs, skip, and use **Stop Music** from Echo's Jam panel. Those users
 do not need Spotify accounts and should add their songs through Echo, not through
 their own Spotify apps. Spotify playback is always targeted back to the one
 configured desktop device and Premium host account. Echo does
 not offer a fake queue-removal control because Spotify's API cannot remove an
-individual queued item. When the source-host user starts or joins a Jam from
-that same Echo desktop client, Echo automatically sets its local Jam relay to
-0% so the PC does not play Spotify directly and then play the delayed relay on
-top of it. The user can still change the Jam volume slider explicitly.
+individual queued item. The configured source PC has local-only **Allow Echo
+Jam to use Spotify on this PC** and **Hear Jam on this PC** switches before Echo
+login and in the Jam panel. Hear Jam uses the independent Jam Volume without
+changing anyone else's level. Stop Music pauses playback for everyone but
+preserves the active Jam, queue, listeners, capture route, and audio sockets.
 
-Listener audio uses `/api/jam/audio?jam_protocol_version=2&generation=...`.
+Listener audio uses `/api/jam/audio?jam_protocol_version=3&generation=...`.
 Credentials are not placed in that URL: the listener's first WebSocket frame is
 an auth message containing its bound LiveKit token, and the server replies
 `{"type":"ready"}` only after validating its identity and current Jam membership.
@@ -151,8 +155,12 @@ the manual full-snapshot outage procedure above. Do not let the already-running
 old watcher perform that first release. Subsequent watcher processes publish and
 roll back the control binary and full viewer snapshot as one unit.
 
-For Jam v2, an authenticated `/api/jam/state` response must report
-`jam_protocol_version: 2`; verify `source_status` is `ready` before Start and
+Jam v3 is a coordinated control-plane/viewer and Windows source-desktop release.
+Do not deploy the server side while the configured source PC still runs a v2
+desktop binary: the v3 server deliberately rejects that source. After both
+sides are updated, an authenticated `/api/jam/state` response must report
+`jam_protocol_version: 3`, `source_availability_known: true`, and
+`source_enabled: true`; verify `source_status` is `ready` before Start and
 `live` while audible playback is expected before declaring the full Jam audio
 path operational. `silent` is a short playback/capture warmup state; `stalled`
 means Echo expected audible playback but did not receive it.

--- a/docs/eli5/spotify-jam-host-source.md
+++ b/docs/eli5/spotify-jam-host-source.md
@@ -2,8 +2,8 @@
 
 ## The simple version
 
-Echo has one shared Jam and one Spotify source PC. That PC runs Spotify Desktop
-and Echo Desktop in the same signed-in Windows session. Echo's server controls
+Echo has one shared Jam and one Spotify source PC. That PC runs the Microsoft
+Store build of Spotify Desktop and Echo Desktop in the same signed-in Windows session. Echo's server controls
 the same Premium account and exact Spotify Connect device. Everyone else joins
 through Echo; listeners do not need Spotify accounts.
 
@@ -23,10 +23,11 @@ Echo, and shows the same controls again in the Jam panel:
 
 Turning Allow on while idle does not reroute anything. When a Jam starts, Echo
 temporarily routes only Spotify Desktop to the exact
-`CABLE Input (VB-Audio Virtual Cable)` endpoint, captures the cable signal, and
-relays it to every listener. The Windows default output and other apps are not
-changed. If Hear Jam is off, only Echo's local relay is muted; the saved Jam
-Volume is not changed.
+`CABLE Input (VB-Audio Virtual Cable)` endpoint as a silent local sink. Echo
+captures Spotify itself through Windows process loopback and relays that audio
+to every listener. The Windows default output and other apps are not changed.
+If Hear Jam is off, only Echo's local relay is muted; the saved Jam Volume is
+not changed.
 
 Any authenticated Echo participant can start or join the one global Jam,
 search, add songs, skip, and use **Stop Music**. Stop Music pauses the exact
@@ -38,12 +39,27 @@ Turning Allow off, reaching the last-listener empty timeout, or ending the Jam
 is different: Echo pauses the bound Spotify device first, then releases its
 temporary Spotify-only route and capture.
 
+Echo journals Spotify's prior output before takeover so it can restore the
+exact route. A generation-fenced source teardown command restores immediately.
+Turning Allow off gives the server three seconds to send that command before
+Echo restores locally. A broken connection keeps Spotify silent for 36 seconds
+so heartbeat checks, the watchdog, and the server pause can finish. App exit
+waits up to 16 seconds for the teardown command and otherwise leaves the silent
+route journaled. After a forced kill or preserved exit, startup recovery waits
+until that exact old Echo process has been observed dead
+for 36 seconds, then restores the saved route (or Windows Default if the old
+endpoint vanished). A reboot, logoff, or Fast User Switch can assign a new
+Windows session number. Echo treats the old number as a note, then restores only
+through Spotify in Echo's current session when the Store app identity still
+matches.
+
 ## Required pieces
 
 The source PC needs:
 
 - the matching Echo Desktop Windows binary;
-- Spotify Desktop signed into the Premium account authorized by Echo OAuth;
+- the Microsoft Store build of Spotify Desktop signed into the Premium account
+  authorized by Echo OAuth;
 - VB-CABLE with `CABLE Input (VB-Audio Virtual Cable)` present;
 - the exact configured Spotify device name or ID; and
 - source credentials and a trusted HTTPS connection matching the server.
@@ -61,5 +77,5 @@ credentials.
 - VB-CABLE is missing or its playback endpoint does not have the exact name.
 - The source token or ID differs between the server and source `config.json`.
 - The source URL does not match a certificate trusted by Windows.
-- Spotify reports playback but no cable frames arrive; Echo reports the source
+- Spotify reports playback but no process-loopback frames arrive; Echo reports the source
   as stalled instead of claiming that audio is healthy.

--- a/docs/eli5/spotify-jam-host-source.md
+++ b/docs/eli5/spotify-jam-host-source.md
@@ -37,11 +37,18 @@ need Spotify accounts, and they add songs through Echo rather than their own
 Spotify apps. The configured source PC's Premium account is the one Spotify
 account and playback device behind the shared Jam.
 
+The red **Stop Music** button is shared like Skip: any authenticated Echo
+participant can stop the sound for everyone. Echo pauses playback on the exact
+configured Spotify desktop device but keeps the Jam, listeners, queue, and
+audio connections open. Adding a song starts playback again. This is separate
+from Echo's host-only Jam teardown, so “Stop Music” never secretly removes
+everyone from the Jam.
+
 ## How we know it works
 
-- Control tests: 50 passed.
+- Control tests: 53 passed.
 - Windows desktop tests: 80 passed.
-- Viewer tests: 123 passed.
+- Viewer tests: 127 passed.
 - Full Cargo workspace check passed.
 - Atomic viewer publish/rollback tests passed.
 - Desktop deploy-config preservation tests passed.

--- a/docs/eli5/spotify-jam-host-source.md
+++ b/docs/eli5/spotify-jam-host-source.md
@@ -1,78 +1,65 @@
 # Spotify Jam host-source reliability
 
-## What broke
+## The simple version
 
-Echo said a Spotify Jam was running, but listeners received silence unless a
-separate interactive Spotify/Echo setup happened to be open on the server PC.
-The viewer and deployed server could also be on different Jam contracts, which
-made a broken combination look current.
+Echo has one shared Jam and one Spotify source PC. That PC runs Spotify Desktop
+and Echo Desktop in the same signed-in Windows session. Echo's server controls
+the same Premium account and exact Spotify Connect device. Everyone else joins
+through Echo; listeners do not need Spotify accounts.
 
-## Why it broke
+The server cannot capture the user's Spotify audio itself because it runs as a
+Windows service in a different session. The configured Echo Desktop client is
+therefore the only source. It sends authenticated, generation-tagged audio to
+the server using Jam protocol v3.
 
-The control plane runs as a Windows service in session 0. Spotify runs in the
-signed-in user's interactive session. Windows process-loopback capture in the
-service session cannot capture that Spotify process tree. The old fallback also
-let any viewer race to become the audio source and shared capture ownership with
-screen sharing.
+## What the source-PC user does
 
-## What changed
+The source PC shows **Spotify Jam on this PC** before the user even logs into
+Echo, and shows the same controls again in the Jam panel:
 
-One explicitly configured Echo desktop client on the Spotify PC is now the only
-Jam source. It captures Spotify in the same interactive Windows session and
-sends generation-tagged PCM over an authenticated protocol-v2 WebSocket. The
-control plane rejects stale sources/actions, targets one exact Spotify Connect
-device, reports real source health, and only records queue changes that Spotify
-accepted. Viewer assets are published as one verified snapshot. The listener
-audio URL contains only the protocol version and current generation; the first
-WebSocket frame authenticates with the listener's bound LiveKit token. When the
-source host starts or joins the Jam, its local relayed copy is muted
-automatically to prevent double playback over Spotify's direct output.
-If Windows capture stops delivering packets while Spotify is still playing,
-the server asks that same source to replace only its Jam capture handle; current
-listeners stay connected and resume when the replacement reports ready.
+- **Allow Echo Jam to use Spotify on this PC** permits temporary takeover.
+- **Hear Jam on this PC** chooses whether this PC also plays Echo's synchronized
+  relay. Its loudness is the separate Jam Volume setting.
 
-Echo has one global shared Jam at a time. Any authenticated Echo user can start
-it, join it, search, add songs, and skip from Echo's Jam panel. Listeners do not
-need Spotify accounts, and they add songs through Echo rather than their own
-Spotify apps. The configured source PC's Premium account is the one Spotify
-account and playback device behind the shared Jam.
+Turning Allow on while idle does not reroute anything. When a Jam starts, Echo
+temporarily routes only Spotify Desktop to the exact
+`CABLE Input (VB-Audio Virtual Cable)` endpoint, captures the cable signal, and
+relays it to every listener. The Windows default output and other apps are not
+changed. If Hear Jam is off, only Echo's local relay is muted; the saved Jam
+Volume is not changed.
 
-The red **Stop Music** button is shared like Skip: any authenticated Echo
-participant can stop the sound for everyone. Echo pauses playback on the exact
-configured Spotify desktop device but keeps the Jam, listeners, queue, and
-audio connections open. Adding a song starts playback again. This is separate
-from Echo's host-only Jam teardown, so “Stop Music” never secretly removes
-everyone from the Jam.
+Any authenticated Echo participant can start or join the one global Jam,
+search, add songs, skip, and use **Stop Music**. Stop Music pauses the exact
+Spotify device already bound to the Jam without transferring playback. The Jam,
+listeners, queue, capture route, and audio connections stay open, so adding a
+song can start playback again.
 
-## How we know it works
+Turning Allow off, reaching the last-listener empty timeout, or ending the Jam
+is different: Echo pauses the bound Spotify device first, then releases its
+temporary Spotify-only route and capture.
 
-- Control tests: 53 passed.
-- Windows desktop tests: 80 passed.
-- Viewer tests: 127 passed.
-- Full Cargo workspace check passed.
-- Atomic viewer publish/rollback tests passed.
-- Desktop deploy-config preservation tests passed.
-- The capture tests prove Spotify selection stays in Echo's Windows session,
-  uses Spotify's root process tree, and reconnects if that process is replaced.
+## Required pieces
 
-The remaining proof is a live end-to-end run with the Premium host account,
-Spotify desktop, and the newly provisioned Echo source client on the same PC.
+The source PC needs:
 
-## Does this need a desktop update?
+- the matching Echo Desktop Windows binary;
+- Spotify Desktop signed into the Premium account authorized by Echo OAuth;
+- VB-CABLE with `CABLE Input (VB-Audio Virtual Cable)` present;
+- the exact configured Spotify device name or ID; and
+- source credentials and a trusted HTTPS connection matching the server.
 
-Yes, on the configured Spotify source PC. The server/control plane and complete
-server-served viewer snapshot must also be deployed. Ordinary listener PCs do
-not need Jam-source credentials; they receive the viewer update from the server.
+Protocol v3 crosses a release boundary: deploy the control plane and its whole
+viewer bundle, then update the configured source PC's Echo Desktop binary.
+Ordinary listener PCs get the viewer from the server and never receive source
+credentials.
 
 ## What could still go wrong?
 
-- Spotify or Echo is closed, or they run in different Windows sessions.
-- Echo OAuth and the Spotify desktop app use different Spotify accounts.
-- The configured Spotify device name is missing or matches multiple devices.
-- A rotating Spotify device ID was pinned instead of using an exact unique name.
-- The source client uses a server URL that does not match a trusted TLS
-  certificate.
-- The source token differs between the control environment and source client's
-  `config.json`.
-- Spotify reports playback but Windows delivers no audible process-loopback
-  frames; Echo now exposes this as `stalled` instead of pretending it works.
+- Spotify or Echo Desktop is closed, or they run in different Windows sessions.
+- Echo OAuth and Spotify Desktop use different Spotify accounts.
+- The configured Spotify device is missing, ambiguous, or has a stale pinned ID.
+- VB-CABLE is missing or its playback endpoint does not have the exact name.
+- The source token or ID differs between the server and source `config.json`.
+- The source URL does not match a certificate trusted by Windows.
+- Spotify reports playback but no cable frames arrive; Echo reports the source
+  as stalled instead of claiming that audio is healthy.


### PR DESCRIPTION
## Summary

- ELI5: Echo can temporarily borrow only Spotify when a Jam starts, while Windows Default and every other app stay untouched.
- Adds source-PC-only **Allow Echo Jam to use Spotify on this PC** and **Hear Jam on this PC** controls before Echo login and in the Jam panel.
- Adds shared **Stop Music** for any authenticated Echo participant. It pauses the exact Jam-bound Spotify device without ending the Jam, clearing the queue, or disconnecting listeners.
- Restores a distinct host-only **End Jam** action for full teardown.
- Upgrades the source/server/viewer contract to Jam protocol v3 with explicit source availability, generation fencing, pause-before-route-release, crash journaling, multi-process locking, and reboot/logoff recovery.
- Why now: the old flow required manual Spotify output routing and could not safely distinguish normal local listening from a remote Jam takeover.
- Linked issue: none.

## User-facing impact

- [x] User-visible behavior changed
- [ ] No user-visible behavior change

Spotify may remain on Windows Default during normal use. An active Jam temporarily routes only the Microsoft Store Spotify app to VB-CABLE, captures Spotify by process, and relays it through Echo. The source PC can opt out locally; remote Jam playback otherwise has priority. Stop Music preserves the session so another queued song can resume playback. End Jam or local Allow Off returns Spotify to its recorded prior route.

## Repro + validation evidence

### Before (bug repro)

1. Spotify had to be manually assigned to VB-CABLE for Echo to capture it.
2. That prevented normal source-PC listening and made remote Jam playback hard to distinguish/control locally.
3. Source loss and route restoration were not one generation-fenced pause-before-release lifecycle.

### After (fix verification)

1. Leave Spotify on Windows Default while idle.
2. Start a Jam: Echo validates the exact Store Spotify process, journals its prior per-app route, routes only Spotify to the exact CABLE endpoint, opens process-loopback capture, and then permits Spotify playback.
3. Use Stop Music: playback pauses for everyone while the Jam generation, queue, listeners, capture route, and audio sockets remain intact.
4. Use End Jam or local Allow Off: Echo pauses the exact bound device before restoring Spotify's prior route.
5. Crash/reconnect/reboot recovery stays fail-closed and generation/application fenced.

### Evidence (required)

- [ ] Logs attached
- [ ] Video/GIF/screenshots attached
- [x] Validation notes included below
- [ ] Installed-build Spotify/VB-CABLE round trip completed (required before release)

## Regression checklist (media/session)

- [ ] Room switch works without UI/state desync (not changed)
- [ ] Screen-share stop/start retains expected audio behavior (not changed)
- [x] Jam join/leave/listen state remains consistent on failures
- [ ] Mic/camera/share indicators match actual publish state (not changed)
- [x] Disconnect/reconnect leaves no stale Jam listeners, generation, or route ownership

## Verification commands run

- [x] `npm.cmd run verify:quick` - guardrails + 134 viewer tests
- [x] `cargo test -p echo-core-control --offline` from `core/` - 68 passed
- [x] `cargo test -p echo-core-client --offline -- --test-threads=1` from `core/` - 105 passed, 1 intentional live test ignored
- [x] `cargo check -p echo-core-client --offline --quiet` from `core/`
- [x] `powershell -NoProfile -ExecutionPolicy Bypass -File .\core\deploy\test-viewer-runtime-lib.ps1`
- [x] Targeted Rust formatting and `git diff --check`

## Release impact

Both server/viewer and Windows desktop binary. Protocol v3 must be shipped as one coordinated release. Ordinary listener PCs receive the viewer from the server; the configured Spotify source PC requires the matching desktop binary. Version bump and packaging are intentionally deferred to the release step.

## Risk

- [ ] Low
- [ ] Medium
- [x] High - touches Spotify playback, native per-app Windows audio policy, source crash recovery, and a coordinated protocol boundary.

The implementation fails closed: ambiguous exits retain the silent route long enough for the server to pause, journal mutations are serialized across Echo processes, and restoration uses compare-and-swap semantics.

## Rollback plan

End any active Jam first, then roll back the control binary, complete viewer snapshot, and source-PC desktop binary together. The desktop journal preserves the exact prior Spotify per-app route and restores it on coordinated teardown or verified dead-owner recovery.
