### PR TITLE
Phase 1: add Private Clubhouse responsive shell

### DIFF
--- a/core/control/src/config.rs
+++ b/core/control/src/config.rs
@@ -159,7 +159,8 @@ pub fn stamp_viewer_index(viewer_dir: &PathBuf, v: &str) {
     match fs::read_to_string(&index_path) {
         Ok(html) => {
             let assets = [
-                "style.css", "jam.css",
+                "style.css", "jam.css", "clubhouse-shell.css",
+                "layout-policy.js", "ui-shell.js",
                 "livekit-client.umd.js", "room-switch-state.js", "jam-session-state.js", "publish-state-reconcile.js",
                 "state.js", "debug.js", "urls.js", "settings.js", "display-status.js",
                 "native-presenter.js", "identity.js",
@@ -236,6 +237,9 @@ mod tests {
             dir.join("index.html"),
             r#"
             <link rel="stylesheet" href="capture-picker.css?v=old" />
+            <link rel="stylesheet" href="clubhouse-shell.css?v=old" />
+            <script src="layout-policy.js?v=old"></script>
+            <script src="ui-shell.js?v=old"></script>
             <script src="display-status.js?v=old"></script>
             <script src="native-presenter.js?v=old"></script>
             <script src="admin-panel.js?v=old"></script>
@@ -247,6 +251,9 @@ mod tests {
 
         let stamped = fs::read_to_string(dir.join("index.html")).unwrap();
         assert!(stamped.contains("capture-picker.css?v=0.6.12.test"));
+        assert!(stamped.contains("clubhouse-shell.css?v=0.6.12.test"));
+        assert!(stamped.contains("layout-policy.js?v=0.6.12.test"));
+        assert!(stamped.contains("ui-shell.js?v=0.6.12.test"));
         assert!(stamped.contains("display-status.js?v=0.6.12.test"));
         assert!(stamped.contains("native-presenter.js?v=0.6.12.test"));
         assert!(stamped.contains("admin-panel.js?v=0.6.12.test"));

--- a/core/control/src/main.rs
+++ b/core/control/src/main.rs
@@ -414,6 +414,9 @@ async fn main() {
             let watched_files = [
                 "app.js",
                 "style.css",
+                "clubhouse-shell.css",
+                "layout-policy.js",
+                "ui-shell.js",
                 "index.html",
                 "connect.js",
                 "room-status.js",

--- a/core/deploy/test-viewer-runtime-lib.ps1
+++ b/core/deploy/test-viewer-runtime-lib.ps1
@@ -22,10 +22,11 @@ try {
         "identity.js", "auth.js", "connect.js", "room-status.js",
         "audio-routing.js", "media-controls.js", "participants.js", "chat.js",
         "soundboard.js", "jam-session-state.js", "jam.js", "style.css",
-        "jam.css", "livekit-client.umd.js", "rnnoise-processor.js",
+        "jam.css", "clubhouse-shell.css", "layout-policy.js", "ui-shell.js",
+        "livekit-client.umd.js", "rnnoise-processor.js",
         "rnnoise.wasm", "rnnoise_simd.wasm", "ultrainstinct.gif"
     )
-    Set-Content -LiteralPath (Join-Path $source "index.html") -Value '<link rel="stylesheet" href="style.css?v=source"><script src="jam.js?v=source"></script>' -NoNewline
+    Set-Content -LiteralPath (Join-Path $source "index.html") -Value '<link rel="stylesheet" href="style.css?v=source"><link rel="stylesheet" href="clubhouse-shell.css?v=source"><script src="layout-policy.js?v=source"></script><script src="ui-shell.js?v=source"></script><script src="jam.js?v=source"></script>' -NoNewline
     foreach ($requiredFile in $requiredFiles) {
         Set-Content -LiteralPath (Join-Path $source $requiredFile) -Value ("fixture-" + $requiredFile) -NoNewline
     }
@@ -90,7 +91,7 @@ try {
     Assert-ViewerSnapshot -SourceDirectory $source -CandidateDirectory $runtime | Out-Null
 
     # Runtime cache stamping is expected and must not create a false parity failure.
-    Set-Content -LiteralPath (Join-Path $runtime "index.html") -Value '<link rel="stylesheet" href="style.css?v=0.6.29.12345"><script src="jam.js?v=0.6.29.12345"></script>' -NoNewline
+    Set-Content -LiteralPath (Join-Path $runtime "index.html") -Value '<link rel="stylesheet" href="style.css?v=0.6.29.12345"><link rel="stylesheet" href="clubhouse-shell.css?v=0.6.29.12345"><script src="layout-policy.js?v=0.6.29.12345"></script><script src="ui-shell.js?v=0.6.29.12345"></script><script src="jam.js?v=0.6.29.12345"></script>' -NoNewline
     Assert-ViewerSnapshot -SourceDirectory $source -CandidateDirectory $runtime | Out-Null
     & (Join-Path $scriptDir "publish-viewer-runtime.ps1") `
         -SourceDirectory $source `

--- a/core/deploy/viewer-runtime-lib.ps1
+++ b/core/deploy/viewer-runtime-lib.ps1
@@ -94,6 +94,9 @@ function Assert-ViewerSource([string]$SourceDirectory) {
         "jam.js",
         "style.css",
         "jam.css",
+        "clubhouse-shell.css",
+        "layout-policy.js",
+        "ui-shell.js",
         "livekit-client.umd.js",
         # Loaded dynamically by rnnoise.js, so index.html reference scanning
         # cannot discover these release-critical assets.

--- a/core/viewer-tests/README.md
+++ b/core/viewer-tests/README.md
@@ -16,10 +16,10 @@ The harness:
 It does not use `core/viewer-next/` and does not clone the production viewer
 markup into a second test-only page.
 
-Phase 0 injects `layout-policy.js` explicitly because the production
-`index.html` does not load a mode controller yet. Phase 1 must wire the policy
-before first paint and replace that injected-policy check with an assertion on
-the production root's live `data-ui-mode` value.
+Phase 1 exercises `layout-policy.js` and the shell controller through the real
+production `index.html`. The suite verifies the pre-paint rollout flag,
+production `data-ui-mode` wiring and hysteresis, stable media/feature nodes,
+and positive V2 geometry without importing the policy out of band.
 
 ## Setup
 
@@ -37,8 +37,6 @@ npm test
 From the repository root, use `npm run verify:viewer:layout` after setup.
 
 Known legacy failures at `960x540`, `640x480`, and narrow Chat execute on every
-run as narrowly scoped sentinels. They assert the exact current bad geometry
-(collapsed participant viewport or zero-width stage), so unrelated runtime or
-browser failures still fail the suite. When Clubhouse corrects that geometry,
-the sentinel fails and must be replaced by the corresponding positive contract
-assertion. That conversion is a rollout gate, not an optional cleanup.
+run under the explicit `?echo-ui-shell-v2=0` override. They retain the legacy
+rollback baseline while separate V2 tests assert a usable participant region
+and nonzero Chat-stage geometry at the same viewports.

--- a/core/viewer-tests/fixtures/install-scenario.js
+++ b/core/viewer-tests/fixtures/install-scenario.js
@@ -72,7 +72,15 @@
     });
   }
 
-  function makeParticipant(index, longNames) {
+  const unbrokenDisplayName = "W".repeat(60);
+
+  function makeParticipant(index, longNames, unbrokenNames) {
+    if (unbrokenNames) {
+      return {
+        identity: `layout-fixture-${index}`,
+        name: unbrokenDisplayName,
+      };
+    }
     const suffix = longNames
       ? " — The Fellowship Member With An Intentionally Long Display Name"
       : "";
@@ -82,7 +90,7 @@
     };
   }
 
-  function addParticipants(count, cameraCount, longNames) {
+  function addParticipants(count, cameraCount, longNames, unbrokenNames) {
     if (typeof ensureParticipantCard !== "function") {
       throw new Error("production ensureParticipantCard renderer is unavailable");
     }
@@ -93,7 +101,10 @@
     let attachedCameras = 0;
     for (let index = 1; index <= count; index += 1) {
       const isLocal = index === 1;
-      const cardRef = ensureParticipantCard(makeParticipant(index, longNames), isLocal);
+      const cardRef = ensureParticipantCard(
+        makeParticipant(index, longNames, unbrokenNames),
+        isLocal,
+      );
       if (!cardRef || isLocal || attachedCameras >= cameraCount) continue;
 
       const media = createVideoTrackStub(`fixture-camera-${index}`, 16 / 9);
@@ -149,10 +160,16 @@
       shareAspects: [16 / 9],
       chatOpen: false,
       longNames: false,
+      unbrokenNames: false,
     }, options || {});
 
     resetRoom();
-    addParticipants(scenario.participants, scenario.cameras, scenario.longNames);
+    addParticipants(
+      scenario.participants,
+      scenario.cameras,
+      scenario.longNames,
+      scenario.unbrokenNames,
+    );
     addScreenShares(scenario.screenShares, scenario.shareAspects);
     populateChat(scenario.chatOpen);
     await nextFrame();
@@ -165,5 +182,90 @@
     };
   }
 
-  window.EchoLayoutTestScenario = Object.freeze({ install: install });
+  function captureIdentitySnapshot() {
+    const participantCard = document.querySelector(".user-card.has-camera");
+    const cameraVideo = participantCard && participantCard.querySelector("video");
+    const screenTile = document.querySelector("#screen-grid > .tile");
+    const screenVideo = screenTile && screenTile.querySelector("video");
+    const chatInput = document.getElementById("chat-input");
+    const participantIdentity = participantCard && participantCard.dataset.identity;
+
+    if (!participantCard || !cameraVideo || !screenTile || !screenVideo || !chatInput) {
+      throw new Error("identity fixture requires a camera, screen share, and Chat input");
+    }
+
+    const cameraTrack = cameraVideo.srcObject && cameraVideo.srcObject.getVideoTracks()[0];
+    const screenTrack = screenVideo.srcObject && screenVideo.srcObject.getVideoTracks()[0];
+    if (!cameraTrack || !screenTrack) {
+      throw new Error("production media renderers did not preserve fixture tracks");
+    }
+
+    window.__echoLayoutIdentitySnapshot = {
+      cameraStream: cameraVideo.srcObject,
+      cameraSdkTrack: cameraVideo._lkTrack,
+      cameraTrack: cameraTrack,
+      cameraVideo: cameraVideo,
+      chatInput: chatInput,
+      chatPanel: document.getElementById("chat-panel"),
+      participantCard: participantCard,
+      participantState: participantState.get(participantIdentity),
+      screenStream: screenVideo.srcObject,
+      screenSdkTrack: screenVideo._lkTrack,
+      screenTile: screenTile,
+      screenTrack: screenTrack,
+      screenVideo: screenVideo,
+    };
+
+    return inspectIdentitySnapshot();
+  }
+
+  function inspectIdentitySnapshot() {
+    const saved = window.__echoLayoutIdentitySnapshot;
+    if (!saved) throw new Error("captureIdentitySnapshot must be called first");
+    const currentCard = document.querySelector(".user-card.has-camera");
+    const currentCameraVideo = currentCard && currentCard.querySelector("video");
+    const currentTile = document.querySelector("#screen-grid > .tile");
+    const currentScreenVideo = currentTile && currentTile.querySelector("video");
+    const participantIdentity = currentCard && currentCard.dataset.identity;
+
+    return {
+      cameraStream: saved.cameraStream === (currentCameraVideo && currentCameraVideo.srcObject),
+      cameraSdkTrack: saved.cameraSdkTrack === (currentCameraVideo && currentCameraVideo._lkTrack),
+      cameraTrack: saved.cameraTrack === (
+        currentCameraVideo &&
+        currentCameraVideo.srcObject &&
+        currentCameraVideo.srcObject.getVideoTracks()[0]
+      ),
+      cameraTrackState: saved.cameraTrack.readyState,
+      cameraVideo: saved.cameraVideo === currentCameraVideo && saved.cameraVideo.isConnected,
+      chatFocused: document.activeElement === saved.chatInput,
+      chatInput: saved.chatInput === document.getElementById("chat-input") && saved.chatInput.isConnected,
+      chatPanel: saved.chatPanel === document.getElementById("chat-panel") && saved.chatPanel.isConnected,
+      chatOpen: document.querySelector(".room-layout").classList.contains("chat-open"),
+      draft: saved.chatInput.value,
+      participantCard: saved.participantCard === currentCard && saved.participantCard.isConnected,
+      participantMarker: saved.participantState && saved.participantState.__layoutFixtureMarker,
+      participantState: saved.participantState === participantState.get(participantIdentity),
+      selectionEnd: saved.chatInput.selectionEnd,
+      selectionStart: saved.chatInput.selectionStart,
+      screenStream: saved.screenStream === (currentScreenVideo && currentScreenVideo.srcObject),
+      screenSdkTrack: saved.screenSdkTrack === (currentScreenVideo && currentScreenVideo._lkTrack),
+      screenTile: saved.screenTile === currentTile && saved.screenTile.isConnected,
+      screenTrack: saved.screenTrack === (
+        currentScreenVideo &&
+        currentScreenVideo.srcObject &&
+        currentScreenVideo.srcObject.getVideoTracks()[0]
+      ),
+      screenTrackState: saved.screenTrack.readyState,
+      screenVideo: saved.screenVideo === currentScreenVideo && saved.screenVideo.isConnected,
+      shareFocused: saved.screenTile.classList.contains("is-focused"),
+    };
+  }
+
+  window.EchoLayoutTestScenario = Object.freeze({
+    captureIdentitySnapshot: captureIdentitySnapshot,
+    inspectIdentitySnapshot: inspectIdentitySnapshot,
+    install: install,
+    unbrokenDisplayName: unbrokenDisplayName,
+  });
 })();

--- a/core/viewer-tests/package.json
+++ b/core/viewer-tests/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "browser:install": "playwright install chromium",
-    "test": "playwright test tests/layout.geometry.spec.js",
+    "test": "playwright test",
     "test:all": "playwright test",
     "test:headed": "playwright test --headed"
   },

--- a/core/viewer-tests/tests/helpers/geometry.js
+++ b/core/viewer-tests/tests/helpers/geometry.js
@@ -32,6 +32,35 @@ export async function expectHorizontallyContained(child, parent, tolerance = 1) 
   expect(childRect.right).toBeLessThanOrEqual(parentRect.right + tolerance);
 }
 
+export async function expectContained(child, parent, tolerance = 1) {
+  const [childRect, parentRect] = await Promise.all([visibleRect(child), visibleRect(parent)]);
+  expect(childRect.left).toBeGreaterThanOrEqual(parentRect.left - tolerance);
+  expect(childRect.right).toBeLessThanOrEqual(parentRect.right + tolerance);
+  expect(childRect.top).toBeGreaterThanOrEqual(parentRect.top - tolerance);
+  expect(childRect.bottom).toBeLessThanOrEqual(parentRect.bottom + tolerance);
+}
+
+export async function expectSingleLineEllipsis(locator) {
+  await expect(locator).toBeVisible();
+  const result = await locator.evaluate((element) => {
+    const style = window.getComputedStyle(element);
+    return {
+      clientWidth: element.clientWidth,
+      overflow: style.overflowX,
+      scrollWidth: element.scrollWidth,
+      textOverflow: style.textOverflow,
+      whiteSpace: style.whiteSpace,
+    };
+  });
+
+  expect(result.clientWidth).toBeGreaterThan(0);
+  expect(result.scrollWidth).toBeGreaterThan(result.clientWidth);
+  expect(result.whiteSpace).toBe("nowrap");
+  expect(result.overflow).toBe("hidden");
+  expect(result.textOverflow).toBe("ellipsis");
+  return result;
+}
+
 export async function expectMinimumUsableRegion(locator, minimums) {
   await expect(locator).toBeVisible();
   const geometry = await locator.evaluate((element) => ({

--- a/core/viewer-tests/tests/layout.geometry.spec.js
+++ b/core/viewer-tests/tests/layout.geometry.spec.js
@@ -10,7 +10,6 @@ import {
 
 const testDirectory = path.dirname(fileURLToPath(import.meta.url));
 const fixturePath = path.resolve(testDirectory, "..", "fixtures", "install-scenario.js");
-const policyPath = path.resolve(testDirectory, "..", "..", "viewer", "layout-policy.js");
 const runtimeErrors = new WeakMap();
 const transparentPng = Buffer.from(
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=",
@@ -58,7 +57,7 @@ test.afterEach(async ({ page }) => {
 });
 
 async function openProductionViewer(page, scenario) {
-  await page.goto("/", { waitUntil: "domcontentloaded" });
+  await page.goto("/?echo-ui-shell-v2=0", { waitUntil: "domcontentloaded" });
   await page.addScriptTag({ path: fixturePath });
   return page.evaluate((options) => window.EchoLayoutTestScenario.install(options), scenario);
 }
@@ -191,47 +190,6 @@ for (const viewport of [
     expect(collapsed.firstCardVisibleRatio).toBeLessThan(0.25);
   });
 }
-
-test("browser policy classifies the supported viewport matrix without loading production wiring", async ({ page }) => {
-  await page.goto("/", { waitUntil: "domcontentloaded" });
-  await page.addScriptTag({ path: policyPath });
-
-  const matrix = [
-    { width: 1920, height: 1080, expected: "theater" },
-    { width: 1440, height: 900, expected: "theater" },
-    { width: 1280, height: 720, expected: "theater" },
-    { width: 1024, height: 768, expected: "lounge" },
-    { width: 960, height: 540, expected: "compact" },
-    { width: 800, height: 600, expected: "compact" },
-    { width: 640, height: 480, expected: "compact" },
-    { width: 639, height: 479, expected: "mini" },
-  ];
-
-  for (const sample of matrix) {
-    const mode = await page.evaluate(
-      ({ width, height }) => window.EchoLayoutPolicy.classifyLayoutMode(width, height),
-      sample,
-    );
-    expect(mode, `${sample.width}x${sample.height}`).toBe(sample.expected);
-  }
-
-  const transition = await page.evaluate(() => {
-    const policy = window.EchoLayoutPolicy;
-    const initial = policy.resolveLayoutMode({ width: 768, height: 1024 });
-    const retained = policy.resolveLayoutMode({
-      width: 600,
-      height: 900,
-      previousMode: initial,
-    });
-    const downgraded = policy.resolveLayoutMode({
-      width: 591,
-      height: 900,
-      previousMode: retained,
-    });
-    return [initial, retained, downgraded];
-  });
-  expect(transition).toEqual(["compact", "compact", "mini"]);
-});
 
 test(
   "records the legacy narrow-Chat stage collapse",

--- a/core/viewer-tests/tests/shell.phase1.spec.js
+++ b/core/viewer-tests/tests/shell.phase1.spec.js
@@ -1,0 +1,942 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, test } from "@playwright/test";
+import {
+  expectContained,
+  expectMinimumUsableRegion,
+  expectNoDocumentOverflow,
+  expectNoOverlap,
+  expectSingleLineEllipsis,
+  intersectionArea,
+} from "./helpers/geometry.js";
+
+const testDirectory = path.dirname(fileURLToPath(import.meta.url));
+const fixturePath = path.resolve(testDirectory, "..", "fixtures", "install-scenario.js");
+const runtimeErrors = new WeakMap();
+const transparentPng = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=",
+  "base64",
+);
+const shellSelectors = Object.freeze([
+  "#clubhouse-shell",
+  '.room-top[data-ui-region="shell-header"]',
+  '.room-layout[data-ui-region="workspace"]',
+  '.room-main[data-ui-region="primary-stage"]',
+  '.room-sidebar[data-ui-region="utility-host"]',
+  '#call-controls[data-ui-region="control-dock"]',
+  "#shell-overlay-root",
+  "#shell-notification-layer",
+]);
+const preservedDraft = "Phase 1 draft survives every shell transition";
+
+test.beforeEach(async ({ page }) => {
+  const errors = [];
+  runtimeErrors.set(page, errors);
+  page.on("pageerror", (error) => errors.push(`pageerror: ${error.message}`));
+  page.on("console", (message) => {
+    if (message.type() === "error") errors.push(`console.error: ${message.text()}`);
+  });
+
+  await page.route("**/api/**", async (route) => {
+    const url = new URL(route.request().url());
+    if (url.pathname === "/api/online") {
+      await route.fulfill({ status: 200, contentType: "application/json", body: "[]" });
+      return;
+    }
+    if (url.pathname.startsWith("/api/avatar/")) {
+      await route.fulfill({ status: 200, contentType: "image/png", body: transparentPng });
+      return;
+    }
+    if (url.pathname === "/api/version") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ latest_client: "" }),
+      });
+      return;
+    }
+    errors.push(`unexpected API request: ${route.request().method()} ${url.pathname}`);
+    await route.fulfill({
+      status: 501,
+      contentType: "application/json",
+      body: JSON.stringify({ error: "unmodeled viewer-test endpoint" }),
+    });
+  });
+});
+
+test.afterEach(async ({ page }) => {
+  await page.waitForTimeout(25);
+  expect(runtimeErrors.get(page) || [], "production page must run without runtime errors").toEqual([]);
+});
+
+async function primePersistedVariant(page, persistedValue) {
+  await page.addInitScript(({ value }) => {
+    if (value === null) localStorage.removeItem("echo-ui-shell-v2");
+    else localStorage.setItem("echo-ui-shell-v2", value);
+
+    window.__echoShellFirstFrame = new Promise((resolve) => {
+      requestAnimationFrame(() => resolve(
+        document.documentElement && document.documentElement.getAttribute("data-ui-shell"),
+      ));
+    });
+  }, { value: persistedValue });
+}
+
+async function openPhaseOneViewer(page, scenario) {
+  await page.goto("/?echo-ui-shell-v2=1", { waitUntil: "domcontentloaded" });
+  await expect(page.locator("html")).toHaveAttribute("data-ui-shell", "v2");
+  await page.addScriptTag({ path: fixturePath });
+  return page.evaluate((options) => window.EchoLayoutTestScenario.install(options), scenario);
+}
+
+async function settleResize(page, viewport, expectedMode) {
+  await page.setViewportSize(viewport);
+  await expect.poll(
+    () => page.evaluate(() => ({ height: window.innerHeight, width: window.innerWidth })),
+    { message: `browser viewport should become ${viewport.width}x${viewport.height}` },
+  ).toEqual({ height: viewport.height, width: viewport.width });
+  await page.evaluate(() => new Promise((resolve) => {
+    requestAnimationFrame(() => requestAnimationFrame(resolve));
+  }));
+  await expect(page.locator("html")).toHaveAttribute("data-ui-mode", expectedMode);
+}
+
+async function expectCanonicalStructure(page) {
+  for (const selector of shellSelectors) {
+    await expect(page.locator(selector), `${selector} must be unique`).toHaveCount(1);
+  }
+
+  const structure = await page.evaluate((selectors) => {
+    const shell = document.getElementById("clubhouse-shell");
+    const header = document.querySelector('.room-top[data-ui-region="shell-header"]');
+    const workspace = document.querySelector('.room-layout[data-ui-region="workspace"]');
+    const stage = document.querySelector('.room-main[data-ui-region="primary-stage"]');
+    const utility = document.querySelector('.room-sidebar[data-ui-region="utility-host"]');
+    const dock = document.querySelector('#call-controls[data-ui-region="control-dock"]');
+    const idCounts = new Map();
+    document.querySelectorAll("[id]").forEach((element) => {
+      idCounts.set(element.id, (idCounts.get(element.id) || 0) + 1);
+    });
+    return {
+      duplicateIds: Array.from(idCounts.entries()).filter((entry) => entry[1] > 1),
+      shellContainsRegions: shell.contains(header) && shell.contains(workspace) && shell.contains(dock),
+      uniqueSelectors: selectors.every((selector) => document.querySelectorAll(selector).length === 1),
+      workspaceContainsRegions: workspace.contains(stage) && workspace.contains(utility),
+    };
+  }, shellSelectors);
+
+  expect(structure).toEqual({
+    duplicateIds: [],
+    shellContainsRegions: true,
+    uniqueSelectors: true,
+    workspaceContainsRegions: true,
+  });
+}
+
+const flagCases = [
+  {
+    title: "defaults to legacy when neither storage nor query overrides the shell",
+    persisted: null,
+    query: "",
+    expected: "legacy",
+  },
+  {
+    title: "uses the persisted V2 shell when the query is absent",
+    persisted: "1",
+    query: "",
+    expected: "v2",
+  },
+  {
+    title: "uses the persisted legacy shell when the query is absent",
+    persisted: "0",
+    query: "",
+    expected: "legacy",
+  },
+  {
+    title: "query V2 overrides persisted legacy",
+    persisted: "0",
+    query: "?echo-ui-shell-v2=1",
+    expected: "v2",
+  },
+  {
+    title: "query legacy overrides persisted V2",
+    persisted: "1",
+    query: "?echo-ui-shell-v2=0",
+    expected: "legacy",
+  },
+];
+
+for (const flagCase of flagCases) {
+  test(flagCase.title, async ({ page }) => {
+    await page.setViewportSize({ width: 1024, height: 768 });
+    await primePersistedVariant(page, flagCase.persisted);
+    await page.goto(`/${flagCase.query}`, { waitUntil: "domcontentloaded" });
+
+    const root = page.locator("html");
+    await expect(root).toHaveAttribute("data-ui-shell", flagCase.expected);
+    expect(await page.evaluate(() => window.__echoShellFirstFrame)).toBe(flagCase.expected);
+    if (flagCase.expected === "v2") {
+      await expect(root).toHaveAttribute("data-ui-mode", "lounge");
+    } else {
+      await expect(root).not.toHaveAttribute("data-ui-mode", /.+/);
+    }
+  });
+}
+
+test("production controller applies live layout modes and the full hysteresis sequence", async ({ page }) => {
+  await page.setViewportSize({ width: 768, height: 1024 });
+  await page.goto("/?echo-ui-shell-v2=1", { waitUntil: "domcontentloaded" });
+
+  await expect(page.locator("html")).toHaveAttribute("data-ui-shell", "v2");
+  await expect(page.locator("html")).toHaveAttribute("data-ui-mode", "compact");
+  expect(await page.evaluate(() => ({
+    applyVariant: typeof window.EchoUiShell?.applyVariant,
+    policy: typeof window.EchoLayoutPolicy?.resolveLayoutPolicy,
+  }))).toEqual({ applyVariant: "function", policy: "function" });
+
+  await page.evaluate(() => {
+    const root = document.documentElement;
+    window.__echoModeHistory = [root.getAttribute("data-ui-mode")];
+    window.__echoModeObserver = new MutationObserver(() => {
+      const current = root.getAttribute("data-ui-mode");
+      if (window.__echoModeHistory.at(-1) !== current) window.__echoModeHistory.push(current);
+    });
+    window.__echoModeObserver.observe(root, {
+      attributes: true,
+      attributeFilter: ["data-ui-mode"],
+    });
+  });
+
+  const sequence = [
+    [{ width: 600, height: 900 }, "compact"],
+    [{ width: 591, height: 900 }, "mini"],
+    [{ width: 687, height: 900 }, "mini"],
+    [{ width: 688, height: 900 }, "compact"],
+    [{ width: 948, height: 648 }, "lounge"],
+    [{ width: 1328, height: 768 }, "theater"],
+    [{ width: 1280, height: 720 }, "theater"],
+    [{ width: 1231, height: 720 }, "lounge"],
+    [{ width: 851, height: 620 }, "compact"],
+  ];
+
+  for (const [viewport, expectedMode] of sequence) {
+    await settleResize(page, viewport, expectedMode);
+  }
+
+  expect(await page.evaluate(() => window.__echoModeHistory)).toEqual([
+    "compact",
+    "mini",
+    "compact",
+    "lounge",
+    "theater",
+    "lounge",
+    "compact",
+  ]);
+  await expect(page.locator("html")).toHaveAttribute("data-ui-short", "");
+  await expect(page.locator("html")).not.toHaveAttribute("data-ui-very-short", "");
+});
+
+test("V2 exposes one canonical semantic shell structure", async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 720 });
+  await openPhaseOneViewer(page, {
+    participants: 4,
+    cameras: 2,
+    screenShares: 1,
+  });
+  await expectCanonicalStructure(page);
+});
+
+test("canonical nodes, media tracks, participant state, and Chat draft survive resize and variant toggles", async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 720 });
+  await openPhaseOneViewer(page, {
+    participants: 4,
+    cameras: 2,
+    screenShares: 1,
+    chatOpen: true,
+    unbrokenNames: true,
+  });
+  await expectCanonicalStructure(page);
+
+  await page.evaluate(({ selectors, draft }) => {
+    const cameraCard = document.querySelector(".user-card.has-camera");
+    const state = participantState.get(cameraCard.dataset.identity);
+    state.__layoutFixtureMarker = "participant-state-preserved";
+    document.querySelector("#screen-grid > .tile").click();
+    const chatInput = document.getElementById("chat-input");
+    chatInput.value = draft;
+    chatInput.focus();
+    chatInput.setSelectionRange(8, 15);
+    window.__echoCanonicalNodeSnapshot = selectors.map((selector) => document.querySelector(selector));
+    window.EchoLayoutTestScenario.captureIdentitySnapshot();
+  }, { selectors: shellSelectors, draft: preservedDraft });
+
+  async function expectPreserved(label) {
+    const preserved = await page.evaluate((selectors) => {
+      const savedNodes = window.__echoCanonicalNodeSnapshot;
+      return {
+        canonicalNodes: selectors.every((selector, index) => (
+          document.querySelectorAll(selector).length === 1 &&
+          document.querySelector(selector) === savedNodes[index] &&
+          savedNodes[index].isConnected
+        )),
+        identity: window.EchoLayoutTestScenario.inspectIdentitySnapshot(),
+      };
+    }, shellSelectors);
+
+    expect(preserved, label).toEqual({
+      canonicalNodes: true,
+      identity: {
+        cameraSdkTrack: true,
+        cameraStream: true,
+        cameraTrack: true,
+        cameraTrackState: "live",
+        cameraVideo: true,
+        chatFocused: true,
+        chatInput: true,
+        chatOpen: true,
+        chatPanel: true,
+        draft: preservedDraft,
+        participantCard: true,
+        participantMarker: "participant-state-preserved",
+        participantState: true,
+        selectionEnd: 15,
+        selectionStart: 8,
+        screenSdkTrack: true,
+        screenStream: true,
+        screenTile: true,
+        screenTrack: true,
+        screenTrackState: "live",
+        screenVideo: true,
+        shareFocused: true,
+      },
+    });
+  }
+
+  await expectPreserved("initial V2 state");
+  await settleResize(page, { width: 1024, height: 768 }, "lounge");
+  await expectPreserved("lounge resize");
+  await settleResize(page, { width: 640, height: 480 }, "compact");
+  await expectPreserved("compact resize");
+
+  await page.evaluate(() => window.EchoUiShell.applyVariant("legacy"));
+  await expect(page.locator("html")).toHaveAttribute("data-ui-shell", "legacy");
+  await expectPreserved("legacy live toggle");
+
+  await page.evaluate(() => window.EchoUiShell.applyVariant("v2"));
+  await expect(page.locator("html")).toHaveAttribute("data-ui-shell", "v2");
+  await expectPreserved("V2 live toggle");
+  await expectCanonicalStructure(page);
+});
+
+for (const viewport of [
+  { width: 960, height: 540, veryShort: false },
+  { width: 640, height: 480, veryShort: true },
+]) {
+  test(`V2 keeps a usable participant region at ${viewport.width}x${viewport.height}`, async ({ page }) => {
+    await page.setViewportSize({ width: viewport.width, height: viewport.height });
+    await openPhaseOneViewer(page, {
+      participants: 4,
+      cameras: 2,
+      screenShares: 1,
+      longNames: true,
+    });
+
+    const root = page.locator("html");
+    await expect(root).toHaveAttribute("data-ui-mode", "compact");
+    await expect(root).toHaveAttribute("data-ui-short", "");
+    if (viewport.veryShort) {
+      await expect(root).toHaveAttribute("data-ui-very-short", "");
+    } else {
+      await expect(root).not.toHaveAttribute("data-ui-very-short", "");
+    }
+
+    const userList = page.locator("#user-list");
+    const geometry = await userList.evaluate((element) => {
+      const firstCard = element.querySelector(".user-card");
+      const listRect = element.getBoundingClientRect();
+      const cardRect = firstCard.getBoundingClientRect();
+      const visibleHeight = Math.max(
+        0,
+        Math.min(listRect.bottom, cardRect.bottom, window.innerHeight) -
+          Math.max(listRect.top, cardRect.top, 0),
+      );
+      return {
+        clientHeight: element.clientHeight,
+        clientWidth: element.clientWidth,
+        firstCardVisibleRatio: visibleHeight / Math.max(1, cardRect.height),
+        listBottom: listRect.bottom,
+        listTop: listRect.top,
+        scrollHeight: element.scrollHeight,
+        viewportHeight: window.innerHeight,
+      };
+    });
+
+    const geometryLabel = `${viewport.width}x${viewport.height}: ${JSON.stringify(geometry)}`;
+    expect.soft(geometry.clientWidth, geometryLabel).toBeGreaterThanOrEqual(160);
+    expect.soft(geometry.clientHeight, geometryLabel).toBeGreaterThanOrEqual(160);
+    expect.soft(geometry.firstCardVisibleRatio, geometryLabel).toBeGreaterThanOrEqual(0.5);
+    expect.soft(geometry.listTop, geometryLabel).toBeGreaterThanOrEqual(-1);
+    expect.soft(geometry.listBottom, geometryLabel).toBeLessThanOrEqual(geometry.viewportHeight + 1);
+    expect.soft(geometry.scrollHeight, geometryLabel).toBeGreaterThanOrEqual(geometry.clientHeight);
+    await expectNoDocumentOverflow(page);
+  });
+}
+
+test("V2 keeps a nonzero usable stage when Chat is open at 800x600", async ({ page }) => {
+  await page.setViewportSize({ width: 800, height: 600 });
+  await openPhaseOneViewer(page, {
+    participants: 4,
+    cameras: 2,
+    screenShares: 1,
+    chatOpen: true,
+  });
+
+  await expect(page.locator("html")).toHaveAttribute("data-ui-mode", "compact");
+  await expect(page.locator("#chat-panel")).toBeVisible();
+  await expectMinimumUsableRegion(page.locator(".room-main"), { width: 160, height: 120 });
+  await expectNoDocumentOverflow(page);
+});
+
+test("V2 ellipsizes a 60-character unbroken name without overlapping camera controls", async ({ page }) => {
+  await page.setViewportSize({ width: 640, height: 480 });
+  await openPhaseOneViewer(page, {
+    participants: 4,
+    cameras: 2,
+    screenShares: 0,
+    unbrokenNames: true,
+  });
+
+  const longName = "W".repeat(60);
+  const standardName = page.locator(".user-card:not(.has-camera) .user-name").first();
+  const standardMeta = standardName.locator("xpath=parent::*");
+  await expect(standardName).toHaveText(longName);
+  await expect(standardName).toHaveAttribute("title", longName);
+  await expectSingleLineEllipsis(standardName);
+  await expectContained(standardName, standardMeta);
+
+  const cameraCard = page.locator(".user-card.has-camera").first();
+  const overlay = cameraCard.locator(".cam-overlay");
+  const overlayName = overlay.locator(".cam-overlay-name");
+  const overlayControls = overlay.locator(".cam-overlay-controls");
+  const focusTarget = overlayControls.locator("button:visible").first();
+  await focusTarget.focus();
+  await expect(focusTarget).toBeFocused();
+
+  const focusPresentation = await cameraCard.evaluate((card) => {
+    const overlayElement = card.querySelector(".cam-overlay");
+    const style = window.getComputedStyle(overlayElement);
+    return {
+      focusWithin: card.matches(":focus-within"),
+      opacity: Number.parseFloat(style.opacity),
+      pointerEvents: style.pointerEvents,
+    };
+  });
+  expect(focusPresentation.focusWithin).toBe(true);
+  expect(focusPresentation.opacity).toBeGreaterThanOrEqual(0.99);
+  expect(focusPresentation.pointerEvents).not.toBe("none");
+
+  await expect(overlayName).toHaveText(longName);
+  await expect(overlayName).toHaveAttribute("title", longName);
+  await expectSingleLineEllipsis(overlayName);
+  await expectContained(overlayName, overlay);
+  await expectContained(overlayControls, overlay);
+  await expectNoOverlap(overlayName, overlayControls);
+
+  const controlRects = await overlayControls.locator(":scope > button:visible").evaluateAll((buttons) => (
+    buttons.map((button) => {
+      const rect = button.getBoundingClientRect();
+      return {
+        bottom: rect.bottom,
+        height: rect.height,
+        left: rect.left,
+        right: rect.right,
+        top: rect.top,
+        width: rect.width,
+      };
+    })
+  ));
+  expect(controlRects.length).toBeGreaterThan(0);
+  for (let first = 0; first < controlRects.length; first += 1) {
+    for (let second = first + 1; second < controlRects.length; second += 1) {
+      expect(intersectionArea(controlRects[first], controlRects[second])).toBeLessThanOrEqual(1);
+    }
+  }
+  await expectNoDocumentOverflow(page);
+});
+
+for (const viewport of [
+  { width: 1280, height: 720, mode: "theater" },
+  { width: 640, height: 480, mode: "compact" },
+]) {
+  test(`camera cards stay usable and contained at ${viewport.width}x${viewport.height}`, async ({ page }) => {
+    await page.setViewportSize(viewport);
+    await openPhaseOneViewer(page, {
+      participants: 4,
+      cameras: 2,
+      screenShares: 1,
+    });
+    await expect(page.locator("html")).toHaveAttribute("data-ui-mode", viewport.mode);
+
+    const cards = page.locator(".user-card.has-camera");
+    await expect(cards).toHaveCount(2);
+    for (let index = 0; index < await cards.count(); index += 1) {
+      const card = cards.nth(index);
+      await card.evaluate((element) => element.scrollIntoView({ block: "nearest" }));
+      const geometry = await card.evaluate((element) => {
+        const list = element.closest("#user-list");
+        const overlay = element.querySelector(".cam-overlay");
+        const cardRect = element.getBoundingClientRect();
+        const listRect = list.getBoundingClientRect();
+        const overlayRect = overlay.getBoundingClientRect();
+        return {
+          card: { bottom: cardRect.bottom, height: cardRect.height, left: cardRect.left, right: cardRect.right, top: cardRect.top },
+          list: { bottom: listRect.bottom, left: listRect.left, right: listRect.right, top: listRect.top },
+          overlay: { bottom: overlayRect.bottom, left: overlayRect.left, right: overlayRect.right, top: overlayRect.top },
+          overflowX: element.scrollWidth - element.clientWidth,
+        };
+      });
+      expect.soft(geometry.card.height).toBeGreaterThanOrEqual(139.5);
+      expect.soft(geometry.card.left).toBeGreaterThanOrEqual(geometry.list.left - 1);
+      expect.soft(geometry.card.right).toBeLessThanOrEqual(geometry.list.right + 1);
+      expect.soft(geometry.card.top).toBeGreaterThanOrEqual(geometry.list.top - 1);
+      expect.soft(geometry.card.bottom).toBeLessThanOrEqual(geometry.list.bottom + 1);
+      expect.soft(geometry.overlay.left).toBeGreaterThanOrEqual(geometry.card.left - 1);
+      expect.soft(geometry.overlay.right).toBeLessThanOrEqual(geometry.card.right + 1);
+      expect.soft(geometry.overlay.top).toBeGreaterThanOrEqual(geometry.card.top - 1);
+      expect.soft(geometry.overlay.bottom).toBeLessThanOrEqual(geometry.card.bottom + 1);
+      expect.soft(geometry.overflowX).toBeLessThanOrEqual(1);
+    }
+  });
+}
+
+for (const viewport of [
+  { width: 1280, height: 720, mode: "theater" },
+  { width: 1024, height: 768, mode: "lounge" },
+]) {
+  test(`${viewport.mode} camera-card grid tracks prevent card overlap`, async ({ page }) => {
+    await page.setViewportSize(viewport);
+    await openPhaseOneViewer(page, { participants: 4, cameras: 2, screenShares: 0 });
+    await expect(page.locator("html")).toHaveAttribute("data-ui-mode", viewport.mode);
+
+    const cardRects = await page.locator(".user-card.has-camera").evaluateAll((cards) => cards.map((card) => {
+      const rect = card.getBoundingClientRect();
+      return { bottom: rect.bottom, height: rect.height, left: rect.left, right: rect.right, top: rect.top, width: rect.width };
+    }));
+    expect(cardRects).toHaveLength(2);
+    for (let first = 0; first < cardRects.length; first += 1) {
+      for (let second = first + 1; second < cardRects.length; second += 1) {
+        expect(intersectionArea(cardRects[first], cardRects[second])).toBeLessThanOrEqual(1);
+      }
+    }
+  });
+}
+
+for (const viewport of [
+  { width: 800, height: 600, mode: "compact" },
+  { width: 600, height: 900, mode: "mini" },
+]) {
+  test(`${viewport.mode} camera volume popup stays contained and all sliders are hittable`, async ({ page }) => {
+    await page.setViewportSize(viewport);
+    await openPhaseOneViewer(page, { participants: 3, cameras: 1, screenShares: 0 });
+    await expect(page.locator("html")).toHaveAttribute("data-ui-mode", viewport.mode);
+
+    const card = page.locator(".user-card.is-remote.has-camera").first();
+    await card.evaluate((element) => element.scrollIntoView({ block: "nearest" }));
+    await card.locator(".cam-overlay-controls .icon-button").first().click();
+    const popup = card.locator(".vol-popup");
+    await expect(popup).toHaveClass(/is-open/);
+    await expect(popup).toBeVisible();
+
+    const geometry = await card.evaluate((element) => {
+      const toRect = (node) => {
+        const rect = node.getBoundingClientRect();
+        return { bottom: rect.bottom, left: rect.left, right: rect.right, top: rect.top };
+      };
+      const popupElement = element.querySelector(".vol-popup");
+      const sliders = Array.from(popupElement.querySelectorAll('input[type="range"]'));
+      return {
+        card: toRect(element),
+        popup: toRect(popupElement),
+        sliders: sliders.map((slider) => {
+          const rect = slider.getBoundingClientRect();
+          const hit = document.elementFromPoint(rect.left + (rect.width / 2), rect.top + (rect.height / 2));
+          return { rect: toRect(slider), hittable: hit === slider || slider.contains(hit) };
+        }),
+      };
+    });
+    expect(geometry.sliders).toHaveLength(3);
+    expect(geometry.popup.left).toBeGreaterThanOrEqual(geometry.card.left - 1);
+    expect(geometry.popup.right).toBeLessThanOrEqual(geometry.card.right + 1);
+    expect(geometry.popup.top).toBeGreaterThanOrEqual(geometry.card.top - 1);
+    expect(geometry.popup.bottom).toBeLessThanOrEqual(geometry.card.bottom + 1);
+    expect(geometry.sliders.every((slider) => slider.hittable)).toBe(true);
+  });
+}
+
+test("non-camera participant overlays are absent from rendering and interaction", async ({ page }) => {
+  await page.setViewportSize({ width: 1024, height: 768 });
+  await openPhaseOneViewer(page, {
+    participants: 4,
+    cameras: 1,
+    screenShares: 0,
+  });
+
+  const overlays = page.locator(".user-card.is-remote:not(.has-camera) .cam-overlay");
+  expect(await overlays.count()).toBeGreaterThan(0);
+  const presentations = await overlays.evaluateAll((elements) => elements.map((element) => {
+    const button = element.querySelector("button");
+    button?.focus();
+    return {
+      active: document.activeElement === button,
+      display: getComputedStyle(element).display,
+      renderedRects: element.getClientRects().length,
+    };
+  }));
+  for (const presentation of presentations) {
+    expect(presentation).toEqual({ active: false, display: "none", renderedRects: 0 });
+  }
+});
+
+for (const viewport of [
+  { width: 800, height: 600, mode: "compact" },
+  { width: 600, height: 900, mode: "mini" },
+]) {
+  test(`${viewport.mode} dock icons remain distinct and Leave remains destructive`, async ({ page }) => {
+    await page.setViewportSize(viewport);
+    await openPhaseOneViewer(page, { participants: 2, cameras: 0, screenShares: 0 });
+    await expect(page.locator("html")).toHaveAttribute("data-ui-mode", viewport.mode);
+
+    const presentation = await page.locator("#call-controls").evaluate((dock) => {
+      const ids = ["toggle-mic", "toggle-cam", "toggle-screen", "dock-output", "dock-leave"];
+      const controls = ids.map((id) => {
+        const button = dock.querySelector(`#${id}`);
+        const style = getComputedStyle(button);
+        const pseudo = getComputedStyle(button, "::before");
+        return {
+          background: style.backgroundColor,
+          border: style.borderColor,
+          color: style.color,
+          icon: style.getPropertyValue("--club-control-icon").trim(),
+          mask: pseudo.maskImage || pseudo.webkitMaskImage,
+          visible: button.getClientRects().length > 0,
+        };
+      });
+      return controls;
+    });
+
+    const expectedVisibility = viewport.mode === "mini"
+      ? [true, true, true, false, true]
+      : [true, true, true, true, true];
+    expect(presentation.map((control) => control.visible)).toEqual(expectedVisibility);
+    expect(presentation.every((control) => control.icon && control.icon !== "none")).toBe(true);
+    expect(presentation.every((control) => control.mask && control.mask !== "none")).toBe(true);
+    expect(new Set(presentation.map((control) => control.icon)).size).toBe(presentation.length);
+
+    const neutral = presentation[3];
+    const leave = presentation[4];
+    const leaveRgb = leave.color.match(/\d+(?:\.\d+)?/g).map(Number);
+    expect(leave.color).not.toBe(neutral.color);
+    expect(leave.border).not.toBe(neutral.border);
+    expect(leave.background).not.toBe(neutral.background);
+    expect(leaveRgb[0]).toBeGreaterThan(leaveRgb[1]);
+    expect(leaveRgb[0]).toBeGreaterThan(leaveRgb[2]);
+  });
+}
+
+test("More has a visible affordance, focuses its first command, and restores focus on Escape", async ({ page }) => {
+  await page.setViewportSize({ width: 1024, height: 768 });
+  await openPhaseOneViewer(page, { participants: 2, cameras: 0, screenShares: 0 });
+
+  const more = page.locator("#shell-more-actions");
+  const menu = page.locator("#shell-overflow-menu");
+  const firstCommand = menu.locator("button:not(.hidden):not(:disabled):visible").first();
+  const visual = await more.evaluate((button) => {
+    const rect = button.getBoundingClientRect();
+    const pseudo = getComputedStyle(button, "::before");
+    return {
+      content: pseudo.content,
+      height: rect.height,
+      opacity: Number.parseFloat(getComputedStyle(button).opacity),
+      width: rect.width,
+    };
+  });
+  expect(visual.width).toBeGreaterThanOrEqual(40);
+  expect(visual.height).toBeGreaterThanOrEqual(40);
+  expect(visual.opacity).toBeGreaterThan(0);
+  expect(visual.content).not.toBe("none");
+  expect(visual.content).not.toBe('""');
+
+  await more.focus();
+  await page.keyboard.press("Enter");
+  await expect(more).toHaveAttribute("aria-expanded", "true");
+  await expect(page.locator('.room-top[data-ui-region="shell-header"]')).toHaveClass(/shell-overflow-open/);
+  await expect(firstCommand).toBeFocused();
+  await page.keyboard.press("Escape");
+  await expect(more).toHaveAttribute("aria-expanded", "false");
+  await expect(page.locator('.room-top[data-ui-region="shell-header"]')).not.toHaveClass(/shell-overflow-open/);
+  await expect(more).toBeFocused();
+
+  await more.click();
+  await expect(firstCommand).toBeFocused();
+  await page.keyboard.press("Escape");
+  await expect(more).toBeFocused();
+});
+
+test("responsive mode changes close More and preserve keyboard focus", async ({ page }) => {
+  await page.setViewportSize({ width: 600, height: 900 });
+  await openPhaseOneViewer(page, { participants: 2, cameras: 0, screenShares: 0 });
+  await expect(page.locator("html")).toHaveAttribute("data-ui-mode", "mini");
+
+  const more = page.locator("#shell-more-actions");
+  await page.locator("#open-settings").evaluate((button) => { button.disabled = false; });
+  await more.click();
+  await expect(page.locator("#open-settings")).toBeFocused();
+  await expect(more).toHaveAttribute("aria-expanded", "true");
+
+  await settleResize(page, { width: 800, height: 600 }, "compact");
+  await expect(more).toHaveAttribute("aria-expanded", "false");
+  await expect(page.locator('.room-top[data-ui-region="shell-header"]')).not.toHaveClass(/shell-overflow-open/);
+  await expect(more).toBeFocused();
+});
+
+test("360px mini People sheet contains its header, list, and participant cards", async ({ page }) => {
+  await page.setViewportSize({ width: 360, height: 640 });
+  await openPhaseOneViewer(page, { participants: 4, cameras: 1, screenShares: 0 });
+  await expect(page.locator("html")).toHaveAttribute("data-ui-mode", "mini");
+
+  const geometry = await page.evaluate(() => {
+    const rect = (element) => {
+      const box = element.getBoundingClientRect();
+      return { bottom: box.bottom, left: box.left, right: box.right, top: box.top, width: box.width };
+    };
+    const sheet = document.getElementById("room-sidebar");
+    const header = sheet.querySelector(".sidebar-header");
+    const list = document.getElementById("user-list");
+    const cards = Array.from(list.querySelectorAll(".user-card"));
+    return {
+      sheet: rect(sheet),
+      header: rect(header),
+      list: rect(list),
+      cards: cards.map(rect),
+      sheetClientWidth: sheet.clientWidth,
+      sheetScrollWidth: sheet.scrollWidth,
+      listClientWidth: list.clientWidth,
+      listScrollWidth: list.scrollWidth,
+    };
+  });
+
+  expect(geometry.sheetScrollWidth).toBeLessThanOrEqual(geometry.sheetClientWidth + 1);
+  expect(geometry.listScrollWidth).toBeLessThanOrEqual(geometry.listClientWidth + 1);
+  for (const region of [geometry.header, geometry.list, ...geometry.cards]) {
+    expect(region.width).toBeGreaterThan(0);
+    expect(region.left).toBeGreaterThanOrEqual(geometry.sheet.left - 1);
+    expect(region.right).toBeLessThanOrEqual(geometry.sheet.right + 1);
+  }
+  await expectNoDocumentOverflow(page);
+});
+
+test("theater Chat retains the primary stage height", async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 720 });
+  await openPhaseOneViewer(page, {
+    participants: 4,
+    cameras: 2,
+    screenShares: 1,
+    chatOpen: false,
+  });
+  await expect(page.locator("html")).toHaveAttribute("data-ui-mode", "theater");
+
+  const stage = page.locator('.room-main[data-ui-region="primary-stage"]');
+  const heightBefore = (await stage.boundingBox()).height;
+  await page.evaluate(() => {
+    document.querySelector(".room-layout").classList.add("chat-open");
+    document.getElementById("chat-panel").classList.remove("hidden");
+  });
+  await expect(page.locator("#chat-panel")).toBeVisible();
+  const heightAfter = (await stage.boundingBox()).height;
+  expect(Math.abs(heightAfter - heightBefore)).toBeLessThanOrEqual(1);
+});
+
+test("utility collapse reclaims theater stage width", async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 720 });
+  await openPhaseOneViewer(page, { participants: 4, cameras: 1, screenShares: 1 });
+  const stage = page.locator('.room-main[data-ui-region="primary-stage"]');
+  const layout = page.locator('.room-layout[data-ui-region="workspace"]');
+  const toggle = page.locator("#shell-toggle-utility");
+  const widthBefore = (await stage.boundingBox()).width;
+
+  await toggle.click();
+  await expect(layout).toHaveClass(/utility-collapsed/);
+  await expect(toggle).toHaveAttribute("aria-expanded", "false");
+  const widthAfter = (await stage.boundingBox()).width;
+  expect(widthAfter).toBeGreaterThan(widthBefore + 200);
+});
+
+for (const viewport of [
+  { width: 1024, height: 768, mode: "lounge" },
+  { width: 800, height: 600, mode: "compact" },
+]) {
+  test(`${viewport.mode} utility expansion gates the stage and collapse restores it`, async ({ page }) => {
+    await page.setViewportSize(viewport);
+    await openPhaseOneViewer(page, { participants: 4, cameras: 1, screenShares: 1 });
+    await expect(page.locator("html")).toHaveAttribute("data-ui-mode", viewport.mode);
+
+    const stage = page.locator('.room-main[data-ui-region="primary-stage"]');
+    const layout = page.locator('.room-layout[data-ui-region="workspace"]');
+    const utility = page.locator('.room-sidebar[data-ui-region="utility-host"]');
+    const toggle = page.locator("#shell-toggle-utility");
+    await expect.poll(() => stage.evaluate((element) => element.inert)).toBe(true);
+
+    await toggle.click();
+    await expect(layout).toHaveClass(/utility-collapsed/);
+    await expect.poll(() => stage.evaluate((element) => element.inert)).toBe(false);
+    await expect(toggle).toHaveAttribute("aria-expanded", "false");
+    await expect.poll(() => utility.evaluate((element) => getComputedStyle(element).visibility)).toBe("hidden");
+
+    const sizes = await page.evaluate(() => {
+      const workspace = document.querySelector('.room-layout[data-ui-region="workspace"]').getBoundingClientRect();
+      const primary = document.querySelector('.room-main[data-ui-region="primary-stage"]').getBoundingClientRect();
+      return { stageHeight: primary.height, stageWidth: primary.width, workspaceHeight: workspace.height, workspaceWidth: workspace.width };
+    });
+    expect(sizes.stageWidth).toBeGreaterThanOrEqual(sizes.workspaceWidth - 2);
+    expect(sizes.stageHeight).toBeGreaterThanOrEqual(sizes.workspaceHeight - 2);
+  });
+}
+
+for (const viewport of [
+  { width: 800, height: 600, mode: "compact" },
+  { width: 600, height: 900, mode: "mini" },
+]) {
+  test(`${viewport.mode} Chat uses essentially the full workspace`, async ({ page }) => {
+    await page.setViewportSize(viewport);
+    await openPhaseOneViewer(page, {
+      participants: 4,
+      cameras: 1,
+      screenShares: 1,
+      chatOpen: true,
+    });
+    await expect(page.locator("html")).toHaveAttribute("data-ui-mode", viewport.mode);
+    const geometry = await page.evaluate(() => {
+      const workspace = document.querySelector('.room-layout[data-ui-region="workspace"]').getBoundingClientRect();
+      const chat = document.getElementById("chat-panel").getBoundingClientRect();
+      return {
+        heightRatio: chat.height / workspace.height,
+        widthRatio: chat.width / workspace.width,
+        chat: { bottom: chat.bottom, left: chat.left, right: chat.right, top: chat.top },
+        workspace: { bottom: workspace.bottom, left: workspace.left, right: workspace.right, top: workspace.top },
+      };
+    });
+    expect(geometry.widthRatio).toBeGreaterThanOrEqual(0.95);
+    expect(geometry.heightRatio).toBeGreaterThanOrEqual(0.95);
+    expect(geometry.chat.left).toBeGreaterThanOrEqual(geometry.workspace.left - 1);
+    expect(geometry.chat.right).toBeLessThanOrEqual(geometry.workspace.right + 1);
+    expect(geometry.chat.top).toBeGreaterThanOrEqual(geometry.workspace.top - 1);
+    expect(geometry.chat.bottom).toBeLessThanOrEqual(geometry.workspace.bottom + 1);
+  });
+}
+
+test("Output opens Settings with focus inside and Escape restores the dock opener", async ({ page }) => {
+  await page.setViewportSize({ width: 1024, height: 768 });
+  await openPhaseOneViewer(page, { participants: 2, cameras: 0, screenShares: 0 });
+  const output = page.locator("#dock-output");
+  const settings = page.locator("#settings-panel");
+  await output.evaluate((button) => { button.disabled = false; });
+
+  await output.click();
+  await expect(settings).toBeVisible();
+  await expect(output).toHaveAttribute("aria-expanded", "true");
+  await expect.poll(() => settings.evaluate((panel) => panel.contains(document.activeElement))).toBe(true);
+
+  await page.keyboard.press("Escape");
+  await expect(settings).toBeHidden();
+  await expect(output).toHaveAttribute("aria-expanded", "false");
+  await expect(output).toBeFocused();
+});
+
+test("Settings falls back to visible More when its dock opener disappears in mini", async ({ page }) => {
+  await page.setViewportSize({ width: 800, height: 600 });
+  await openPhaseOneViewer(page, { participants: 2, cameras: 0, screenShares: 0 });
+  const output = page.locator("#dock-output");
+  await output.evaluate((button) => { button.disabled = false; });
+  await output.click();
+  await expect(page.locator("#settings-panel")).toBeVisible();
+
+  await settleResize(page, { width: 591, height: 900 }, "mini");
+  await expect(output).toBeHidden();
+  await page.keyboard.press("Escape");
+  await expect(page.locator("#settings-panel")).toBeHidden();
+  await expect(page.locator("#shell-more-actions")).toBeFocused();
+});
+
+test("legacy rollback keeps Settings nonmodal and restores a visible legacy control", async ({ page }) => {
+  await page.setViewportSize({ width: 800, height: 600 });
+  await openPhaseOneViewer(page, { participants: 2, cameras: 0, screenShares: 0 });
+  const output = page.locator("#dock-output");
+  const legacySettings = page.locator("#open-settings");
+  await output.evaluate((button) => { button.disabled = false; });
+  await legacySettings.evaluate((button) => { button.disabled = false; });
+  await output.click();
+  await expect(page.locator("#settings-panel")).toHaveAttribute("aria-modal", "");
+
+  await page.evaluate(() => window.EchoUiShell.applyVariant("legacy"));
+  await expect(page.locator("html")).toHaveAttribute("data-ui-shell", "legacy");
+  await expect(page.locator("#settings-panel")).not.toHaveAttribute("aria-modal", "");
+  await expect(page.locator("#settings-scrim")).toBeHidden();
+  await expect.poll(() => page.locator("#clubhouse-shell").evaluate((element) => element.inert)).toBe(false);
+
+  await page.locator("#close-settings").click();
+  await expect(page.locator("#settings-panel")).toBeHidden();
+  await expect(legacySettings).toBeFocused();
+});
+
+test("screen volume becomes visible and interactive on keyboard focus", async ({ page }) => {
+  await page.setViewportSize({ width: 1024, height: 768 });
+  await openPhaseOneViewer(page, { participants: 2, cameras: 0, screenShares: 1 });
+  await page.locator("#shell-toggle-utility").click();
+  await expect.poll(() => page.locator('.room-main[data-ui-region="primary-stage"]').evaluate((element) => element.inert)).toBe(false);
+  const tile = page.locator("#screen-grid > .tile").first();
+  const wrap = tile.locator(".tile-volume-wrap");
+  const slider = wrap.locator("input[type=range]");
+  await wrap.evaluate((element) => element.classList.remove("hidden"));
+  await slider.focus();
+  await expect(slider).toBeFocused();
+  await expect.poll(() => wrap.evaluate((element) => Number.parseFloat(getComputedStyle(element).opacity))).toBeGreaterThanOrEqual(0.99);
+  await expect.poll(() => wrap.evaluate((element) => getComputedStyle(element).pointerEvents)).not.toBe("none");
+  expect(await tile.evaluate((element) => element.matches(":focus-within"))).toBe(true);
+});
+
+test("participant chime and mute controls expose participant-specific accessible names", async ({ page }) => {
+  await page.setViewportSize({ width: 1024, height: 768 });
+  await openPhaseOneViewer(page, { participants: 3, cameras: 1, screenShares: 0 });
+
+  const remoteCards = page.locator(".user-card.is-remote");
+  await expect(remoteCards).toHaveCount(2);
+  for (let index = 0; index < await remoteCards.count(); index += 1) {
+    const card = remoteCards.nth(index);
+    const participantName = (await card.locator(".user-name").textContent()).trim();
+    const escapedName = participantName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const namedForParticipant = new RegExp(escapedName, "i");
+    const chimeToggle = card.locator(".participant-chime-toggle");
+    const chimeSlider = card.locator(".chime-volume-row input[type=range]");
+    await expect(chimeToggle).toHaveAttribute("aria-label", namedForParticipant);
+    await expect(chimeSlider).toHaveAttribute("aria-label", namedForParticipant);
+    const baseMuteButtons = card.locator(".user-indicators .mute-button");
+    await expect(baseMuteButtons).toHaveCount(2);
+    for (let muteIndex = 0; muteIndex < 2; muteIndex += 1) {
+      await expect(baseMuteButtons.nth(muteIndex)).toHaveAttribute("aria-label", namedForParticipant);
+    }
+    if (await card.evaluate((element) => !element.classList.contains("has-camera"))) {
+      await expect(chimeToggle).toHaveAccessibleName(namedForParticipant);
+      for (let muteIndex = 0; muteIndex < 2; muteIndex += 1) {
+        await expect(baseMuteButtons.nth(muteIndex)).toHaveAccessibleName(namedForParticipant);
+      }
+    }
+  }
+
+  const cameraCard = page.locator(".user-card.is-remote.has-camera").first();
+  const cameraName = (await cameraCard.locator(".user-name").textContent()).trim();
+  const cameraNamePattern = new RegExp(cameraName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "i");
+  const overlayMutes = cameraCard.locator(".cam-overlay .mute-button");
+  await expect(overlayMutes).toHaveCount(2);
+  await expect(overlayMutes.nth(0)).toHaveAccessibleName(cameraNamePattern);
+  await expect(overlayMutes.nth(1)).toHaveAccessibleName(cameraNamePattern);
+});

