### PR TITLE
Establish responsive Clubhouse UI foundation

### DIFF
--- a/.github/workflows/pr-viewer-layout.yml
+++ b/.github/workflows/pr-viewer-layout.yml
@@ -1,0 +1,58 @@
+name: PR Viewer Layout
+
+on:
+  pull_request:
+    branches: [main, dev]
+    paths:
+      - "core/viewer/**"
+      - "core/viewer-tests/**"
+      - ".github/workflows/pr-viewer-layout.yml"
+      - "package.json"
+  workflow_dispatch:
+
+concurrency:
+  group: pr-viewer-layout-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  geometry:
+    name: viewer-geometry
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: core/viewer-tests/package-lock.json
+
+      - name: Install browser test dependencies
+        working-directory: core/viewer-tests
+        run: npm ci
+
+      - name: Install Chromium
+        working-directory: core/viewer-tests
+        run: npx playwright install --with-deps chromium
+
+      - name: Run production viewer geometry tests
+        working-directory: core/viewer-tests
+        run: npm test
+
+      - name: Upload failure evidence
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: viewer-layout-failure
+          path: |
+            core/viewer-tests/playwright-report/
+            core/viewer-tests/test-results/
+          if-no-files-found: ignore
+          retention-days: 7

--- a/core/viewer-tests/.gitignore
+++ b/core/viewer-tests/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+playwright-report/
+test-results/

--- a/core/viewer-tests/README.md
+++ b/core/viewer-tests/README.md
@@ -1,0 +1,44 @@
+# Production Viewer Layout Tests
+
+This package provides browser-level geometry coverage for the served
+`core/viewer/` UI. It is intentionally a sibling of the viewer rather than a
+child directory: Echo deploys every file under `core/viewer/`, while this test
+package must never ship to users.
+
+The harness:
+
+- serves the real production HTML, CSS, JavaScript, and assets with caching off;
+- injects deterministic participants and screen tiles through production
+  renderer functions;
+- checks layout policy and geometry without connecting to LiveKit; and
+- retains traces and screenshots when a browser assertion fails.
+
+It does not use `core/viewer-next/` and does not clone the production viewer
+markup into a second test-only page.
+
+Phase 0 injects `layout-policy.js` explicitly because the production
+`index.html` does not load a mode controller yet. Phase 1 must wire the policy
+before first paint and replace that injected-policy check with an assertion on
+the production root's live `data-ui-mode` value.
+
+## Setup
+
+```bash
+npm ci
+npm run browser:install
+```
+
+## Run
+
+```bash
+npm test
+```
+
+From the repository root, use `npm run verify:viewer:layout` after setup.
+
+Known legacy failures at `960x540`, `640x480`, and narrow Chat execute on every
+run as narrowly scoped sentinels. They assert the exact current bad geometry
+(collapsed participant viewport or zero-width stage), so unrelated runtime or
+browser failures still fail the suite. When Clubhouse corrects that geometry,
+the sentinel fails and must be replaced by the corresponding positive contract
+assertion. That conversion is a rollout gate, not an optional cleanup.

--- a/core/viewer-tests/fixtures/install-scenario.js
+++ b/core/viewer-tests/fixtures/install-scenario.js
@@ -1,0 +1,169 @@
+(function installEchoLayoutScenarioFixture() {
+  "use strict";
+
+  function nextFrame() {
+    return new Promise(function (resolve) {
+      requestAnimationFrame(function () {
+        requestAnimationFrame(resolve);
+      });
+    });
+  }
+
+  function resetRoom() {
+    const priorMedia = window.__echoLayoutFixtureMedia;
+    if (priorMedia) {
+      priorMedia.tracks.forEach(function (track) { track.stop(); });
+    }
+    window.__echoLayoutFixtureMedia = { canvases: [], tracks: [] };
+
+    if (typeof CHANGELOG_LATEST !== "undefined") {
+      localStorage.setItem("echo-changelog-seen", CHANGELOG_LATEST);
+    }
+    document.querySelectorAll(".whats-new-overlay, .updates-overlay").forEach(function (overlay) {
+      overlay.remove();
+    });
+    document.getElementById("connect-panel").classList.add("hidden");
+    document.querySelector(".app > header").classList.add("portal-hidden");
+    document.querySelector(".room-panel").classList.remove("hidden");
+    document.querySelector(".room-layout").classList.remove("chat-open");
+    document.getElementById("chat-panel").classList.add("hidden");
+    document.getElementById("user-list").replaceChildren();
+    document.getElementById("screen-grid").replaceChildren();
+
+    if (typeof participantCards !== "undefined") participantCards.clear();
+    if (typeof participantState !== "undefined") participantState.clear();
+    if (typeof screenTileBySid !== "undefined") screenTileBySid.clear();
+  }
+
+  function createVideoTrackStub(label, aspectRatio) {
+    const aspect = Number.isFinite(aspectRatio) && aspectRatio > 0 ? aspectRatio : 16 / 9;
+    const canvas = document.createElement("canvas");
+    if (aspect >= 1) {
+      canvas.height = 360;
+      canvas.width = Math.round(canvas.height * aspect);
+    } else {
+      canvas.width = 360;
+      canvas.height = Math.round(canvas.width / aspect);
+    }
+    const context = canvas.getContext("2d");
+    context.fillStyle = "#132238";
+    context.fillRect(0, 0, canvas.width, canvas.height);
+    context.fillStyle = "#38bdf8";
+    context.fillRect(0, 0, Math.max(8, canvas.width / 5), canvas.height);
+
+    const stream = canvas.captureStream(1);
+    const mediaStreamTrack = stream.getVideoTracks()[0];
+    if (!mediaStreamTrack) throw new Error("unable to create fixture video track");
+
+    const track = {
+      sid: label,
+      mediaStreamTrack: mediaStreamTrack,
+      requestKeyFrame: function () {},
+    };
+    window.__echoLayoutFixtureMedia.canvases.push(canvas);
+    window.__echoLayoutFixtureMedia.tracks.push(mediaStreamTrack);
+    return { track: track, width: canvas.width, height: canvas.height };
+  }
+
+  function exposeFixtureDimensions(video, media) {
+    Object.defineProperties(video, {
+      videoWidth: { configurable: true, get: function () { return media.width; } },
+      videoHeight: { configurable: true, get: function () { return media.height; } },
+    });
+  }
+
+  function makeParticipant(index, longNames) {
+    const suffix = longNames
+      ? " — The Fellowship Member With An Intentionally Long Display Name"
+      : "";
+    return {
+      identity: `layout-fixture-${index}`,
+      name: `Friend ${index}${suffix}`,
+    };
+  }
+
+  function addParticipants(count, cameraCount, longNames) {
+    if (typeof ensureParticipantCard !== "function") {
+      throw new Error("production ensureParticipantCard renderer is unavailable");
+    }
+    if (typeof updateAvatarVideo !== "function") {
+      throw new Error("production updateAvatarVideo renderer is unavailable");
+    }
+
+    let attachedCameras = 0;
+    for (let index = 1; index <= count; index += 1) {
+      const isLocal = index === 1;
+      const cardRef = ensureParticipantCard(makeParticipant(index, longNames), isLocal);
+      if (!cardRef || isLocal || attachedCameras >= cameraCount) continue;
+
+      const media = createVideoTrackStub(`fixture-camera-${index}`, 16 / 9);
+      updateAvatarVideo(cardRef, media.track);
+      const video = cardRef.avatar.querySelector("video");
+      if (!video) throw new Error("production camera renderer did not create a video element");
+      exposeFixtureDimensions(video, media);
+      video.classList.add("layout-fixture-camera");
+      video.setAttribute("aria-label", `${cardRef.card.dataset.identity} camera fixture`);
+      attachedCameras += 1;
+    }
+  }
+
+  function addScreenShares(count, aspectRatios) {
+    if (typeof addScreenTile !== "function" || typeof createLockedVideoElement !== "function") {
+      throw new Error("production screen renderer is unavailable");
+    }
+
+    for (let index = 0; index < count; index += 1) {
+      const aspectRatio = aspectRatios[index] || 16 / 9;
+      const media = createVideoTrackStub(`fixture-screen-${index + 1}`, aspectRatio);
+      const video = createLockedVideoElement(media.track);
+      exposeFixtureDimensions(video, media);
+      video.classList.add("layout-fixture-screen");
+      video.setAttribute("aria-label", `screen share ${index + 1}`);
+      addScreenTile(`Shared by Friend ${index + 2}`, video, media.track.sid);
+    }
+  }
+
+  function populateChat(open) {
+    const panel = document.getElementById("chat-panel");
+    const roomLayout = document.querySelector(".room-layout");
+    panel.classList.toggle("hidden", !open);
+    roomLayout.classList.toggle("chat-open", open);
+    if (!open) return;
+
+    const messages = document.getElementById("chat-messages");
+    messages.replaceChildren();
+    for (let index = 1; index <= 8; index += 1) {
+      const message = document.createElement("div");
+      message.className = "chat-message";
+      message.textContent = `Friend ${index}: responsive fixture message ${index}`;
+      messages.appendChild(message);
+    }
+    document.getElementById("chat-input").value = "Draft text must survive a resize";
+  }
+
+  async function install(options) {
+    const scenario = Object.assign({
+      participants: 4,
+      cameras: 2,
+      screenShares: 1,
+      shareAspects: [16 / 9],
+      chatOpen: false,
+      longNames: false,
+    }, options || {});
+
+    resetRoom();
+    addParticipants(scenario.participants, scenario.cameras, scenario.longNames);
+    addScreenShares(scenario.screenShares, scenario.shareAspects);
+    populateChat(scenario.chatOpen);
+    await nextFrame();
+
+    return {
+      cameraCards: document.querySelectorAll(".user-card.has-camera").length,
+      participantCards: document.querySelectorAll(".user-card").length,
+      screenTiles: document.querySelectorAll("#screen-grid > .tile").length,
+      chatOpen: document.querySelector(".room-layout").classList.contains("chat-open"),
+    };
+  }
+
+  window.EchoLayoutTestScenario = Object.freeze({ install: install });
+})();

--- a/core/viewer-tests/package-lock.json
+++ b/core/viewer-tests/package-lock.json
@@ -1,0 +1,81 @@
+{
+  "name": "@echo/viewer-tests",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@echo/viewer-tests",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@playwright/test": "1.58.2"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/core/viewer-tests/package.json
+++ b/core/viewer-tests/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@echo/viewer-tests",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "engines": {
+    "node": ">=22"
+  },
+  "scripts": {
+    "browser:install": "playwright install chromium",
+    "test": "playwright test tests/layout.geometry.spec.js",
+    "test:all": "playwright test",
+    "test:headed": "playwright test --headed"
+  },
+  "devDependencies": {
+    "@playwright/test": "1.58.2"
+  }
+}