--- a/core/viewer/app.js
+++ b/core/viewer/app.js
@@ -103,6 +103,223 @@ if (debugCopyBtn) {
   });
 }
 
+// Clubhouse presentation controls are static DOM nodes. They proxy existing
+// state owners instead of creating a second media/control implementation.
+var dockOutputButton = document.getElementById("dock-output");
+var dockLeaveButton = document.getElementById("dock-leave");
+var shellUtilityButton = document.getElementById("shell-toggle-utility");
+var shellMoreButton = document.getElementById("shell-more-actions");
+var shellOverflowMenu = document.getElementById("shell-overflow-menu");
+var shellHeader = document.querySelector('[data-ui-region="shell-header"]');
+var shellLayout = document.querySelector('[data-ui-region="workspace"]');
+var shellStage = document.querySelector('[data-ui-region="primary-stage"]');
+var clubhouseShell = document.getElementById("clubhouse-shell");
+var settingsScrim = document.getElementById("settings-scrim");
+var settingsReturnFocus = null;
+var settingsModalActive = false;
+
+function setShellOverflowOpen(open, options) {
+  if (!shellHeader || !shellMoreButton) return;
+  shellHeader.classList.toggle("shell-overflow-open", !!open);
+  shellMoreButton.setAttribute("aria-expanded", open ? "true" : "false");
+  if (open && (!options || options.focus !== false) && shellOverflowMenu) {
+    var firstCommand = Array.from(shellOverflowMenu.querySelectorAll("button:not(.hidden):not(:disabled)"))
+      .find(function(command) { return command.getClientRects().length > 0; });
+    if (firstCommand) firstCommand.focus();
+  } else if (!open && options && options.restoreFocus) {
+    shellMoreButton.focus();
+  }
+}
+
+function settingsFocusableElements() {
+  if (!settingsPanel) return [];
+  return Array.from(settingsPanel.querySelectorAll(
+    'button:not(:disabled), input:not(:disabled), select:not(:disabled), textarea:not(:disabled), [tabindex]:not([tabindex="-1"])'
+  )).filter(function(element) {
+    return element.getClientRects().length > 0;
+  });
+}
+
+function isRenderedFocusable(element) {
+  return !!(element
+    && element.isConnected
+    && !element.disabled
+    && element.getClientRects().length > 0
+    && !element.closest("[inert]"));
+}
+
+function setSettingsModalPresentation(modal) {
+  settingsModalActive = !!modal;
+  settingsPanel?.toggleAttribute("aria-modal", settingsModalActive);
+  if (settingsScrim) settingsScrim.classList.toggle("hidden", !settingsModalActive);
+  if (connectPanel) connectPanel.inert = settingsModalActive;
+  if (clubhouseShell) clubhouseShell.inert = settingsModalActive;
+}
+
+function focusSettingsReturnTarget(preferred) {
+  var isV2 = document.documentElement.dataset.uiShell === "v2";
+  var candidates = isV2
+    ? [preferred, shellMoreButton, openSettingsButton, shellUtilityButton, connectBtn]
+    : [preferred, openSettingsButton, connectBtn];
+  var target = candidates.find(isRenderedFocusable);
+  if (target) target.focus();
+}
+
+function syncSettingsModalPresentation() {
+  if (!settingsPanel) return;
+  var panelOpen = !settingsPanel.classList.contains("hidden");
+  var shouldBeModal = panelOpen && document.documentElement.dataset.uiShell === "v2";
+  var becomingModal = shouldBeModal && !settingsModalActive;
+  if (becomingModal && !settingsReturnFocus) {
+    settingsReturnFocus = isRenderedFocusable(shellMoreButton) ? shellMoreButton : openSettingsButton;
+  }
+  setSettingsModalPresentation(shouldBeModal);
+  if (becomingModal) {
+    requestAnimationFrame(function() {
+      var focusTarget = closeSettingsButton || settingsFocusableElements()[0];
+      if (focusTarget) focusTarget.focus();
+    });
+  }
+}
+
+function setSettingsPanelOpen(open, returnFocusTarget) {
+  if (!settingsPanel) return;
+  var modal = !!open && document.documentElement.dataset.uiShell === "v2";
+  if (open) {
+    settingsReturnFocus = modal ? (returnFocusTarget || document.activeElement) : null;
+    settingsPanel.classList.remove("hidden");
+  } else {
+    settingsPanel.classList.add("hidden");
+  }
+  setSettingsModalPresentation(modal);
+  if (dockOutputButton) dockOutputButton.setAttribute("aria-expanded", open ? "true" : "false");
+  if (openSettingsButton) openSettingsButton.setAttribute("aria-expanded", open ? "true" : "false");
+  if (modal) {
+    requestAnimationFrame(function() {
+      var focusTarget = closeSettingsButton || settingsFocusableElements()[0];
+      if (focusTarget) focusTarget.focus();
+    });
+  } else {
+    var focusReturn = settingsReturnFocus;
+    settingsReturnFocus = null;
+    if (!open && focusReturn) focusSettingsReturnTarget(focusReturn);
+  }
+}
+
+function syncClubhouseUtilityPresentation() {
+  if (!shellLayout || !shellStage) return;
+  var isV2 = document.documentElement.dataset.uiShell === "v2";
+  var mode = document.documentElement.dataset.uiMode;
+  var collapsed = shellLayout.classList.contains("utility-collapsed");
+  var chatOpen = shellLayout.classList.contains("chat-open") && chatPanel && !chatPanel.classList.contains("hidden");
+  var overlaysStage = mode === "lounge" || mode === "compact" || mode === "mini";
+  shellStage.inert = !!(isV2 && overlaysStage && !collapsed);
+  if (shellUtilityButton) {
+    shellUtilityButton.textContent = chatOpen ? "Chat" : "People";
+    shellUtilityButton.setAttribute("aria-expanded", collapsed ? "false" : "true");
+    shellUtilityButton.setAttribute(
+      "aria-label",
+      (collapsed ? "Show " : "Hide ") + (chatOpen ? "Chat" : "People and tools")
+    );
+  }
+}
+
+if (dockOutputButton && settingsPanel) {
+  dockOutputButton.addEventListener("click", function() {
+    if (!dockOutputButton.disabled) setSettingsPanelOpen(true, dockOutputButton);
+  });
+}
+
+if (settingsScrim) {
+  settingsScrim.addEventListener("click", function() {
+    setSettingsPanelOpen(false);
+  });
+}
+
+if (dockLeaveButton && disconnectTopBtn) {
+  dockLeaveButton.addEventListener("click", function() {
+    if (!disconnectTopBtn.disabled) disconnectTopBtn.click();
+  });
+}
+
+if (shellMoreButton) {
+  shellMoreButton.addEventListener("click", function(event) {
+    event.stopPropagation();
+    var open = !shellHeader.classList.contains("shell-overflow-open");
+    setShellOverflowOpen(open, { focus: open });
+  });
+}
+
+if (shellOverflowMenu) {
+  shellOverflowMenu.addEventListener("click", function(event) {
+    var command = event.target.closest("button");
+    if (!command) return;
+    setShellOverflowOpen(false);
+    requestAnimationFrame(function() {
+      if (document.activeElement === command) shellMoreButton?.focus();
+    });
+  });
+}
+
+if (shellUtilityButton && shellLayout) {
+  shellUtilityButton.addEventListener("click", function() {
+    shellLayout.classList.toggle("utility-collapsed");
+    syncClubhouseUtilityPresentation();
+  });
+}
+
+if (openChatButton) openChatButton.addEventListener("click", syncClubhouseUtilityPresentation);
+if (closeChatButton) closeChatButton.addEventListener("click", syncClubhouseUtilityPresentation);
+window.addEventListener("echo:ui-shell-change", function() {
+  syncClubhouseUtilityPresentation();
+  syncSettingsModalPresentation();
+  if (!shellHeader?.classList.contains("shell-overflow-open")) return;
+  var canRestoreMoreFocus = document.documentElement.dataset.uiShell === "v2"
+    && shellMoreButton
+    && shellMoreButton.getClientRects().length > 0;
+  setShellOverflowOpen(false, { restoreFocus: canRestoreMoreFocus });
+});
+if (shellLayout && typeof MutationObserver === "function") {
+  var shellLayoutObserver = new MutationObserver(syncClubhouseUtilityPresentation);
+  shellLayoutObserver.observe(shellLayout, { attributes: true, attributeFilter: ["class"] });
+}
+
+document.addEventListener("click", function(event) {
+  if (shellHeader && !shellHeader.contains(event.target)) setShellOverflowOpen(false);
+});
+
+document.addEventListener("keydown", function(event) {
+  if (settingsModalActive && settingsPanel && !settingsPanel.classList.contains("hidden")) {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      setSettingsPanelOpen(false);
+      return;
+    }
+    if (event.key === "Tab") {
+      var focusable = settingsFocusableElements();
+      if (!focusable.length) {
+        event.preventDefault();
+        return;
+      }
+      var first = focusable[0];
+      var last = focusable[focusable.length - 1];
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    }
+    return;
+  }
+  if (event.key !== "Escape" || !shellHeader?.classList.contains("shell-overflow-open")) return;
+  event.preventDefault();
+  setShellOverflowOpen(false, { restoreFocus: true });
+});
+
+syncClubhouseUtilityPresentation();
+
 // Connection lifecycle (hookPublication, switchRoom, connectToRoom, connect, disconnect,
 // setPublishButtonsEnabled, renderPublishButtons, reconcileLocalPublishIndicators,
 // buildChimeSettingsUI) are in connect.js