--- a/core/viewer-tests/playwright.config.mjs
+++ b/core/viewer-tests/playwright.config.mjs
@@ -1,0 +1,38 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests",
+  fullyParallel: false,
+  forbidOnly: Boolean(process.env.CI),
+  retries: process.env.CI ? 1 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI
+    ? [["line"], ["html", { open: "never" }]]
+    : [["list"], ["html", { open: "never" }]],
+  timeout: 30_000,
+  expect: {
+    timeout: 5_000,
+  },
+  use: {
+    baseURL: "http://127.0.0.1:4175",
+    headless: true,
+    reducedMotion: "reduce",
+    screenshot: "only-on-failure",
+    trace: "retain-on-failure",
+    video: "off",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: {
+        ...devices["Desktop Chrome"],
+      },
+    },
+  ],
+  webServer: {
+    command: "node ./scripts/serve-viewer.mjs",
+    url: "http://127.0.0.1:4175/healthz",
+    reuseExistingServer: false,
+    timeout: 30_000,
+  },
+});

--- a/core/viewer-tests/scripts/serve-viewer.mjs
+++ b/core/viewer-tests/scripts/serve-viewer.mjs
@@ -1,0 +1,91 @@
+import http from "node:http";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { readFile, stat } from "node:fs/promises";
+
+const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
+const viewerRoot = path.resolve(scriptDirectory, "..", "..", "viewer");
+const port = Number.parseInt(process.env.PORT || "4175", 10);
+
+const contentTypes = new Map([
+  [".css", "text/css; charset=utf-8"],
+  [".gif", "image/gif"],
+  [".html", "text/html; charset=utf-8"],
+  [".jpg", "image/jpeg"],
+  [".js", "text/javascript; charset=utf-8"],
+  [".json", "application/json; charset=utf-8"],
+  [".png", "image/png"],
+  [".svg", "image/svg+xml"],
+  [".wasm", "application/wasm"],
+]);
+
+function send(response, statusCode, body, contentType) {
+  response.writeHead(statusCode, {
+    "Cache-Control": "no-store",
+    "Content-Length": Buffer.byteLength(body),
+    "Content-Type": contentType,
+    "X-Content-Type-Options": "nosniff",
+  });
+  response.end(body);
+}
+
+function resolveViewerFile(requestUrl) {
+  const url = new URL(requestUrl, `http://127.0.0.1:${port}`);
+  const pathname = decodeURIComponent(url.pathname);
+  const relativePath = pathname === "/" ? "index.html" : pathname.replace(/^\/+/, "");
+  const candidate = path.resolve(viewerRoot, relativePath);
+  const rootPrefix = `${viewerRoot}${path.sep}`;
+
+  if (candidate !== viewerRoot && !candidate.startsWith(rootPrefix)) {
+    return null;
+  }
+  return candidate;
+}
+
+const server = http.createServer(async (request, response) => {
+  if (request.url === "/healthz") {
+    send(response, 200, "ok", "text/plain; charset=utf-8");
+    return;
+  }
+
+  if (request.method !== "GET" && request.method !== "HEAD") {
+    send(response, 405, "method not allowed", "text/plain; charset=utf-8");
+    return;
+  }
+
+  let filePath;
+  try {
+    filePath = resolveViewerFile(request.url || "/");
+  } catch {
+    send(response, 400, "bad request", "text/plain; charset=utf-8");
+    return;
+  }
+  if (!filePath) {
+    send(response, 403, "forbidden", "text/plain; charset=utf-8");
+    return;
+  }
+
+  try {
+    const fileStat = await stat(filePath);
+    if (!fileStat.isFile()) throw new Error("not a file");
+    const body = await readFile(filePath);
+    const contentType = contentTypes.get(path.extname(filePath).toLowerCase()) || "application/octet-stream";
+    response.writeHead(200, {
+      "Cache-Control": "no-store",
+      "Content-Length": body.length,
+      "Content-Type": contentType,
+      "X-Content-Type-Options": "nosniff",
+    });
+    response.end(request.method === "HEAD" ? undefined : body);
+  } catch {
+    send(response, 404, "not found", "text/plain; charset=utf-8");
+  }
+});
+
+server.listen(port, "127.0.0.1", () => {
+  console.log(`[viewer-tests] serving ${viewerRoot} at http://127.0.0.1:${port}`);
+});
+
+for (const signal of ["SIGINT", "SIGTERM"]) {
+  process.on(signal, () => server.close(() => process.exit(0)));
+}

--- a/core/viewer-tests/tests/helpers/geometry.js
+++ b/core/viewer-tests/tests/helpers/geometry.js
@@ -1,0 +1,57 @@
+import { expect } from "@playwright/test";
+
+export async function visibleRect(locator) {
+  await expect(locator).toBeVisible();
+  return locator.evaluate((element) => {
+    const rect = element.getBoundingClientRect();
+    return {
+      bottom: rect.bottom,
+      height: rect.height,
+      left: rect.left,
+      right: rect.right,
+      top: rect.top,
+      width: rect.width,
+    };
+  });
+}
+
+export function intersectionArea(first, second) {
+  const width = Math.max(0, Math.min(first.right, second.right) - Math.max(first.left, second.left));
+  const height = Math.max(0, Math.min(first.bottom, second.bottom) - Math.max(first.top, second.top));
+  return width * height;
+}
+
+export async function expectNoOverlap(first, second, tolerance = 1) {
+  const [firstRect, secondRect] = await Promise.all([visibleRect(first), visibleRect(second)]);
+  expect(intersectionArea(firstRect, secondRect)).toBeLessThanOrEqual(tolerance);
+}
+
+export async function expectHorizontallyContained(child, parent, tolerance = 1) {
+  const [childRect, parentRect] = await Promise.all([visibleRect(child), visibleRect(parent)]);
+  expect(childRect.left).toBeGreaterThanOrEqual(parentRect.left - tolerance);
+  expect(childRect.right).toBeLessThanOrEqual(parentRect.right + tolerance);
+}
+
+export async function expectMinimumUsableRegion(locator, minimums) {
+  await expect(locator).toBeVisible();
+  const geometry = await locator.evaluate((element) => ({
+    clientHeight: element.clientHeight,
+    clientWidth: element.clientWidth,
+    scrollHeight: element.scrollHeight,
+    scrollWidth: element.scrollWidth,
+  }));
+  expect(geometry.clientWidth).toBeGreaterThanOrEqual(minimums.width || 1);
+  expect(geometry.clientHeight).toBeGreaterThanOrEqual(minimums.height || 1);
+  return geometry;
+}
+
+export async function expectNoDocumentOverflow(page, tolerance = 1) {
+  const geometry = await page.evaluate(() => ({
+    clientHeight: document.documentElement.clientHeight,
+    clientWidth: document.documentElement.clientWidth,
+    scrollHeight: document.documentElement.scrollHeight,
+    scrollWidth: document.documentElement.scrollWidth,
+  }));
+  expect(geometry.scrollWidth).toBeLessThanOrEqual(geometry.clientWidth + tolerance);
+  expect(geometry.scrollHeight).toBeLessThanOrEqual(geometry.clientHeight + tolerance);
+}

--- a/core/viewer-tests/tests/layout.geometry.spec.js
+++ b/core/viewer-tests/tests/layout.geometry.spec.js
@@ -1,0 +1,259 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, test } from "@playwright/test";
+import {
+  expectHorizontallyContained,
+  expectMinimumUsableRegion,
+  expectNoDocumentOverflow,
+  expectNoOverlap,
+} from "./helpers/geometry.js";
+
+const testDirectory = path.dirname(fileURLToPath(import.meta.url));
+const fixturePath = path.resolve(testDirectory, "..", "fixtures", "install-scenario.js");
+const policyPath = path.resolve(testDirectory, "..", "..", "viewer", "layout-policy.js");
+const runtimeErrors = new WeakMap();
+const transparentPng = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=",
+  "base64",
+);
+
+test.beforeEach(async ({ page }) => {
+  const errors = [];
+  runtimeErrors.set(page, errors);
+  page.on("pageerror", (error) => errors.push(`pageerror: ${error.message}`));
+  page.on("console", (message) => {
+    if (message.type() === "error") errors.push(`console.error: ${message.text()}`);
+  });
+
+  await page.route("**/api/**", async (route) => {
+    const url = new URL(route.request().url());
+    if (url.pathname === "/api/online") {
+      await route.fulfill({ status: 200, contentType: "application/json", body: "[]" });
+      return;
+    }
+    if (url.pathname.startsWith("/api/avatar/")) {
+      await route.fulfill({ status: 200, contentType: "image/png", body: transparentPng });
+      return;
+    }
+    if (url.pathname === "/api/version") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ latest_client: "" }),
+      });
+      return;
+    }
+    errors.push(`unexpected API request: ${route.request().method()} ${url.pathname}`);
+    await route.fulfill({
+      status: 501,
+      contentType: "application/json",
+      body: JSON.stringify({ error: "unmodeled viewer-test endpoint" }),
+    });
+  });
+});
+
+test.afterEach(async ({ page }) => {
+  await page.waitForTimeout(25);
+  expect(runtimeErrors.get(page) || [], "production page must boot without runtime errors").toEqual([]);
+});
+
+async function openProductionViewer(page, scenario) {
+  await page.goto("/", { waitUntil: "domcontentloaded" });
+  await page.addScriptTag({ path: fixturePath });
+  return page.evaluate((options) => window.EchoLayoutTestScenario.install(options), scenario);
+}
+
+test("production viewer scenario uses real participant and screen renderers", async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 900 });
+  const installed = await openProductionViewer(page, {
+    participants: 4,
+    cameras: 2,
+    screenShares: 2,
+    shareAspects: [16 / 9, 32 / 9],
+    longNames: true,
+  });
+
+  expect(installed).toEqual({
+    cameraCards: 2,
+    participantCards: 4,
+    screenTiles: 2,
+    chatOpen: false,
+  });
+  await expect(page.locator(".user-card")).toHaveCount(4);
+  await expect(page.locator(".user-card.has-camera")).toHaveCount(2);
+  await expect(page.locator(".user-card").first()).not.toHaveClass(/has-camera/);
+  await expect(page.locator(".layout-fixture-camera")).toHaveCount(2);
+  await expect(page.locator("#screen-grid > .tile")).toHaveCount(2);
+  await expect(page.locator("#screen-grid > .tile .tile-overlay")).toHaveCount(2);
+  await expect(page.locator("#screen-grid > .tile .tile-fullscreen-btn")).toHaveCount(2);
+  await expect(page.locator("#screen-grid > .tile .tile-volume-wrap")).toHaveCount(2);
+  await expect(page.locator(".user-card").first()).toHaveAttribute("data-identity", "layout-fixture-1");
+  await expect(page.locator("#screen-grid > .tile").nth(1)).toHaveClass(/superwide/);
+});
+
+test("wide production room keeps primary regions separated and inside the viewport", async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await openProductionViewer(page, {
+    participants: 4,
+    cameras: 2,
+    screenShares: 1,
+    longNames: true,
+  });
+
+  const roomLayout = page.locator(".room-layout");
+  const stage = page.locator(".room-main");
+  const sidebar = page.locator(".room-sidebar");
+  await expectNoOverlap(stage, sidebar);
+  await expectHorizontallyContained(stage, roomLayout);
+  await expectHorizontallyContained(sidebar, roomLayout);
+  await expectMinimumUsableRegion(stage, { width: 400, height: 240 });
+  await expectMinimumUsableRegion(sidebar, { width: 300, height: 240 });
+  await expectNoDocumentOverflow(page);
+});
+
+test("production nodes and draft state survive the baseline desktop resize matrix", async ({ page }) => {
+  await page.setViewportSize({ width: 1920, height: 1080 });
+  await openProductionViewer(page, {
+    participants: 4,
+    cameras: 2,
+    screenShares: 1,
+    longNames: true,
+  });
+
+  await page.evaluate(() => {
+    window.__layoutFixtureCard = document.querySelector(".user-card");
+    window.__layoutFixtureTile = document.querySelector("#screen-grid > .tile");
+    document.getElementById("chat-input").value = "Draft preserved across resize";
+  });
+
+  for (const viewport of [
+    { width: 1920, height: 1080 },
+    { width: 1440, height: 900 },
+    { width: 1280, height: 720 },
+    { width: 1024, height: 768 },
+  ]) {
+    await page.setViewportSize(viewport);
+    await page.evaluate(() => new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve))));
+
+    const preserved = await page.evaluate(() => ({
+      card: window.__layoutFixtureCard === document.querySelector(".user-card"),
+      draft: document.getElementById("chat-input").value,
+      tile: window.__layoutFixtureTile === document.querySelector("#screen-grid > .tile"),
+    }));
+    expect(preserved, `${viewport.width}x${viewport.height}`).toEqual({
+      card: true,
+      draft: "Draft preserved across resize",
+      tile: true,
+    });
+    await expectNoOverlap(page.locator(".room-main"), page.locator(".room-sidebar"));
+    await expectNoDocumentOverflow(page);
+  }
+});
+
+for (const viewport of [
+  { width: 960, height: 540 },
+  { width: 640, height: 480 },
+]) {
+  test(`records the legacy participant-region collapse at ${viewport.width}x${viewport.height}`, async ({ page }) => {
+    test.info().annotations.push({
+      type: "known-legacy-failure",
+      description: "Replace this sentinel with the >=160px contract assertion when Clubhouse lands",
+    });
+    await page.setViewportSize(viewport);
+    await openProductionViewer(page, {
+      participants: 4,
+      cameras: 2,
+      screenShares: 1,
+      longNames: true,
+    });
+
+    const userList = page.locator("#user-list");
+    const collapsed = await userList.evaluate((element) => {
+      const firstCard = element.querySelector(".user-card");
+      const listRect = element.getBoundingClientRect();
+      const cardRect = firstCard.getBoundingClientRect();
+      const visibleHeight = Math.max(
+        0,
+        Math.min(listRect.bottom, cardRect.bottom, document.documentElement.clientHeight) -
+          Math.max(listRect.top, cardRect.top, 0),
+      );
+      return {
+        clientHeight: element.clientHeight,
+        firstCardVisibleRatio: visibleHeight / Math.max(1, cardRect.height),
+        scrollHeight: element.scrollHeight,
+      };
+    });
+
+    expect(collapsed.clientHeight).toBeGreaterThan(0);
+    expect(collapsed.clientHeight).toBeLessThan(160);
+    expect(collapsed.scrollHeight).toBeGreaterThan(collapsed.clientHeight * 5);
+    expect(collapsed.firstCardVisibleRatio).toBeGreaterThan(0);
+    expect(collapsed.firstCardVisibleRatio).toBeLessThan(0.25);
+  });
+}
+
+test("browser policy classifies the supported viewport matrix without loading production wiring", async ({ page }) => {
+  await page.goto("/", { waitUntil: "domcontentloaded" });
+  await page.addScriptTag({ path: policyPath });
+
+  const matrix = [
+    { width: 1920, height: 1080, expected: "theater" },
+    { width: 1440, height: 900, expected: "theater" },
+    { width: 1280, height: 720, expected: "theater" },
+    { width: 1024, height: 768, expected: "lounge" },
+    { width: 960, height: 540, expected: "compact" },
+    { width: 800, height: 600, expected: "compact" },
+    { width: 640, height: 480, expected: "compact" },
+    { width: 639, height: 479, expected: "mini" },
+  ];
+
+  for (const sample of matrix) {
+    const mode = await page.evaluate(
+      ({ width, height }) => window.EchoLayoutPolicy.classifyLayoutMode(width, height),
+      sample,
+    );
+    expect(mode, `${sample.width}x${sample.height}`).toBe(sample.expected);
+  }
+
+  const transition = await page.evaluate(() => {
+    const policy = window.EchoLayoutPolicy;
+    const initial = policy.resolveLayoutMode({ width: 768, height: 1024 });
+    const retained = policy.resolveLayoutMode({
+      width: 600,
+      height: 900,
+      previousMode: initial,
+    });
+    const downgraded = policy.resolveLayoutMode({
+      width: 591,
+      height: 900,
+      previousMode: retained,
+    });
+    return [initial, retained, downgraded];
+  });
+  expect(transition).toEqual(["compact", "compact", "mini"]);
+});
+
+test(
+  "records the legacy narrow-Chat stage collapse",
+  async ({ page }) => {
+    test.info().annotations.push({
+      type: "known-legacy-failure",
+      description: "Replace this sentinel with active drawer non-overlap assertions when Clubhouse lands",
+    });
+    await page.setViewportSize({ width: 800, height: 600 });
+    await openProductionViewer(page, {
+      participants: 4,
+      cameras: 2,
+      screenShares: 1,
+      chatOpen: true,
+    });
+
+    const stage = page.locator(".room-main");
+    const sidebar = page.locator(".room-sidebar");
+    const chat = page.locator("#chat-panel");
+    const stageBox = await stage.boundingBox();
+    expect(stageBox?.width || 0).toBeLessThan(1);
+    await expectNoOverlap(sidebar, chat);
+    await expectNoDocumentOverflow(page);
+  },
+);