@@ -217,14 +434,17 @@ if (toggleRoomAudioButton) {
 }
 
 if (openSettingsButton && settingsPanel) {
-  openSettingsButton.addEventListener("click", () => {
-    settingsPanel.classList.toggle("hidden");
+  openSettingsButton.addEventListener("click", function() {
+    var returnTarget = document.documentElement.dataset.uiShell === "v2" && shellMoreButton
+      ? shellMoreButton
+      : openSettingsButton;
+    setSettingsPanelOpen(settingsPanel.classList.contains("hidden"), returnTarget);
   });
 }
 
 if (closeSettingsButton && settingsPanel) {
-  closeSettingsButton.addEventListener("click", () => {
-    settingsPanel.classList.add("hidden");
+  closeSettingsButton.addEventListener("click", function() {
+    setSettingsPanelOpen(false);
   });
 }
 

--- a/core/viewer/clubhouse-shell.css
+++ b/core/viewer/clubhouse-shell.css
@@ -1,0 +1,1141 @@
+/*
+ * Echo Chamber — Private Clubhouse shell
+ *
+ * The production default remains legacy. Every visual override is scoped to
+ * data-ui-shell="v2" so the presentation can be enabled or rolled back without
+ * changing room, participant, media, Chat, or Jam state ownership.
+ */
+
+.shell-v2-only {
+  display: none !important;
+}
+
+:root:not([data-ui-shell="v2"]) .clubhouse-popup-chime {
+  display: none !important;
+}
+
+.shell-overflow-menu,
+.shell-overlay-root {
+  display: contents;
+}
+
+.shell-notification-layer {
+  position: fixed;
+  inset: 0;
+  z-index: 60;
+  pointer-events: none;
+}
+
+:root[data-ui-shell="v2"] .settings-scrim {
+  position: fixed;
+  inset: 0;
+  z-index: 29;
+  background: rgba(5, 7, 10, 0.58);
+  backdrop-filter: blur(2px);
+}
+
+:root[data-ui-shell="v2"] {
+  color-scheme: dark;
+  --club-bg: #080a0e;
+  --club-workspace: #0d1117;
+  --club-surface: #131820;
+  --club-surface-raised: #19202a;
+  --club-surface-hover: #202936;
+  --club-text: #f1f0ec;
+  --club-text-muted: #a7adb6;
+  --club-text-faint: #747c88;
+  --club-brass: #c9a86a;
+  --club-brass-bright: #e1c488;
+  --club-oxblood: #79343b;
+  --club-live: #4fc3c8;
+  --club-success: #4cc38a;
+  --club-warning: #e2a84a;
+  --club-danger: #e56a6a;
+  --club-border: rgba(241, 240, 236, 0.09);
+  --club-border-strong: rgba(241, 240, 236, 0.17);
+  --club-shadow: 0 20px 55px rgba(0, 0, 0, 0.38);
+  --club-space-1: 4px;
+  --club-space-2: 8px;
+  --club-space-3: 12px;
+  --club-space-4: 16px;
+  --club-space-6: 24px;
+  --club-radius-control: 10px;
+  --club-radius-card: 12px;
+  --club-radius-panel: 16px;
+  --club-radius-pill: 999px;
+  --club-motion-fast: 120ms;
+  --club-motion-normal: 180ms;
+  --club-motion-panel: 240ms;
+  --club-shell-padding: 24px;
+  --club-shell-gap: 16px;
+  --club-header-size: 56px;
+  --club-dock-size: 64px;
+  --club-layer-region: 0;
+  --club-layer-sticky: 20;
+  --club-layer-utility-scrim: 25;
+  --club-layer-utility: 30;
+  --club-layer-modal-scrim: 40;
+  --club-layer-modal: 50;
+  --club-layer-notification: 60;
+}
+
+:root[data-ui-shell="v2"][data-ui-mode="lounge"] {
+  --club-shell-padding: 16px;
+}
+
+:root[data-ui-shell="v2"][data-ui-mode="compact"] {
+  --club-shell-padding: 12px;
+  --club-shell-gap: 12px;
+  --club-header-size: 52px;
+}
+
+:root[data-ui-shell="v2"][data-ui-mode="mini"] {
+  --club-shell-padding: 8px;
+  --club-shell-gap: 8px;
+  --club-header-size: 48px;
+}
+
+:root[data-ui-shell="v2"] body {
+  height: 100vh;
+  height: 100dvh;
+  overflow: hidden;
+  color: var(--club-text);
+  font-family: "Segoe UI Variable Text", "Segoe UI", system-ui, sans-serif;
+  font-size: 14px;
+  background:
+    radial-gradient(circle at 12% -12%, rgba(201, 168, 106, 0.13), transparent 34%),
+    radial-gradient(circle at 88% 112%, rgba(79, 195, 200, 0.07), transparent 38%),
+    linear-gradient(145deg, #0b0c10 0%, var(--club-bg) 48%, #090d12 100%);
+}
+
+:root[data-ui-shell="v2"] body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  z-index: -1;
+  pointer-events: none;
+  opacity: 0.22;
+  background-image:
+    linear-gradient(rgba(255, 255, 255, 0.012) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255, 255, 255, 0.01) 1px, transparent 1px);
+  background-size: 32px 32px;
+  mask-image: linear-gradient(to bottom, black, transparent 82%);
+}
+
+:root[data-ui-shell="v2"] .shell-v2-only {
+  display: inline-flex !important;
+}
+
+:root[data-ui-shell="v2"] .app {
+  width: 100%;
+  max-width: none;
+  height: 100vh;
+  height: 100dvh;
+  padding:
+    max(var(--club-shell-padding), env(safe-area-inset-top))
+    max(var(--club-shell-padding), env(safe-area-inset-right))
+    max(var(--club-shell-padding), env(safe-area-inset-bottom))
+    max(var(--club-shell-padding), env(safe-area-inset-left));
+  gap: 0;
+  overflow: hidden;
+}
+
+:root[data-ui-shell="v2"] .app > .legacy-brand-header {
+  display: none !important;
+}
+
+:root[data-ui-shell="v2"] .settings-scrim {
+  z-index: var(--club-layer-modal-scrim);
+}
+
+:root[data-ui-shell="v2"] .settings-panel {
+  z-index: var(--club-layer-modal);
+}
+
+:root[data-ui-shell="v2"] .app:has(#connect-panel:not(.hidden)) {
+  display: block;
+  overflow-y: auto;
+}
+
+:root[data-ui-shell="v2"] .app:has(#connect-panel:not(.hidden)) #clubhouse-shell {
+  display: none;
+}
+
+:root[data-ui-shell="v2"] .app:has(#connect-panel.hidden) {
+  display: grid;
+  grid-template-rows: minmax(0, 1fr);
+}
+
+:root[data-ui-shell="v2"] #clubhouse-shell {
+  width: 100%;
+  height: 100%;
+  min-width: 0;
+  min-height: 0;
+  padding: 0;
+  display: grid;
+  grid-template-rows: var(--club-header-size) minmax(0, 1fr) var(--club-dock-size);
+  gap: var(--club-shell-gap);
+  overflow: hidden;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+  backdrop-filter: none;
+}
+
+/* Club header */
+:root[data-ui-shell="v2"] .room-top {
+  position: relative;
+  z-index: var(--club-layer-sticky);
+  min-width: 0;
+  min-height: var(--club-header-size);
+  height: var(--club-header-size);
+  margin: 0;
+  padding: 7px 10px;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: var(--club-space-3);
+  flex-wrap: nowrap;
+  border: 1px solid var(--club-border);
+  border-radius: var(--club-radius-panel);
+  background: linear-gradient(110deg, rgba(25, 32, 42, 0.98), rgba(15, 19, 25, 0.96));
+  box-shadow: 0 10px 34px rgba(0, 0, 0, 0.24), inset 0 1px rgba(255, 255, 255, 0.035);
+}
+
+:root[data-ui-shell="v2"] .clubhouse-brand {
+  min-width: 0;
+  align-items: center;
+  gap: 9px;
+}
+
+:root[data-ui-shell="v2"] .clubhouse-crest {
+  width: 38px;
+  height: 38px;
+  flex: 0 0 38px;
+  object-fit: cover;
+  border-radius: 50%;
+  border: 1px solid rgba(225, 196, 136, 0.58);
+  box-shadow: 0 0 0 3px rgba(201, 168, 106, 0.08), 0 5px 16px rgba(0, 0, 0, 0.42);
+}
+
+:root[data-ui-shell="v2"] .clubhouse-wordmark {
+  min-width: 0;
+  display: grid;
+  line-height: 1.05;
+}
+
+:root[data-ui-shell="v2"] .clubhouse-wordmark strong {
+  overflow: hidden;
+  color: var(--club-text);
+  font-size: 14px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+:root[data-ui-shell="v2"] .clubhouse-wordmark span {
+  margin-top: 3px;
+  color: var(--club-brass);
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: 10px;
+  font-style: italic;
+  letter-spacing: 0.035em;
+  white-space: nowrap;
+}
+
+:root[data-ui-shell="v2"] .room-switcher {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  overflow: hidden;
+}
+
+:root[data-ui-shell="v2"] .room-title {
+  flex: 0 0 auto;
+  margin: 0;
+  color: var(--club-text-faint);
+  font-size: 10px;
+  letter-spacing: 0.11em;
+}
+
+:root[data-ui-shell="v2"] .room-list {
+  min-width: 0;
+  display: flex;
+  flex: 1 1 auto;
+  flex-wrap: nowrap;
+  gap: 5px;
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+
+:root[data-ui-shell="v2"] .room-list::-webkit-scrollbar {
+  display: none;
+}
+
+:root[data-ui-shell="v2"] .room-status-btn {
+  min-height: 34px;
+  flex: 0 0 auto;
+  padding: 6px 11px;
+  border-color: var(--club-border);
+  border-radius: var(--club-radius-pill);
+  color: var(--club-text-muted);
+  background: rgba(255, 255, 255, 0.025);
+}
+
+:root[data-ui-shell="v2"] .room-status-btn.is-active {
+  border-color: rgba(201, 168, 106, 0.46);
+  color: var(--club-brass-bright);
+  background: rgba(201, 168, 106, 0.1);
+  box-shadow: inset 0 0 0 1px rgba(201, 168, 106, 0.08);
+}
+
+:root[data-ui-shell="v2"] .jam-banner {
+  min-width: 0;
+  max-width: 280px;
+}
+
+:root[data-ui-shell="v2"] .room-actions {
+  position: relative;
+  min-width: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  flex-wrap: nowrap;
+}
+
+:root[data-ui-shell="v2"] .room-actions #disconnect-top {
+  display: none;
+}
+
+:root[data-ui-shell="v2"] .shell-overflow-menu {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  z-index: var(--club-layer-utility);
+  width: min(220px, calc(100vw - 24px));
+  padding: 7px;
+  display: none;
+  gap: 4px;
+  border: 1px solid var(--club-border-strong);
+  border-radius: 13px;
+  background: rgba(19, 24, 32, 0.985);
+  box-shadow: var(--club-shadow);
+}
+
+:root[data-ui-shell="v2"] .room-top.shell-overflow-open .shell-overflow-menu {
+  display: grid;
+}
+
+:root[data-ui-shell="v2"] .shell-overflow-menu > button:not(.hidden) {
+  width: 100%;
+  min-height: 38px;
+  justify-content: flex-start;
+  border-color: transparent;
+  background: transparent;
+}
+
+:root[data-ui-shell="v2"] .shell-overflow-menu > button:hover:not(:disabled) {
+  border-color: var(--club-border);
+  color: var(--club-brass-bright);
+  background: rgba(201, 168, 106, 0.08);
+}
+
+:root[data-ui-shell="v2"] #shell-toggle-utility,
+:root[data-ui-shell="v2"] #shell-more-actions {
+  min-width: 40px;
+  min-height: 40px;
+  padding: 0 11px;
+  align-items: center;
+  justify-content: center;
+  border-color: var(--club-border);
+  border-radius: var(--club-radius-control);
+  color: var(--club-text-muted);
+  background: rgba(255, 255, 255, 0.035);
+}
+
+:root[data-ui-shell="v2"] #shell-toggle-utility[aria-expanded="true"] {
+  border-color: rgba(201, 168, 106, 0.34);
+  color: var(--club-brass-bright);
+  background: rgba(201, 168, 106, 0.08);
+}
+
+:root[data-ui-shell="v2"] #shell-more-actions::before {
+  content: "•••";
+  font-size: 17px;
+  line-height: 1;
+  letter-spacing: 2px;
+}
+
+:root[data-ui-shell="v2"] #shell-more-actions {
+  font-size: 0;
+}
+
+:root[data-ui-shell="v2"]:not([data-ui-mode="mini"]) .shell-overflow-menu #open-settings {
+  display: none;
+}
+
+/* Workspace and stage */
+:root[data-ui-shell="v2"] .room-layout,
+:root[data-ui-shell="v2"] .room-main,
+:root[data-ui-shell="v2"] .room-sidebar,
+:root[data-ui-shell="v2"] .chat-panel,
+:root[data-ui-shell="v2"] .screens-grid,
+:root[data-ui-shell="v2"] .user-list {
+  min-width: 0;
+  min-height: 0;
+}
+
+:root[data-ui-shell="v2"] .room-layout {
+  position: relative;
+  z-index: var(--club-layer-region);
+  width: 100%;
+  height: 100%;
+  gap: var(--club-shell-gap);
+  overflow: hidden;
+}
+
+:root[data-ui-shell="v2"][data-ui-mode="theater"] .room-layout {
+  grid-template-columns: minmax(0, 1fr) clamp(320px, 24vw, 360px);
+}
+
+:root[data-ui-shell="v2"] .room-main {
+  position: relative;
+  padding: 12px;
+  gap: 8px;
+  overflow: hidden;
+  border: 1px solid var(--club-border);
+  border-radius: var(--club-radius-panel);
+  background:
+    radial-gradient(circle at 50% 0%, rgba(201, 168, 106, 0.035), transparent 42%),
+    var(--club-workspace);
+  box-shadow: inset 0 1px rgba(255, 255, 255, 0.025), 0 16px 42px rgba(0, 0, 0, 0.22);
+}
+
+:root[data-ui-shell="v2"] .grid-header h2,
+:root[data-ui-shell="v2"] .sidebar-title-row h2,
+:root[data-ui-shell="v2"] .chat-header h3 {
+  color: var(--club-text-muted);
+  font-size: 11px;
+  font-weight: 650;
+  letter-spacing: 0.12em;
+}
+
+:root[data-ui-shell="v2"] .grid-header h2 {
+  font-size: 0;
+}
+
+:root[data-ui-shell="v2"] .grid-header h2::before {
+  content: "THE STAGE";
+  font-size: 11px;
+}
+
+:root[data-ui-shell="v2"] .screens-grid {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+}
+
+:root[data-ui-shell="v2"] .screens-grid:empty::before {
+  content: "No one is sharing\A Use Share Screen when you are ready to take the stage.";
+  width: min(440px, calc(100% - 32px));
+  min-height: 150px;
+  margin: auto;
+  padding: 88px 24px 22px;
+  display: grid;
+  place-items: center;
+  align-self: center;
+  justify-self: center;
+  color: var(--club-text-muted);
+  font-size: 13px;
+  line-height: 1.55;
+  text-align: center;
+  white-space: pre-line;
+  border: 1px dashed rgba(201, 168, 106, 0.2);
+  border-radius: var(--club-radius-panel);
+  background:
+    url("badge.jpg") center 18px / 58px 58px no-repeat,
+    linear-gradient(145deg, rgba(201, 168, 106, 0.045), rgba(255, 255, 255, 0.012));
+  opacity: 0.78;
+}
+
+:root[data-ui-shell="v2"] .screens-grid .tile {
+  padding: 0;
+  gap: 0;
+  overflow: hidden;
+  border-color: var(--club-border);
+  border-radius: var(--club-radius-card);
+  background: #05070a;
+  box-shadow: 0 16px 38px rgba(0, 0, 0, 0.34);
+}
+
+:root[data-ui-shell="v2"] .screens-grid .tile h3 {
+  position: absolute;
+  top: 8px;
+  left: 8px;
+  right: auto;
+  z-index: 6;
+  width: max-content;
+  max-width: calc(100% - 60px);
+  min-width: 0;
+  padding: 5px 9px;
+  overflow: hidden;
+  color: rgba(241, 240, 236, 0.88);
+  font-size: 11px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  border-radius: 7px;
+  background: rgba(5, 7, 10, 0.68);
+  backdrop-filter: blur(8px);
+}
+
+:root[data-ui-shell="v2"] .tile-fullscreen-btn {
+  opacity: 1;
+}
+
+:root[data-ui-shell="v2"] .tile-volume-wrap,
+:root[data-ui-shell="v2"] .screens-grid .tile:focus-within .tile-volume-wrap:not(.hidden),
+:root[data-ui-shell="v2"] .tile-volume-wrap:focus-within:not(.hidden) {
+  transition-duration: var(--club-motion-fast);
+}
+
+:root[data-ui-shell="v2"] .screens-grid .tile:focus-within .tile-volume-wrap:not(.hidden),
+:root[data-ui-shell="v2"] .tile-volume-wrap:focus-within:not(.hidden) {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+/* Utility rail: People and Chat share the same visual slot. */
+:root[data-ui-shell="v2"] .room-sidebar,
+:root[data-ui-shell="v2"] .chat-panel {
+  min-width: 0;
+  padding: 12px;
+  gap: 10px;
+  grid-template-columns: minmax(0, 1fr);
+  overflow: hidden;
+  border: 1px solid var(--club-border);
+  border-radius: var(--club-radius-panel);
+  background: linear-gradient(160deg, rgba(25, 32, 42, 0.99), rgba(13, 17, 23, 0.985));
+  box-shadow: 0 16px 42px rgba(0, 0, 0, 0.28), inset 0 1px rgba(255, 255, 255, 0.03);
+  backdrop-filter: none;
+}
+
+:root[data-ui-shell="v2"] .room-layout.chat-open {
+  grid-template-columns: minmax(0, 1fr) clamp(320px, 24vw, 360px);
+}
+
+:root[data-ui-shell="v2"] .room-layout.chat-open .room-sidebar {
+  grid-column: 2;
+  grid-row: 1;
+  visibility: hidden;
+  pointer-events: none;
+}
+
+:root[data-ui-shell="v2"] .room-layout.chat-open .chat-panel {
+  grid-column: 2;
+  grid-row: 1;
+}
+
+:root[data-ui-shell="v2"] .sidebar-header {
+  min-width: 0;
+  padding-bottom: 8px;
+  border-color: var(--club-border);
+}
+
+:root[data-ui-shell="v2"] .sidebar-title-row {
+  min-width: 0;
+  gap: 7px;
+}
+
+:root[data-ui-shell="v2"] .sidebar-title-row h2 {
+  font-size: 0;
+}
+
+:root[data-ui-shell="v2"] .sidebar-title-row h2::before {
+  content: "PEOPLE";
+  font-size: 11px;
+}
+
+:root[data-ui-shell="v2"] .sidebar-actions {
+  min-width: 0;
+  gap: 5px;
+}
+
+:root[data-ui-shell="v2"] .sidebar-actions button {
+  min-width: 0;
+  min-height: 32px;
+  padding: 5px 6px;
+  overflow: hidden;
+  color: var(--club-text-muted);
+  font-size: 11px;
+  text-overflow: ellipsis;
+  border-color: var(--club-border);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.025);
+}
+
+:root[data-ui-shell="v2"] .sidebar-actions button:hover:not(:disabled),
+:root[data-ui-shell="v2"] .sidebar-actions button:focus-visible:not(:disabled) {
+  border-color: rgba(201, 168, 106, 0.34);
+  color: var(--club-brass-bright);
+  background: rgba(201, 168, 106, 0.08);
+}
+
+:root[data-ui-shell="v2"] .user-list {
+  min-width: 0;
+  max-width: 100%;
+  container-type: inline-size;
+  padding: 1px 3px 8px 1px;
+  gap: 8px;
+  grid-auto-rows: max-content;
+  align-items: start;
+  overflow-x: hidden;
+  overscroll-behavior: contain;
+}
+
+/* Participant cards */
+:root[data-ui-shell="v2"] .user-card {
+  container-type: inline-size;
+  min-width: 0;
+  border-color: var(--club-border);
+  border-radius: var(--club-radius-card);
+  background: rgba(255, 255, 255, 0.025);
+  box-shadow: none;
+}
+
+:root[data-ui-shell="v2"] .user-card:hover {
+  border-color: var(--club-border-strong);
+  background: rgba(255, 255, 255, 0.042);
+  box-shadow: none;
+}
+
+:root[data-ui-shell="v2"] .user-card:has(.icon-button.is-active) {
+  border-color: rgba(79, 195, 200, 0.72);
+  box-shadow: 0 0 0 2px rgba(79, 195, 200, 0.1), 0 12px 28px rgba(0, 0, 0, 0.2);
+}
+
+:root[data-ui-shell="v2"] .user-card:not(.has-camera) {
+  padding: 10px;
+  gap: 0;
+}
+
+:root[data-ui-shell="v2"] .user-card:not(.has-camera) .user-name {
+  position: absolute;
+  top: 10px;
+  left: 64px;
+  right: 10px;
+  min-width: 0;
+  overflow: hidden;
+  color: var(--club-text);
+  font-size: 13px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+:root[data-ui-shell="v2"] .user-card:not(.has-camera) .user-header {
+  grid-template-columns: 44px minmax(0, 1fr);
+  gap: 10px;
+}
+
+:root[data-ui-shell="v2"] .user-card:not(.has-camera) .user-avatar {
+  width: 44px;
+  height: 44px;
+  border-radius: 10px;
+  color: var(--club-brass);
+  font-size: 13px;
+  border-color: rgba(201, 168, 106, 0.15);
+  background: linear-gradient(145deg, #232831, #11151c);
+}
+
+:root[data-ui-shell="v2"] .user-card:not(.has-camera) .user-meta {
+  padding-top: 22px;
+  gap: 6px;
+}
+
+:root[data-ui-shell="v2"] .user-indicators {
+  margin: 0;
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 5px;
+}
+
+:root[data-ui-shell="v2"] .indicator-row {
+  width: auto;
+  flex: 0 0 auto;
+  gap: 4px;
+}
+
+:root[data-ui-shell="v2"] .indicator-only {
+  width: 30px;
+  height: 30px;
+}
+
+:root[data-ui-shell="v2"] .participant-chime-toggle {
+  min-width: 40px;
+  min-height: 40px;
+  padding: 4px 8px;
+  align-items: center;
+  border: 1px solid var(--club-border);
+  border-radius: 7px;
+  color: var(--club-text-faint);
+  font-size: 10px;
+  background: transparent;
+}
+
+:root[data-ui-shell="v2"] .participant-chime-toggle:hover,
+:root[data-ui-shell="v2"] .participant-chime-toggle[aria-expanded="true"] {
+  color: var(--club-brass-bright);
+  border-color: rgba(201, 168, 106, 0.3);
+  background: rgba(201, 168, 106, 0.07);
+}
+
+:root[data-ui-shell="v2"] .chime-volume-row {
+  display: none;
+}
+
+:root[data-ui-shell="v2"] .chime-volume-row.is-open {
+  display: grid;
+}
+
+:root[data-ui-shell="v2"] .user-card.has-camera {
+  min-height: 140px;
+  aspect-ratio: 16 / 9;
+  overflow: hidden;
+  border-radius: var(--club-radius-card);
+  background: #06080b;
+}
+
+:root[data-ui-shell="v2"] .user-card.has-camera .user-header,
+:root[data-ui-shell="v2"] .user-card.has-camera .user-avatar,
+:root[data-ui-shell="v2"] .user-card.has-camera .user-avatar video {
+  width: 100%;
+  height: 100%;
+  min-height: 0;
+  border-radius: var(--club-radius-card);
+}
+
+:root[data-ui-shell="v2"] .user-card:not(.has-camera) .cam-overlay {
+  display: none;
+}
+
+:root[data-ui-shell="v2"] .user-card.has-camera .cam-overlay {
+  min-width: 0;
+  padding: 28px 9px 8px;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  opacity: 1;
+  pointer-events: auto;
+  border-radius: 0 0 var(--club-radius-card) var(--club-radius-card);
+  background: linear-gradient(transparent, rgba(3, 5, 8, 0.92));
+}
+
+:root[data-ui-shell="v2"] .user-card.has-camera .cam-overlay-name {
+  align-self: center;
+  overflow: hidden;
+  color: var(--club-text);
+  font-size: 12px;
+  text-overflow: ellipsis;
+}
+
+:root[data-ui-shell="v2"] .user-card.has-camera .cam-overlay-controls {
+  min-width: 0;
+  gap: 3px;
+}
+
+:root[data-ui-shell="v2"] .cam-overlay-controls .icon-button,
+:root[data-ui-shell="v2"] .cam-overlay-controls .mute-button,
+:root[data-ui-shell="v2"] .cam-overlay-controls .watch-toggle-btn {
+  width: 40px;
+  min-width: 40px;
+  height: 40px;
+  min-height: 40px;
+  padding: 0;
+  display: inline-grid;
+  place-items: center;
+  overflow: hidden;
+  font-size: 0;
+  border-color: rgba(255, 255, 255, 0.14);
+  color: var(--club-text);
+  background: rgba(5, 7, 10, 0.58);
+}
+
+:root[data-ui-shell="v2"] .cam-overlay-controls .mute-button::before {
+  content: "×";
+  font-size: 16px;
+  line-height: 1;
+}
+
+:root[data-ui-shell="v2"] .cam-overlay-controls .watch-toggle-btn::before {
+  content: "◉";
+  font-size: 13px;
+}
+
+:root[data-ui-shell="v2"] .cam-overlay .vol-popup {
+  left: auto;
+  right: 0;
+  bottom: 54px;
+  width: min(260px, calc(100cqw - 18px));
+  min-width: min(230px, calc(100cqw - 18px));
+  margin-bottom: 0;
+  transform: none;
+  border-color: var(--club-border-strong);
+  background: rgba(19, 24, 32, 0.985);
+}
+
+:root[data-ui-shell="v2"] .user-card.is-local .user-controls {
+  display: none;
+}
+
+/* Persistent call dock */
+:root[data-ui-shell="v2"] #call-controls.publish-actions.hidden {
+  display: flex !important;
+}
+
+:root[data-ui-shell="v2"] #call-controls {
+  position: relative;
+  z-index: var(--club-layer-sticky);
+  width: max-content;
+  max-width: 100%;
+  min-height: var(--club-dock-size);
+  margin: 0 auto;
+  padding: 8px;
+  align-self: center;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  flex-wrap: nowrap;
+  overflow: hidden;
+  border: 1px solid var(--club-border-strong);
+  border-radius: 18px;
+  background: rgba(19, 24, 32, 0.97);
+  box-shadow: 0 16px 42px rgba(0, 0, 0, 0.36), inset 0 1px rgba(255, 255, 255, 0.045);
+  backdrop-filter: blur(14px);
+}
+
+:root[data-ui-shell="v2"] #call-controls button {
+  min-width: 40px;
+  min-height: 40px;
+  padding: 0 12px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  flex: 0 0 auto;
+  color: var(--club-text-muted);
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1;
+  white-space: nowrap;
+  border: 1px solid transparent;
+  border-radius: var(--club-radius-control);
+  background: transparent;
+}
+
+:root[data-ui-shell="v2"] #call-controls button::before {
+  content: "";
+  width: 18px;
+  height: 18px;
+  flex: 0 0 18px;
+  background: currentColor;
+  -webkit-mask: var(--club-control-icon) center / contain no-repeat;
+  mask: var(--club-control-icon) center / contain no-repeat;
+}
+
+:root[data-ui-shell="v2"] #call-controls #toggle-mic {
+  --club-control-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cg fill='none' stroke='black' stroke-width='2' stroke-linecap='round'%3E%3Cpath d='M12 2a3 3 0 0 0-3 3v7a3 3 0 0 0 6 0V5a3 3 0 0 0-3-3Z'/%3E%3Cpath d='M19 10v2a7 7 0 0 1-14 0v-2M12 19v3'/%3E%3C/g%3E%3C/svg%3E");
+}
+
+:root[data-ui-shell="v2"] #call-controls #toggle-cam {
+  --club-control-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cg fill='none' stroke='black' stroke-width='2' stroke-linejoin='round'%3E%3Crect x='3' y='6' width='13' height='12' rx='2'/%3E%3Cpath d='m16 10 5-3v10l-5-3Z'/%3E%3C/g%3E%3C/svg%3E");
+}
+
+:root[data-ui-shell="v2"] #call-controls #toggle-screen {
+  --club-control-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cg fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Crect x='3' y='4' width='18' height='13' rx='2'/%3E%3Cpath d='M8 21h8M12 17v4M9 10l3-3 3 3M12 7v6'/%3E%3C/g%3E%3C/svg%3E");
+}
+
+:root[data-ui-shell="v2"] #call-controls #dock-output {
+  --club-control-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cg fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M11 5 6 9H3v6h3l5 4Z'/%3E%3Cpath d='M15.5 8.5a5 5 0 0 1 0 7M18 6a8 8 0 0 1 0 12'/%3E%3C/g%3E%3C/svg%3E");
+}
+
+:root[data-ui-shell="v2"] #call-controls #dock-leave {
+  --club-control-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cg fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M4 14.5c4.8-3.4 11.2-3.4 16 0'/%3E%3Cpath d='m7 13-2 5 4 2 2-4M17 13l2 5-4 2-2-4'/%3E%3C/g%3E%3C/svg%3E");
+}
+
+:root[data-ui-shell="v2"] #call-controls button:hover:not(:disabled),
+:root[data-ui-shell="v2"] #call-controls button:focus-visible:not(:disabled) {
+  color: var(--club-text);
+  border-color: var(--club-border);
+  background: rgba(255, 255, 255, 0.055);
+}
+
+:root[data-ui-shell="v2"] #call-controls button.is-on {
+  color: var(--club-live);
+  border-color: rgba(79, 195, 200, 0.34);
+  background: rgba(79, 195, 200, 0.09);
+}
+
+:root[data-ui-shell="v2"] #call-controls #dock-leave {
+  margin-left: 6px;
+  color: var(--club-danger);
+  border-color: rgba(229, 106, 106, 0.2);
+  background: rgba(121, 52, 59, 0.11);
+}
+
+:root[data-ui-shell="v2"] #call-controls button:disabled {
+  opacity: 0.56;
+}
+
+/* Lounge: stage remains full-size while the persistent People/Chat surface overlays it. */
+:root[data-ui-shell="v2"][data-ui-mode="lounge"] .room-layout,
+:root[data-ui-shell="v2"][data-ui-mode="compact"] .room-layout,
+:root[data-ui-shell="v2"][data-ui-mode="mini"] .room-layout {
+  display: block;
+}
+
+:root[data-ui-shell="v2"][data-ui-mode="lounge"] .room-layout:not(.utility-collapsed)::after,
+:root[data-ui-shell="v2"][data-ui-mode="compact"] .room-layout:not(.utility-collapsed)::after,
+:root[data-ui-shell="v2"][data-ui-mode="mini"] .room-layout:not(.utility-collapsed)::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: var(--club-layer-utility-scrim);
+  pointer-events: auto;
+  background: rgba(5, 7, 10, 0.34);
+}
+
+:root[data-ui-shell="v2"] .room-layout.utility-collapsed {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+:root[data-ui-shell="v2"] .room-layout.utility-collapsed .room-sidebar,
+:root[data-ui-shell="v2"] .room-layout.utility-collapsed .chat-panel {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  visibility: hidden;
+  pointer-events: none;
+}
+
+:root[data-ui-shell="v2"][data-ui-mode="lounge"] .room-main,
+:root[data-ui-shell="v2"][data-ui-mode="compact"] .room-main,
+:root[data-ui-shell="v2"][data-ui-mode="mini"] .room-main {
+  width: 100%;
+  height: 100%;
+}
+
+:root[data-ui-shell="v2"][data-ui-mode="lounge"] .room-sidebar,
+:root[data-ui-shell="v2"][data-ui-mode="lounge"] .chat-panel {
+  position: absolute;
+  inset-block: 0;
+  right: 0;
+  z-index: var(--club-layer-utility);
+  width: clamp(320px, 42vw, 380px);
+  height: 100%;
+}
+
+:root[data-ui-shell="v2"][data-ui-mode="lounge"] .room-layout.chat-open .chat-panel {
+  grid-column: auto;
+  grid-row: auto;
+}
+
+/* Compact and mini: People/Chat becomes a dock-safe bottom sheet. */
+:root[data-ui-shell="v2"][data-ui-mode="compact"] .room-sidebar,
+:root[data-ui-shell="v2"][data-ui-mode="compact"] .chat-panel,
+:root[data-ui-shell="v2"][data-ui-mode="mini"] .room-sidebar,
+:root[data-ui-shell="v2"][data-ui-mode="mini"] .chat-panel {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: var(--club-layer-utility);
+  width: 100%;
+  height: min(240px, 78%);
+  border-radius: 16px 16px 12px 12px;
+}
+
+:root[data-ui-shell="v2"][data-ui-mode="compact"] .room-sidebar::before,
+:root[data-ui-shell="v2"][data-ui-mode="mini"] .room-sidebar::before {
+  content: "";
+  position: absolute;
+  top: 6px;
+  left: 50%;
+  width: 38px;
+  height: 3px;
+  transform: translateX(-50%);
+  border-radius: var(--club-radius-pill);
+  background: var(--club-border-strong);
+}
+
+:root[data-ui-shell="v2"][data-ui-mode="mini"] .room-sidebar,
+:root[data-ui-shell="v2"][data-ui-mode="mini"] .chat-panel {
+  height: min(220px, 78%);
+}
+
+:root[data-ui-shell="v2"][data-ui-mode="compact"] .room-layout.chat-open .chat-panel,
+:root[data-ui-shell="v2"][data-ui-mode="mini"] .room-layout.chat-open .chat-panel {
+  top: 0;
+  bottom: 0;
+  height: 100%;
+  grid-column: auto;
+  grid-row: auto;
+  border-radius: var(--club-radius-panel);
+}
+
+:root[data-ui-shell="v2"][data-ui-mode="compact"] .sidebar-header,
+:root[data-ui-shell="v2"][data-ui-mode="mini"] .sidebar-header {
+  padding-bottom: 6px;
+}
+
+:root[data-ui-shell="v2"][data-ui-mode="compact"] .sidebar-title-row,
+:root[data-ui-shell="v2"][data-ui-mode="mini"] .sidebar-title-row {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+
+:root[data-ui-shell="v2"][data-ui-mode="compact"] .sidebar-title-row h2,
+:root[data-ui-shell="v2"][data-ui-mode="mini"] .sidebar-title-row h2 {
+  flex: 0 0 auto;
+}
+
+:root[data-ui-shell="v2"][data-ui-mode="compact"] .sidebar-actions,
+:root[data-ui-shell="v2"][data-ui-mode="mini"] .sidebar-actions {
+  flex: 0 0 auto;
+}
+
+:root[data-ui-shell="v2"][data-ui-mode="compact"] .sidebar-actions button,
+:root[data-ui-shell="v2"][data-ui-mode="mini"] .sidebar-actions button {
+  width: auto;
+  min-width: 38px;
+  flex: 0 0 auto;
+  padding-inline: 8px;
+}
+
+:root[data-ui-shell="v2"][data-ui-mode="compact"] .user-list,
+:root[data-ui-shell="v2"][data-ui-mode="mini"] .user-list {
+  grid-template-columns: repeat(auto-fill, minmax(min(240px, 100%), 1fr));
+  grid-auto-flow: row;
+  align-items: start;
+}
+
+:root[data-ui-shell="v2"][data-ui-mode="compact"] #call-controls button,
+:root[data-ui-shell="v2"][data-ui-mode="mini"] #call-controls button {
+  width: 44px;
+  min-width: 44px;
+  height: 44px;
+  min-height: 44px;
+  padding: 0;
+  font-size: 0;
+}
+
+:root[data-ui-shell="v2"][data-ui-mode="compact"] #call-controls button::before,
+:root[data-ui-shell="v2"][data-ui-mode="mini"] #call-controls button::before {
+  width: 19px;
+  height: 19px;
+  flex-basis: 19px;
+}
+
+:root[data-ui-shell="v2"][data-ui-mode="mini"] #call-controls #dock-output {
+  display: none;
+}
+
+:root[data-ui-shell="v2"][data-ui-mode="mini"] .clubhouse-wordmark span,
+:root[data-ui-shell="v2"][data-ui-mode="mini"] .room-title,
+:root[data-ui-shell="v2"][data-ui-mode="mini"] .jam-banner {
+  display: none !important;
+}
+
+:root[data-ui-shell="v2"][data-ui-mode="mini"] .clubhouse-wordmark strong {
+  max-width: 96px;
+}
+
+:root[data-ui-shell="v2"][data-ui-mode="mini"] .room-top {
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  padding: 5px 7px;
+  gap: 7px;
+}
+
+:root[data-ui-shell="v2"][data-ui-mode="mini"] .clubhouse-crest {
+  width: 34px;
+  height: 34px;
+  flex-basis: 34px;
+}
+
+:root[data-ui-shell="v2"][data-ui-mode="mini"] #call-controls {
+  padding-inline: 6px;
+  gap: 4px;
+}
+
+@container (max-width: 303px) {
+  :root[data-ui-shell="v2"] .user-card:not(.has-camera) .user-name {
+    left: 58px;
+  }
+
+  :root[data-ui-shell="v2"] .user-card:not(.has-camera) .user-header {
+    grid-template-columns: 38px minmax(0, 1fr);
+    gap: 9px;
+  }
+
+  :root[data-ui-shell="v2"] .user-card:not(.has-camera) .user-avatar {
+    width: 38px;
+    height: 38px;
+  }
+
+  :root[data-ui-shell="v2"] .participant-chime-toggle {
+    width: 30px;
+    padding: 0;
+    overflow: hidden;
+    font-size: 0;
+  }
+
+  :root[data-ui-shell="v2"] .participant-chime-toggle::before {
+    content: "♪";
+    font-size: 13px;
+  }
+}
+
+@container (max-width: 239px) {
+  :root[data-ui-shell="v2"] .user-card:not(.has-camera) .mute-button,
+  :root[data-ui-shell="v2"] .user-card:not(.has-camera) .watch-toggle-btn {
+    max-width: 30px;
+    padding-inline: 4px;
+    overflow: hidden;
+    font-size: 0;
+  }
+
+  :root[data-ui-shell="v2"] .user-card:not(.has-camera) .mute-button::before {
+    content: "×";
+    font-size: 14px;
+  }
+}
+
+@media (hover: none), (pointer: coarse) {
+  :root[data-ui-shell="v2"] button,
+  :root[data-ui-shell="v2"] .icon-button {
+    min-width: 44px;
+    min-height: 44px;
+  }
+
+  :root[data-ui-shell="v2"] .cam-overlay,
+  :root[data-ui-shell="v2"] .tile-volume-wrap:not(.hidden) {
+    opacity: 1;
+    pointer-events: auto;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  :root[data-ui-shell="v2"] *,
+  :root[data-ui-shell="v2"] *::before,
+  :root[data-ui-shell="v2"] *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+  }
+}

--- a/core/viewer/connect.js
+++ b/core/viewer/connect.js
@@ -159,6 +159,13 @@ function setPublishButtonsEnabled(enabled) {
   micBtn.disabled = !enabled;
   camBtn.disabled = !enabled;
   screenBtn.disabled = !enabled;
+  var dockOutput = document.getElementById("dock-output");
+  var dockLeave = document.getElementById("dock-leave");
+  if (dockOutput) {
+    dockOutput.disabled = !enabled;
+    if (!enabled) dockOutput.setAttribute("aria-expanded", "false");
+  }
+  if (dockLeave) dockLeave.disabled = !enabled;
   if (flipCamBtn) {
     flipCamBtn.disabled = !enabled;
     // Show flip button only on mobile devices
@@ -171,6 +178,12 @@ function renderPublishButtons() {
   micBtn.textContent = micEnabled ? "Disable Mic" : "Enable Mic";
   camBtn.textContent = camEnabled ? "Disable Camera" : "Enable Camera";
   screenBtn.textContent = screenEnabled ? "Stop Sharing" : "Share Screen";
+  micBtn.title = micEnabled ? "Disable microphone" : "Enable microphone";
+  camBtn.title = camEnabled ? "Disable camera" : "Enable camera";
+  screenBtn.title = screenEnabled ? "Stop sharing screen" : "Share screen";
+  micBtn.setAttribute("aria-pressed", micEnabled ? "true" : "false");
+  camBtn.setAttribute("aria-pressed", camEnabled ? "true" : "false");
+  screenBtn.setAttribute("aria-pressed", screenEnabled ? "true" : "false");
   micBtn.classList.toggle("is-on", micEnabled);
   camBtn.classList.toggle("is-on", camEnabled);
   screenBtn.classList.toggle("is-on", screenEnabled);
@@ -1741,7 +1754,8 @@ async function disconnect() {
   if (deviceStatusEl && deviceStatusHome) {
     deviceStatusHome.appendChild(deviceStatusEl);
   }
-  if (settingsPanel) settingsPanel.classList.add("hidden");
+  if (typeof setSettingsPanelOpen === "function") setSettingsPanelOpen(false);
+  else if (settingsPanel) settingsPanel.classList.add("hidden");
   connectBtn.disabled = false;
   disconnectBtn.disabled = true;
   disconnectTopBtn.disabled = true;

--- a/core/viewer/index.html
+++ b/core/viewer/index.html
@@ -4,13 +4,16 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Echo Chamber</title>
+    <script src="layout-policy.js?v=0.6.11.1777930912"></script>
+    <script src="ui-shell.js?v=0.6.11.1777930912"></script>
     <link rel="stylesheet" href="style.css?v=0.6.11.1777930912" />
     <link rel="stylesheet" href="jam.css?v=0.6.11.1777930912" />
     <link rel="stylesheet" href="capture-picker.css?v=0.6.11.1777930912" />
+    <link rel="stylesheet" href="clubhouse-shell.css?v=0.6.11.1777930912" />
   </head>
   <body>
-    <main class="app">
-      <header>
+    <main id="ui-root" class="app">
+      <header class="legacy-brand-header">
         <div class="header-brand">
           <img src="badge.jpg" alt="Fellowship Badge" class="header-badge" />
           <div>
@@ -82,12 +85,6 @@
           </div>
         </div>
 
-        <div class="actions publish-actions hidden">
-          <button id="toggle-mic" disabled>Enable Mic</button>
-          <button id="toggle-cam" disabled>Enable Camera</button>
-          <button id="flip-cam" class="flip-cam-btn hidden" disabled>Flip</button>
-          <button id="toggle-screen" disabled>Share Screen</button>
-        </div>
         <div id="status" class="status">Idle</div>
         <button id="advanced-toggle" type="button" class="advanced-toggle">Advanced</button>
         <div id="advanced-section" class="advanced-section hidden">
@@ -105,32 +102,43 @@
         </div>
       </section>
 
-      <section class="panel room-panel">
-        <div class="room-top">
-          <div>
+      <section id="clubhouse-shell" class="panel room-panel" data-ui-region="connected-shell">
+        <div class="room-top" data-ui-region="shell-header">
+          <div class="clubhouse-brand shell-v2-only" aria-label="Echo Chamber private clubhouse">
+            <img src="badge.jpg" alt="" class="clubhouse-crest" />
+            <div class="clubhouse-wordmark">
+              <strong>Echo Chamber</strong>
+              <span>Private Clubhouse</span>
+            </div>
+          </div>
+          <div class="room-switcher">
             <div class="room-title">Rooms</div>
             <div id="room-list" class="room-list hidden"></div>
           </div>
           <div id="jam-banner" class="jam-banner hidden"></div>
           <div class="room-actions">
-            <button id="open-admin-dash" type="button" class="hidden" onclick="toggleAdminDash()">Dashboard</button>
-            <button id="open-settings" type="button" disabled>Settings</button>
-            <button id="open-bug-report" type="button" class="bug-report-btn" disabled>Feedback</button>
-            <button id="open-updates" type="button">Updates</button>
-            <button id="debug-toggle" type="button">Debug</button>
+            <div id="shell-overflow-menu" class="shell-overflow-menu">
+              <button id="open-admin-dash" type="button" class="hidden" onclick="toggleAdminDash()">Dashboard</button>
+              <button id="open-settings" type="button" aria-controls="settings-panel" aria-haspopup="dialog" aria-expanded="false" disabled>Settings</button>
+              <button id="open-bug-report" type="button" class="bug-report-btn" disabled>Feedback</button>
+              <button id="open-updates" type="button">Updates</button>
+              <button id="debug-toggle" type="button">Debug</button>
+            </div>
             <button id="disconnect-top" type="button" disabled>Disconnect</button>
+            <button id="shell-toggle-utility" type="button" class="shell-v2-only" aria-controls="room-sidebar chat-panel" aria-expanded="true" aria-label="Hide People and tools">People</button>
+            <button id="shell-more-actions" type="button" class="shell-v2-only" aria-controls="shell-overflow-menu" aria-expanded="false" aria-label="More clubhouse actions">More</button>
           </div>
         </div>
         <div id="pg13-banner" class="pg13-banner hidden">PG-13 Mode</div>
-        <div class="room-layout">
-          <div class="room-main">
+        <div class="room-layout" data-ui-region="workspace">
+          <div class="room-main" data-ui-region="primary-stage">
             <div class="grid-header">
               <h2>Screens</h2>
               <button id="echo-display-status" type="button" class="echo-display-status hidden"></button>
             </div>
             <div id="screen-grid" class="media-grid screens-grid"></div>
           </div>
-          <aside class="room-sidebar">
+          <aside id="room-sidebar" class="room-sidebar" data-ui-region="utility-host" data-ui-tool="people">
             <div class="sidebar-header">
               <div class="sidebar-title-row">
                 <h2>Active Users</h2>
@@ -150,7 +158,7 @@
             </div>
             <div id="user-list" class="user-list"></div>
           </aside>
-          <div id="chat-panel" class="chat-panel hidden" role="dialog" aria-label="Chat">
+          <div id="chat-panel" class="chat-panel hidden" data-ui-tool="chat" role="dialog" aria-label="Chat">
             <div class="chat-header">
               <h3>Chat</h3>
               <div class="chat-actions">
@@ -168,8 +176,18 @@
             </div>
           </div>
         </div>
+        <nav id="call-controls" class="actions publish-actions hidden shell-control-dock" data-ui-region="control-dock" aria-label="Call controls">
+          <button id="toggle-mic" type="button" data-control="microphone" aria-pressed="false" title="Enable microphone" disabled>Enable Mic</button>
+          <button id="toggle-cam" type="button" data-control="camera" aria-pressed="false" title="Enable camera" disabled>Enable Camera</button>
+          <button id="flip-cam" type="button" class="flip-cam-btn hidden" title="Flip camera" disabled>Flip</button>
+          <button id="toggle-screen" type="button" data-control="screen-share" aria-pressed="false" title="Share screen" disabled>Share Screen</button>
+          <button id="dock-output" type="button" data-control="output" aria-controls="settings-panel" aria-haspopup="dialog" aria-expanded="false" title="Output settings" disabled>Output</button>
+          <button id="dock-leave" type="button" data-control="leave" title="Leave room" disabled>Leave</button>
+        </nav>
         <div id="audio-bucket" class="audio-bucket"></div>
       </section>
+      <div id="shell-overlay-root" class="shell-overlay-root" data-ui-region="overlay-root">
+      <div id="settings-scrim" class="settings-scrim hidden" aria-hidden="true"></div>
       <div id="settings-panel" class="settings-panel hidden" role="dialog" aria-label="Settings">
         <div class="settings-header">
           <h3>Settings</h3>
@@ -408,6 +426,8 @@
         <div id="admin-dash-bugs" class="admin-dash-content hidden"><div class="adm-empty">Loading...</div></div>
         <div id="admin-dash-deploys" class="admin-dash-content hidden"><div class="adm-empty">Loading...</div></div>
       </div>
+      </div>
+      <div id="shell-notification-layer" class="shell-notification-layer" data-ui-region="notification-layer" aria-live="polite"></div>
     </main>
     <div id="debug-panel" class="debug-panel hidden">
       <div class="debug-panel-header">

--- a/core/viewer/participants-avatar.js
+++ b/core/viewer/participants-avatar.js
@@ -27,6 +27,8 @@ function iconSvg(name) {
 
 // ── Participant card ──
 
+var participantControlIdSequence = 0;
+
 function getRemoteParticipantsForScreenIdentity(identity) {
   var matches = [];
   if (!identity || !room || !room.remoteParticipants) return matches;
@@ -176,13 +178,16 @@ function ensureParticipantCard(participant, isLocal = false) {
     return participantCards.get(key);
   }
   debugLog(`creating NEW participant card for ${key}, isLocal=${isLocal}`);
+  var participantControlId = ++participantControlIdSequence;
+  var participantDisplayName = participant.name || "Guest";
   const card = document.createElement("div");
-  card.className = "user-card";
+  card.className = "user-card " + (isLocal ? "is-local" : "is-remote");
   card.dataset.identity = key;
 
   const title = document.createElement("div");
   title.className = "user-name";
   title.textContent = participant.name || "Guest";
+  title.title = title.textContent;
   card.append(title);
 
   const header = document.createElement("div");
@@ -248,6 +253,9 @@ function ensureParticipantCard(participant, isLocal = false) {
   let popMicPct = null;
   let popScreenSlider = null;
   let popScreenPct = null;
+  let popChimeSlider = null;
+  let popChimePct = null;
+  let chimeToggleButton = null;
   if (!isLocal) {
     const indicators = document.createElement("div");
     indicators.className = "user-indicators";
@@ -259,18 +267,22 @@ function ensureParticipantCard(participant, isLocal = false) {
     micIndicator.type = "button";
     micIndicator.className = "icon-button indicator-only";
     micIndicator.innerHTML = iconSvg("mic");
+    micIndicator.setAttribute("aria-label", "Microphone audio settings for " + (participant.name || "Guest"));
     micMuteButton = document.createElement("button");
     micMuteButton.type = "button";
     micMuteButton.className = "mute-button";
     micMuteButton.textContent = "Mute";
+    micMuteButton.setAttribute("aria-label", "Mute microphone audio from " + participantDisplayName);
     screenIndicator = document.createElement("button");
     screenIndicator.type = "button";
     screenIndicator.className = "icon-button indicator-only";
     screenIndicator.innerHTML = iconSvg("screen");
+    screenIndicator.setAttribute("aria-label", "Screen audio settings for " + (participant.name || "Guest"));
     screenMuteButton = document.createElement("button");
     screenMuteButton.type = "button";
     screenMuteButton.className = "mute-button";
     screenMuteButton.textContent = "Mute";
+    screenMuteButton.setAttribute("aria-label", "Mute screen audio from " + participantDisplayName);
     micIndicatorRow.append(micIndicator, micMuteButton);
     screenIndicatorRow.append(screenIndicator, screenMuteButton);
     var watchToggleBtn = document.createElement("button");
@@ -449,6 +461,7 @@ function ensureParticipantCard(participant, isLocal = false) {
     micSlider.max = "3";
     micSlider.step = "0.01";
     micSlider.value = "1";
+    micSlider.setAttribute("aria-label", "Microphone volume for " + participantDisplayName);
     micPct = document.createElement("span");
     micPct.className = "vol-pct";
     micPct.textContent = "100%";
@@ -463,12 +476,14 @@ function ensureParticipantCard(participant, isLocal = false) {
     screenSlider.max = "3";
     screenSlider.step = "0.01";
     screenSlider.value = "1";
+    screenSlider.setAttribute("aria-label", "Screen volume for " + participantDisplayName);
     screenPct = document.createElement("span");
     screenPct.className = "vol-pct";
     screenPct.textContent = "100%";
     screenRow.append(screenLabel, screenSlider, screenPct);
     var chimeRow = document.createElement("div");
-    chimeRow.className = "audio-row";
+    chimeRow.className = "audio-row chime-volume-row";
+    chimeRow.id = "chime-volume-" + participantControlId;
     const chimeLabel = document.createElement("span");
     chimeLabel.textContent = "Chime";
     chimeSlider = document.createElement("input");
@@ -477,10 +492,24 @@ function ensureParticipantCard(participant, isLocal = false) {
     chimeSlider.max = "1";
     chimeSlider.step = "0.01";
     chimeSlider.value = "0.5";
+    chimeSlider.setAttribute("aria-label", "Chime volume for " + participantDisplayName);
     chimePct = document.createElement("span");
     chimePct.className = "vol-pct";
     chimePct.textContent = "50%";
     chimeRow.append(chimeLabel, chimeSlider, chimePct);
+    chimeToggleButton = document.createElement("button");
+    chimeToggleButton.type = "button";
+    chimeToggleButton.className = "participant-chime-toggle shell-v2-only";
+    chimeToggleButton.textContent = "Chime volume";
+    chimeToggleButton.setAttribute("aria-label", "Chime volume for " + participantDisplayName);
+    chimeToggleButton.setAttribute("aria-controls", chimeRow.id);
+    chimeToggleButton.setAttribute("aria-expanded", "false");
+    chimeToggleButton.addEventListener("click", function() {
+      const open = !chimeRow.classList.contains("is-open");
+      chimeRow.classList.toggle("is-open", open);
+      chimeToggleButton.setAttribute("aria-expanded", open ? "true" : "false");
+    });
+    indicators.append(chimeToggleButton);
     audioControls.append(micRow, screenRow, chimeRow);
     meta.append(indicators, audioControls);
 
@@ -492,6 +521,7 @@ function ensureParticipantCard(participant, isLocal = false) {
     var overlayName = document.createElement("span");
     overlayName.className = "cam-overlay-name";
     overlayName.textContent = participant.name || "Guest";
+    overlayName.title = overlayName.textContent;
 
     var overlayControls = document.createElement("div");
     overlayControls.className = "cam-overlay-controls";
@@ -501,6 +531,7 @@ function ensureParticipantCard(participant, isLocal = false) {
     ovMicBtn.type = "button";
     ovMicBtn.className = "icon-button indicator-only";
     ovMicBtn.innerHTML = iconSvg("mic");
+    ovMicBtn.setAttribute("aria-label", "Microphone volume for " + overlayName.textContent);
     ovMicBtn.addEventListener("click", function(e) {
       e.stopPropagation();
       var popup = camOverlay.querySelector(".vol-popup");
@@ -512,6 +543,7 @@ function ensureParticipantCard(participant, isLocal = false) {
     ovMicMute.type = "button";
     ovMicMute.className = "mute-button";
     ovMicMute.textContent = "Mute";
+    ovMicMute.setAttribute("aria-label", "Mute microphone audio from " + participantDisplayName);
     ovMicMute.addEventListener("click", function(e) {
       e.stopPropagation();
       micMuteButton.click();
@@ -522,6 +554,7 @@ function ensureParticipantCard(participant, isLocal = false) {
     ovScreenBtn.type = "button";
     ovScreenBtn.className = "icon-button indicator-only";
     ovScreenBtn.innerHTML = iconSvg("screen");
+    ovScreenBtn.setAttribute("aria-label", "Screen volume for " + overlayName.textContent);
     ovScreenBtn.addEventListener("click", function(e) {
       e.stopPropagation();
       var popup = camOverlay.querySelector(".vol-popup");
@@ -533,6 +566,7 @@ function ensureParticipantCard(participant, isLocal = false) {
     ovScreenMute.type = "button";
     ovScreenMute.className = "mute-button";
     ovScreenMute.textContent = "Mute";
+    ovScreenMute.setAttribute("aria-label", "Mute screen audio from " + participantDisplayName);
     ovScreenMute.addEventListener("click", function(e) {
       e.stopPropagation();
       screenMuteButton.click();
@@ -589,6 +623,7 @@ function ensureParticipantCard(participant, isLocal = false) {
     popMicSlider.max = "3";
     popMicSlider.step = "0.01";
     popMicSlider.value = micSlider.value;
+    popMicSlider.setAttribute("aria-label", "Microphone volume for " + participantDisplayName);
     popMicPct = document.createElement("span");
     popMicPct.className = "vol-pct";
     popMicPct.textContent = micPct.textContent;
@@ -605,13 +640,30 @@ function ensureParticipantCard(participant, isLocal = false) {
     popScreenSlider.max = "3";
     popScreenSlider.step = "0.01";
     popScreenSlider.value = screenSlider.value;
+    popScreenSlider.setAttribute("aria-label", "Screen volume for " + participantDisplayName);
     popScreenPct = document.createElement("span");
     popScreenPct.className = "vol-pct";
     popScreenPct.textContent = screenPct.textContent;
     if (Number(screenSlider.value) > 1) popScreenPct.classList.add("boosted");
     popScreenRow.append(popScreenLabel, popScreenSlider, popScreenPct);
 
-    volPopup.append(popMicRow, popScreenRow);
+    var popChimeRow = document.createElement("div");
+    popChimeRow.className = "audio-row clubhouse-popup-chime";
+    var popChimeLabel = document.createElement("span");
+    popChimeLabel.textContent = "Chime";
+    popChimeSlider = document.createElement("input");
+    popChimeSlider.type = "range";
+    popChimeSlider.min = "0";
+    popChimeSlider.max = "1";
+    popChimeSlider.step = "0.01";
+    popChimeSlider.value = chimeSlider.value;
+    popChimeSlider.setAttribute("aria-label", "Chime volume for " + participantDisplayName);
+    popChimePct = document.createElement("span");
+    popChimePct.className = "vol-pct";
+    popChimePct.textContent = chimePct.textContent;
+    popChimeRow.append(popChimeLabel, popChimeSlider, popChimePct);
+
+    volPopup.append(popMicRow, popScreenRow, popChimeRow);
     camOverlay.append(overlayName, overlayControls, volPopup);
 
     // Close popup when clicking outside
@@ -647,16 +699,19 @@ function ensureParticipantCard(participant, isLocal = false) {
     micControl.type = "button";
     micControl.className = "icon-button";
     micControl.innerHTML = iconSvg("mic");
+    micControl.setAttribute("aria-label", "Toggle microphone");
     micControl.addEventListener("click", () => toggleMic().catch(() => {}));
     const camControl = document.createElement("button");
     camControl.type = "button";
     camControl.className = "icon-button";
     camControl.innerHTML = iconSvg("camera");
+    camControl.setAttribute("aria-label", "Toggle camera");
     camControl.addEventListener("click", () => toggleCam().catch(() => {}));
     const screenControl = document.createElement("button");
     screenControl.type = "button";
     screenControl.className = "icon-button";
     screenControl.innerHTML = iconSvg("screen");
+    screenControl.setAttribute("aria-label", "Toggle screen share");
     screenControl.addEventListener("click", () => toggleScreen().catch(() => {}));
     row.append(micControl, camControl, screenControl);
     controls.append(enableAll, row);
@@ -755,10 +810,12 @@ function ensureParticipantCard(participant, isLocal = false) {
     micMuteButton.addEventListener("click", () => {
       state.micUserMuted = !state.micUserMuted;
       micMuteButton.textContent = state.micUserMuted ? "Unmute" : "Mute";
+      micMuteButton.setAttribute("aria-label", (state.micUserMuted ? "Unmute" : "Mute") + " microphone audio from " + participantDisplayName);
       micMuteButton.classList.toggle("is-muted", state.micUserMuted);
       // Sync overlay mute button
       if (ovMicMute) {
         ovMicMute.textContent = state.micUserMuted ? "Unmute" : "Mute";
+        ovMicMute.setAttribute("aria-label", (state.micUserMuted ? "Unmute" : "Mute") + " microphone audio from " + participantDisplayName);
         ovMicMute.classList.toggle("is-muted", state.micUserMuted);
       }
       applyParticipantAudioVolumes(state);
@@ -769,10 +826,12 @@ function ensureParticipantCard(participant, isLocal = false) {
     screenMuteButton.addEventListener("click", () => {
       state.screenUserMuted = !state.screenUserMuted;
       screenMuteButton.textContent = state.screenUserMuted ? "Unmute" : "Mute";
+      screenMuteButton.setAttribute("aria-label", (state.screenUserMuted ? "Unmute" : "Mute") + " screen audio from " + participantDisplayName);
       screenMuteButton.classList.toggle("is-muted", state.screenUserMuted);
       // Sync overlay mute button
       if (ovScreenMute) {
         ovScreenMute.textContent = state.screenUserMuted ? "Unmute" : "Mute";
+        ovScreenMute.setAttribute("aria-label", (state.screenUserMuted ? "Unmute" : "Mute") + " screen audio from " + participantDisplayName);
         ovScreenMute.classList.toggle("is-muted", state.screenUserMuted);
       }
       applyParticipantAudioVolumes(state);
@@ -806,6 +865,8 @@ function ensureParticipantCard(participant, isLocal = false) {
     chimeSlider.addEventListener("input", () => {
       state.chimeVolume = Number(chimeSlider.value);
       if (chimePct) chimePct.textContent = Math.round(state.chimeVolume * 100) + "%";
+      if (popChimeSlider) popChimeSlider.value = state.chimeVolume;
+      if (popChimePct) popChimePct.textContent = Math.round(state.chimeVolume * 100) + "%";
       saveParticipantVolume(key, state.micVolume, state.screenVolume, state.chimeVolume);
     });
   }
@@ -831,6 +892,17 @@ function ensureParticipantCard(participant, isLocal = false) {
       if (popScreenPct) { popScreenPct.textContent = pctText; popScreenPct.classList.toggle("boosted", val > 1); }
       if (screenPct) { screenPct.textContent = pctText; screenPct.classList.toggle("boosted", val > 1); }
       applyParticipantAudioVolumes(state);
+      saveParticipantVolume(key, state.micVolume, state.screenVolume, state.chimeVolume);
+    });
+  }
+  if (popChimeSlider) {
+    popChimeSlider.addEventListener("input", function() {
+      var val = Number(popChimeSlider.value);
+      state.chimeVolume = val;
+      if (chimeSlider) chimeSlider.value = val;
+      var pctText = Math.round(val * 100) + "%";
+      if (popChimePct) popChimePct.textContent = pctText;
+      if (chimePct) chimePct.textContent = pctText;
       saveParticipantVolume(key, state.micVolume, state.screenVolume, state.chimeVolume);
     });
   }
@@ -860,6 +932,8 @@ function ensureParticipantCard(participant, isLocal = false) {
         state.chimeVolume = savedVol.chime;
         chimeSlider.value = savedVol.chime;
         if (chimePct) chimePct.textContent = Math.round(savedVol.chime * 100) + "%";
+        if (popChimeSlider) popChimeSlider.value = savedVol.chime;
+        if (popChimePct) popChimePct.textContent = Math.round(savedVol.chime * 100) + "%";
       }
       applyParticipantAudioVolumes(state);
       debugLog("[vol-prefs] restored " + key + " mic=" + (savedVol.mic || 1) + " screen=" + (savedVol.screen || 1) + " chime=" + (savedVol.chime != null ? savedVol.chime : 0.5));
@@ -890,7 +964,10 @@ function ensureParticipantCard(participant, isLocal = false) {
     popMicSlider,
     popMicPct,
     popScreenSlider,
-    popScreenPct
+    popScreenPct,
+    popChimeSlider,
+    popChimePct,
+    chimeToggleButton
   });
   participantState.set(key, state);
   debugLog(`participant card created and added to DOM for ${key}, card.isConnected=${card.isConnected}, avatar exists=${!!avatar}`);

--- a/core/viewer/participants-grid.js
+++ b/core/viewer/participants-grid.js
@@ -9,6 +9,7 @@ function addTile(label, element) {
   tile.className = "tile";
   const title = document.createElement("h3");
   title.textContent = label;
+  title.title = label;
   tile.appendChild(title);
   tile.appendChild(element);
   screenGridEl.appendChild(tile);
@@ -69,6 +70,7 @@ function addScreenTile(label, element, trackSid) {
   var fsBtn = document.createElement("button");
   fsBtn.className = "tile-fullscreen-btn";
   fsBtn.title = "Fullscreen";
+  fsBtn.setAttribute("aria-label", "Open shared screen fullscreen");
   fsBtn.innerHTML = "&#x26F6;"; // ⛶ fullscreen icon
   fsBtn.addEventListener("click", function(e) {
     e.stopPropagation(); // don't trigger tile focus toggle

--- a/core/viewer/ui-shell.js
+++ b/core/viewer/ui-shell.js
@@ -1,0 +1,254 @@
+(function (root, factory) {
+  if (typeof module === "object" && module.exports) {
+    module.exports = factory();
+    return;
+  }
+
+  if (root.EchoUiShell && root.EchoUiShell.__echoUiShellApi) {
+    return;
+  }
+
+  const api = factory();
+  Object.defineProperty(api, "__echoUiShellApi", { value: true });
+  root.EchoUiShell = api;
+  if (root.document) {
+    api.install({
+      window: root,
+      document: root.document,
+      policy: root.EchoLayoutPolicy,
+    });
+  }
+})(typeof globalThis !== "undefined" ? globalThis : this, function () {
+  "use strict";
+
+  const FLAG_NAME = "echo-ui-shell-v2";
+  const LEGACY_VARIANT = "legacy";
+  const V2_VARIANT = "v2";
+  let installedController = null;
+
+  function parseFlagValue(value) {
+    if (value === true || value === 1) return true;
+    if (value === false || value === 0) return false;
+    if (value == null) return null;
+
+    const normalized = String(value).trim().toLowerCase();
+    if (["1", "true", "on", "yes", "enabled", V2_VARIANT].includes(normalized)) {
+      return true;
+    }
+    if (["0", "false", "off", "no", "disabled", LEGACY_VARIANT].includes(normalized)) {
+      return false;
+    }
+    return null;
+  }
+
+  function readQueryOverride(search) {
+    try {
+      const params = new URLSearchParams(String(search || ""));
+      return parseFlagValue(params.get(FLAG_NAME));
+    } catch (_error) {
+      return null;
+    }
+  }
+
+  function resolveShellVariant(options) {
+    const input = options || {};
+    const queryOverride = readQueryOverride(input.search);
+    if (queryOverride != null) return queryOverride ? V2_VARIANT : LEGACY_VARIANT;
+
+    const storedOverride = parseFlagValue(input.storedValue);
+    if (storedOverride != null) return storedOverride ? V2_VARIANT : LEGACY_VARIANT;
+    return LEGACY_VARIANT;
+  }
+
+  function normalizeVariant(value) {
+    if (value === V2_VARIANT || parseFlagValue(value) === true) return V2_VARIANT;
+    return LEGACY_VARIANT;
+  }
+
+  function safeReadStorage(storage) {
+    try {
+      return storage && typeof storage.getItem === "function"
+        ? storage.getItem(FLAG_NAME)
+        : null;
+    } catch (_error) {
+      return null;
+    }
+  }
+
+  function safeWriteStorage(storage, variant) {
+    try {
+      if (storage && typeof storage.setItem === "function") {
+        storage.setItem(FLAG_NAME, variant === V2_VARIANT ? "1" : "0");
+      }
+    } catch (_error) {
+      // Storage can be unavailable in privacy-restricted webviews. The active
+      // document still receives the requested presentation variant.
+    }
+  }
+
+  function createShellController(options) {
+    const input = options || {};
+    const win = input.window;
+    const doc = input.document;
+    const policy = input.policy;
+    const rootElement = doc && doc.documentElement;
+    let previousMode = null;
+    let scheduledFrame = null;
+    let started = false;
+    let lastNotification = null;
+
+    if (!win || !doc || !rootElement) {
+      throw new Error("Echo UI shell requires a window and document");
+    }
+
+    const requestFrame = typeof win.requestAnimationFrame === "function"
+      ? win.requestAnimationFrame.bind(win)
+      : function (callback) { return win.setTimeout(callback, 0); };
+    const cancelFrame = typeof win.cancelAnimationFrame === "function"
+      ? win.cancelAnimationFrame.bind(win)
+      : function (handle) { win.clearTimeout(handle); };
+
+    function clearResponsiveAttributes() {
+      delete rootElement.dataset.uiMode;
+      rootElement.removeAttribute("data-ui-short");
+      rootElement.removeAttribute("data-ui-very-short");
+    }
+
+    function readViewport() {
+      return {
+        width: Number(rootElement.clientWidth) || Number(win.innerWidth) || 0,
+        height: Number(rootElement.clientHeight) || Number(win.innerHeight) || 0,
+      };
+    }
+
+    function notifyPresentationChange(resolved) {
+      const detail = {
+        variant: rootElement.dataset.uiShell || LEGACY_VARIANT,
+        mode: resolved ? resolved.mode : null,
+        isShort: !!(resolved && resolved.isShort),
+        isVeryShort: !!(resolved && resolved.isVeryShort),
+      };
+      const signature = JSON.stringify(detail);
+      if (signature === lastNotification) return;
+      lastNotification = signature;
+      if (typeof win.dispatchEvent === "function" && typeof win.CustomEvent === "function") {
+        win.dispatchEvent(new win.CustomEvent("echo:ui-shell-change", { detail }));
+      }
+    }
+
+    function measureNow() {
+      if (rootElement.dataset.uiShell !== V2_VARIANT) {
+        previousMode = null;
+        clearResponsiveAttributes();
+        notifyPresentationChange(null);
+        return null;
+      }
+
+      if (!policy || typeof policy.resolveLayoutPolicy !== "function") {
+        rootElement.dataset.uiShell = LEGACY_VARIANT;
+        previousMode = null;
+        clearResponsiveAttributes();
+        notifyPresentationChange(null);
+        return null;
+      }
+
+      const viewport = readViewport();
+      const resolved = policy.resolveLayoutPolicy({
+        width: viewport.width,
+        height: viewport.height,
+        previousMode,
+      });
+      previousMode = resolved.mode;
+      rootElement.dataset.uiMode = resolved.mode;
+      rootElement.toggleAttribute("data-ui-short", !!resolved.isShort);
+      rootElement.toggleAttribute("data-ui-very-short", !!resolved.isVeryShort);
+      notifyPresentationChange(resolved);
+      return resolved;
+    }
+
+    function scheduleMeasure() {
+      if (scheduledFrame != null) return;
+      scheduledFrame = requestFrame(function () {
+        scheduledFrame = null;
+        measureNow();
+      });
+    }
+
+    function applyVariant(value, applyOptions) {
+      const requested = normalizeVariant(value);
+      const nextVariant = requested === V2_VARIANT &&
+        policy && typeof policy.resolveLayoutPolicy === "function"
+        ? V2_VARIANT
+        : LEGACY_VARIANT;
+      const priorVariant = rootElement.dataset.uiShell;
+      rootElement.dataset.uiShell = nextVariant;
+      if (priorVariant !== nextVariant) previousMode = null;
+      if (applyOptions && applyOptions.persist) {
+        safeWriteStorage(win.localStorage, nextVariant);
+      }
+      return measureNow();
+    }
+
+    function start(initialVariant) {
+      if (started) return measureNow();
+      started = true;
+      win.addEventListener("resize", scheduleMeasure, { passive: true });
+      return applyVariant(initialVariant);
+    }
+
+    function stop() {
+      if (!started) return;
+      started = false;
+      win.removeEventListener("resize", scheduleMeasure);
+      if (scheduledFrame != null) {
+        cancelFrame(scheduledFrame);
+        scheduledFrame = null;
+      }
+    }
+
+    return Object.freeze({
+      applyVariant,
+      measureNow,
+      scheduleMeasure,
+      start,
+      stop,
+    });
+  }
+
+  function install(options) {
+    if (installedController) return installedController;
+    const input = options || {};
+    const win = input.window;
+    const doc = input.document;
+    if (!win || !doc) return null;
+
+    const variant = resolveShellVariant({
+      search: win.location && win.location.search,
+      storedValue: safeReadStorage(win.localStorage),
+    });
+    installedController = createShellController({
+      window: win,
+      document: doc,
+      policy: input.policy,
+    });
+    installedController.start(variant);
+    return installedController;
+  }
+
+  function applyVariant(value, options) {
+    return installedController ? installedController.applyVariant(value, options) : null;
+  }
+
+  return {
+    FLAG_NAME,
+    LEGACY_VARIANT,
+    V2_VARIANT,
+    applyVariant,
+    createShellController,
+    install,
+    normalizeVariant,
+    parseFlagValue,
+    readQueryOverride,
+    resolveShellVariant,
+  };
+});

--- a/core/viewer/ui-shell.test.js
+++ b/core/viewer/ui-shell.test.js
@@ -1,0 +1,178 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const {
+  createShellController,
+  parseFlagValue,
+  resolveShellVariant,
+} = require("./ui-shell.js");
+
+function createHarness(policyOverride) {
+  const attributes = new Set();
+  const rootElement = {
+    clientWidth: 1280,
+    clientHeight: 720,
+    dataset: {},
+    removeAttribute(name) {
+      attributes.delete(name);
+    },
+    toggleAttribute(name, force) {
+      if (force) attributes.add(name);
+      else attributes.delete(name);
+    },
+  };
+  const listeners = new Map();
+  const frames = new Map();
+  let frameId = 0;
+  const storage = new Map();
+  const win = {
+    innerWidth: 1280,
+    innerHeight: 720,
+    localStorage: {
+      getItem(key) { return storage.has(key) ? storage.get(key) : null; },
+      setItem(key, value) { storage.set(key, String(value)); },
+    },
+    addEventListener(type, listener) {
+      const values = listeners.get(type) || [];
+      values.push(listener);
+      listeners.set(type, values);
+    },
+    removeEventListener(type, listener) {
+      listeners.set(type, (listeners.get(type) || []).filter((value) => value !== listener));
+    },
+    requestAnimationFrame(callback) {
+      frameId += 1;
+      frames.set(frameId, callback);
+      return frameId;
+    },
+    cancelAnimationFrame(id) {
+      frames.delete(id);
+    },
+  };
+  const policy = policyOverride === undefined
+    ? {
+      resolveLayoutPolicy({ width, height, previousMode }) {
+        const mode = width >= 1280 && height >= 720
+          ? "theater"
+          : width >= 900 && height >= 600
+            ? "lounge"
+            : width >= 640 && height >= 480
+              ? "compact"
+              : "mini";
+        return {
+          mode: previousMode === "compact" && width === 600 ? "compact" : mode,
+          width,
+          height,
+          isShort: height < 650,
+          isVeryShort: height < 520,
+        };
+      },
+    }
+    : policyOverride;
+
+  return {
+    attributes,
+    document: { documentElement: rootElement },
+    flushFrame() {
+      const pending = Array.from(frames.entries());
+      frames.clear();
+      pending.forEach(([, callback]) => callback());
+    },
+    frames,
+    listeners,
+    policy,
+    rootElement,
+    storage,
+    window: win,
+  };
+}
+
+test("flag parsing accepts explicit on and off values without guessing", () => {
+  for (const value of [true, 1, "1", "true", "on", "yes", "enabled", "v2"]) {
+    assert.equal(parseFlagValue(value), true, String(value));
+  }
+  for (const value of [false, 0, "0", "false", "off", "no", "disabled", "legacy"]) {
+    assert.equal(parseFlagValue(value), false, String(value));
+  }
+  for (const value of [null, undefined, "", "surprise"]) {
+    assert.equal(parseFlagValue(value), null, String(value));
+  }
+});
+
+test("query override wins over storage and absence defaults to legacy", () => {
+  assert.equal(resolveShellVariant({ search: "", storedValue: null }), "legacy");
+  assert.equal(resolveShellVariant({ search: "", storedValue: "1" }), "v2");
+  assert.equal(resolveShellVariant({ search: "?echo-ui-shell-v2=1", storedValue: "0" }), "v2");
+  assert.equal(resolveShellVariant({ search: "?echo-ui-shell-v2=0", storedValue: "1" }), "legacy");
+});
+
+test("controller writes responsive attributes and clears them in legacy mode", () => {
+  const harness = createHarness();
+  const controller = createShellController(harness);
+
+  controller.start("v2");
+  assert.equal(harness.rootElement.dataset.uiShell, "v2");
+  assert.equal(harness.rootElement.dataset.uiMode, "theater");
+  assert.equal(harness.attributes.has("data-ui-short"), false);
+  assert.equal(harness.attributes.has("data-ui-very-short"), false);
+
+  harness.rootElement.clientWidth = 640;
+  harness.rootElement.clientHeight = 480;
+  controller.measureNow();
+  assert.equal(harness.rootElement.dataset.uiMode, "compact");
+  assert.equal(harness.attributes.has("data-ui-short"), true);
+  assert.equal(harness.attributes.has("data-ui-very-short"), true);
+
+  controller.applyVariant("legacy");
+  assert.equal(harness.rootElement.dataset.uiShell, "legacy");
+  assert.equal(harness.rootElement.dataset.uiMode, undefined);
+  assert.equal(harness.attributes.has("data-ui-short"), false);
+  assert.equal(harness.attributes.has("data-ui-very-short"), false);
+});
+
+test("resize bursts coalesce into one animation-frame measurement", () => {
+  let measurements = 0;
+  const harness = createHarness({
+    resolveLayoutPolicy({ width, height }) {
+      measurements += 1;
+      return { mode: "lounge", width, height, isShort: false, isVeryShort: false };
+    },
+  });
+  const controller = createShellController(harness);
+  controller.start("v2");
+  assert.equal(measurements, 1);
+  assert.equal(harness.listeners.get("resize").length, 1);
+
+  const resize = harness.listeners.get("resize")[0];
+  resize();
+  resize();
+  resize();
+  assert.equal(harness.frames.size, 1);
+  assert.equal(measurements, 1);
+  harness.flushFrame();
+  assert.equal(measurements, 2);
+
+  controller.start("v2");
+  assert.equal(harness.listeners.get("resize").length, 1);
+  controller.stop();
+  assert.equal(harness.listeners.get("resize").length, 0);
+});
+
+test("missing layout policy fails closed to the legacy presentation", () => {
+  const harness = createHarness(null);
+  const controller = createShellController(harness);
+  assert.equal(controller.start("v2"), null);
+  assert.equal(harness.rootElement.dataset.uiShell, "legacy");
+  assert.equal(harness.rootElement.dataset.uiMode, undefined);
+});
+
+test("runtime variant changes can persist without rebuilding the controller", () => {
+  const harness = createHarness();
+  const controller = createShellController(harness);
+  controller.start("legacy");
+  controller.applyVariant("v2", { persist: true });
+  assert.equal(harness.storage.get("echo-ui-shell-v2"), "1");
+  controller.applyVariant("legacy", { persist: true });
+  assert.equal(harness.storage.get("echo-ui-shell-v2"), "0");
+  assert.equal(harness.listeners.get("resize").length, 1);
+});

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -44,11 +44,12 @@ The browser suite remains separate from `verify:quick` so the dependency-free
 PR baseline stays fast. The path-filtered `PR Viewer Layout` workflow runs it
 for production viewer and layout-test changes.
 
-Phase 0 records known legacy narrow-layout failures as narrowly scoped
-sentinels that assert the exact current bad geometry. Unrelated runtime failures
-still fail normally, and a corrected layout makes the sentinel fail until it is
-replaced by the positive contract assertion. That conversion is required before
-default-on rollout.
+Known legacy narrow-layout failures remain as narrowly scoped sentinels under
+the forced legacy presentation. Phase 1 adds positive V2 assertions at the same
+viewports, plus rollout-flag, hysteresis, canonical-node identity, media-track
+identity, Chat draft/focus, long-name, and control-overlap coverage. Unrelated
+runtime failures still fail normally. Both rollback and corrected geometry must
+remain green before default-on rollout.
 
 ### Layer 3 — Release confidence checks (as needed)
 - Smoke tests on release candidate builds

--- a/docs/UI-RESPONSIVE-CONTRACT.md
+++ b/docs/UI-RESPONSIVE-CONTRACT.md
@@ -1,6 +1,6 @@
 # Echo Chamber Responsive UI Contract
 
-Status: proposed contract for the Clubhouse UI foundation
+Status: Phase 0 contract landed; Phase 1 Clubhouse shell is implemented behind an off-by-default flag
 
 Applies to: `core/viewer/` in the browser and Windows desktop shell
 
@@ -487,6 +487,13 @@ but production default changes require an explicit release decision.
 - Preserve current feature placement unless moving it is required to establish
   a single stable region.
 - Verify that toggling the flag never duplicates media or feature listeners.
+
+The Phase 1 implementation also establishes the first real connected-shell
+presentation for the existing primary controls and People/Chat surfaces. It
+reuses the original buttons, panels, participant cards, media elements, and
+state owners; resize and live flag changes only alter CSS presentation. Jam
+continues to use its existing panel and is migrated into the shared utility
+host in Phase 2.
 
 ### Phase 2 - Dock and Utility Host
 

--- a/docs/VALIDATION.md
+++ b/docs/VALIDATION.md
@@ -37,15 +37,19 @@ npm run verify:viewer:layout
 
 The tests load the production `core/viewer/index.html`, inject deterministic
 room scenarios through production participant/screen renderers, and establish
-desktop geometry and resize-state baselines. Known narrow-layout failures run
-as exact bad-geometry sentinels during Phase 0; Clubhouse implementation PRs
-must replace them with positive contract assertions. The suite is deliberately
-outside `core/viewer/`, so its dependencies and fixtures are never copied into
-the served viewer snapshot.
+desktop geometry and resize-state baselines. Legacy narrow-layout failures run
+as exact bad-geometry sentinels under `?echo-ui-shell-v2=0`; separate positive
+V2 assertions prove that the Clubhouse shell fixes the same geometry without
+removing rollback coverage. The suite is deliberately outside `core/viewer/`,
+so its dependencies and fixtures are never copied into the served viewer
+snapshot.
 
-During Phase 0 the pure layout policy is injected by the test and is not yet
-loaded by production `index.html`. Phase 1 must replace that check with live
-mode-controller coverage before the new shell can be enabled.
+Phase 1 exercises the production-loaded layout policy and mode controller. Its
+browser coverage verifies rollout-flag precedence and first-frame selection,
+hysteresis, canonical region uniqueness, media/track/state identity across
+resize and live variant changes, usable geometry down to `360x640`, long-name
+ellipsis, non-overlapping camera cards, popup hit testing, keyboard focus
+restoration, accessible control names, and legacy rollback behavior.
 
 CI equivalent:
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Echo Chamber repo metadata. Active development lives under core/.",
   "scripts": {
     "verify:guardrails": "node tools/verify/guardrails.mjs",
-    "verify:viewer": "node --check core/viewer/app.js && node --check core/viewer/jam.js && node --test core/viewer/*.test.js",
+    "verify:viewer": "node --check core/viewer/app.js && node --check core/viewer/jam.js && node --check core/viewer/ui-shell.js && node --test core/viewer/*.test.js",
     "verify:viewer:layout": "npm --prefix core/viewer-tests test",
     "verify:quick": "npm run verify:guardrails && npm run verify:viewer"
   }


### PR DESCRIPTION
## Summary
- add the off-by-default Private Clubhouse connected shell using the existing production DOM and state owners
- add responsive theater/lounge/compact/mini presentation, persistent call dock, People/Chat utility behavior, and accessible focus/modal handling
- include new shell assets in viewer stamping, watcher, and deployment snapshot validation
- add deterministic browser coverage for rollout/rollback, media identity, geometry, overflow, overlap, hit targets, and keyboard focus

## Rollout
- default remains legacy
- preview with `?echo-ui-shell-v2=1`
- rollback with `?echo-ui-shell-v2=0`
- stacked on #213 / `codex/clubhouse-ui-foundation`
- server/viewer-only; no desktop binary rebuild
- no live deployment performed

## Verification
- `npm run verify:quick` — 151 passed
- `npm run verify:viewer:layout` — 41 passed
- `powershell -NoProfile -ExecutionPolicy Bypass -File core/deploy/test-viewer-runtime-lib.ps1` — passed
- `cargo test --manifest-path core/control/Cargo.toml config::tests` — passed
- `tools/verify/quick.sh` — passed