--- a/core/viewer/layout-policy.js
+++ b/core/viewer/layout-policy.js
@@ -1,0 +1,360 @@
+(function (root, factory) {
+  if (typeof module === "object" && module.exports) {
+    module.exports = factory();
+  } else {
+    root.EchoLayoutPolicy = factory();
+  }
+})(typeof globalThis !== "undefined" ? globalThis : this, function () {
+  "use strict";
+
+  const MODES = Object.freeze({
+    MINI: "mini",
+    COMPACT: "compact",
+    LOUNGE: "lounge",
+    THEATER: "theater",
+  });
+
+  const MODE_ORDER = Object.freeze([
+    MODES.MINI,
+    MODES.COMPACT,
+    MODES.LOUNGE,
+    MODES.THEATER,
+  ]);
+
+  const DEFAULT_MODE_THRESHOLDS = Object.freeze({
+    mini: Object.freeze({ minWidth: 0, minHeight: 0 }),
+    compact: Object.freeze({ minWidth: 640, minHeight: 480 }),
+    lounge: Object.freeze({ minWidth: 900, minHeight: 600 }),
+    theater: Object.freeze({ minWidth: 1280, minHeight: 720 }),
+    hysteresis: 48,
+  });
+
+  const DEFAULT_TILE_ASPECT_RATIO = 16 / 9;
+  const DEFAULT_GRID_GAP = 12;
+  const GRID_SCORE_WEIGHTS = Object.freeze({
+    area: 0.72,
+    balance: 0.2,
+    occupancy: 0.08,
+  });
+
+  function finiteNonNegative(value, fallback) {
+    const number = Number(value);
+    return Number.isFinite(number) && number >= 0 ? number : fallback;
+  }
+
+  function finitePositive(value, fallback) {
+    const number = Number(value);
+    return Number.isFinite(number) && number > 0 ? number : fallback;
+  }
+
+  function normalizeGeometry(width, height) {
+    return {
+      width: finiteNonNegative(width, 0),
+      height: finiteNonNegative(height, 0),
+    };
+  }
+
+  function isMode(mode) {
+    return MODE_ORDER.indexOf(mode) !== -1;
+  }
+
+  function normalizeThresholds(overrides) {
+    const source = overrides || {};
+    const normalized = {
+      hysteresis: finiteNonNegative(
+        source.hysteresis,
+        DEFAULT_MODE_THRESHOLDS.hysteresis
+      ),
+    };
+
+    let previousWidth = 0;
+    let previousHeight = 0;
+    for (let index = 0; index < MODE_ORDER.length; index += 1) {
+      const mode = MODE_ORDER[index];
+      const defaults = DEFAULT_MODE_THRESHOLDS[mode];
+      const candidate = source[mode] || {};
+      const minWidth = Math.max(
+        previousWidth,
+        finiteNonNegative(candidate.minWidth, defaults.minWidth)
+      );
+      const minHeight = Math.max(
+        previousHeight,
+        finiteNonNegative(candidate.minHeight, defaults.minHeight)
+      );
+      normalized[mode] = { minWidth, minHeight };
+      previousWidth = minWidth;
+      previousHeight = minHeight;
+    }
+
+    return normalized;
+  }
+
+  function classifyLayoutMode(width, height, thresholdOverrides) {
+    const geometry = normalizeGeometry(width, height);
+    const thresholds = normalizeThresholds(thresholdOverrides);
+    let mode = MODES.MINI;
+
+    for (let index = 1; index < MODE_ORDER.length; index += 1) {
+      const candidateMode = MODE_ORDER[index];
+      const minimums = thresholds[candidateMode];
+      if (
+        geometry.width >= minimums.minWidth &&
+        geometry.height >= minimums.minHeight
+      ) {
+        mode = candidateMode;
+      } else {
+        break;
+      }
+    }
+
+    return mode;
+  }
+
+  /**
+   * Resolve the responsive mode while retaining the previous mode inside a
+   * symmetric dead band. Upgrades require crossing a boundary by the full
+   * hysteresis distance; downgrades require crossing it in the other direction.
+   * This keeps slow window drags from bouncing between adjacent layouts.
+   */
+  function resolveLayoutMode(options) {
+    const input = options || {};
+    const geometry = normalizeGeometry(input.width, input.height);
+    const thresholds = normalizeThresholds(input.thresholds);
+    const previousMode = input.previousMode;
+
+    if (!isMode(previousMode)) {
+      return classifyLayoutMode(geometry.width, geometry.height, thresholds);
+    }
+
+    const hysteresis = thresholds.hysteresis;
+    let index = MODE_ORDER.indexOf(previousMode);
+
+    // A large resize may cross more than one boundary in a single observation.
+    while (index < MODE_ORDER.length - 1) {
+      const nextMode = MODE_ORDER[index + 1];
+      const nextMinimums = thresholds[nextMode];
+      if (
+        geometry.width >= nextMinimums.minWidth + hysteresis &&
+        geometry.height >= nextMinimums.minHeight + hysteresis
+      ) {
+        index += 1;
+      } else {
+        break;
+      }
+    }
+
+    while (index > 0) {
+      const currentMode = MODE_ORDER[index];
+      const currentMinimums = thresholds[currentMode];
+      if (
+        geometry.width < Math.max(0, currentMinimums.minWidth - hysteresis) ||
+        geometry.height < Math.max(0, currentMinimums.minHeight - hysteresis)
+      ) {
+        index -= 1;
+      } else {
+        break;
+      }
+    }
+
+    return MODE_ORDER[index];
+  }
+
+  function resolveLayoutPolicy(options) {
+    const input = options || {};
+    const geometry = normalizeGeometry(input.width, input.height);
+    const mode = resolveLayoutMode(input);
+
+    return {
+      mode,
+      width: geometry.width,
+      height: geometry.height,
+      isShort: geometry.height < 650,
+      isVeryShort: geometry.height < 520,
+    };
+  }
+
+  function fitAspectRatio(maxWidth, maxHeight, aspectRatio) {
+    const width = finiteNonNegative(maxWidth, 0);
+    const height = finiteNonNegative(maxHeight, 0);
+    const aspect = finitePositive(aspectRatio, DEFAULT_TILE_ASPECT_RATIO);
+
+    if (width === 0 || height === 0) {
+      return { width: 0, height: 0, area: 0, aspectRatio: aspect };
+    }
+
+    let fittedWidth;
+    let fittedHeight;
+    if (width / height > aspect) {
+      fittedHeight = height;
+      fittedWidth = height * aspect;
+    } else {
+      fittedWidth = width;
+      fittedHeight = width / aspect;
+    }
+
+    return {
+      width: fittedWidth,
+      height: fittedHeight,
+      area: fittedWidth * fittedHeight,
+      aspectRatio: aspect,
+    };
+  }
+
+  function normalizeGridOptions(options) {
+    const input = options || {};
+    return {
+      width: finiteNonNegative(input.width, 0),
+      height: finiteNonNegative(input.height, 0),
+      tileCount: Math.max(0, Math.floor(finiteNonNegative(input.tileCount, 0))),
+      gap: finiteNonNegative(input.gap, DEFAULT_GRID_GAP),
+      aspectRatio: finitePositive(input.aspectRatio, DEFAULT_TILE_ASPECT_RATIO),
+    };
+  }
+
+  function invalidGridCandidate(input, columns, reason) {
+    return {
+      valid: false,
+      reason,
+      columns,
+      rows: 0,
+      tileCount: input.tileCount,
+      score: Number.NEGATIVE_INFINITY,
+    };
+  }
+
+  function scoreGridCandidate(options) {
+    const input = normalizeGridOptions(options);
+    const columns = Math.floor(finiteNonNegative(options && options.columns, 0));
+
+    if (input.tileCount === 0) {
+      return invalidGridCandidate(input, columns, "no-tiles");
+    }
+    if (columns < 1 || columns > input.tileCount) {
+      return invalidGridCandidate(input, columns, "invalid-columns");
+    }
+
+    const rows = Math.ceil(input.tileCount / columns);
+    const availableWidth = input.width - input.gap * (columns - 1);
+    const availableHeight = input.height - input.gap * (rows - 1);
+    if (availableWidth <= 0 || availableHeight <= 0) {
+      return invalidGridCandidate(input, columns, "insufficient-space");
+    }
+
+    const cellWidth = availableWidth / columns;
+    const cellHeight = availableHeight / rows;
+    const fitted = fitAspectRatio(cellWidth, cellHeight, input.aspectRatio);
+    const balance = Math.min(columns, rows) / Math.max(columns, rows);
+    const occupancy = input.tileCount / (columns * rows);
+    const quality =
+      GRID_SCORE_WEIGHTS.area +
+      GRID_SCORE_WEIGHTS.balance * balance +
+      GRID_SCORE_WEIGHTS.occupancy * occupancy;
+    const score = fitted.area * quality;
+    const totalWidth = fitted.width * columns + input.gap * (columns - 1);
+    const totalHeight = fitted.height * rows + input.gap * (rows - 1);
+
+    return {
+      valid: true,
+      reason: null,
+      columns,
+      rows,
+      tileCount: input.tileCount,
+      gap: input.gap,
+      aspectRatio: input.aspectRatio,
+      cellWidth,
+      cellHeight,
+      tileWidth: fitted.width,
+      tileHeight: fitted.height,
+      tileArea: fitted.area,
+      balance,
+      occupancy,
+      score,
+      totalWidth,
+      totalHeight,
+      unusedWidth: Math.max(0, input.width - totalWidth),
+      unusedHeight: Math.max(0, input.height - totalHeight),
+    };
+  }
+
+  function listGridCandidates(options) {
+    const input = normalizeGridOptions(options);
+    const candidates = [];
+    for (let columns = 1; columns <= input.tileCount; columns += 1) {
+      candidates.push(scoreGridCandidate({
+        width: input.width,
+        height: input.height,
+        tileCount: input.tileCount,
+        gap: input.gap,
+        aspectRatio: input.aspectRatio,
+        columns,
+      }));
+    }
+    return candidates;
+  }
+
+  function candidateIsBetter(candidate, best) {
+    if (!candidate.valid) return false;
+    if (!best || !best.valid) return true;
+
+    const epsilon = 1e-9;
+    if (candidate.score > best.score + epsilon) return true;
+    if (candidate.score < best.score - epsilon) return false;
+    if (candidate.tileArea > best.tileArea + epsilon) return true;
+    if (candidate.tileArea < best.tileArea - epsilon) return false;
+    if (candidate.occupancy > best.occupancy + epsilon) return true;
+    if (candidate.occupancy < best.occupancy - epsilon) return false;
+    if (candidate.balance > best.balance + epsilon) return true;
+    if (candidate.balance < best.balance - epsilon) return false;
+
+    // Stable final tie-breaker: fewer columns makes repeated calls deterministic.
+    return candidate.columns < best.columns;
+  }
+
+  function chooseOptimalGrid(options) {
+    const input = normalizeGridOptions(options);
+    if (input.tileCount === 0) {
+      return {
+        valid: true,
+        reason: "empty",
+        columns: 0,
+        rows: 0,
+        tileCount: 0,
+        tileWidth: 0,
+        tileHeight: 0,
+        tileArea: 0,
+        score: 0,
+        totalWidth: 0,
+        totalHeight: 0,
+      };
+    }
+
+    const candidates = listGridCandidates(input);
+    let best = null;
+    for (let index = 0; index < candidates.length; index += 1) {
+      if (candidateIsBetter(candidates[index], best)) {
+        best = candidates[index];
+      }
+    }
+
+    return best || invalidGridCandidate(input, 0, "insufficient-space");
+  }
+
+  return {
+    DEFAULT_GRID_GAP,
+    DEFAULT_MODE_THRESHOLDS,
+    DEFAULT_TILE_ASPECT_RATIO,
+    GRID_SCORE_WEIGHTS,
+    MODES,
+    MODE_ORDER,
+    chooseOptimalGrid,
+    classifyLayoutMode,
+    fitAspectRatio,
+    isMode,
+    listGridCandidates,
+    normalizeGeometry,
+    normalizeThresholds,
+    resolveLayoutMode,
+    resolveLayoutPolicy,
+    scoreGridCandidate,
+  };
+});

--- a/core/viewer/layout-policy.test.js
+++ b/core/viewer/layout-policy.test.js
@@ -1,0 +1,375 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const vm = require("node:vm");
+const {
+  DEFAULT_MODE_THRESHOLDS,
+  MODES,
+  MODE_ORDER,
+  chooseOptimalGrid,
+  classifyLayoutMode,
+  fitAspectRatio,
+  isMode,
+  listGridCandidates,
+  normalizeGeometry,
+  normalizeThresholds,
+  resolveLayoutMode,
+  resolveLayoutPolicy,
+  scoreGridCandidate,
+} = require("./layout-policy.js");
+
+const EPSILON = 1e-7;
+
+function approximatelyEqual(actual, expected, epsilon = EPSILON) {
+  assert.ok(
+    Math.abs(actual - expected) <= epsilon,
+    `expected ${actual} to be within ${epsilon} of ${expected}`
+  );
+}
+
+test("browser build exposes the same policy through EchoLayoutPolicy", () => {
+  const source = fs.readFileSync(path.join(__dirname, "layout-policy.js"), "utf8");
+  const context = { globalThis: {} };
+  vm.runInNewContext(source, context, { filename: "layout-policy.js" });
+
+  assert.equal(typeof context.globalThis.EchoLayoutPolicy, "object");
+  assert.equal(
+    context.globalThis.EchoLayoutPolicy.resolveLayoutMode({ width: 1280, height: 720 }),
+    MODES.THEATER
+  );
+  assert.equal(typeof context.globalThis.EchoLayoutPolicy.chooseOptimalGrid, "function");
+});
+
+test("named layout modes are stable and ordered from smallest to largest", () => {
+  assert.deepEqual(MODE_ORDER, [
+    MODES.MINI,
+    MODES.COMPACT,
+    MODES.LOUNGE,
+    MODES.THEATER,
+  ]);
+  for (const mode of MODE_ORDER) assert.equal(isMode(mode), true);
+  assert.equal(isMode("desktop"), false);
+  assert.equal(isMode(null), false);
+});
+
+test("geometry normalization is deterministic for invalid measurements", () => {
+  assert.deepEqual(normalizeGeometry(1280, 720), { width: 1280, height: 720 });
+  assert.deepEqual(normalizeGeometry("900", "600"), { width: 900, height: 600 });
+  assert.deepEqual(normalizeGeometry(-1, Number.NaN), { width: 0, height: 0 });
+  assert.deepEqual(normalizeGeometry(Infinity, undefined), { width: 0, height: 0 });
+});
+
+test("base classification changes exactly at every width and height boundary", () => {
+  const cases = [
+    [639, 2000, MODES.MINI],
+    [640, 479, MODES.MINI],
+    [640, 480, MODES.COMPACT],
+    [899, 2000, MODES.COMPACT],
+    [900, 599, MODES.COMPACT],
+    [900, 600, MODES.LOUNGE],
+    [1279, 2000, MODES.LOUNGE],
+    [1280, 719, MODES.LOUNGE],
+    [1280, 720, MODES.THEATER],
+  ];
+
+  for (const [width, height, expected] of cases) {
+    assert.equal(classifyLayoutMode(width, height), expected, `${width}x${height}`);
+  }
+});
+
+test("base classification is constrained by the weaker geometry axis", () => {
+  assert.equal(classifyLayoutMode(2560, 479), MODES.MINI);
+  assert.equal(classifyLayoutMode(2560, 480), MODES.COMPACT);
+  assert.equal(classifyLayoutMode(2560, 600), MODES.LOUNGE);
+  assert.equal(classifyLayoutMode(899, 1440), MODES.COMPACT);
+  assert.equal(classifyLayoutMode(900, 1440), MODES.LOUNGE);
+});
+
+test("custom thresholds are monotonic even when overrides are malformed", () => {
+  const thresholds = normalizeThresholds({
+    compact: { minWidth: 700, minHeight: 500 },
+    lounge: { minWidth: 600, minHeight: 400 },
+    theater: { minWidth: -1, minHeight: Number.NaN },
+    hysteresis: -20,
+  });
+
+  assert.deepEqual(thresholds.compact, { minWidth: 700, minHeight: 500 });
+  assert.deepEqual(thresholds.lounge, { minWidth: 700, minHeight: 500 });
+  assert.deepEqual(thresholds.theater, { minWidth: 1280, minHeight: 720 });
+  assert.equal(thresholds.hysteresis, DEFAULT_MODE_THRESHOLDS.hysteresis);
+});
+
+test("unknown previous mode uses nominal thresholds without hysteresis", () => {
+  assert.equal(resolveLayoutMode({ width: 1280, height: 720 }), MODES.THEATER);
+  assert.equal(
+    resolveLayoutMode({ width: 900, height: 600, previousMode: "unknown" }),
+    MODES.LOUNGE
+  );
+});
+
+test("every upward transition requires crossing both axes by hysteresis", () => {
+  const h = DEFAULT_MODE_THRESHOLDS.hysteresis;
+  const transitions = [
+    [MODES.MINI, MODES.COMPACT],
+    [MODES.COMPACT, MODES.LOUNGE],
+    [MODES.LOUNGE, MODES.THEATER],
+  ];
+
+  for (const [from, to] of transitions) {
+    const boundary = DEFAULT_MODE_THRESHOLDS[to];
+    assert.equal(
+      resolveLayoutMode({
+        width: boundary.minWidth + h - 1,
+        height: boundary.minHeight + h,
+        previousMode: from,
+      }),
+      from,
+      `${from}->${to} waits for width`
+    );
+    assert.equal(
+      resolveLayoutMode({
+        width: boundary.minWidth + h,
+        height: boundary.minHeight + h - 1,
+        previousMode: from,
+      }),
+      from,
+      `${from}->${to} waits for height`
+    );
+    assert.equal(
+      resolveLayoutMode({
+        width: boundary.minWidth + h,
+        height: boundary.minHeight + h,
+        previousMode: from,
+      }),
+      to,
+      `${from}->${to} crosses at inclusive upper edge`
+    );
+  }
+});
+
+test("every downward transition retains mode through the lower hysteresis edge", () => {
+  const h = DEFAULT_MODE_THRESHOLDS.hysteresis;
+  const transitions = [
+    [MODES.COMPACT, MODES.MINI],
+    [MODES.LOUNGE, MODES.COMPACT],
+    [MODES.THEATER, MODES.LOUNGE],
+  ];
+
+  for (const [from, to] of transitions) {
+    const boundary = DEFAULT_MODE_THRESHOLDS[from];
+    assert.equal(
+      resolveLayoutMode({
+        width: boundary.minWidth - h,
+        height: boundary.minHeight - h,
+        previousMode: from,
+      }),
+      from,
+      `${from} remains at inclusive lower edge`
+    );
+    assert.equal(
+      resolveLayoutMode({
+        width: boundary.minWidth - h - 1,
+        height: boundary.minHeight + h,
+        previousMode: from,
+      }),
+      to,
+      `${from}->${to} leaves on width`
+    );
+    assert.equal(
+      resolveLayoutMode({
+        width: boundary.minWidth + h,
+        height: boundary.minHeight - h - 1,
+        previousMode: from,
+      }),
+      to,
+      `${from}->${to} leaves on height`
+    );
+  }
+});
+
+test("large geometry jumps can traverse every mode in one decision", () => {
+  assert.equal(
+    resolveLayoutMode({ width: 2000, height: 1200, previousMode: MODES.MINI }),
+    MODES.THEATER
+  );
+  assert.equal(
+    resolveLayoutMode({ width: 320, height: 240, previousMode: MODES.THEATER }),
+    MODES.MINI
+  );
+});
+
+test("hysteresis prevents repeated resize samples around all nominal boundaries", () => {
+  const samples = [
+    [MODES.COMPACT, 640, 480],
+    [MODES.LOUNGE, 900, 600],
+    [MODES.THEATER, 1280, 720],
+  ];
+
+  for (const [mode, width, height] of samples) {
+    assert.equal(resolveLayoutMode({ width: width - 20, height, previousMode: mode }), mode);
+    assert.equal(resolveLayoutMode({ width: width + 20, height, previousMode: mode }), mode);
+    assert.equal(resolveLayoutMode({ width, height: height - 20, previousMode: mode }), mode);
+    assert.equal(resolveLayoutMode({ width, height: height + 20, previousMode: mode }), mode);
+  }
+});
+
+test("resolved policy exposes mode and height pressure without presentation commands", () => {
+  assert.deepEqual(resolveLayoutPolicy({ width: 1400, height: 800 }), {
+    mode: MODES.THEATER,
+    width: 1400,
+    height: 800,
+    isShort: false,
+    isVeryShort: false,
+  });
+
+  const mini = resolveLayoutPolicy({ width: 500, height: 500 });
+  assert.equal(mini.mode, MODES.MINI);
+  assert.equal(mini.isShort, true);
+  assert.equal(mini.isVeryShort, true);
+  assert.deepEqual(Object.keys(mini).sort(), [
+    "height",
+    "isShort",
+    "isVeryShort",
+    "mode",
+    "width",
+  ]);
+});
+
+test("aspect fitting honors landscape and portrait constraints exactly", () => {
+  const heightLimited = fitAspectRatio(1000, 400, 16 / 9);
+  approximatelyEqual(heightLimited.height, 400);
+  approximatelyEqual(heightLimited.width, 400 * (16 / 9));
+
+  const widthLimited = fitAspectRatio(400, 1000, 16 / 9);
+  approximatelyEqual(widthLimited.width, 400);
+  approximatelyEqual(widthLimited.height, 400 / (16 / 9));
+
+  const portrait = fitAspectRatio(300, 300, 9 / 16);
+  approximatelyEqual(portrait.height, 300);
+  approximatelyEqual(portrait.width, 300 * (9 / 16));
+});
+
+test("aspect fitting returns safe zero geometry for unavailable space", () => {
+  assert.deepEqual(fitAspectRatio(0, 100, 16 / 9), {
+    width: 0,
+    height: 0,
+    area: 0,
+    aspectRatio: 16 / 9,
+  });
+  assert.equal(fitAspectRatio(-10, Number.NaN, -1).area, 0);
+});
+
+test("candidate scoring accounts for gaps and incomplete final rows", () => {
+  const candidate = scoreGridCandidate({
+    width: 1000,
+    height: 600,
+    tileCount: 5,
+    columns: 3,
+    gap: 10,
+    aspectRatio: 16 / 9,
+  });
+
+  assert.equal(candidate.valid, true);
+  assert.equal(candidate.columns, 3);
+  assert.equal(candidate.rows, 2);
+  assert.equal(candidate.occupancy, 5 / 6);
+  approximatelyEqual(candidate.cellWidth, (1000 - 20) / 3);
+  approximatelyEqual(candidate.cellHeight, (600 - 10) / 2);
+  assert.ok(candidate.totalWidth <= 1000 + EPSILON);
+  assert.ok(candidate.totalHeight <= 600 + EPSILON);
+});
+
+test("candidate scoring rejects impossible column and space geometry", () => {
+  assert.equal(scoreGridCandidate({ tileCount: 0, columns: 1 }).reason, "no-tiles");
+  assert.equal(scoreGridCandidate({ tileCount: 3, columns: 0 }).reason, "invalid-columns");
+  assert.equal(scoreGridCandidate({ tileCount: 3, columns: 4 }).reason, "invalid-columns");
+  assert.equal(
+    scoreGridCandidate({ width: 10, height: 10, tileCount: 2, columns: 2, gap: 20 }).reason,
+    "insufficient-space"
+  );
+});
+
+test("candidate listing is complete and ordered by column count", () => {
+  const candidates = listGridCandidates({ width: 1200, height: 700, tileCount: 8 });
+  assert.equal(candidates.length, 8);
+  assert.deepEqual(candidates.map((candidate) => candidate.columns), [1, 2, 3, 4, 5, 6, 7, 8]);
+});
+
+test("optimal grids choose expected arrangements for representative shapes", () => {
+  assert.deepEqual(
+    { columns: chooseOptimalGrid({ width: 1280, height: 720, tileCount: 1 }).columns,
+      rows: chooseOptimalGrid({ width: 1280, height: 720, tileCount: 1 }).rows },
+    { columns: 1, rows: 1 }
+  );
+
+  const standardFour = chooseOptimalGrid({ width: 1280, height: 720, tileCount: 4 });
+  assert.deepEqual({ columns: standardFour.columns, rows: standardFour.rows }, { columns: 2, rows: 2 });
+
+  const wideFour = chooseOptimalGrid({ width: 2200, height: 360, tileCount: 4 });
+  assert.deepEqual({ columns: wideFour.columns, rows: wideFour.rows }, { columns: 4, rows: 1 });
+
+  const portraitThree = chooseOptimalGrid({ width: 500, height: 1200, tileCount: 3 });
+  assert.deepEqual({ columns: portraitThree.columns, rows: portraitThree.rows }, { columns: 1, rows: 3 });
+});
+
+test("empty optimal grid has a stable zero-sized result", () => {
+  assert.deepEqual(chooseOptimalGrid({ width: 1000, height: 600, tileCount: 0 }), {
+    valid: true,
+    reason: "empty",
+    columns: 0,
+    rows: 0,
+    tileCount: 0,
+    tileWidth: 0,
+    tileHeight: 0,
+    tileArea: 0,
+    score: 0,
+    totalWidth: 0,
+    totalHeight: 0,
+  });
+});
+
+test("grid geometry never exceeds its container across an exhaustive matrix", () => {
+  const widths = [240, 320, 480, 640, 900, 1280, 1920, 2560];
+  const heights = [180, 240, 360, 480, 600, 720, 1080, 1440];
+  const aspects = [4 / 3, 16 / 9, 21 / 9, 9 / 16];
+  const gaps = [0, 6, 12, 24];
+
+  for (const width of widths) {
+    for (const height of heights) {
+      for (let tileCount = 1; tileCount <= 16; tileCount += 1) {
+        for (const aspectRatio of aspects) {
+          for (const gap of gaps) {
+            const layout = chooseOptimalGrid({ width, height, tileCount, aspectRatio, gap });
+            assert.equal(layout.valid, true, `${width}x${height}, n=${tileCount}`);
+            assert.ok(layout.columns >= 1 && layout.columns <= tileCount);
+            assert.equal(layout.rows, Math.ceil(tileCount / layout.columns));
+            assert.ok(layout.columns * layout.rows >= tileCount);
+            assert.ok(layout.tileWidth >= 0 && Number.isFinite(layout.tileWidth));
+            assert.ok(layout.tileHeight >= 0 && Number.isFinite(layout.tileHeight));
+            assert.ok(layout.score >= 0 && Number.isFinite(layout.score));
+            assert.ok(layout.totalWidth <= width + EPSILON);
+            assert.ok(layout.totalHeight <= height + EPSILON);
+            approximatelyEqual(layout.tileWidth / layout.tileHeight, aspectRatio, 1e-6);
+          }
+        }
+      }
+    }
+  }
+});
+
+test("optimal score cannot decrease when both container axes grow", () => {
+  for (let tileCount = 1; tileCount <= 12; tileCount += 1) {
+    const small = chooseOptimalGrid({ width: 800, height: 450, tileCount });
+    const large = chooseOptimalGrid({ width: 1200, height: 675, tileCount });
+    assert.ok(large.score + EPSILON >= small.score, `tileCount=${tileCount}`);
+  }
+});
+
+test("grid selection is deterministic across repeated evaluations", () => {
+  const input = { width: 1111, height: 777, tileCount: 11, gap: 13, aspectRatio: 16 / 10 };
+  const first = chooseOptimalGrid(input);
+  for (let index = 0; index < 100; index += 1) {
+    assert.deepEqual(chooseOptimalGrid(input), first);
+  }
+});

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -11,6 +11,8 @@ agents.
   basics
 - [Testing](./TESTING.md) - verification model, CI expectations, regression
   strategy
+- [Responsive UI contract](./UI-RESPONSIVE-CONTRACT.md) - connected-shell
+  geometry, state-preservation rules, and Clubhouse rollout gates
 - [Codex operating model](./CODEX.md) - canonical project/thread/worktree rules
 - [Release Boundaries](./RELEASE-BOUNDARIES.md) - when desktop-binary updates
   are required vs server-only deploys

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -20,6 +20,35 @@ Goal: make regressions hard and PR review lightweight by relying on automated ve
 - Broader test sets
 - Slower integration scenarios
 - Stress/race-focused checks
+- Production-viewer browser geometry tests
+
+The browser suite is isolated in `core/viewer-tests/`. It serves the real
+`core/viewer/` page and injects deterministic participants and screen tiles
+through production renderers; it does not depend on or exercise
+`core/viewer-next/`.
+
+First-time setup:
+
+```bash
+npm --prefix core/viewer-tests ci
+npm --prefix core/viewer-tests run browser:install
+```
+
+Normal run:
+
+```bash
+npm run verify:viewer:layout
+```
+
+The browser suite remains separate from `verify:quick` so the dependency-free
+PR baseline stays fast. The path-filtered `PR Viewer Layout` workflow runs it
+for production viewer and layout-test changes.
+
+Phase 0 records known legacy narrow-layout failures as narrowly scoped
+sentinels that assert the exact current bad geometry. Unrelated runtime failures
+still fail normally, and a corrected layout makes the sentinel fail until it is
+replaced by the positive contract assertion. That conversion is required before
+default-on rollout.
 
 ### Layer 3 — Release confidence checks (as needed)
 - Smoke tests on release candidate builds

--- a/docs/UI-RESPONSIVE-CONTRACT.md
+++ b/docs/UI-RESPONSIVE-CONTRACT.md
@@ -1,0 +1,532 @@
+# Echo Chamber Responsive UI Contract
+
+Status: proposed contract for the Clubhouse UI foundation
+
+Applies to: `core/viewer/` in the browser and Windows desktop shell
+
+This document defines the responsive behavior that future UI work must preserve.
+It is intentionally stricter than a visual mockup: it describes layout ownership,
+state preservation, accessibility, and the geometry guarantees that make the UI
+safe to change while a room is live.
+
+The words **must**, **should**, and **may** are normative. A later PR may revise
+this contract deliberately, but implementation work must not silently diverge
+from it.
+
+## Principles
+
+1. **State truth outranks visual convenience.** Responsive changes must never
+   imply that a microphone, camera, share, Jam, or room connection changed when
+   only its presentation changed.
+2. **One connected shell, one stable DOM.** The same region and media nodes adapt
+   across geometry. Do not build separate desktop and constrained DOM trees.
+3. **CSS owns geometry.** JavaScript may select a named layout mode and manage
+   interaction state; CSS performs sizing, positioning, wrapping, truncation,
+   and container adaptation.
+4. **Primary controls do not move.** Mic, camera, share, output, and leave remain
+   in the control dock in the same order after connection.
+5. **One secondary tool at a time.** People, Chat, Jam, and future utility tools
+   share one panel host instead of progressively squeezing the stage with new
+   columns.
+6. **Progressive disclosure beats removal.** Space-constrained layouts collapse
+   labels and secondary controls, but do not make essential actions or state
+   inaccessible.
+7. **A resize is not a lifecycle event.** It must not reconnect a room, republish
+   media, recreate a participant card, or reset user input.
+8. **The prejoin page may scroll; the connected workspace must compose.** Short
+   windows must not clip setup controls, and connected regions must have explicit
+   internal scroll owners.
+
+## Canonical Regions
+
+The connected viewer has these canonical regions:
+
+| Region | Purpose | Lifetime |
+| --- | --- | --- |
+| Shell header | Brand, room switcher, connection state, account/overflow actions | Mounted for the connected session |
+| Primary stage | Shared screens, focused media, and intentional empty state | Mounted for the connected session |
+| Utility host | Exactly one active secondary tool such as People, Chat, or Jam | Mounted once; presentation changes by mode |
+| Control dock | Mic, camera, share, output, and leave controls | Mounted and visible for the connected session |
+| Overlay root | Settings, confirmations, pickers, lightboxes, and other modal surfaces | Mounted once; contains the topmost overlay |
+| Notification layer | Toasts, banners, and polite/assertive live regions | Mounted once for the application |
+
+The prejoin portal is a separate route/state, not a compressed version of the
+connected shell. It must have a vertical scroll fallback and must not reserve
+space for the connected control dock.
+
+The preferred DOM relationship is:
+
+```text
+ui-root
+|- shell-header
+|- workspace
+|  |- primary-stage
+|  `- utility-host
+|- control-dock
+|- overlay-root
+`- notification-layer
+```
+
+Mode changes must restyle these nodes in place. They must not clone them, create
+duplicate IDs, or re-register feature listeners.
+
+## Responsive Inputs
+
+Layout decisions use **CSS viewport pixels**, not physical pixels, monitor
+resolution, `window.outerWidth`, or a device-name heuristic. Browser zoom and
+Windows display scaling therefore participate naturally.
+
+The mode controller reads `document.documentElement.clientWidth` and
+`document.documentElement.clientHeight`. Both axes constrain the named mode;
+height also exposes pressure flags for density tuning. Safe-area insets and
+coarse-pointer queries are CSS inputs and do not alter the named mode.
+
+### Geometry Modes
+
+Mode selection considers both viewport axes. Initial load selects the largest
+mode whose minimum width **and** minimum height are satisfied.
+
+| Mode | Minimum width | Minimum height | Utility / dock | Cameras with active share |
+| --- | ---: | ---: | --- | ---: |
+| `mini` | `0px` | `0px` | Sheet / essential | One focused camera |
+| `compact` | `640px` | `480px` | Sheet / icons | One camera in a reserved strip |
+| `lounge` | `900px` | `600px` | Overlay / labeled | Up to four, horizontal |
+| `theater` | `1280px` | `720px` | Pinned rail / labeled | Up to four, vertical |
+
+The root exposes the selected mode as
+`data-ui-mode="mini|compact|lounge|theater"`. Mode names are behavioral
+contracts; component CSS must not invent overlapping breakpoint vocabularies
+such as `desktop`, `tablet`, or `small-desktop`.
+
+### Hysteresis
+
+Initial load uses the canonical thresholds above. Once mounted, transitions use
+a symmetric `48px` deadband on both axes so window-edge dragging and fractional
+zoom do not repeatedly open, close, or reannounce controls.
+
+- An upgrade requires both width and height to reach the next mode's minimum
+  plus `48px`.
+- A downgrade occurs when either width or height falls below the current mode's
+  minimum minus `48px`.
+- A large resize may cross more than one mode in one decision.
+- Geometry inside the deadband retains the current mode.
+
+Examples:
+
+| Transition | Enter/leave condition after mount |
+| --- | --- |
+| `mini` to `compact` | width `>= 688px` **and** height `>= 528px` |
+| `compact` to `mini` | width `< 592px` **or** height `< 432px` |
+| `compact` to `lounge` | width `>= 948px` **and** height `>= 648px` |
+| `lounge` to `compact` | width `< 852px` **or** height `< 552px` |
+| `lounge` to `theater` | width `>= 1328px` **and** height `>= 768px` |
+| `theater` to `lounge` | width `< 1232px` **or** height `< 672px` |
+
+Mode is not persisted across launches; each new document starts from the
+canonical initial-load thresholds.
+
+`core/viewer/layout-policy.js` is the executable counterpart to these values.
+Any threshold, mode-order, or hysteresis change must update that module, its
+deterministic tests, and this contract in the same PR. Runtime JavaScript
+consumes only `mode`, `isShort`, and `isVeryShort`; CSS owns how those values
+present rails, sheets, docks, and camera strips.
+
+Resize observations must be coalesced to an animation frame. The controller
+must emit at most one mode change for a settled measurement and must not add a
+human-visible debounce delay. The transition function must be a pure helper with
+deterministic boundary tests.
+
+### Height Pressure Flags
+
+The layout policy additionally exposes `isShort` below `650px` and
+`isVeryShort` below `520px`. These flags may reduce nonessential spacing and
+increase panel scroll area. They must not choose a different utility
+presentation, hide primary actions, or detach media; those decisions belong to
+the named geometry mode.
+
+Because these flags only tune CSS density and do not open, close, or move an
+interactive surface, they do not have independent hysteresis.
+
+## CSS and JavaScript Ownership
+
+| Concern | Owner |
+| --- | --- |
+| Region tracks, gaps, padding, fixed/sticky placement | CSS |
+| Drawer, rail, sheet, and full-screen panel geometry | CSS keyed by root mode |
+| Component adaptation within its allocated width | CSS container queries |
+| Text wrapping, ellipsis, icon/label presentation | CSS |
+| Safe-area insets, coarse-pointer sizing, reduced motion | CSS media queries |
+| Width/height mode selection and hysteresis | One JavaScript mode controller |
+| Active utility tool, panel open state, and return focus | JavaScript UI state |
+| Modal focus containment and background inertness | JavaScript behavior plus CSS presentation |
+| Media tile allocation inside the stage | Existing media-grid layout owner |
+| Room, publication, subscription, Jam, and participant truth | Existing feature state owners |
+
+JavaScript must not write per-breakpoint pixel widths, move feature nodes between
+alternate parents, or decide which text happens to fit. A component that needs
+local adaptation declares a containment boundary and uses container queries.
+
+The existing screen-grid allocator may continue calculating media tile geometry
+inside the stage. It receives the stage's available rectangle; it must not
+duplicate shell breakpoints or control utility-panel behavior.
+
+A no-JavaScript/failure fallback may use media queries at the canonical
+thresholds. The supported runtime, however, uses the named root mode so behavior
+and geometry change together.
+
+## Geometry Invariants
+
+### Connected Shell
+
+- The connected root occupies the dynamic viewport (`100dvh`) with a `100vh`
+  fallback.
+- The root and all grid/flex descendants that own overflow must use
+  `min-width: 0` and `min-height: 0` where appropriate.
+- The connected document has no horizontal scrollbar at supported widths.
+- The document body does not vertically scroll while connected. The stage,
+  utility body, and intentional modal bodies are the only scroll owners.
+- The prejoin portal is allowed to vertically scroll when its content exceeds
+  the viewport.
+- Shell padding is `24px` in `theater`, `16px` in `lounge`, `12px` in
+  `compact`, and `8px` in `mini`, before safe-area additions.
+- The ordinary region gap is `16px`. Components may use smaller values from the
+  shared spacing scale; they must not introduce arbitrary shell gaps.
+
+### Header and Dock
+
+- The shell header targets a `56px` block size in `theater` and `lounge`,
+  `52px` in `compact`, and `48px` in `mini`.
+- The dock reserves at least `64px` plus the bottom safe-area inset.
+- Stage and panel content must reserve the dock's occupied block size; controls
+  and scroll endpoints must never sit underneath it.
+- Desktop pointer targets are at least `40px` square. Coarse-pointer targets are
+  at least `44px` square.
+- The dock remains visually centered and may have a maximum inline size, but it
+  must never overflow the viewport or wrap a primary action into a second row.
+
+### Theater Mode
+
+- Workspace columns are `minmax(0, 1fr)` plus a utility rail of
+  `clamp(320px, 24vw, 360px)` with a `16px` gap.
+- Opening or switching a utility tool reuses the rail; it never adds another
+  workspace column.
+- Closing an optional tool may return its width to the stage. If People is the
+  product's persistent default tool, closing another tool returns to People
+  rather than leaving an empty rail.
+- With a share active, up to four visible cameras use a vertical stage strip.
+  Additional cameras remain available in People without detaching their media.
+
+### Lounge Mode
+
+- The stage owns the full workspace width.
+- The utility host becomes an end-edge drawer with an inline size of
+  `clamp(320px, 42vw, 380px)`.
+- Opening the drawer overlays the stage; it does not resize the stage or trigger
+  a media-grid mode change beyond normal occlusion/resize observation.
+- The drawer has a workspace-bounded scrim while open. The obscured stage is
+  inert, but the drawer and call dock remain interactive.
+- The dock retains labels. With a share active, up to four visible cameras use
+  a horizontal stage strip.
+
+### Compact Mode
+
+- The workspace is one column.
+- The utility host is a bottom sheet for short, task-oriented content and a
+  full-screen surface for scroll-heavy tools such as Chat or a populated Jam.
+- A bottom sheet may not cover the control dock. Its maximum block size is the
+  dynamic viewport minus the header, dock, safe areas, and one shell gap.
+- The dock uses icon variants with accessible names.
+- With a share active, one selected camera uses a reserved horizontal strip.
+  It remains in normal layout flow and may not overlap the share, controls, or
+  status.
+
+### Mini Mode
+
+- The workspace is one column and the dock shows only essential connected-
+  session actions; secondary actions move to overflow.
+- The utility host uses a bottom sheet or full-screen surface as in `compact`,
+  with tighter safe-area-aware geometry.
+- With a share active, at most one selected camera receives focused placement.
+  Other cameras remain available through People.
+- Mini mode must not depend on hover to reveal any action.
+
+### Layering
+
+Components use semantic layer tokens rather than one-off `z-index` values:
+
+| Layer | Token intent |
+| --- | --- |
+| Base regions | `0` |
+| Sticky header and dock | `20` |
+| Utility scrim, bounded above the dock | `25` |
+| Utility drawer/sheet | `30` |
+| True modal scrim | `40` |
+| Modal/picker/lightbox | `50` |
+| Toasts and critical banners | `60` |
+
+Nested component overlays must remain inside their region's stacking context.
+Only the overlay root and notification layer may escape the shell layer system.
+
+## Control Dock Contract
+
+The dock is the single home for connected-session actions. From start edge to
+end edge, the stable primary order is:
+
+1. Microphone
+2. Camera
+3. Screen share
+4. Output/audio device entry point
+5. Leave room, visually separated as destructive
+
+The foundation may reserve one contextual slot, but a feature may not displace
+or reorder the primary controls. Secondary features such as Theme, Feedback,
+Updates, Debug, and administrative tools belong in the shell overflow or their
+own authorized surface.
+
+Each control must expose actual state (`on`, `off`, `muted`, `starting`,
+`failed`) rather than only optimistic intent. Resizing or changing mode must not
+clear a pending state. Icon-only presentations retain an accessible name and a
+mouse/keyboard tooltip.
+
+The dock appears only after a room connection has reached the UI's connected
+state. Reconnecting may annotate or temporarily disable affected actions, but
+must not remove the dock and cause the workspace to jump.
+
+## Utility Panel Contract
+
+- There is one utility host and at most one active tool.
+- Tool selection and open/closed state survive geometry-mode transitions.
+- A mode transition changes the host from pinned rail to overlay drawer to
+  sheet/full-screen without recreating the active tool.
+- Each tool owns one scrollable body. Its header and critical footer actions
+  remain visible.
+- Utility rails, drawers, and sheets are not true modal dialogs. When a utility
+  surface obscures the stage, only the obscured stage becomes inert; the active
+  utility surface and the call dock remain keyboard-operable. Escape closes the
+  surface and focus returns to the invoking control. Confirmations, pickers, and
+  other true dialogs use the overlay root and may contain focus normally.
+- Switching tools deliberately may preserve tool-local state such as an
+  unsent chat draft, Jam search text, queue position, and participant scroll.
+- Opening Chat must never add a third workspace column. Opening Settings must
+  never compete with a still-interactive drawer at the same layer.
+
+## Cards, Labels, and Truncation
+
+Cards adapt to their own inline size rather than the global viewport. The shared
+card contract uses these container bands:
+
+| Container width | Presentation |
+| --- | --- |
+| `>= 304px` | Full identity, status, and labeled primary action |
+| `240px` through `303px` | Condensed spacing; secondary labels collapse |
+| `< 240px` | Minimal/icon presentation; identity and primary state remain |
+
+Feature-specific thresholds may vary only when backed by a documented content
+requirement and visual tests.
+
+Content priority is:
+
+1. Identity/title and primary state
+2. Primary action
+3. Critical warning or error
+4. Status badges
+5. Descriptive copy and secondary controls
+
+Rules:
+
+- Participant names, room names, track titles, and song titles use
+  `min-width: 0` and a single-line ellipsis in dense headers. The full value
+  remains in the accessible name and is available on focus/hover.
+- Descriptive and status copy may wrap to two lines before truncating. Errors
+  that require action must not be ellipsized without an expansion path.
+- Buttons do not truncate ambiguous text. They switch to a known icon-only
+  variant with an accessible label.
+- Badges do not shrink into unreadable fragments; lower-priority badges move
+  into the overflow menu.
+- Unbounded user content uses `overflow-wrap: anywhere` in a scroll owner; it
+  must not widen a region.
+- Camera state must not relocate participant identity or audio controls.
+- Set-and-forget controls, including per-participant chime volume, belong in an
+  audio/settings popover. A non-default override may expose a compact state
+  indicator on the card.
+- Hover may enhance a card but must not be the only route to mute, volume,
+  fullscreen, or overflow actions.
+
+## Media Nodes and State Preservation
+
+Responsive behavior must preserve media and application state by identity, not
+merely reproduce a similar-looking result.
+
+During a geometry-mode or height-pressure change, implementations must not:
+
+- call LiveKit `attach`, `detach`, publish, unpublish, subscribe, or unsubscribe
+  solely because geometry changed;
+- replace or clone an active `<video>` or `<audio>` element;
+- reconstruct participant cards or screen tiles;
+- disconnect/reconnect the room or its data channels;
+- reset microphone, screen, chime, Jam, or per-participant volume;
+- clear selected room/tool state, focused share, chat draft, or queue/search
+  state;
+- toggle an active media container to `display: none` as a breakpoint shortcut,
+  because that can affect adaptive-stream visibility and decode behavior.
+
+The same media element must remain connected to the same track across a resize.
+CSS may change its containing geometry and `object-fit`. The media-grid owner may
+recalculate tile tracks after its container changes size.
+
+If an intentional user action hides or stops watching media, that feature's
+existing state machine remains the owner. Responsive code must not impersonate
+that action.
+
+Acceptance tests for the shell must retain references to representative media
+nodes, cross every hysteresis boundary in both directions, and assert object
+identity, track identity, publication state, volume, and selected UI state.
+
+## Accessibility and Input Contract
+
+- All interactive controls must be reachable and operable by keyboard.
+- Every interactive element has a visible `:focus-visible` treatment with at
+  least a `2px` indicator that is not color-confusable with the background.
+- Icon-only controls have an accessible name. Tooltips supplement but do not
+  replace that name.
+- Theater's rail follows normal document focus order. Utility drawers and
+  sheets keep both the active utility and call dock in the keyboard order while
+  only the obscured stage is inert; Escape closes them and restores focus to
+  their invoker. True modal confirmations, pickers, and dialogs contain focus,
+  make their background inert, and close on Escape when safe.
+- Utility-tool selectors use the tabs pattern only if they behave as tabs;
+  otherwise they use ordinary toggle buttons with `aria-expanded` and
+  `aria-controls`.
+- State is never communicated by color alone. Muted, disconnected, warning,
+  active, and destructive states include text or an icon with an accessible
+  label.
+- Polite status changes use an appropriate live region. Connection loss and
+  destructive failures may use assertive announcement; routine resize and mode
+  changes are not announced.
+- Coarse-pointer targets are at least `44px` by `44px`, with at least `8px`
+  separation where adjacent destructive and non-destructive actions could be
+  confused.
+- At 200% text zoom, primary controls remain available, no horizontal page
+  scroll appears, and clipped text has an accessible expansion route.
+- `prefers-reduced-motion: reduce` disables decorative drift, pulse, shimmer,
+  and large panel transitions. Essential state changes remain immediate.
+- Safe-area insets are honored on every edge used by a fixed dock, drawer, or
+  sheet.
+
+## Viewport and Content Matrix
+
+All dimensions below are CSS pixels. These are minimum required validation
+fixtures, not device sniffing rules. Unless a row names a prior mode, its
+expected mode is the fresh-document classification without hysteresis history.
+
+| Viewport / condition | Expected mode | Required content case | Expected behavior |
+| --- | --- | --- | --- |
+| `1920 x 1080` | `theater` | Four shares, twelve people, utility open | Rail remains within `320-360px`; stage has no horizontal overflow |
+| `1366 x 768` | `theater` | Two shares, eight long participant names | Dock stays one row; names truncate; stage remains usable |
+| `1280 x 720` | `theater` on initial load | One ultrawide share, People open | Rail uses its minimum range; share preserves aspect ratio |
+| `1024 x 768` | `lounge` | Two shares, Chat open with draft | Overlay does not shrink stage; draft survives close/reopen |
+| `900 x 700` | `lounge` | Jam populated with long song titles | Internal Jam scrolls; dock and destructive actions remain visible |
+| `900 x 540` | `compact`, `isShort` | One share plus one camera | Sheet and icon dock fit; camera uses a reserved strip without overlap |
+| `768 x 1024` | `compact` | Camera tiles plus People | Sheet fits inside safe area; no hover-only controls |
+| `640 x 480` | `compact` on initial load, `isShort`, `isVeryShort` | Connected empty stage | Essential empty-state action and dock remain reachable |
+| `600 x 900` | `mini` | Chat history, attachment, software keyboard | Full-screen/sheet content scrolls above dock; composer remains reachable |
+| `360 x 640` | `mini`, `isShort` | Prejoin error; connected empty stage | Prejoin scrolls; connected dock uses essential controls; no horizontal scroll |
+| 200% zoom at `1920 x 1080` | Approximately `compact` by CSS geometry | People and status copy | Mode follows CSS viewport; controls do not clip or overlap |
+| Resize `compact` from `768 x 1024` to `600 x 900` | `compact` retained | Connected shell with utility open | Hysteresis prevents a presentation jump inside the lower deadband |
+| Continue that resize to `591 x 900` | `mini` | Same mounted nodes and state | Mode changes once; no media or feature node is recreated |
+
+Every viewport is also checked with:
+
+- no active share and a useful empty-state action;
+- one and four simultaneous shares;
+- one, eight, and twenty participants;
+- a 60-character unbroken display name and long localized-style labels;
+- utility closed and each registered utility tool open;
+- reconnecting, disabled, error, and destructive-confirmation states;
+- mouse, keyboard-only, and coarse-pointer emulation.
+
+## Verification Requirements
+
+Foundation and migration PRs must include proportionate evidence:
+
+1. Deterministic mode-transition tests covering every threshold and deadband.
+2. DOM-identity tests proving representative media elements survive mode
+   changes.
+3. State-preservation tests for active tool, participant volume, focused share,
+   and at least one unsaved text input.
+4. Geometry assertions or screenshots for the viewport/content matrix.
+5. Keyboard checks for dock, tool selection, drawer/sheet close, modal focus,
+   and focus restoration.
+6. No-horizontal-overflow checks at each required viewport and 200% zoom.
+7. Reduced-motion and coarse-pointer checks.
+
+Visual snapshots may verify geometry, but they do not replace state and media
+identity assertions.
+
+## Migration and Feature-Flag Phases
+
+The rollout flag is named `echo-ui-shell-v2`. It controls presentation only and
+must not select alternate room, media, participant, or Jam state machines.
+
+The flag should be resolved before first paint and exposed as a root attribute.
+The new and legacy presentation must use the same feature nodes; do not create a
+second hidden connected UI. A development/test override may force either value,
+but production default changes require an explicit release decision.
+
+### Phase 0 - Contract and Measurements
+
+- Land this contract and document baseline viewport evidence.
+- Add no production behavior and keep the flag absent/off.
+- Identify current scroll owners, media-node owners, and overlay collisions.
+
+### Phase 1 - Foundation Behind Flag
+
+- Add semantic shell regions, shared geometry/layer tokens, and the tested mode
+  controller.
+- Keep the flag off by default.
+- Preserve current feature placement unless moving it is required to establish
+  a single stable region.
+- Verify that toggling the flag never duplicates media or feature listeners.
+
+### Phase 2 - Dock and Utility Host
+
+- Move existing primary call controls into the stable dock without changing
+  their state owners.
+- Migrate People first, then Chat and Jam, into the single utility host.
+- Ship each migration independently under the same flag with legacy fallback.
+
+### Phase 3 - Canary Default-On
+
+- Enable the flag by default for Sam's explicit canary/test build.
+- Validate the full viewport/content matrix and real room transitions.
+- Keep a one-switch rollback that restores legacy presentation without stored-
+  state conversion or a server restart.
+
+### Phase 4 - General Default and Cleanup
+
+- Make the new shell the production default only after canary evidence is clean.
+- Keep forced legacy presentation for at least one normal release unless an
+  urgent defect requires longer.
+- Remove legacy layout CSS, the flag, and dual-path tests in a focused cleanup
+  PR after the rollback window closes.
+
+## Foundation PR Non-Goals
+
+The foundation PR must not:
+
+- redesign every feature panel or restyle all themes;
+- change room, auth, control-plane, SFU, TURN, or LiveKit protocol behavior;
+- change microphone, camera, screen-share, participant, Chat, Soundboard, or Jam
+  state machines;
+- introduce a new frontend framework or revive `core/viewer-next/`;
+- replace the existing media-grid allocation algorithm;
+- add mobile-only product features or claim native-mobile parity;
+- migrate persisted settings or require a new server schema;
+- remove the legacy layout before the feature-flag rollback window;
+- treat hover effects, animation, or theme polish as acceptance criteria for
+  responsive correctness;
+- perform a production deploy or desktop release merely because the contract
+  and inert foundation land.
+
+The foundation is successful when it creates a safe, testable responsive shell
+that later PRs can populate without moving state ownership or risking live media.

--- a/docs/VALIDATION.md
+++ b/docs/VALIDATION.md
@@ -24,6 +24,37 @@ CI equivalent:
 
 - `PR Verification (Quick)` workflow (`.github/workflows/pr-verify-quick.yml`)
 
+## Viewer Layout Verification
+
+Required for connected-shell, participant-card, screen-grid, panel, dock, or
+responsive CSS changes:
+
+```bash
+npm --prefix core/viewer-tests ci
+npm --prefix core/viewer-tests run browser:install
+npm run verify:viewer:layout
+```
+
+The tests load the production `core/viewer/index.html`, inject deterministic
+room scenarios through production participant/screen renderers, and establish
+desktop geometry and resize-state baselines. Known narrow-layout failures run
+as exact bad-geometry sentinels during Phase 0; Clubhouse implementation PRs
+must replace them with positive contract assertions. The suite is deliberately
+outside `core/viewer/`, so its dependencies and fixtures are never copied into
+the served viewer snapshot.
+
+During Phase 0 the pure layout policy is injected by the test and is not yet
+loaded by production `index.html`. Phase 1 must replace that check with live
+mode-controller coverage before the new shell can be enabled.
+
+CI equivalent:
+
+- path-filtered `PR Viewer Layout` workflow
+  (`.github/workflows/pr-viewer-layout.yml`)
+
+Chromium geometry coverage does not replace the Windows WebView2 smoke required
+before a UI release.
+
 ## Extended Verification
 
 Recommended for risky fixes:

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "verify:guardrails": "node tools/verify/guardrails.mjs",
     "verify:viewer": "node --check core/viewer/app.js && node --check core/viewer/jam.js && node --test core/viewer/*.test.js",
+    "verify:viewer:layout": "npm --prefix core/viewer-tests test",
     "verify:quick": "npm run verify:guardrails && npm run verify:viewer"
   }
 }


### PR DESCRIPTION
## What changed

- Defines the responsive Clubhouse contract and four-mode layout policy with hysteresis.
- Adds exhaustive deterministic grid and mode-transition tests.
- Adds an isolated Playwright harness against the real production viewer, plus path-filtered CI.
- Records the exact legacy narrow-layout failures as sentinels.

## Why

The interactive concept exposed overlap and layout collapse, while the existing suite protects media and state behavior rather than rendered geometry. This creates the safety rails we need before moving production UI nodes.

## Impact

- No production UI appearance or media behavior change.
- No desktop binary release.
- No deployment required.
- `layout-policy.js` is intentionally inert until Phase 1 wires it behind `echo-ui-shell-v2`.

## Known legacy failures captured

- Participant-region collapse at 960×540 and 640×480.
- At 800×600, opening Chat restores a three-column layout and collapses the stage to zero width.

These sentinels must be replaced with positive contract assertions before the new shell becomes default-on.

## Validation

- `npm run verify:quick` — 145/145 viewer tests pass.
- `npm run verify:viewer:layout` — 7/7 Playwright tests pass.
- `tools/verify/quick.sh` — full quick verification passes, including Rust control-plane `cargo check`.
- Fresh `npm ci` audit — 0 vulnerabilities.