### PR TITLE
Phase 2: unify responsive People, Chat, and Jam tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,14 @@
 # Changelog
 
-## 0.6.31
+## 0.6.33
 
 - Experience: The source PC can allow or deny Echo's Spotify takeover, mute Jam monitoring locally, and set an independent local Jam volume without changing what listeners hear.
 - Control: Jam participants can use Stop Music to pause Spotify while keeping the Jam, queue, listeners, and source connection ready to resume; host-only End Jam still performs the full teardown.
 - Reliability: Echo temporarily routes only Spotify into VB-CABLE while a Jam is active and restores Spotify's previous output when the Jam ends, takeover is disabled, or the source recovers from an interruption.
-- Release: Desktop and control package versions are bumped to 0.6.31.
+- Interface: The Private Clubhouse shell now gives the shared stage priority, keeps People, Chat, and Jam responsive from theater down to mini layouts, and consolidates each participant's voice, shared-audio, and join-chime controls into one menu.
+- Media: The Camera Lobby fills and stacks its available space, the capture picker rejects Windows shell surfaces that only produce black frames, and the empty stage uses the full-proportion clubhouse crest.
+- Fix: Entire-monitor audio capture now excludes the active Echo desktop process tree, preventing Echo playback from being recaptured when a stale or second Echo process exists.
+- Release: Desktop and control package versions are aligned at 0.6.33.
 
 ## 0.6.30
 

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -1326,7 +1326,7 @@ dependencies = [
 
 [[package]]
 name = "echo-core-control"
-version = "0.6.32"
+version = "0.6.33"
 dependencies = [
  "argon2",
  "axum",

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -1304,7 +1304,7 @@ dependencies = [
 
 [[package]]
 name = "echo-core-client"
-version = "0.6.31"
+version = "0.6.33"
 dependencies = [
  "base64 0.22.1",
  "futures-util",

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -1326,7 +1326,7 @@ dependencies = [
 
 [[package]]
 name = "echo-core-control"
-version = "0.6.31"
+version = "0.6.32"
 dependencies = [
  "argon2",
  "axum",

--- a/core/client/Cargo.toml
+++ b/core/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "echo-core-client"
-version = "0.6.31"
+version = "0.6.33"
 edition = "2021"
 description = "Echo Chamber native desktop client"
 

--- a/core/client/src/audio_capture.rs
+++ b/core/client/src/audio_capture.rs
@@ -33,7 +33,6 @@ const LOOPBACK_MODE_EXCLUDE_TREE: u32 = 1;
 const VT_BLOB: u16 = 65;
 const BITS_PER_BYTE: u16 = 8;
 const OWNED_CAPTURE_CHANNEL_CAPACITY: usize = 64;
-const KNOWN_ECHO_PROCESS_NAMES: [&str; 2] = ["Echo Chamber.exe", "echo-core-client.exe"];
 
 /// Manual repr(C) structs for process loopback activation params.
 /// These may not be available in all versions of the windows crate.
@@ -361,41 +360,16 @@ fn validate_selected_spotify_root_pid(
     }
 }
 
-fn select_preferred_playback_exclusion_process<'a>(
-    candidates: &'a [(&'a str, Vec<(u32, u32)>)],
-) -> Option<(&'a str, u32)> {
-    candidates
-        .iter()
-        .find_map(|(name, processes)| select_root_process_pid(processes).map(|pid| (*name, pid)))
-}
-
-fn playback_exclusion_process_names() -> Vec<String> {
-    let mut names = Vec::new();
-    if let Ok(path) = std::env::current_exe() {
-        if let Some(file_name) = path.file_name().and_then(|name| name.to_str()) {
-            names.push(file_name.to_string());
-        }
-    }
-    for name in KNOWN_ECHO_PROCESS_NAMES {
-        if !names
-            .iter()
-            .any(|existing| existing.eq_ignore_ascii_case(name))
-        {
-            names.push(name.to_string());
-        }
-    }
-    names
-}
-
-fn find_playback_feedback_exclusion_pid() -> Option<(String, u32)> {
-    let names = playback_exclusion_process_names();
-    let candidates = names
-        .iter()
-        .map(|name| (name.as_str(), find_processes_by_name(name)))
-        .collect::<Vec<_>>();
-
-    select_preferred_playback_exclusion_process(&candidates)
-        .map(|(name, pid)| (name.to_string(), pid))
+fn current_playback_feedback_exclusion_target() -> (String, u32) {
+    let exe_name = std::env::current_exe()
+        .ok()
+        .and_then(|path| {
+            path.file_name()
+                .map(|name| name.to_string_lossy().into_owned())
+        })
+        .unwrap_or_else(|| "Echo desktop".to_string());
+    let pid = unsafe { GetCurrentProcessId() };
+    (exe_name, pid)
 }
 
 fn system_audio_feedback_capture_loopback_mode() -> u32 {
@@ -617,12 +591,10 @@ pub fn start_system_capture_excluding_echo(app: AppHandle) -> Result<()> {
         return Err(Error::new(E_FAIL, msg));
     }
 
-    let Some((exe_name, exclude_pid)) = find_playback_feedback_exclusion_pid() else {
-        let msg =
-            "Cannot find Echo playback process to exclude; refusing unsafe system audio capture";
-        log_audio_capture(&format!("[audio-capture] {}", msg));
-        return Err(Error::new(E_FAIL, msg));
-    };
+    // Echo's WebView2 playback processes are children of this Tauri process.
+    // Target the current process tree directly so a stale or second Echo
+    // instance can never be selected for exclusion instead of this one.
+    let (exe_name, exclude_pid) = current_playback_feedback_exclusion_target();
 
     log_audio_capture(&format!(
         "[audio-capture] start_system_capture_excluding_echo requested exclude={} pid={}",
@@ -1068,8 +1040,8 @@ fn capture_loop(
 mod tests {
     use super::{
         audio_capture_frame_diagnostic, audio_capture_peak_from_f32_bytes,
-        process_loopback_fallback_format, process_loopback_initialize_flags,
-        select_preferred_playback_exclusion_process, select_root_process_pid,
+        current_playback_feedback_exclusion_target, process_loopback_fallback_format,
+        process_loopback_initialize_flags, select_root_process_pid,
         select_root_process_pid_for_session, system_audio_feedback_capture_loopback_mode,
         system_loopback_initialize_flags, try_send_owned_capture_event,
         validate_selected_spotify_root_pid, ProcessCaptureEvent, LOOPBACK_MODE_EXCLUDE_TREE,
@@ -1078,6 +1050,7 @@ mod tests {
         AUDCLNT_STREAMFLAGS_AUTOCONVERTPCM, AUDCLNT_STREAMFLAGS_EVENTCALLBACK,
         AUDCLNT_STREAMFLAGS_LOOPBACK,
     };
+    use windows::Win32::System::Threading::GetCurrentProcessId;
 
     #[test]
     fn process_loopback_fallback_uses_pcm16_format() {
@@ -1125,29 +1098,10 @@ mod tests {
     }
 
     #[test]
-    fn selects_echo_client_root_for_feedback_exclusion() {
-        let candidates = vec![
-            ("Echo Chamber.exe", vec![(50, 10), (51, 50)]),
-            ("echo-core-client.exe", vec![(80, 12)]),
-        ];
+    fn feedback_exclusion_targets_this_echo_process() {
+        let (_exe_name, selected_pid) = current_playback_feedback_exclusion_target();
 
-        assert_eq!(
-            select_preferred_playback_exclusion_process(&candidates),
-            Some(("Echo Chamber.exe", 50))
-        );
-    }
-
-    #[test]
-    fn falls_back_to_known_client_name_for_feedback_exclusion() {
-        let candidates = vec![
-            ("Echo Chamber.exe", vec![]),
-            ("echo-core-client.exe", vec![(80, 12)]),
-        ];
-
-        assert_eq!(
-            select_preferred_playback_exclusion_process(&candidates),
-            Some(("echo-core-client.exe", 80))
-        );
+        assert_eq!(selected_pid, unsafe { GetCurrentProcessId() });
     }
 
     #[test]

--- a/core/client/src/screen_capture.rs
+++ b/core/client/src/screen_capture.rs
@@ -258,6 +258,79 @@ fn wgc_draw_border_setting(scope: &str) -> windows_capture::settings::DrawBorder
     }
 }
 
+fn is_unsupported_system_capture_window(title: &str, exe_name: Option<&str>) -> bool {
+    let normalized_title = title.trim().to_ascii_lowercase();
+    if matches!(
+        normalized_title.as_str(),
+        "program manager" | "windows input experience" | "msctfime ui" | "default ime"
+    ) {
+        return true;
+    }
+
+    matches!(
+        exe_name.map(str::to_ascii_lowercase).as_deref(),
+        Some("textinputhost.exe")
+            | Some("shellexperiencehost.exe")
+            | Some("searchhost.exe")
+            | Some("lockapp.exe")
+    )
+}
+
+fn executable_name_for_pid(pid: u32) -> Option<String> {
+    use windows::Win32::Foundation::HMODULE;
+    use windows::Win32::System::ProcessStatus::GetModuleFileNameExW;
+    use windows::Win32::System::Threading::{OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION};
+
+    unsafe {
+        let handle = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, pid).ok()?;
+        let mut buf = [0u16; 260];
+        let len = GetModuleFileNameExW(handle, HMODULE::default(), &mut buf);
+        let _ = windows::Win32::Foundation::CloseHandle(handle);
+        if len == 0 {
+            return None;
+        }
+        let path = String::from_utf16_lossy(&buf[..len as usize]);
+        path.rsplit('\\').next().map(|name| name.to_lowercase())
+    }
+}
+
+fn validate_capture_window(source_id: u64) -> Result<(), String> {
+    use windows::Win32::Foundation::HWND;
+    use windows::Win32::UI::WindowsAndMessaging::{
+        GetWindowTextW, GetWindowThreadProcessId, IsWindow,
+    };
+
+    let hwnd = HWND(source_id as *mut _);
+    if hwnd.0.is_null() || !unsafe { IsWindow(hwnd) }.as_bool() {
+        return Err("The selected window is no longer available".to_string());
+    }
+
+    let mut title_buf = [0u16; 512];
+    let title_len = unsafe { GetWindowTextW(hwnd, &mut title_buf) };
+    if title_len == 0 {
+        return Err("The selected window no longer has capturable content".to_string());
+    }
+    let title = String::from_utf16_lossy(&title_buf[..title_len as usize]);
+
+    let mut pid = 0;
+    unsafe {
+        GetWindowThreadProcessId(hwnd, Some(&mut pid));
+    }
+    if pid == 0 {
+        return Err("The selected window process is no longer available".to_string());
+    }
+
+    let exe = executable_name_for_pid(pid);
+    if is_unsupported_system_capture_window(&title, exe.as_deref()) {
+        return Err(format!(
+            "{} is a Windows system surface and cannot be screen shared",
+            title.trim()
+        ));
+    }
+
+    Ok(())
+}
+
 // ── Public API (called from Tauri IPC) ──
 
 /// List available capture sources (monitors + windows).
@@ -266,8 +339,6 @@ pub fn list_sources() -> Vec<CaptureSource> {
     use windows::Win32::Graphics::Gdi::{
         EnumDisplayMonitors, GetMonitorInfoW, HDC, HMONITOR, MONITORINFOEXW,
     };
-    use windows::Win32::System::ProcessStatus::GetModuleFileNameExW;
-    use windows::Win32::System::Threading::{OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION};
     use windows::Win32::UI::WindowsAndMessaging::{
         GetWindowLongW, GetWindowThreadProcessId, IsWindowVisible, GWL_EXSTYLE, WS_EX_TOOLWINDOW,
     };
@@ -368,25 +439,6 @@ pub fn list_sources() -> Vec<CaptureSource> {
         "lockapp.exe",
     ];
 
-    /// Get the executable name for a process ID.
-    fn exe_name_for_pid(pid: u32) -> Option<String> {
-        use windows::Win32::Foundation::HMODULE;
-        use windows::Win32::System::ProcessStatus::GetModuleFileNameExW;
-        use windows::Win32::System::Threading::{OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION};
-
-        unsafe {
-            let handle = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, pid).ok()?;
-            let mut buf = [0u16; 260];
-            let len = GetModuleFileNameExW(handle, HMODULE::default(), &mut buf);
-            let _ = windows::Win32::Foundation::CloseHandle(handle);
-            if len == 0 {
-                return None;
-            }
-            let path = String::from_utf16_lossy(&buf[..len as usize]);
-            path.rsplit('\\').next().map(|s| s.to_lowercase())
-        }
-    }
-
     match windows_capture::window::Window::enumerate() {
         Ok(windows) => {
             for w in windows {
@@ -426,7 +478,10 @@ pub fn list_sources() -> Vec<CaptureSource> {
                 }
 
                 // Classify: game vs window
-                let exe = exe_name_for_pid(pid);
+                let exe = executable_name_for_pid(pid);
+                if is_unsupported_system_capture_window(&title, exe.as_deref()) {
+                    continue;
+                }
                 let is_game = match &exe {
                     Some(name) => !NON_GAME_EXES.iter().any(|&known| known == name.as_str()),
                     None => false, // can't determine → default to window
@@ -460,6 +515,10 @@ pub async fn start_share(
     app: AppHandle,
     health: Arc<CaptureHealthState>,
 ) -> Result<(), String> {
+    // The source may have closed or its HWND may have been reused since the
+    // picker was rendered. Revalidate the live window before interrupting an
+    // existing share or spawning a new capture task.
+    validate_capture_window(source_id)?;
     stop_share();
 
     let running = Arc::new(AtomicBool::new(true));
@@ -1519,6 +1578,22 @@ mod tests {
             capture_source_visibility_warning(true, false, false, 1.0),
             None
         );
+    }
+
+    #[test]
+    fn capture_picker_omits_windows_shell_surfaces_that_encode_black_frames() {
+        assert!(is_unsupported_system_capture_window(
+            "Windows Input Experience",
+            Some("TextInputHost.exe")
+        ));
+        assert!(is_unsupported_system_capture_window(
+            "Search",
+            Some("SearchHost.exe")
+        ));
+        assert!(!is_unsupported_system_capture_window(
+            "PowerPoint - Quarterly Review",
+            Some("POWERPNT.EXE")
+        ));
     }
 
     #[test]

--- a/core/client/tauri.conf.json
+++ b/core/client/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "Echo Chamber",
-  "version": "0.6.31",
+  "version": "0.6.33",
   "identifier": "com.echochamber.app",
   "build": {
     "frontendDist": "../viewer"

--- a/core/control/Cargo.toml
+++ b/core/control/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "echo-core-control"
-version = "0.6.31"
+version = "0.6.32"
 edition = "2021"
 
 [dependencies]

--- a/core/control/Cargo.toml
+++ b/core/control/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "echo-core-control"
-version = "0.6.32"
+version = "0.6.33"
 edition = "2021"
 
 [dependencies]

--- a/core/control/src/config.rs
+++ b/core/control/src/config.rs
@@ -168,7 +168,7 @@ pub fn stamp_viewer_index(viewer_dir: &PathBuf, v: &str) {
                 "chat.js", "soundboard.js", "admin-panel.js",
                 "screen-share-state.js", "screen-share-config.js", "screen-share-quality.js",
                 "screen-share-adaptive.js", "screen-share-native.js",
-                "participants-grid.js", "participants-avatar.js", "participants-fullscreen.js",
+                "participants-grid.js", "grid-layout.js", "participants-avatar.js", "participants-fullscreen.js",
                 "participants.js",
                 "audio-routing.js", "media-controls.js", "admin.js", "connect.js",
                 "app.js", "jam.js", "changelog.js",
@@ -240,6 +240,7 @@ mod tests {
             <link rel="stylesheet" href="clubhouse-shell.css?v=old" />
             <script src="layout-policy.js?v=old"></script>
             <script src="ui-shell.js?v=old"></script>
+            <script src="grid-layout.js?v=old"></script>
             <script src="display-status.js?v=old"></script>
             <script src="native-presenter.js?v=old"></script>
             <script src="admin-panel.js?v=old"></script>
@@ -254,6 +255,7 @@ mod tests {
         assert!(stamped.contains("clubhouse-shell.css?v=0.6.12.test"));
         assert!(stamped.contains("layout-policy.js?v=0.6.12.test"));
         assert!(stamped.contains("ui-shell.js?v=0.6.12.test"));
+        assert!(stamped.contains("grid-layout.js?v=0.6.12.test"));
         assert!(stamped.contains("display-status.js?v=0.6.12.test"));
         assert!(stamped.contains("native-presenter.js?v=0.6.12.test"));
         assert!(stamped.contains("admin-panel.js?v=0.6.12.test"));

--- a/core/control/src/config.rs
+++ b/core/control/src/config.rs
@@ -168,7 +168,7 @@ pub fn stamp_viewer_index(viewer_dir: &PathBuf, v: &str) {
                 "chat.js", "soundboard.js", "admin-panel.js",
                 "screen-share-state.js", "screen-share-config.js", "screen-share-quality.js",
                 "screen-share-adaptive.js", "screen-share-native.js",
-                "participants-grid.js", "grid-layout.js", "participants-avatar.js", "participants-fullscreen.js",
+                "participants-grid.js", "grid-layout.js", "camera-lobby-layout.js", "participants-avatar.js", "participants-fullscreen.js",
                 "participants.js",
                 "audio-routing.js", "media-controls.js", "admin.js", "connect.js",
                 "app.js", "jam.js", "changelog.js",
@@ -241,6 +241,7 @@ mod tests {
             <script src="layout-policy.js?v=old"></script>
             <script src="ui-shell.js?v=old"></script>
             <script src="grid-layout.js?v=old"></script>
+            <script src="camera-lobby-layout.js?v=old"></script>
             <script src="display-status.js?v=old"></script>
             <script src="native-presenter.js?v=old"></script>
             <script src="admin-panel.js?v=old"></script>
@@ -256,6 +257,7 @@ mod tests {
         assert!(stamped.contains("layout-policy.js?v=0.6.12.test"));
         assert!(stamped.contains("ui-shell.js?v=0.6.12.test"));
         assert!(stamped.contains("grid-layout.js?v=0.6.12.test"));
+        assert!(stamped.contains("camera-lobby-layout.js?v=0.6.12.test"));
         assert!(stamped.contains("display-status.js?v=0.6.12.test"));
         assert!(stamped.contains("native-presenter.js?v=0.6.12.test"));
         assert!(stamped.contains("admin-panel.js?v=0.6.12.test"));

--- a/core/control/src/main.rs
+++ b/core/control/src/main.rs
@@ -478,6 +478,7 @@ async fn main() {
                 "clubhouse-shell.css",
                 "layout-policy.js",
                 "ui-shell.js",
+                "grid-layout.js",
                 "index.html",
                 "connect.js",
                 "room-status.js",

--- a/core/viewer-tests/fixtures/install-scenario.js
+++ b/core/viewer-tests/fixtures/install-scenario.js
@@ -29,6 +29,8 @@
     document.getElementById("chat-panel").classList.add("hidden");
     document.getElementById("user-list").replaceChildren();
     document.getElementById("screen-grid").replaceChildren();
+    document.getElementById("camera-lobby-grid").replaceChildren();
+    document.getElementById("camera-lobby").classList.add("hidden");
 
     if (typeof participantCards !== "undefined") participantCards.clear();
     if (typeof participantState !== "undefined") participantState.clear();
@@ -182,6 +184,100 @@
     };
   }
 
+  async function installCameraLobby(options) {
+    const scenario = Object.assign({ count: 1 }, options || {});
+    const count = Math.max(0, Math.floor(Number(scenario.count) || 0));
+    resetRoom();
+
+    const LK = getLiveKitClient();
+    const participants = [];
+    for (let index = 0; index < count; index += 1) {
+      const media = createVideoTrackStub(`fixture-lobby-camera-${index + 1}`, 16 / 9);
+      const publication = {
+        kind: LK.Track.Kind.Video,
+        source: LK.Track.Source.Camera,
+        track: media.track,
+        trackSid: media.track.sid,
+      };
+      participants.push({
+        identity: `lobby-fixture-${index + 1}`,
+        name: `Lobby Friend ${index + 1}`,
+        trackPublications: new Map([[publication.trackSid, publication]]),
+      });
+    }
+
+    room = {
+      localParticipant: participants[0] || {
+        identity: "lobby-fixture-empty",
+        name: "Lobby Friend",
+        trackPublications: new Map(),
+      },
+      remoteParticipants: new Map(
+        participants.slice(1).map(function (participant) {
+          return [participant.identity, participant];
+        })
+      ),
+    };
+
+    openCameraLobby();
+    if (typeof window._echoRecalcCameraLobby === "function") {
+      window._echoRecalcCameraLobby();
+    }
+    await nextFrame();
+    await nextFrame();
+
+    return {
+      count: document.querySelectorAll("#camera-lobby-grid > .camera-lobby-tile").length,
+      panelVisible: !document.getElementById("camera-lobby").classList.contains("hidden"),
+    };
+  }
+
+  function captureCameraLobbySnapshot() {
+    const tiles = Array.from(document.querySelectorAll("#camera-lobby-grid > .camera-lobby-tile"));
+    const videos = tiles.map(function (tile) { return tile.querySelector("video"); });
+    if (tiles.length === 0 || videos.some(function (video) { return !video; })) {
+      throw new Error("camera lobby snapshot requires rendered camera tiles");
+    }
+
+    window.__echoCameraLobbySnapshot = {
+      tiles: tiles,
+      videos: videos,
+      streams: videos.map(function (video) { return video.srcObject; }),
+      tracks: videos.map(function (video) {
+        return video.srcObject && video.srcObject.getVideoTracks()[0];
+      }),
+    };
+    return inspectCameraLobbySnapshot();
+  }
+
+  function inspectCameraLobbySnapshot() {
+    const saved = window.__echoCameraLobbySnapshot;
+    if (!saved) throw new Error("captureCameraLobbySnapshot must be called first");
+    const tiles = Array.from(document.querySelectorAll("#camera-lobby-grid > .camera-lobby-tile"));
+    const videos = tiles.map(function (tile) { return tile.querySelector("video"); });
+
+    return {
+      count: tiles.length,
+      streams: saved.streams.every(function (stream, index) {
+        return stream === (videos[index] && videos[index].srcObject);
+      }),
+      tiles: saved.tiles.every(function (tile, index) {
+        return tile === tiles[index] && tile.isConnected;
+      }),
+      trackStates: saved.tracks.map(function (track) { return track && track.readyState; }),
+      tracks: saved.tracks.every(function (track, index) {
+        return track === (
+          videos[index] &&
+          videos[index].srcObject &&
+          videos[index].srcObject.getVideoTracks()[0]
+        );
+      }),
+      videos: saved.videos.every(function (video, index) {
+        return video === videos[index] && video.isConnected;
+      }),
+    };
+  }
+
   function captureIdentitySnapshot() {
     const participantCard = document.querySelector(".user-card.has-camera");
     const cameraVideo = participantCard && participantCard.querySelector("video");
@@ -263,9 +359,12 @@
   }
 
   window.EchoLayoutTestScenario = Object.freeze({
+    captureCameraLobbySnapshot: captureCameraLobbySnapshot,
     captureIdentitySnapshot: captureIdentitySnapshot,
+    inspectCameraLobbySnapshot: inspectCameraLobbySnapshot,
     inspectIdentitySnapshot: inspectIdentitySnapshot,
     install: install,
+    installCameraLobby: installCameraLobby,
     unbrokenDisplayName: unbrokenDisplayName,
   });
 })();

--- a/core/viewer-tests/tests/camera-lobby.layout.spec.js
+++ b/core/viewer-tests/tests/camera-lobby.layout.spec.js
@@ -1,0 +1,273 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, test } from "@playwright/test";
+import { expectNoDocumentOverflow } from "./helpers/geometry.js";
+
+const testDirectory = path.dirname(fileURLToPath(import.meta.url));
+const fixturePath = path.resolve(testDirectory, "..", "fixtures", "install-scenario.js");
+const runtimeErrors = new WeakMap();
+const transparentPng = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=",
+  "base64",
+);
+
+test.beforeEach(async ({ page }) => {
+  const errors = [];
+  runtimeErrors.set(page, errors);
+  page.on("pageerror", (error) => errors.push(`pageerror: ${error.message}`));
+  page.on("console", (message) => {
+    if (message.type() === "error") errors.push(`console: ${message.text()}`);
+  });
+
+  await page.route("**/api/**", async (route) => {
+    const url = new URL(route.request().url());
+    if (url.pathname === "/api/online") {
+      await route.fulfill({ status: 200, contentType: "application/json", body: "[]" });
+      return;
+    }
+    if (url.pathname.startsWith("/api/avatar/")) {
+      await route.fulfill({ status: 200, contentType: "image/png", body: transparentPng });
+      return;
+    }
+    if (url.pathname === "/api/version") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ latest_client: "" }),
+      });
+      return;
+    }
+    errors.push(`unexpected API request: ${route.request().method()} ${url.pathname}`);
+    await route.fulfill({
+      status: 501,
+      contentType: "application/json",
+      body: JSON.stringify({ error: "unmodeled viewer-test endpoint" }),
+    });
+  });
+});
+
+test.afterEach(async ({ page }) => {
+  await page.waitForTimeout(25);
+  expect(runtimeErrors.get(page) || [], "production page must run without runtime errors").toEqual([]);
+});
+
+async function openCameraLobbyFixture(page, count, viewport) {
+  await page.setViewportSize(viewport);
+  await page.goto("/?echo-ui-shell-v2=1", { waitUntil: "domcontentloaded" });
+  await expect(page.locator("html")).toHaveAttribute("data-ui-shell", "v2");
+  await page.addScriptTag({ path: fixturePath });
+  const installed = await page.evaluate(
+    (tileCount) => window.EchoLayoutTestScenario.installCameraLobby({ count: tileCount }),
+    count,
+  );
+  expect(installed).toEqual({ count, panelVisible: true });
+  await expect(page.locator("#camera-lobby-grid")).toHaveAttribute("data-layout-count", String(count));
+}
+
+async function inspectLobbyLayout(page) {
+  return page.evaluate(() => {
+    function rect(element) {
+      const bounds = element.getBoundingClientRect();
+      return {
+        bottom: bounds.bottom,
+        height: bounds.height,
+        left: bounds.left,
+        right: bounds.right,
+        top: bounds.top,
+        width: bounds.width,
+      };
+    }
+
+    function number(style, property) {
+      const value = Number.parseFloat(style[property]);
+      return Number.isFinite(value) ? value : 0;
+    }
+
+    function intersectionArea(first, second) {
+      const width = Math.max(0, Math.min(first.right, second.right) - Math.max(first.left, second.left));
+      const height = Math.max(0, Math.min(first.bottom, second.bottom) - Math.max(first.top, second.top));
+      return width * height;
+    }
+
+    const panel = document.getElementById("camera-lobby");
+    const header = panel.querySelector(".camera-lobby-header");
+    const grid = document.getElementById("camera-lobby-grid");
+    const style = getComputedStyle(grid);
+    const tiles = Array.from(grid.querySelectorAll(":scope > .camera-lobby-tile"));
+    const tileRects = tiles.map(rect);
+    const buttonRects = Array.from(header.querySelectorAll("button")).map(rect);
+    const width = Math.max(0, grid.clientWidth - number(style, "paddingLeft") - number(style, "paddingRight"));
+    const height = Math.max(0, grid.clientHeight - number(style, "paddingTop") - number(style, "paddingBottom"));
+    const gap = Math.max(number(style, "columnGap"), number(style, "rowGap"));
+    const expected = window.EchoLayoutPolicy.chooseOptimalGrid({
+      width,
+      height,
+      tileCount: tiles.length,
+      gap,
+      aspectRatio: window.EchoLayoutPolicy.DEFAULT_TILE_ASPECT_RATIO,
+    });
+
+    let maxTileIntersection = 0;
+    for (let first = 0; first < tileRects.length; first += 1) {
+      for (let second = first + 1; second < tileRects.length; second += 1) {
+        maxTileIntersection = Math.max(maxTileIntersection, intersectionArea(tileRects[first], tileRects[second]));
+      }
+    }
+
+    let maxButtonIntersection = 0;
+    for (let first = 0; first < buttonRects.length; first += 1) {
+      for (let second = first + 1; second < buttonRects.length; second += 1) {
+        maxButtonIntersection = Math.max(maxButtonIntersection, intersectionArea(buttonRects[first], buttonRects[second]));
+      }
+    }
+
+    return {
+      actual: {
+        columns: Number(grid.dataset.layoutColumns),
+        rows: Number(grid.dataset.layoutRows),
+      },
+      buttonRects,
+      expected,
+      grid: rect(grid),
+      gridOverflow: {
+        x: grid.scrollWidth - grid.clientWidth,
+        y: grid.scrollHeight - grid.clientHeight,
+      },
+      header: rect(header),
+      maxButtonIntersection,
+      maxTileIntersection,
+      panel: rect(panel),
+      tileRects,
+      videoCount: grid.querySelectorAll(":scope > .camera-lobby-tile > video").length,
+    };
+  });
+}
+
+function expectContained(child, parent, label) {
+  expect.soft(child.left, `${label} left`).toBeGreaterThanOrEqual(parent.left - 1);
+  expect.soft(child.right, `${label} right`).toBeLessThanOrEqual(parent.right + 1);
+  expect.soft(child.top, `${label} top`).toBeGreaterThanOrEqual(parent.top - 1);
+  expect.soft(child.bottom, `${label} bottom`).toBeLessThanOrEqual(parent.bottom + 1);
+}
+
+function expectHealthyLobbyLayout(presentation, count, expectedTracks) {
+  expect(presentation.expected.valid).toBe(true);
+  expect(presentation.actual).toEqual({
+    columns: presentation.expected.columns,
+    rows: presentation.expected.rows,
+  });
+  expect(presentation.actual).toEqual(expectedTracks);
+  expect(presentation.videoCount).toBe(count);
+  expect(presentation.maxTileIntersection).toBeLessThanOrEqual(1);
+  expect(presentation.maxButtonIntersection).toBeLessThanOrEqual(1);
+  expect(presentation.gridOverflow.x).toBeLessThanOrEqual(1);
+  expect(presentation.gridOverflow.y).toBeLessThanOrEqual(1);
+
+  presentation.tileRects.forEach((tile, index) => {
+    expectContained(tile, presentation.grid, `tile ${index + 1}`);
+    expect.soft(tile.width, `tile ${index + 1} width`).toBeCloseTo(presentation.expected.tileWidth, 0);
+    expect.soft(tile.height, `tile ${index + 1} height`).toBeCloseTo(presentation.expected.tileHeight, 0);
+    expect.soft(tile.width / tile.height, `tile ${index + 1} aspect`).toBeCloseTo(16 / 9, 2);
+  });
+  presentation.buttonRects.forEach((button, index) => {
+    expectContained(button, presentation.panel, `header button ${index + 1}`);
+  });
+}
+
+for (const scenario of [
+  {
+    name: "one camera fills the wide lobby's limiting axis",
+    count: 1,
+    viewport: { width: 1440, height: 800 },
+    expectedTracks: { columns: 1, rows: 1 },
+  },
+  {
+    name: "two cameras stack in a tall lobby instead of shrinking side by side",
+    count: 2,
+    viewport: { width: 820, height: 1200 },
+    expectedTracks: { columns: 1, rows: 2 },
+  },
+  {
+    name: "many cameras stay balanced and contained in a narrow lobby",
+    count: 6,
+    viewport: { width: 520, height: 780 },
+    expectedTracks: { columns: 2, rows: 3 },
+  },
+]) {
+  test(scenario.name, async ({ page }) => {
+    await openCameraLobbyFixture(page, scenario.count, scenario.viewport);
+    await page.evaluate(() => window.EchoLayoutTestScenario.captureCameraLobbySnapshot());
+
+    const before = await inspectLobbyLayout(page);
+    expectHealthyLobbyLayout(before, scenario.count, scenario.expectedTracks);
+    await expectNoDocumentOverflow(page);
+
+    const resizedViewport = {
+      width: scenario.viewport.width - 12,
+      height: scenario.viewport.height + 8,
+    };
+    await page.setViewportSize(resizedViewport);
+    await expect.poll(() => page.evaluate(() => ({
+      height: window.innerHeight,
+      width: window.innerWidth,
+    }))).toEqual(resizedViewport);
+    await page.evaluate(() => window._echoRecalcCameraLobby());
+    await page.evaluate(() => new Promise((resolve) => {
+      requestAnimationFrame(() => requestAnimationFrame(resolve));
+    }));
+
+    const after = await inspectLobbyLayout(page);
+    expectHealthyLobbyLayout(after, scenario.count, scenario.expectedTracks);
+    expect(await page.evaluate(() => window.EchoLayoutTestScenario.inspectCameraLobbySnapshot())).toEqual({
+      count: scenario.count,
+      streams: true,
+      tiles: true,
+      trackStates: Array(scenario.count).fill("live"),
+      tracks: true,
+      videos: true,
+    });
+    await expectNoDocumentOverflow(page);
+  });
+}
+
+test("layout sizing does not break the Camera Lobby's enlarged tile", async ({ page }) => {
+  const viewport = { width: 1280, height: 720 };
+  await openCameraLobbyFixture(page, 1, viewport);
+  await page.evaluate(() => window.EchoLayoutTestScenario.captureCameraLobbySnapshot());
+
+  const tile = page.locator("#camera-lobby-grid > .camera-lobby-tile");
+  await tile.click();
+  await expect(tile).toHaveClass(/enlarged/);
+  const enlarged = await tile.evaluate((element) => {
+    const rect = element.getBoundingClientRect();
+    const panel = document.getElementById("camera-lobby").getBoundingClientRect();
+    return {
+      bottom: rect.bottom,
+      left: rect.left,
+      panel: {
+        bottom: panel.bottom,
+        left: panel.left,
+        right: panel.right,
+        top: panel.top,
+      },
+      right: rect.right,
+      top: rect.top,
+    };
+  });
+  expect(Math.abs(enlarged.left - (enlarged.panel.left + 20))).toBeLessThanOrEqual(2);
+  expect(Math.abs(enlarged.top - (enlarged.panel.top + 20))).toBeLessThanOrEqual(2);
+  expect(Math.abs(enlarged.right - (enlarged.panel.right - 20))).toBeLessThanOrEqual(2);
+  expect(Math.abs(enlarged.bottom - (enlarged.panel.bottom - 20))).toBeLessThanOrEqual(2);
+
+  await tile.click();
+  await expect(tile).not.toHaveClass(/enlarged/);
+  expect(await page.evaluate(() => window.EchoLayoutTestScenario.inspectCameraLobbySnapshot())).toEqual({
+    count: 1,
+    streams: true,
+    tiles: true,
+    trackStates: ["live"],
+    tracks: true,
+    videos: true,
+  });
+  await expectNoDocumentOverflow(page);
+});

--- a/core/viewer-tests/tests/shell.phase1.spec.js
+++ b/core/viewer-tests/tests/shell.phase1.spec.js
@@ -22,7 +22,7 @@ const shellSelectors = Object.freeze([
   '.room-top[data-ui-region="shell-header"]',
   '.room-layout[data-ui-region="workspace"]',
   '.room-main[data-ui-region="primary-stage"]',
-  '.room-sidebar[data-ui-region="utility-host"]',
+  '.utility-host[data-ui-region="utility-host"]',
   '#call-controls[data-ui-region="control-dock"]',
   "#shell-overlay-root",
   "#shell-notification-layer",
@@ -111,7 +111,7 @@ async function expectCanonicalStructure(page) {
     const header = document.querySelector('.room-top[data-ui-region="shell-header"]');
     const workspace = document.querySelector('.room-layout[data-ui-region="workspace"]');
     const stage = document.querySelector('.room-main[data-ui-region="primary-stage"]');
-    const utility = document.querySelector('.room-sidebar[data-ui-region="utility-host"]');
+    const utility = document.querySelector('.utility-host[data-ui-region="utility-host"]');
     const dock = document.querySelector('#call-controls[data-ui-region="control-dock"]');
     const idCounts = new Map();
     document.querySelectorAll("[id]").forEach((element) => {
@@ -782,7 +782,7 @@ for (const viewport of [
 
     const stage = page.locator('.room-main[data-ui-region="primary-stage"]');
     const layout = page.locator('.room-layout[data-ui-region="workspace"]');
-    const utility = page.locator('.room-sidebar[data-ui-region="utility-host"]');
+    const utility = page.locator('.utility-host[data-ui-region="utility-host"]');
     const toggle = page.locator("#shell-toggle-utility");
     await expect.poll(() => stage.evaluate((element) => element.inert)).toBe(true);
 

--- a/core/viewer-tests/tests/shell.phase1.spec.js
+++ b/core/viewer-tests/tests/shell.phase1.spec.js
@@ -397,6 +397,323 @@ test("V2 keeps a nonzero usable stage when Chat is open at 800x600", async ({ pa
   await expectNoDocumentOverflow(page);
 });
 
+test("single-share presentation fills the grid independently of decoded resolution", async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 720 });
+  await openPhaseOneViewer(page, {
+    participants: 2,
+    cameras: 0,
+    screenShares: 1,
+    shareAspects: [16 / 9],
+  });
+  await expect(page.locator("html")).toHaveAttribute("data-ui-mode", "theater");
+
+  const grid = page.locator("#screen-grid");
+  const tile = grid.locator(":scope > .tile");
+  const video = tile.locator("video.screen-video-surface");
+  const fullscreen = tile.locator(".tile-fullscreen-btn");
+  const stageHeading = page.locator(".room-main .grid-header h2");
+  await expect(tile).toHaveCount(1);
+  await expect(video).toHaveCount(1);
+  await expect(fullscreen).toBeVisible();
+  await expect(stageHeading).not.toHaveCSS("display", "none");
+  await expect(stageHeading).toHaveCSS("position", "absolute");
+  await expect(page.getByRole("heading", { name: "The Stage" })).toHaveCount(1);
+
+  let baselineTile = null;
+  for (const decoded of [
+    { width: 320, height: 180 },
+    { width: 640, height: 360 },
+    { width: 1280, height: 720 },
+    { width: 1920, height: 1080 },
+  ]) {
+    await video.evaluate((element, dimensions) => {
+      Object.defineProperties(element, {
+        videoHeight: { configurable: true, get: () => dimensions.height },
+        videoWidth: { configurable: true, get: () => dimensions.width },
+      });
+      element.dispatchEvent(new Event("resize"));
+    }, decoded);
+    await page.evaluate(() => new Promise((resolve) => {
+      requestAnimationFrame(() => requestAnimationFrame(resolve));
+    }));
+
+    const presentation = await page.evaluate(() => {
+      function rect(element) {
+        const bounds = element.getBoundingClientRect();
+        return {
+          bottom: bounds.bottom,
+          height: bounds.height,
+          left: bounds.left,
+          right: bounds.right,
+          top: bounds.top,
+          width: bounds.width,
+        };
+      }
+      const gridElement = document.getElementById("screen-grid");
+      const tileElement = gridElement.querySelector(":scope > .tile");
+      const videoElement = tileElement.querySelector("video.screen-video-surface");
+      const fullscreenElement = tileElement.querySelector(".tile-fullscreen-btn");
+      const fullscreenStyle = getComputedStyle(fullscreenElement);
+      const gridRect = rect(gridElement);
+      const tileRect = rect(tileElement);
+      return {
+        decoded: { height: videoElement.videoHeight, width: videoElement.videoWidth },
+        fillRatio: (tileRect.width * tileRect.height) / (gridRect.width * gridRect.height),
+        fullscreen: rect(fullscreenElement),
+        fullscreenPosition: fullscreenStyle.position,
+        grid: gridRect,
+        objectFit: getComputedStyle(videoElement).objectFit,
+        tile: tileRect,
+        video: rect(videoElement),
+      };
+    });
+
+    expect(presentation.decoded, `${decoded.width}x${decoded.height} decoded size`).toEqual(decoded);
+    expect(presentation.fillRatio, `${decoded.width}px decoded width`).toBeGreaterThanOrEqual(0.95);
+    expect(presentation.objectFit).toBe("contain");
+    expect(presentation.fullscreenPosition).toBe("absolute");
+    expect(presentation.fullscreen.width).toBeGreaterThanOrEqual(39.5);
+    expect(presentation.fullscreen.width).toBeLessThanOrEqual(40.5);
+    expect(presentation.fullscreen.height).toBeGreaterThanOrEqual(39.5);
+    expect(presentation.fullscreen.height).toBeLessThanOrEqual(40.5);
+
+    for (const region of [presentation.tile, presentation.video, presentation.fullscreen]) {
+      expect(region.left).toBeGreaterThanOrEqual(presentation.grid.left - 1);
+      expect(region.right).toBeLessThanOrEqual(presentation.grid.right + 1);
+      expect(region.top).toBeGreaterThanOrEqual(presentation.grid.top - 1);
+      expect(region.bottom).toBeLessThanOrEqual(presentation.grid.bottom + 1);
+    }
+    expect(intersectionArea(presentation.fullscreen, presentation.video))
+      .toBeGreaterThanOrEqual(presentation.fullscreen.width * presentation.fullscreen.height * 0.95);
+
+    if (baselineTile) {
+      expect(Math.abs(presentation.tile.left - baselineTile.left)).toBeLessThanOrEqual(1);
+      expect(Math.abs(presentation.tile.top - baselineTile.top)).toBeLessThanOrEqual(1);
+      expect(Math.abs(presentation.tile.width - baselineTile.width)).toBeLessThanOrEqual(1);
+      expect(Math.abs(presentation.tile.height - baselineTile.height)).toBeLessThanOrEqual(1);
+    } else {
+      baselineTile = presentation.tile;
+    }
+  }
+
+  await expectContained(tile, grid);
+  await expectNoDocumentOverflow(page);
+});
+
+test("a retained hidden share enters solo presentation and restores the multi-share grid", async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 720 });
+  await openPhaseOneViewer(page, {
+    participants: 3,
+    cameras: 0,
+    screenShares: 2,
+    shareAspects: [16 / 9, 4 / 3],
+  });
+
+  const root = page.locator("html");
+  const grid = page.locator("#screen-grid");
+  const tiles = grid.locator(":scope > .tile");
+  const firstTile = tiles.nth(0);
+  const secondTile = tiles.nth(1);
+
+  await expect(tiles).toHaveCount(2);
+  await expect(grid).toHaveAttribute("data-visible-tiles", "2");
+  await expect(grid.locator(":scope > .tile[data-grid-visible]")).toHaveCount(2);
+  await expect.poll(() => grid.evaluate((element) => element.style.gridTemplateColumns)).not.toBe("");
+
+  // Production retains unpublished share tiles and hides them with display:none.
+  // The remaining visible tile must still receive the immersive solo treatment.
+  await secondTile.evaluate((element) => { element.style.display = "none"; });
+  await expect(grid).toHaveAttribute("data-visible-tiles", "1");
+  await expect(firstTile).toHaveAttribute("data-grid-visible", "");
+  await expect(secondTile).not.toHaveAttribute("data-grid-visible", "");
+  await expect(grid.locator(":scope > .tile[data-grid-visible]")).toHaveCount(1);
+
+  const solo = await page.evaluate(() => {
+    const gridElement = document.getElementById("screen-grid");
+    const tileElements = Array.from(gridElement.querySelectorAll(":scope > .tile"));
+    const gridRect = gridElement.getBoundingClientRect();
+    const visibleRect = tileElements[0].getBoundingClientRect();
+    return {
+      fillRatio: (visibleRect.width * visibleRect.height) / (gridRect.width * gridRect.height),
+      hiddenDisplay: getComputedStyle(tileElements[1]).display,
+      hiddenHeight: tileElements[1].getBoundingClientRect().height,
+      inlineColumns: gridElement.style.gridTemplateColumns,
+      inlineRows: gridElement.style.gridTemplateRows,
+    };
+  });
+  expect(solo.fillRatio).toBeGreaterThanOrEqual(0.95);
+  expect(solo.hiddenDisplay).toBe("none");
+  expect(solo.hiddenHeight).toBe(0);
+  expect(solo.inlineColumns).toBe("");
+  expect(solo.inlineRows).toBe("");
+  await expectContained(firstTile, grid);
+
+  await secondTile.evaluate((element) => { element.style.display = ""; });
+  await expect(grid).toHaveAttribute("data-visible-tiles", "2");
+  await expect(grid.locator(":scope > .tile[data-grid-visible]")).toHaveCount(2);
+  await expect.poll(() => grid.evaluate((element) => element.style.gridTemplateColumns)).not.toBe("");
+
+  const restored = await page.evaluate(() => {
+    function rect(element) {
+      const bounds = element.getBoundingClientRect();
+      return {
+        bottom: bounds.bottom,
+        height: bounds.height,
+        left: bounds.left,
+        right: bounds.right,
+        top: bounds.top,
+        width: bounds.width,
+      };
+    }
+    const gridElement = document.getElementById("screen-grid");
+    return {
+      grid: rect(gridElement),
+      tiles: Array.from(gridElement.querySelectorAll(":scope > .tile")).map(rect),
+    };
+  });
+  for (const tileRect of restored.tiles) {
+    expect(tileRect.left).toBeGreaterThanOrEqual(restored.grid.left - 1);
+    expect(tileRect.right).toBeLessThanOrEqual(restored.grid.right + 1);
+    expect(tileRect.top).toBeGreaterThanOrEqual(restored.grid.top - 1);
+    expect(tileRect.bottom).toBeLessThanOrEqual(restored.grid.bottom + 1);
+  }
+  expect(intersectionArea(restored.tiles[0], restored.tiles[1])).toBeLessThanOrEqual(1);
+
+  // Focused mode keeps ownership of its tracks while visibility state remains available.
+  await grid.evaluate((element) => { element.classList.add("is-focused"); });
+  await expect.poll(() => grid.evaluate((element) => element.style.gridTemplateColumns)).toBe("");
+  await expect(grid).toHaveAttribute("data-visible-tiles", "2");
+  await grid.evaluate((element) => { element.classList.remove("is-focused"); });
+  await expect.poll(() => grid.evaluate((element) => element.style.gridTemplateColumns)).not.toBe("");
+
+  // The published state is V2-only and must not leak into the legacy rollback.
+  await page.evaluate(() => window.EchoUiShell.applyVariant("legacy"));
+  await expect(root).toHaveAttribute("data-ui-shell", "legacy");
+  await expect.poll(() => grid.evaluate((element) => ({
+    columns: element.style.gridTemplateColumns,
+    rows: element.style.gridTemplateRows,
+    visibleMarkers: element.querySelectorAll(":scope > .tile[data-grid-visible]").length,
+    visibleTiles: element.getAttribute("data-visible-tiles"),
+  }))).toEqual({ columns: "", rows: "", visibleMarkers: 0, visibleTiles: null });
+});
+
+for (const stageCase of [
+  {
+    title: "theater",
+    viewport: { width: 1920, height: 1080 },
+    mode: "theater",
+    shellGap: 16,
+    screenShares: 4,
+  },
+  {
+    title: "lounge",
+    viewport: { width: 1024, height: 768 },
+    mode: "lounge",
+    shellGap: 16,
+    screenShares: 2,
+  },
+  {
+    title: "compact",
+    viewport: { width: 900, height: 540 },
+    mode: "compact",
+    shellGap: 12,
+    screenShares: 3,
+  },
+  {
+    title: "mini",
+    viewport: { width: 360, height: 640 },
+    mode: "mini",
+    shellGap: 8,
+    screenShares: 4,
+  },
+]) {
+  test(`${stageCase.title} active-share stage stays inside shell tracks without tile overlap`, async ({ page }) => {
+    await page.setViewportSize(stageCase.viewport);
+    await openPhaseOneViewer(page, {
+      participants: 4,
+      cameras: 0,
+      screenShares: stageCase.screenShares,
+      shareAspects: [16 / 9, 32 / 9, 4 / 3, 9 / 16].slice(0, stageCase.screenShares),
+    });
+    await expect(page.locator("html")).toHaveAttribute("data-ui-mode", stageCase.mode);
+
+    const header = page.locator('.room-top[data-ui-region="shell-header"]');
+    const workspace = page.locator('.room-layout[data-ui-region="workspace"]');
+    const stage = page.locator('.room-main[data-ui-region="primary-stage"]');
+    const gridHeader = stage.locator(".grid-header");
+    const grid = stage.locator("#screen-grid");
+    const dock = page.locator('#call-controls[data-ui-region="control-dock"]');
+    const tiles = grid.locator(":scope > .tile");
+
+    await expect(tiles).toHaveCount(stageCase.screenShares);
+    await expectContained(stage, workspace);
+    await expectContained(gridHeader, stage);
+    await expectContained(grid, stage);
+
+    const geometry = await page.evaluate(() => {
+      function rect(element) {
+        const bounds = element.getBoundingClientRect();
+        return {
+          bottom: bounds.bottom,
+          height: bounds.height,
+          left: bounds.left,
+          right: bounds.right,
+          top: bounds.top,
+          width: bounds.width,
+        };
+      }
+      const gridElement = document.getElementById("screen-grid");
+      return {
+        dock: rect(document.getElementById("call-controls")),
+        grid: rect(gridElement),
+        gridClientHeight: gridElement.clientHeight,
+        gridClientWidth: gridElement.clientWidth,
+        gridHeader: rect(document.querySelector(".room-main .grid-header")),
+        gridScrollHeight: gridElement.scrollHeight,
+        gridScrollWidth: gridElement.scrollWidth,
+        header: rect(document.querySelector('.room-top[data-ui-region="shell-header"]')),
+        stage: rect(document.querySelector('.room-main[data-ui-region="primary-stage"]')),
+        tiles: Array.from(gridElement.querySelectorAll(":scope > .tile")).map(rect),
+      };
+    });
+
+    expect(geometry.stage.top).toBeGreaterThanOrEqual(geometry.header.bottom + stageCase.shellGap - 1);
+    expect(geometry.stage.bottom).toBeLessThanOrEqual(geometry.dock.top - stageCase.shellGap + 1);
+    expect(geometry.gridHeader.bottom).toBeLessThanOrEqual(geometry.grid.top + 1);
+    expect(geometry.gridScrollWidth).toBeLessThanOrEqual(geometry.gridClientWidth + 1);
+    expect(geometry.gridScrollHeight).toBeLessThanOrEqual(geometry.gridClientHeight + 1);
+
+    for (const tileRect of geometry.tiles) {
+      expect(tileRect.width).toBeGreaterThan(1);
+      expect(tileRect.height).toBeGreaterThan(1);
+      expect(tileRect.left).toBeGreaterThanOrEqual(geometry.grid.left - 1);
+      expect(tileRect.right).toBeLessThanOrEqual(geometry.grid.right + 1);
+      expect(tileRect.top).toBeGreaterThanOrEqual(geometry.grid.top - 1);
+      expect(tileRect.bottom).toBeLessThanOrEqual(geometry.grid.bottom + 1);
+    }
+    for (let first = 0; first < geometry.tiles.length; first += 1) {
+      for (let second = first + 1; second < geometry.tiles.length; second += 1) {
+        expect(
+          intersectionArea(geometry.tiles[first], geometry.tiles[second]),
+          `${stageCase.title} tiles ${first + 1} and ${second + 1}`,
+        ).toBeLessThanOrEqual(1);
+      }
+    }
+
+    if (stageCase.mode === "theater") {
+      const utility = page.locator('.utility-host[data-ui-region="utility-host"]');
+      await expectNoOverlap(stage, utility);
+      const utilityRect = await utility.evaluate((element) => {
+        const bounds = element.getBoundingClientRect();
+        return { left: bounds.left };
+      });
+      expect(geometry.stage.right).toBeLessThanOrEqual(utilityRect.left - stageCase.shellGap + 1);
+    }
+
+    await expectNoDocumentOverflow(page);
+  });
+}
+
 test("V2 ellipsizes a 60-character unbroken name without overlapping camera controls", async ({ page }) => {
   await page.setViewportSize({ width: 640, height: 480 });
   await openPhaseOneViewer(page, {
@@ -768,7 +1085,9 @@ test("utility collapse reclaims theater stage width", async ({ page }) => {
   await expect(layout).toHaveClass(/utility-collapsed/);
   await expect(toggle).toHaveAttribute("aria-expanded", "false");
   const widthAfter = (await stage.boundingBox()).width;
+  const layoutWidth = (await layout.boundingBox()).width;
   expect(widthAfter).toBeGreaterThan(widthBefore + 200);
+  expect(widthAfter).toBeGreaterThanOrEqual(layoutWidth - 2);
 });
 
 for (const viewport of [

--- a/core/viewer-tests/tests/shell.phase1.spec.js
+++ b/core/viewer-tests/tests/shell.phase1.spec.js
@@ -714,7 +714,7 @@ for (const stageCase of [
   });
 }
 
-test("V2 ellipsizes a 60-character unbroken name without overlapping camera controls", async ({ page }) => {
+test("V2 ellipsizes a 60-character unbroken name without overlapping camera settings", async ({ page }) => {
   await page.setViewportSize({ width: 640, height: 480 });
   await openPhaseOneViewer(page, {
     participants: 4,
@@ -734,8 +734,7 @@ test("V2 ellipsizes a 60-character unbroken name without overlapping camera cont
   const cameraCard = page.locator(".user-card.has-camera").first();
   const overlay = cameraCard.locator(".cam-overlay");
   const overlayName = overlay.locator(".cam-overlay-name");
-  const overlayControls = overlay.locator(".cam-overlay-controls");
-  const focusTarget = overlayControls.locator("button:visible").first();
+  const focusTarget = cameraCard.locator(":scope > .participant-settings-toggle");
   await focusTarget.focus();
   await expect(focusTarget).toBeFocused();
 
@@ -756,28 +755,8 @@ test("V2 ellipsizes a 60-character unbroken name without overlapping camera cont
   await expect(overlayName).toHaveAttribute("title", longName);
   await expectSingleLineEllipsis(overlayName);
   await expectContained(overlayName, overlay);
-  await expectContained(overlayControls, overlay);
-  await expectNoOverlap(overlayName, overlayControls);
-
-  const controlRects = await overlayControls.locator(":scope > button:visible").evaluateAll((buttons) => (
-    buttons.map((button) => {
-      const rect = button.getBoundingClientRect();
-      return {
-        bottom: rect.bottom,
-        height: rect.height,
-        left: rect.left,
-        right: rect.right,
-        top: rect.top,
-        width: rect.width,
-      };
-    })
-  ));
-  expect(controlRects.length).toBeGreaterThan(0);
-  for (let first = 0; first < controlRects.length; first += 1) {
-    for (let second = first + 1; second < controlRects.length; second += 1) {
-      expect(intersectionArea(controlRects[first], controlRects[second])).toBeLessThanOrEqual(1);
-    }
-  }
+  await expectContained(focusTarget, cameraCard);
+  await expectNoOverlap(overlayName, focusTarget);
   await expectNoDocumentOverflow(page);
 });
 
@@ -852,15 +831,15 @@ for (const viewport of [
   { width: 800, height: 600, mode: "compact" },
   { width: 600, height: 900, mode: "mini" },
 ]) {
-  test(`${viewport.mode} camera volume popup stays contained and all sliders are hittable`, async ({ page }) => {
+  test(`${viewport.mode} camera audio settings stay contained and all sliders are hittable`, async ({ page }) => {
     await page.setViewportSize(viewport);
     await openPhaseOneViewer(page, { participants: 3, cameras: 1, screenShares: 0 });
     await expect(page.locator("html")).toHaveAttribute("data-ui-mode", viewport.mode);
 
     const card = page.locator(".user-card.is-remote.has-camera").first();
     await card.evaluate((element) => element.scrollIntoView({ block: "nearest" }));
-    await card.locator(".cam-overlay-controls .icon-button").first().click();
-    const popup = card.locator(".vol-popup");
+    await card.locator(".participant-settings-toggle").click();
+    const popup = card.locator(".participant-settings-popover");
     await expect(popup).toHaveClass(/is-open/);
     await expect(popup).toBeVisible();
 
@@ -869,11 +848,12 @@ for (const viewport of [
         const rect = node.getBoundingClientRect();
         return { bottom: rect.bottom, left: rect.left, right: rect.right, top: rect.top };
       };
-      const popupElement = element.querySelector(".vol-popup");
+      const popupElement = element.querySelector(".participant-settings-popover");
       const sliders = Array.from(popupElement.querySelectorAll('input[type="range"]'));
       return {
         card: toRect(element),
         popup: toRect(popupElement),
+        viewport: { height: window.innerHeight, width: window.innerWidth },
         sliders: sliders.map((slider) => {
           const rect = slider.getBoundingClientRect();
           const hit = document.elementFromPoint(rect.left + (rect.width / 2), rect.top + (rect.height / 2));
@@ -882,10 +862,10 @@ for (const viewport of [
       };
     });
     expect(geometry.sliders).toHaveLength(3);
-    expect(geometry.popup.left).toBeGreaterThanOrEqual(geometry.card.left - 1);
-    expect(geometry.popup.right).toBeLessThanOrEqual(geometry.card.right + 1);
-    expect(geometry.popup.top).toBeGreaterThanOrEqual(geometry.card.top - 1);
-    expect(geometry.popup.bottom).toBeLessThanOrEqual(geometry.card.bottom + 1);
+    expect(geometry.popup.left).toBeGreaterThanOrEqual(0);
+    expect(geometry.popup.right).toBeLessThanOrEqual(geometry.viewport.width);
+    expect(geometry.popup.top).toBeGreaterThanOrEqual(0);
+    expect(geometry.popup.bottom).toBeLessThanOrEqual(geometry.viewport.height);
     expect(geometry.sliders.every((slider) => slider.hittable)).toBe(true);
   });
 }
@@ -1223,7 +1203,7 @@ test("screen volume becomes visible and interactive on keyboard focus", async ({
   expect(await tile.evaluate((element) => element.matches(":focus-within"))).toBe(true);
 });
 
-test("participant chime and mute controls expose participant-specific accessible names", async ({ page }) => {
+test("one participant audio menu owns voice, shared-audio, and chime controls", async ({ page }) => {
   await page.setViewportSize({ width: 1024, height: 768 });
   await openPhaseOneViewer(page, { participants: 3, cameras: 1, screenShares: 0 });
 
@@ -1234,28 +1214,82 @@ test("participant chime and mute controls expose participant-specific accessible
     const participantName = (await card.locator(".user-name").textContent()).trim();
     const escapedName = participantName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
     const namedForParticipant = new RegExp(escapedName, "i");
-    const chimeToggle = card.locator(".participant-chime-toggle");
-    const chimeSlider = card.locator(".chime-volume-row input[type=range]");
-    await expect(chimeToggle).toHaveAttribute("aria-label", namedForParticipant);
-    await expect(chimeSlider).toHaveAttribute("aria-label", namedForParticipant);
+    const settingsToggle = card.locator(".participant-settings-toggle");
+    await expect(settingsToggle).toHaveCount(1);
+    await expect(settingsToggle).toBeVisible();
+    await expect(settingsToggle).toHaveAccessibleName(namedForParticipant);
+
+    await settingsToggle.click();
+    const popup = card.locator(".participant-settings-popover");
+    await expect(popup).toBeVisible();
+    await expect(popup).toHaveAttribute("role", "dialog");
+    await expect(popup).toHaveAccessibleName(namedForParticipant);
+    await expect(popup.locator('input[type="range"]')).toHaveCount(3);
+    await expect(popup.getByLabel(new RegExp(`Microphone volume.*${escapedName}`, "i"))).toBeVisible();
+    await expect(popup.getByLabel(new RegExp(`Screen volume.*${escapedName}`, "i"))).toBeVisible();
+    await expect(popup.getByLabel(new RegExp(`Chime volume.*${escapedName}`, "i"))).toBeVisible();
+    await expect(popup.getByRole("button", { name: new RegExp(`Mute microphone audio.*${escapedName}`, "i") })).toBeVisible();
+    await expect(popup.getByRole("button", { name: new RegExp(`Mute screen audio.*${escapedName}`, "i") })).toBeVisible();
+
+    await page.keyboard.press("Escape");
+    await expect(popup).toBeHidden();
+    await expect(settingsToggle).toBeFocused();
+
     const baseMuteButtons = card.locator(".user-indicators .mute-button");
     await expect(baseMuteButtons).toHaveCount(2);
     for (let muteIndex = 0; muteIndex < 2; muteIndex += 1) {
       await expect(baseMuteButtons.nth(muteIndex)).toHaveAttribute("aria-label", namedForParticipant);
-    }
-    if (await card.evaluate((element) => !element.classList.contains("has-camera"))) {
-      await expect(chimeToggle).toHaveAccessibleName(namedForParticipant);
-      for (let muteIndex = 0; muteIndex < 2; muteIndex += 1) {
-        await expect(baseMuteButtons.nth(muteIndex)).toHaveAccessibleName(namedForParticipant);
-      }
+      await expect(baseMuteButtons.nth(muteIndex)).toBeHidden();
     }
   }
 
-  const cameraCard = page.locator(".user-card.is-remote.has-camera").first();
-  const cameraName = (await cameraCard.locator(".user-name").textContent()).trim();
-  const cameraNamePattern = new RegExp(cameraName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "i");
-  const overlayMutes = cameraCard.locator(".cam-overlay .mute-button");
-  await expect(overlayMutes).toHaveCount(2);
-  await expect(overlayMutes.nth(0)).toHaveAccessibleName(cameraNamePattern);
-  await expect(overlayMutes.nth(1)).toHaveAccessibleName(cameraNamePattern);
+  const firstCard = remoteCards.nth(0);
+  const secondCard = remoteCards.nth(1);
+  const firstToggle = firstCard.locator(".participant-settings-toggle");
+  const secondToggle = secondCard.locator(".participant-settings-toggle");
+  await firstToggle.click();
+  await secondToggle.click();
+  await expect(firstCard.locator(".participant-settings-popover")).toBeHidden();
+  await expect(firstToggle).toHaveAttribute("aria-expanded", "false");
+  await expect(secondCard.locator(".participant-settings-popover")).toBeVisible();
+
+  const secondPopup = secondCard.locator(".participant-settings-popover");
+  const voiceMute = secondPopup.locator(".participant-settings-mute").nth(0);
+  const screenMute = secondPopup.locator(".participant-settings-mute").nth(1);
+  await secondCard.evaluate((card) => {
+    participantCards.get(card.dataset.identity).setParticipantDisplayName("Renamed member");
+  });
+  await expect(secondToggle).toHaveAccessibleName(/Renamed member/i);
+  await expect(secondPopup).toHaveAccessibleName(/Renamed member/i);
+  await expect(secondPopup.getByLabel(/Microphone volume.*Renamed member/i)).toBeVisible();
+  await voiceMute.click();
+  await expect(voiceMute).toHaveAccessibleName(/Unmute microphone audio.*Renamed member/i);
+  await expect(screenMute).toHaveAccessibleName(/Mute screen audio/i);
+
+  const settingsChime = secondPopup.getByLabel(/Chime volume/i);
+  await settingsChime.evaluate((slider) => {
+    slider.value = "0.72";
+    slider.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+  await expect(secondCard.locator(".chime-volume-row input[type=range]")).toHaveValue("0.72");
+
+  await page.locator("#room-sidebar .sidebar-title-row h2").click();
+  await expect(secondPopup).toBeHidden();
+
+  const nonCameraCard = page.locator(".user-card.is-remote:not(.has-camera)").first();
+  const nonCameraGeometry = await nonCameraCard.evaluate((element) => {
+    const avatar = element.querySelector(".user-avatar").getBoundingClientRect();
+    const toggle = element.querySelector(".participant-settings-toggle").getBoundingClientRect();
+    const card = element.getBoundingClientRect();
+    return { avatarWidth: avatar.width, cardRight: card.right, toggleRight: toggle.right };
+  });
+  expect(nonCameraGeometry.avatarWidth).toBeGreaterThanOrEqual(53.5);
+  expect(nonCameraGeometry.toggleRight).toBeLessThanOrEqual(nonCameraGeometry.cardRight + 1);
+
+  await page.evaluate(() => window.EchoUiShell.applyVariant("legacy"));
+  await expect(page.locator("html")).toHaveAttribute("data-ui-shell", "legacy");
+  await expect(nonCameraCard.locator(".participant-settings-toggle")).toBeHidden();
+  for (let muteIndex = 0; muteIndex < 2; muteIndex += 1) {
+    await expect(nonCameraCard.locator(".user-indicators .mute-button").nth(muteIndex)).toBeVisible();
+  }
 });

--- a/core/viewer-tests/tests/shell.phase2.utility.spec.js
+++ b/core/viewer-tests/tests/shell.phase2.utility.spec.js
@@ -1,0 +1,533 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, test } from "@playwright/test";
+
+const testDirectory = path.dirname(fileURLToPath(import.meta.url));
+const fixturePath = path.resolve(testDirectory, "..", "fixtures", "install-scenario.js");
+const runtimeErrors = new WeakMap();
+const apiModels = new WeakMap();
+const transparentPng = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=",
+  "base64",
+);
+const transparentDataUrl = `data:image/png;base64,${transparentPng.toString("base64")}`;
+
+function longText(label) {
+  return `${label} ${"Private Clubhouse Fellowship Anthem ".repeat(4).trim()}`;
+}
+
+function createJamState() {
+  return {
+    jam_protocol_version: 3,
+    active: true,
+    generation: 7,
+    spotify_connected: true,
+    spotify_is_playing: true,
+    playback_stop_supported: true,
+    source_enabled: true,
+    source_availability_known: true,
+    source_status: "live",
+    source_ready: true,
+    source_last_frame_ms: 24,
+    source_peak: 0.42,
+    host_identity: "layout-fixture-1",
+    listener_count: 2,
+    listeners: ["layout-fixture-2", "layout-fixture-3"],
+    now_playing: {
+      name: longText("Now Playing"),
+      artist: longText("The Extremely Long Artist Name"),
+      album_art_url: transparentDataUrl,
+      duration_ms: 240_000,
+      progress_ms: 91_000,
+      is_playing: true,
+    },
+    queue: Array.from({ length: 8 }, (_, index) => ({
+      spotify_uri: `spotify:track:queue-${index + 1}`,
+      name: longText(`Queued Song ${index + 1}`),
+      artist: longText(`Queued Artist ${index + 1}`),
+      album_art_url: transparentDataUrl,
+      duration_ms: 180_000 + index * 1_000,
+      added_by: `Friend ${index + 2}`,
+    })),
+  };
+}
+
+function createSearchTracks() {
+  return Array.from({ length: 6 }, (_, index) => ({
+    spotify_uri: `spotify:track:search-${index + 1}`,
+    name: longText(`Search Result ${index + 1}`),
+    artist: longText(`Search Artist ${index + 1}`),
+    album_art_url: transparentDataUrl,
+    duration_ms: 201_000 + index * 1_000,
+  }));
+}
+
+function increment(model, key) {
+  model.counts[key] = (model.counts[key] || 0) + 1;
+}
+
+test.beforeEach(async ({ page }) => {
+  const errors = [];
+  const model = {
+    counts: Object.create(null),
+    errors,
+    searchTracks: createSearchTracks(),
+    state: createJamState(),
+  };
+  runtimeErrors.set(page, errors);
+  apiModels.set(page, model);
+
+  page.on("pageerror", (error) => errors.push(`pageerror: ${error.message}`));
+  page.on("console", (message) => {
+    if (message.type() === "error") errors.push(`console.error: ${message.text()}`);
+  });
+
+  await page.route("**/api/**", async (route) => {
+    const request = route.request();
+    const url = new URL(request.url());
+    const key = `${request.method()} ${url.pathname}`;
+
+    if (url.pathname === "/api/online") {
+      await route.fulfill({ status: 200, contentType: "application/json", body: "[]" });
+      return;
+    }
+    if (url.pathname.startsWith("/api/avatar/")) {
+      await route.fulfill({ status: 200, contentType: "image/png", body: transparentPng });
+      return;
+    }
+    if (url.pathname === "/api/version") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ latest_client: "" }),
+      });
+      return;
+    }
+    if (url.pathname === "/api/jam/state" && request.method() === "GET") {
+      increment(model, key);
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(model.state),
+      });
+      return;
+    }
+    if (url.pathname === "/api/jam/search" && request.method() === "POST") {
+      increment(model, key);
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ tracks: model.searchTracks }),
+      });
+      return;
+    }
+    if (url.pathname === "/api/jam/playback/stop" && request.method() === "POST") {
+      increment(model, key);
+      model.state.spotify_is_playing = false;
+      if (model.state.now_playing) model.state.now_playing.is_playing = false;
+      await route.fulfill({ status: 200, contentType: "application/json", body: "{}" });
+      return;
+    }
+    if (url.pathname === "/api/jam/stop" && request.method() === "POST") {
+      increment(model, key);
+      model.state.active = false;
+      model.state.spotify_is_playing = false;
+      model.state.now_playing = null;
+      await route.fulfill({ status: 200, contentType: "application/json", body: "{}" });
+      return;
+    }
+
+    errors.push(`unexpected API request: ${key}`);
+    await route.fulfill({
+      status: 501,
+      contentType: "application/json",
+      body: JSON.stringify({ error: "unmodeled Phase 2 viewer-test endpoint" }),
+    });
+  });
+});
+
+test.afterEach(async ({ page }) => {
+  await page.waitForTimeout(25);
+  expect(runtimeErrors.get(page) || [], "production page must run without runtime errors").toEqual([]);
+});
+
+async function nextPaint(page) {
+  await page.evaluate(() => new Promise((resolve) => {
+    requestAnimationFrame(() => requestAnimationFrame(resolve));
+  }));
+}
+
+async function openPhaseTwoViewer(page, scenario = {}) {
+  await page.goto("/?echo-ui-shell-v2=1", { waitUntil: "domcontentloaded" });
+  await expect(page.locator("html")).toHaveAttribute("data-ui-shell", "v2");
+  await page.addScriptTag({ path: fixturePath });
+  await page.evaluate((options) => window.EchoLayoutTestScenario.install(options), {
+    participants: 6,
+    cameras: 2,
+    screenShares: 1,
+    ...scenario,
+  });
+  await page.evaluate(() => {
+    room = {
+      localParticipant: {
+        identity: "layout-fixture-1",
+        name: "Fixture Host",
+        publishData: async function() {},
+      },
+    };
+    adminToken = "phase-2-admin-token";
+    currentAccessToken = "phase-2-participant-token";
+    ["open-chat", "open-jam", "dock-output", "open-settings"].forEach((id) => {
+      const element = document.getElementById(id);
+      if (element) element.disabled = false;
+    });
+  });
+  await nextPaint(page);
+}
+
+async function openJam(page) {
+  const button = page.locator("#open-jam");
+  await expect(button).toBeVisible();
+  await button.click();
+  await expect(page.locator("#jam-panel")).toBeVisible();
+  await expect(page.locator("#jam-spotify-status")).toHaveText("Spotify Connected");
+  await expect(page.locator("#jam-search-section")).toBeVisible();
+}
+
+async function searchJam(page, query = "clubhouse") {
+  const input = page.locator("#jam-search-input");
+  await input.fill(query);
+  await expect(page.locator(".jam-result-item")).toHaveCount(6);
+}
+
+async function expectActiveTool(page, tool) {
+  await expect(page.locator("#utility-host")).toHaveAttribute("data-active-tool", tool);
+  await expect(page.locator("html")).toHaveAttribute("data-ui-utility", tool);
+  const state = await page.evaluate((activeTool) => {
+    const tools = {
+      people: document.getElementById("room-sidebar"),
+      chat: document.getElementById("chat-panel"),
+      jam: document.getElementById("jam-panel"),
+    };
+    return Object.fromEntries(Object.entries(tools).map(([name, element]) => [name, {
+      ariaHidden: element.getAttribute("aria-hidden"),
+      hidden: element.classList.contains("hidden"),
+      inert: element.inert,
+      rendered: element.getClientRects().length > 0 && getComputedStyle(element).visibility !== "hidden",
+      expected: name === activeTool,
+    }]));
+  }, tool);
+
+  for (const [name, value] of Object.entries(state)) {
+    expect(value.rendered, `${name} rendered state`).toBe(value.expected);
+    expect(value.hidden, `${name} hidden class`).toBe(!value.expected);
+    expect(value.inert, `${name} inert state`).toBe(!value.expected);
+    expect(value.ariaHidden, `${name} aria-hidden state`).toBe(value.expected ? "false" : "true");
+  }
+}
+
+async function resizeTo(page, viewport, expectedMode) {
+  await page.setViewportSize(viewport);
+  await expect.poll(() => page.evaluate(() => ({
+    height: window.innerHeight,
+    width: window.innerWidth,
+  }))).toEqual(viewport);
+  await nextPaint(page);
+  await expect(page.locator("html")).toHaveAttribute("data-ui-mode", expectedMode);
+}
+
+test("one logical utility owns stable People, Chat, and portaled Jam tools without losing form state", async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 720 });
+  await openPhaseTwoViewer(page);
+
+  const structure = await page.evaluate(() => {
+    const host = document.getElementById("utility-host");
+    const overlay = document.getElementById("shell-overlay-root");
+    const jam = document.getElementById("jam-panel");
+    window.__phase2JamNode = jam;
+    return {
+      ariaOwns: host.getAttribute("aria-owns"),
+      chatInsideHost: host.contains(document.getElementById("chat-panel")),
+      jamInsideHost: host.contains(jam),
+      jamInsideOverlay: overlay.contains(jam),
+      jamCount: document.querySelectorAll("#jam-panel").length,
+      peopleInsideHost: host.contains(document.getElementById("room-sidebar")),
+      toolCount: document.querySelectorAll("[data-ui-tool]").length,
+    };
+  });
+  expect(structure).toEqual({
+    ariaOwns: "jam-panel",
+    chatInsideHost: true,
+    jamInsideHost: false,
+    jamInsideOverlay: true,
+    jamCount: 1,
+    peopleInsideHost: true,
+    toolCount: 3,
+  });
+  await expectActiveTool(page, "people");
+
+  await page.locator("#open-chat").click();
+  await expectActiveTool(page, "chat");
+  await page.locator("#chat-input").fill("A clubhouse Chat draft that must survive tool switches");
+
+  await page.keyboard.press("Escape");
+  await expectActiveTool(page, "people");
+  await expect(page.locator("#open-chat")).toBeFocused();
+
+  await openJam(page);
+  await expectActiveTool(page, "jam");
+  await searchJam(page);
+  await page.locator("#jam-volume-slider").evaluate((input) => {
+    input.value = "73";
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+  await expect(page.locator("#jam-volume-value")).toHaveText("73%");
+  await page.locator(".jam-body").evaluate((body) => { body.scrollTop = body.scrollHeight; });
+  const jamScrollTop = await page.locator(".jam-body").evaluate((body) => body.scrollTop);
+  expect(jamScrollTop).toBeGreaterThan(0);
+
+  await page.locator("#shell-toggle-utility").click();
+  await expect(page.locator(".room-layout")).toHaveClass(/utility-collapsed/);
+  await expect(page.locator("#jam-panel")).toBeHidden();
+  await expect.poll(() => page.locator("#jam-panel").evaluate((panel) => panel.inert)).toBe(true);
+  await expect.poll(() => page.locator("#utility-host").evaluate((host) => host.inert)).toBe(true);
+
+  await page.locator("#shell-toggle-utility").click();
+  await expectActiveTool(page, "jam");
+  await page.locator("#close-jam").click();
+  await expectActiveTool(page, "people");
+  await page.locator("#open-chat").click();
+  await expectActiveTool(page, "chat");
+  await expect(page.locator("#chat-input")).toHaveValue("A clubhouse Chat draft that must survive tool switches");
+
+  await page.keyboard.press("Escape");
+  await page.locator("#open-jam").click();
+  await expectActiveTool(page, "jam");
+  await expect(page.locator("#jam-search-input")).toHaveValue("clubhouse");
+  await expect(page.locator(".jam-result-item")).toHaveCount(6);
+  await expect(page.locator("#jam-volume-slider")).toHaveValue("73");
+  expect(await page.locator(".jam-body").evaluate((body) => body.scrollTop)).toBe(jamScrollTop);
+  expect(await page.evaluate(() => window.__phase2JamNode === document.getElementById("jam-panel"))).toBe(true);
+});
+
+test("responsive modes and live legacy rollback retain the same centered Jam node and state", async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 720 });
+  await openPhaseTwoViewer(page);
+  await openJam(page);
+  await searchJam(page, "anthem");
+  await page.locator("#jam-volume-slider").evaluate((input) => {
+    input.value = "64";
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+  await page.evaluate(() => { window.__phase2ResponsiveJamNode = document.getElementById("jam-panel"); });
+
+  for (const [viewport, expectedMode] of [
+    [{ width: 900, height: 700 }, "lounge"],
+    [{ width: 600, height: 900 }, "compact"],
+    [{ width: 360, height: 640 }, "mini"],
+  ]) {
+    await resizeTo(page, viewport, expectedMode);
+    await expectActiveTool(page, "jam");
+    expect(await page.evaluate(() => window.__phase2ResponsiveJamNode === document.getElementById("jam-panel"))).toBe(true);
+    await expect(page.locator("#jam-search-input")).toHaveValue("anthem");
+    await expect(page.locator("#jam-volume-slider")).toHaveValue("64");
+  }
+
+  await page.evaluate(() => window.EchoUiShell.applyVariant("legacy"));
+  await expect(page.locator("html")).toHaveAttribute("data-ui-shell", "legacy");
+  await expect(page.locator("#jam-panel")).toBeVisible();
+  const legacy = await page.locator("#jam-panel").evaluate((panel) => {
+    const rect = panel.getBoundingClientRect();
+    return {
+      centerX: rect.left + rect.width / 2,
+      centerY: rect.top + rect.height / 2,
+      sameNode: window.__phase2ResponsiveJamNode === panel,
+      viewportCenterX: window.innerWidth / 2,
+      viewportCenterY: window.innerHeight / 2,
+    };
+  });
+  expect(legacy.sameNode).toBe(true);
+  expect(Math.abs(legacy.centerX - legacy.viewportCenterX)).toBeLessThanOrEqual(1);
+  expect(Math.abs(legacy.centerY - legacy.viewportCenterY)).toBeLessThanOrEqual(1);
+  await expect(page.locator("#jam-search-input")).toHaveValue("anthem");
+  await expect(page.locator("#jam-volume-slider")).toHaveValue("64");
+
+  await page.evaluate(() => window.EchoUiShell.applyVariant("v2"));
+  await expect(page.locator("html")).toHaveAttribute("data-ui-shell", "v2");
+  await expectActiveTool(page, "jam");
+  expect(await page.evaluate(() => window.__phase2ResponsiveJamNode === document.getElementById("jam-panel"))).toBe(true);
+});
+
+test("Jam focus returns through Escape and Settings explicitly inerts the portaled tool", async ({ page }) => {
+  await page.setViewportSize({ width: 1024, height: 768 });
+  await openPhaseTwoViewer(page);
+  await openJam(page);
+
+  await expect(page.locator("#close-jam")).toBeFocused();
+  await page.keyboard.press("Escape");
+  await expectActiveTool(page, "people");
+  await expect(page.locator("#open-jam")).toBeFocused();
+
+  await page.locator("#open-jam").click();
+  await expectActiveTool(page, "jam");
+  const output = page.locator("#dock-output");
+  await output.click();
+  await expect(page.locator("#settings-panel")).toBeVisible();
+  await expect(page.locator("#settings-panel")).toHaveAttribute("aria-modal", "");
+  await expect(page.locator("#close-settings")).toBeFocused();
+  await expect.poll(() => page.locator("#clubhouse-shell").evaluate((shell) => shell.inert)).toBe(true);
+  await expect.poll(() => page.locator("#jam-panel").evaluate((panel) => panel.inert)).toBe(true);
+
+  await page.keyboard.press("Escape");
+  await expect(page.locator("#settings-panel")).toBeHidden();
+  await expect(output).toBeFocused();
+  await expect(page.locator("#jam-panel")).toBeVisible();
+  await expect.poll(() => page.locator("#jam-panel").evaluate((panel) => panel.inert)).toBe(false);
+  await expectActiveTool(page, "jam");
+
+  await page.keyboard.press("Escape");
+  await expectActiveTool(page, "people");
+  await expect(page.locator("#open-jam")).toBeFocused();
+});
+
+test("collapsed Chat records unread messages and a top overlay owns the first Escape", async ({ page }) => {
+  await page.setViewportSize({ width: 1024, height: 768 });
+  await openPhaseTwoViewer(page);
+
+  await page.locator("#open-chat").click();
+  await expectActiveTool(page, "chat");
+  await page.locator("#shell-toggle-utility").click();
+  await expect(page.locator(".room-layout")).toHaveClass(/utility-collapsed/);
+
+  await page.evaluate(() => incrementUnreadChat());
+  await expect(page.locator("#chat-badge")).toHaveText("1");
+  await expect(page.locator("#chat-badge")).not.toHaveClass(/hidden/);
+
+  await page.locator("#shell-toggle-utility").click();
+  await expectActiveTool(page, "chat");
+  await expect(page.locator("#chat-badge")).toHaveClass(/hidden/);
+
+  await page.evaluate((src) => openImageLightbox(src), transparentDataUrl);
+  await expect(page.locator(".image-lightbox")).toBeVisible();
+  await page.keyboard.press("Escape");
+  await expect(page.locator(".image-lightbox")).toHaveCount(0);
+  await expectActiveTool(page, "chat");
+
+  await page.keyboard.press("Escape");
+  await expectActiveTool(page, "people");
+});
+
+test("populated Jam remains inside the workspace and above the dock at representative sizes", async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 720 });
+  await openPhaseTwoViewer(page, { unbrokenNames: true });
+  await openJam(page);
+  await searchJam(page, "responsive");
+
+  for (const [viewport, expectedMode] of [
+    [{ width: 1280, height: 720 }, "theater"],
+    [{ width: 900, height: 700 }, "lounge"],
+    [{ width: 600, height: 900 }, "compact"],
+    [{ width: 360, height: 640 }, "mini"],
+  ]) {
+    await resizeTo(page, viewport, expectedMode);
+    const geometry = await page.evaluate(() => {
+      function rect(selector) {
+        const bounds = document.querySelector(selector).getBoundingClientRect();
+        return {
+          bottom: bounds.bottom,
+          height: bounds.height,
+          left: bounds.left,
+          right: bounds.right,
+          top: bounds.top,
+          width: bounds.width,
+        };
+      }
+      const targetSizes = Array.from(document.querySelectorAll(
+        "#jam-panel button:not(.hidden):not([style*='display:none']):not([style*='display: none'])",
+      )).filter((button) => getComputedStyle(button).display !== "none").map((button) => {
+        const bounds = button.getBoundingClientRect();
+        return { height: bounds.height, id: button.id || button.className, width: bounds.width };
+      });
+      const textOverflow = Array.from(document.querySelectorAll(
+        "#jam-panel .jam-result-info, #jam-panel .jam-now-playing-info, #jam-panel .jam-result-name, #jam-panel .jam-result-artist",
+      )).some((element) => element.scrollWidth > element.clientWidth + 1 && getComputedStyle(element).overflowX === "visible");
+      return {
+        bodyOverflowX: document.body.scrollWidth - window.innerWidth,
+        documentOverflowX: document.documentElement.scrollWidth - window.innerWidth,
+        dock: rect("#call-controls"),
+        header: rect('.room-top[data-ui-region="shell-header"]'),
+        jam: rect("#jam-panel"),
+        search: rect("#jam-search-input"),
+        targetSizes,
+        textOverflow,
+        viewport: { height: window.innerHeight, width: window.innerWidth },
+        workspace: rect('.room-layout[data-ui-region="workspace"]'),
+      };
+    });
+
+    expect(geometry.jam.left).toBeGreaterThanOrEqual(geometry.workspace.left - 1);
+    expect(geometry.jam.right).toBeLessThanOrEqual(geometry.workspace.right + 1);
+    expect(geometry.jam.top).toBeGreaterThanOrEqual(geometry.workspace.top - 1);
+    expect(geometry.jam.bottom).toBeLessThanOrEqual(geometry.workspace.bottom + 1);
+    expect(geometry.jam.top).toBeGreaterThanOrEqual(geometry.header.bottom - 1);
+    expect(geometry.jam.bottom).toBeLessThanOrEqual(geometry.dock.top - 1);
+    expect(geometry.search.top).toBeGreaterThanOrEqual(geometry.jam.top - 1);
+    expect(geometry.search.bottom).toBeLessThanOrEqual(geometry.jam.bottom + 1);
+    expect(geometry.documentOverflowX).toBeLessThanOrEqual(1);
+    expect(geometry.bodyOverflowX).toBeLessThanOrEqual(1);
+    expect(geometry.textOverflow).toBe(false);
+    expect(geometry.targetSizes.length).toBeGreaterThan(4);
+    for (const target of geometry.targetSizes) {
+      expect(target.height, `${target.id} height at ${viewport.width}x${viewport.height}`).toBeGreaterThanOrEqual(39.5);
+      expect(target.width, `${target.id} width at ${viewport.width}x${viewport.height}`).toBeGreaterThanOrEqual(39.5);
+    }
+  }
+});
+
+test("Stop Music preserves the Jam while exact-host End Jam remains a distinct destructive action", async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 720 });
+  await openPhaseTwoViewer(page);
+  await openJam(page);
+  const model = apiModels.get(page);
+  const stopMusic = page.locator("#jam-stop-music-btn");
+  const endJam = page.locator("#jam-end-btn");
+
+  await expect(stopMusic).toBeVisible();
+  await expect(endJam).toBeVisible();
+  await expect(stopMusic).toHaveAttribute("title", /Jam stays open/);
+  await expect(endJam).toHaveAttribute("title", /Ends the Jam/);
+  const visualDistinction = await page.evaluate(() => {
+    const stopStyle = getComputedStyle(document.getElementById("jam-stop-music-btn"));
+    const endStyle = getComputedStyle(document.getElementById("jam-end-btn"));
+    return {
+      backgroundDifferent: stopStyle.backgroundColor !== endStyle.backgroundColor,
+      borderDifferent: stopStyle.borderColor !== endStyle.borderColor,
+      colorDifferent: stopStyle.color !== endStyle.color,
+    };
+  });
+  expect(Object.values(visualDistinction).some(Boolean)).toBe(true);
+
+  await stopMusic.click();
+  await expect.poll(() => model.counts["POST /api/jam/playback/stop"] || 0).toBe(1);
+  expect(model.counts["POST /api/jam/stop"] || 0).toBe(0);
+  await expect(page.locator("#jam-panel")).toBeVisible();
+  await expectActiveTool(page, "jam");
+  await expect(page.locator("#jam-now-playing")).toContainText("No music playing");
+  expect(model.state.active).toBe(true);
+  expect(model.state.generation).toBe(7);
+  expect(model.state.listeners).toEqual(["layout-fixture-2", "layout-fixture-3"]);
+
+  model.state.host_identity = "layout-fixture-1-RECONNECTED";
+  await page.evaluate(() => fetchJamState());
+  await expect(endJam).toBeHidden();
+  await expect(stopMusic).toBeVisible();
+
+  model.state.host_identity = "layout-fixture-1";
+  await page.evaluate(() => fetchJamState());
+  await expect(endJam).toBeVisible();
+  await endJam.click();
+  await expect.poll(() => model.counts["POST /api/jam/stop"] || 0).toBe(1);
+  expect(model.counts["POST /api/jam/playback/stop"] || 0).toBe(1);
+  expect(model.state.active).toBe(false);
+  await expect(endJam).toBeHidden();
+});

--- a/core/viewer-tests/tests/shell.phase2.utility.spec.js
+++ b/core/viewer-tests/tests/shell.phase2.utility.spec.js
@@ -194,6 +194,28 @@ async function openJam(page) {
   await expect(page.locator("#jam-search-section")).toBeVisible();
 }
 
+async function showSourcePcControls(page) {
+  await page.evaluate(() => {
+    if (_jamPollTimer) {
+      clearInterval(_jamPollTimer);
+      _jamPollTimer = null;
+    }
+    _jamSourceLocalControlPending = false;
+    _jamSourceLocalControlLegacy = false;
+    _jamSourceLocalControl = {
+      is_source_host: true,
+      takeover_enabled: true,
+      monitor_enabled: true,
+      takeover_active: true,
+      agent_running: true,
+      target_device_name: "Phase 2 Spotify fixture",
+      last_error: "",
+    };
+    renderJamSourceLocalControl();
+  });
+  await expect(page.locator("#jam-panel [data-jam-source-local-card]")).toBeVisible();
+}
+
 async function searchJam(page, query = "clubhouse") {
   const input = page.locator("#jam-search-input");
   await input.fill(query);
@@ -308,6 +330,84 @@ test("one logical utility owns stable People, Chat, and portaled Jam tools witho
   await expect(page.locator("#jam-volume-slider")).toHaveValue("73");
   expect(await page.locator(".jam-body").evaluate((body) => body.scrollTop)).toBe(jamScrollTop);
   expect(await page.evaluate(() => window.__phase2JamNode === document.getElementById("jam-panel"))).toBe(true);
+});
+
+test("utility navigation uses stable Tools labels instead of changing meanings", async ({ page }) => {
+  await page.setViewportSize({ width: 1024, height: 768 });
+  await openPhaseTwoViewer(page);
+
+  const utilityToggle = page.locator("#shell-toggle-utility");
+  await expect(utilityToggle).toHaveText("Tools");
+  await expect(utilityToggle).toHaveAttribute("aria-label", "Hide clubhouse tools");
+  await expect(page.locator("#room-sidebar h2")).toHaveText("People & tools");
+  await expect(page.locator("#room-sidebar")).toHaveAttribute("aria-label", "People and tools");
+
+  await page.locator("#open-chat").click();
+  await expectActiveTool(page, "chat");
+  await expect(utilityToggle).toHaveText("Tools");
+  await expect(page.locator("#close-chat")).toHaveText("All tools");
+  await expect(page.locator("#close-chat")).toHaveAttribute("aria-label", "Back to People and tools");
+  await page.locator("#close-chat").click();
+
+  await openJam(page);
+  await expectActiveTool(page, "jam");
+  await expect(utilityToggle).toHaveText("Tools");
+  await expect(page.locator("#close-jam")).toHaveText("All tools");
+  await expect(page.locator("#close-jam")).toHaveAttribute("aria-label", "Back to People and tools");
+
+  await utilityToggle.click();
+  await expect(utilityToggle).toHaveText("Tools");
+  await expect(utilityToggle).toHaveAttribute("aria-label", "Show clubhouse tools");
+  await utilityToggle.click();
+  await expectActiveTool(page, "jam");
+  await expect(utilityToggle).toHaveAttribute("aria-label", "Hide clubhouse tools");
+
+  await page.evaluate(() => window.EchoUiShell.applyVariant("legacy"));
+  await expect(page.locator("html")).toHaveAttribute("data-ui-shell", "legacy");
+  await expect(page.locator("#room-sidebar h2")).toHaveText("Active Users");
+  await expect(page.locator("#room-sidebar")).toHaveAttribute("aria-label", "People");
+  await expect(page.locator("#close-chat")).toHaveText("Close");
+  await expect(page.locator("#close-chat")).not.toHaveAttribute("aria-label", /.+/);
+  await expect(page.locator("#close-jam")).toHaveText("Close");
+  await expect(page.locator("#close-jam")).not.toHaveAttribute("aria-label", /.+/);
+
+  await page.evaluate(() => window.EchoUiShell.applyVariant("v2"));
+  await expect(page.locator("#room-sidebar h2")).toHaveText("People & tools");
+  await expect(page.locator("#room-sidebar")).toHaveAttribute("aria-label", "People and tools");
+});
+
+test("Ultra Instinct keeps the Goku GIF visible through the Phase 2 stage", async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 720 });
+  await openPhaseTwoViewer(page, { screenShares: 0 });
+  await page.evaluate(() => applyTheme("ultra-instinct"));
+
+  const presentation = await page.evaluate(() => {
+    const bodyStyle = getComputedStyle(document.body);
+    const stageStyle = getComputedStyle(document.querySelector(".room-main"));
+    const alphaMatch = stageStyle.backgroundColor.match(/rgba\([^,]+,[^,]+,[^,]+,\s*([0-9.]+)\)/);
+    return {
+      bodyBackground: bodyStyle.backgroundImage,
+      particleCanvases: document.querySelectorAll("#ui-particles").length,
+      stageAlpha: alphaMatch ? Number(alphaMatch[1]) : 1,
+    };
+  });
+  expect(presentation.bodyBackground).toContain("ultrainstinct.gif");
+  expect(presentation.particleCanvases).toBe(1);
+  expect(presentation.stageAlpha).toBeGreaterThan(0);
+  expect(presentation.stageAlpha).toBeLessThan(1);
+
+  const gif = await page.evaluate(() => new Promise((resolve) => {
+    const image = new Image();
+    image.addEventListener("load", () => resolve({ height: image.naturalHeight, width: image.naturalWidth }), { once: true });
+    image.addEventListener("error", () => resolve({ height: 0, width: 0 }), { once: true });
+    image.src = `ultrainstinct.gif?phase2-test=${Date.now()}`;
+  }));
+  expect(gif.width).toBeGreaterThan(0);
+  expect(gif.height).toBeGreaterThan(0);
+
+  await page.evaluate(() => window.EchoUiShell.applyVariant("legacy"));
+  await expect(page.locator("html")).toHaveAttribute("data-ui-shell", "legacy");
+  expect(await page.evaluate(() => getComputedStyle(document.body).backgroundImage)).toContain("ultrainstinct.gif");
 });
 
 test("People actions stay visible and contained in the theater rail and mini sheet", async ({ page }) => {
@@ -477,6 +577,96 @@ test("collapsed Chat records unread messages and a top overlay owns the first Es
 
   await page.keyboard.press("Escape");
   await expectActiveTool(page, "people");
+});
+
+test("source-PC settings stay collapsed while playback controls remain reachable", async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 720 });
+  await openPhaseTwoViewer(page);
+  await openJam(page);
+  await showSourcePcControls(page);
+
+  const disclosure = page.locator("#jam-panel .jam-source-local-details");
+  const summary = page.locator("#jam-panel .jam-source-local-summary");
+  const switches = page.locator("#jam-panel .jam-source-local-switch input");
+  await expect(disclosure).not.toHaveAttribute("open", "");
+  await expect(summary).toBeVisible();
+  await expect(switches).toHaveCount(2);
+  await expect(switches.first()).toBeHidden();
+  expect(await page.evaluate(() => {
+    const controls = document.getElementById("jam-host-controls");
+    const card = document.querySelector("#jam-panel [data-jam-source-local-card]");
+    return !!(controls.compareDocumentPosition(card) & Node.DOCUMENT_POSITION_FOLLOWING);
+  })).toBe(true);
+
+  for (const [viewport, expectedMode] of [
+    [{ width: 1280, height: 720 }, "theater"],
+    [{ width: 900, height: 700 }, "lounge"],
+    [{ width: 600, height: 900 }, "compact"],
+    [{ width: 360, height: 640 }, "mini"],
+  ]) {
+    await resizeTo(page, viewport, expectedMode);
+    const body = page.locator("#jam-panel .jam-body");
+    await body.evaluate((element) => { element.scrollTop = 0; });
+    await nextPaint(page);
+
+    const initial = await page.evaluate(() => {
+      function verticalBounds(element) {
+        const rect = element.getBoundingClientRect();
+        return { bottom: rect.bottom, top: rect.top };
+      }
+      const buttonTops = Array.from(document.querySelectorAll("#jam-host-controls button"))
+        .filter((button) => getComputedStyle(button).display !== "none")
+        .map((button) => Math.round(button.getBoundingClientRect().top));
+      return {
+        bodyRect: verticalBounds(document.querySelector("#jam-panel .jam-body")),
+        buttonTops,
+        toolbarRect: verticalBounds(document.getElementById("jam-host-controls")),
+      };
+    });
+    expect(initial.toolbarRect.top).toBeGreaterThanOrEqual(initial.bodyRect.top - 1);
+    expect(initial.toolbarRect.bottom).toBeLessThanOrEqual(initial.bodyRect.bottom + 1);
+    expect(new Set(initial.buttonTops).size, `one playback row at ${viewport.width}x${viewport.height}`).toBe(1);
+
+    await body.evaluate((element) => { element.scrollTop = element.scrollHeight; });
+    await nextPaint(page);
+    const sticky = await page.evaluate(() => {
+      function verticalBounds(element) {
+        const rect = element.getBoundingClientRect();
+        return { bottom: rect.bottom, top: rect.top };
+      }
+      return {
+        bodyRect: verticalBounds(document.querySelector("#jam-panel .jam-body")),
+        toolbarRect: verticalBounds(document.getElementById("jam-host-controls")),
+      };
+    });
+    expect(sticky.toolbarRect.top, `sticky toolbar top at ${viewport.width}x${viewport.height}`)
+      .toBeGreaterThanOrEqual(sticky.bodyRect.top - 1);
+    expect(sticky.toolbarRect.bottom, `sticky toolbar bottom at ${viewport.width}x${viewport.height}`)
+      .toBeLessThanOrEqual(sticky.bodyRect.bottom + 1);
+  }
+
+  await page.locator("#jam-panel .jam-body").evaluate((element) => { element.scrollTop = 0; });
+  await summary.click();
+  await expect(disclosure).toHaveAttribute("open", "");
+  await expect(switches.first()).toBeVisible();
+  const expanded = await page.evaluate(() => {
+    const card = document.querySelector("#jam-panel [data-jam-source-local-card]");
+    const cardRect = card.getBoundingClientRect();
+    const rows = Array.from(card.querySelectorAll(".jam-source-local-switch-row")).map((row) => {
+      const rect = row.getBoundingClientRect();
+      return { left: rect.left, right: rect.right };
+    });
+    return {
+      card: { left: cardRect.left, right: cardRect.right },
+      overflow: card.scrollWidth - card.clientWidth,
+      rows,
+    };
+  });
+  expect(expanded.overflow).toBeLessThanOrEqual(1);
+  for (const row of expanded.rows) {
+    expect(row.left).toBeGreaterThanOrEqual(expanded.card.left - 1);
+    expect(row.right).toBeLessThanOrEqual(expanded.card.right + 1);
+  }
 });
 
 test("populated Jam remains inside the workspace and above the dock at representative sizes", async ({ page }) => {

--- a/core/viewer-tests/tests/shell.phase2.utility.spec.js
+++ b/core/viewer-tests/tests/shell.phase2.utility.spec.js
@@ -410,6 +410,51 @@ test("Ultra Instinct keeps the Goku GIF visible through the Phase 2 stage", asyn
   expect(await page.evaluate(() => getComputedStyle(document.body).backgroundImage)).toContain("ultrainstinct.gif");
 });
 
+test("empty Stage crest is large, naturally proportioned, and contained", async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 720 });
+  await openPhaseTwoViewer(page, { screenShares: 0 });
+
+  for (const [viewport, expectedMode] of [
+    [{ width: 1280, height: 720 }, "theater"],
+    [{ width: 360, height: 640 }, "mini"],
+  ]) {
+    await resizeTo(page, viewport, expectedMode);
+    const presentation = await page.locator("#screen-grid").evaluate((grid) => {
+      const gridRect = grid.getBoundingClientRect();
+      const stageRect = grid.closest(".room-main").getBoundingClientRect();
+      const pseudo = getComputedStyle(grid, "::before");
+      return {
+        backgroundImage: pseudo.backgroundImage,
+        backgroundSize: pseudo.backgroundSize,
+        content: pseudo.content,
+        grid: { bottom: gridRect.bottom, left: gridRect.left, right: gridRect.right, top: gridRect.top },
+        paddingTop: Number.parseFloat(pseudo.paddingTop),
+        stage: { bottom: stageRect.bottom, left: stageRect.left, right: stageRect.right, top: stageRect.top },
+        tiles: grid.querySelectorAll(":scope > .tile").length,
+      };
+    });
+    expect(presentation.tiles).toBe(0);
+    expect(presentation.content).toContain("No one is sharing");
+    expect(presentation.backgroundImage).toContain("badge.jpg");
+    expect(presentation.backgroundSize).toContain("auto");
+    expect(presentation.backgroundSize).not.toContain("58px 58px");
+    expect(presentation.paddingTop).toBeGreaterThanOrEqual(135);
+    expect(presentation.grid.left).toBeGreaterThanOrEqual(presentation.stage.left - 1);
+    expect(presentation.grid.right).toBeLessThanOrEqual(presentation.stage.right + 1);
+    expect(presentation.grid.top).toBeGreaterThanOrEqual(presentation.stage.top - 1);
+    expect(presentation.grid.bottom).toBeLessThanOrEqual(presentation.stage.bottom + 1);
+  }
+
+  const badge = await page.evaluate(() => new Promise((resolve) => {
+    const image = new Image();
+    image.addEventListener("load", () => resolve({ height: image.naturalHeight, width: image.naturalWidth }), { once: true });
+    image.addEventListener("error", () => resolve({ height: 0, width: 0 }), { once: true });
+    image.src = `badge.jpg?empty-stage-test=${Date.now()}`;
+  }));
+  expect(badge.width / badge.height).toBeGreaterThan(1.8);
+  expect(badge.width / badge.height).toBeLessThan(2);
+});
+
 test("People actions stay visible and contained in the theater rail and mini sheet", async ({ page }) => {
   await page.setViewportSize({ width: 1280, height: 720 });
   await openPhaseTwoViewer(page);
@@ -423,6 +468,7 @@ test("People actions stay visible and contained in the theater rail and mini she
     const geometry = await page.evaluate(() => {
       const sidebar = document.getElementById("room-sidebar").getBoundingClientRect();
       const titleRow = document.querySelector("#room-sidebar .sidebar-title-row");
+      const participantAvatar = document.querySelector("#room-sidebar .user-card:not(.has-camera) .user-avatar");
       const actions = Array.from(document.querySelectorAll("#room-sidebar .sidebar-actions button"))
         .filter((button) => getComputedStyle(button).display !== "none")
         .map((button) => {
@@ -449,12 +495,18 @@ test("People actions stay visible and contained in the theater rail and mini she
             fontSize: getComputedStyle(button).fontSize,
           };
         }),
-        sidebar: { bottom: sidebar.bottom, left: sidebar.left, right: sidebar.right, top: sidebar.top },
+        participantAvatarWidth: participantAvatar?.getBoundingClientRect().width || 0,
+        sidebar: { bottom: sidebar.bottom, left: sidebar.left, right: sidebar.right, top: sidebar.top, width: sidebar.width },
         titleOverflow: titleRow.scrollWidth - titleRow.clientWidth,
       };
     });
 
     expect(geometry.actions).toHaveLength(7);
+    if (expectedMode === "theater") {
+      expect(geometry.sidebar.width).toBeGreaterThanOrEqual(299.5);
+      expect(geometry.sidebar.width).toBeLessThanOrEqual(328.5);
+    }
+    expect(geometry.participantAvatarWidth).toBeGreaterThanOrEqual(53.5);
     expect(geometry.titleOverflow).toBeLessThanOrEqual(1);
     expect(geometry.compactLabels).toEqual([
       { after: "none", before: '"Sounds"', fontSize: "0px" },

--- a/core/viewer-tests/tests/shell.phase2.utility.spec.js
+++ b/core/viewer-tests/tests/shell.phase2.utility.spec.js
@@ -310,6 +310,68 @@ test("one logical utility owns stable People, Chat, and portaled Jam tools witho
   expect(await page.evaluate(() => window.__phase2JamNode === document.getElementById("jam-panel"))).toBe(true);
 });
 
+test("People actions stay visible and contained in the theater rail and mini sheet", async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 720 });
+  await openPhaseTwoViewer(page);
+
+  for (const [viewport, expectedMode] of [
+    [{ width: 1280, height: 720 }, "theater"],
+    [{ width: 360, height: 640 }, "mini"],
+  ]) {
+    await resizeTo(page, viewport, expectedMode);
+    await expectActiveTool(page, "people");
+    const geometry = await page.evaluate(() => {
+      const sidebar = document.getElementById("room-sidebar").getBoundingClientRect();
+      const titleRow = document.querySelector("#room-sidebar .sidebar-title-row");
+      const actions = Array.from(document.querySelectorAll("#room-sidebar .sidebar-actions button"))
+        .filter((button) => getComputedStyle(button).display !== "none")
+        .map((button) => {
+          const rect = button.getBoundingClientRect();
+          const hit = document.elementFromPoint(rect.left + rect.width / 2, rect.top + rect.height / 2);
+          return {
+            bottom: rect.bottom,
+            height: rect.height,
+            hit: hit === button || button.contains(hit),
+            id: button.id,
+            left: rect.left,
+            right: rect.right,
+            top: rect.top,
+            width: rect.width,
+          };
+        });
+      return {
+        actions,
+        compactLabels: ["open-soundboard", "open-camera-lobby"].map((id) => {
+          const button = document.getElementById(id);
+          return {
+            after: getComputedStyle(button, "::after").content,
+            before: getComputedStyle(button, "::before").content,
+            fontSize: getComputedStyle(button).fontSize,
+          };
+        }),
+        sidebar: { bottom: sidebar.bottom, left: sidebar.left, right: sidebar.right, top: sidebar.top },
+        titleOverflow: titleRow.scrollWidth - titleRow.clientWidth,
+      };
+    });
+
+    expect(geometry.actions).toHaveLength(7);
+    expect(geometry.titleOverflow).toBeLessThanOrEqual(1);
+    expect(geometry.compactLabels).toEqual([
+      { after: "none", before: '"Sounds"', fontSize: "0px" },
+      { after: "none", before: '"Cameras"', fontSize: "0px" },
+    ]);
+    for (const action of geometry.actions) {
+      expect(action.left, `${action.id} left at ${viewport.width}px`).toBeGreaterThanOrEqual(geometry.sidebar.left - 1);
+      expect(action.right, `${action.id} right at ${viewport.width}px`).toBeLessThanOrEqual(geometry.sidebar.right + 1);
+      expect(action.top, `${action.id} top at ${viewport.width}px`).toBeGreaterThanOrEqual(geometry.sidebar.top - 1);
+      expect(action.bottom, `${action.id} bottom at ${viewport.width}px`).toBeLessThanOrEqual(geometry.sidebar.bottom + 1);
+      expect(action.width, `${action.id} width at ${viewport.width}px`).toBeGreaterThanOrEqual(39.5);
+      expect(action.height, `${action.id} height at ${viewport.width}px`).toBeGreaterThanOrEqual(39.5);
+      expect(action.hit, `${action.id} center hit at ${viewport.width}px`).toBe(true);
+    }
+  }
+});
+
 test("responsive modes and live legacy rollback retain the same centered Jam node and state", async ({ page }) => {
   await page.setViewportSize({ width: 1280, height: 720 });
   await openPhaseTwoViewer(page);

--- a/core/viewer/app.js
+++ b/core/viewer/app.js
@@ -113,10 +113,23 @@ var shellOverflowMenu = document.getElementById("shell-overflow-menu");
 var shellHeader = document.querySelector('[data-ui-region="shell-header"]');
 var shellLayout = document.querySelector('[data-ui-region="workspace"]');
 var shellStage = document.querySelector('[data-ui-region="primary-stage"]');
+var shellUtilityHost = document.getElementById("utility-host");
+var shellUtilityScrim = document.getElementById("utility-scrim");
+var shellPeoplePanel = document.getElementById("room-sidebar");
+var shellJamPanel = document.getElementById("jam-panel");
+var shellOpenJamButton = document.getElementById("open-jam");
+var shellCloseJamButton = document.getElementById("close-jam");
 var clubhouseShell = document.getElementById("clubhouse-shell");
 var settingsScrim = document.getElementById("settings-scrim");
 var settingsReturnFocus = null;
 var settingsModalActive = false;
+var activeUtilityTool = "people";
+var utilityReturnFocus = {
+  people: shellUtilityButton,
+  chat: openChatButton,
+  jam: shellOpenJamButton,
+};
+var syncingClubhouseUtility = false;
 
 function setShellOverflowOpen(open, options) {
   if (!shellHeader || !shellMoreButton) return;
@@ -154,6 +167,7 @@ function setSettingsModalPresentation(modal) {
   if (settingsScrim) settingsScrim.classList.toggle("hidden", !settingsModalActive);
   if (connectPanel) connectPanel.inert = settingsModalActive;
   if (clubhouseShell) clubhouseShell.inert = settingsModalActive;
+  syncClubhouseUtilityPresentation();
 }
 
 function focusSettingsReturnTarget(preferred) {
@@ -206,23 +220,232 @@ function setSettingsPanelOpen(open, returnFocusTarget) {
   }
 }
 
+function normalizeUtilityTool(tool) {
+  return tool === "chat" || tool === "jam" ? tool : "people";
+}
+
+function utilityToolLabel(tool) {
+  if (tool === "chat") return "Chat";
+  if (tool === "jam") return "Jam";
+  return "People";
+}
+
+function focusUtilityReturnTarget(preferred) {
+  var candidates = [preferred, shellUtilityButton, shellMoreButton, connectBtn];
+  var target = candidates.find(isRenderedFocusable);
+  if (target) target.focus();
+}
+
+function focusActiveUtilityTool(tool) {
+  var peopleTarget = shellPeoplePanel
+    ? Array.from(shellPeoplePanel.querySelectorAll(
+        'button:not(:disabled), input:not(:disabled), [tabindex]:not([tabindex="-1"])'
+      )).find(isRenderedFocusable)
+    : null;
+  var target = tool === "chat" ? chatInput : tool === "jam" ? shellCloseJamButton : peopleTarget;
+  if (isRenderedFocusable(target)) target.focus();
+}
+
+function inferVisibleUtilityTool() {
+  if (shellJamPanel && !shellJamPanel.classList.contains("hidden")) return "jam";
+  if (chatPanel && !chatPanel.classList.contains("hidden") && shellLayout?.classList.contains("chat-open")) {
+    return "chat";
+  }
+  return "people";
+}
+
 function syncClubhouseUtilityPresentation() {
-  if (!shellLayout || !shellStage) return;
-  var isV2 = document.documentElement.dataset.uiShell === "v2";
-  var mode = document.documentElement.dataset.uiMode;
-  var collapsed = shellLayout.classList.contains("utility-collapsed");
-  var chatOpen = shellLayout.classList.contains("chat-open") && chatPanel && !chatPanel.classList.contains("hidden");
-  var overlaysStage = mode === "lounge" || mode === "compact" || mode === "mini";
-  shellStage.inert = !!(isV2 && overlaysStage && !collapsed);
-  if (shellUtilityButton) {
-    shellUtilityButton.textContent = chatOpen ? "Chat" : "People";
-    shellUtilityButton.setAttribute("aria-expanded", collapsed ? "false" : "true");
-    shellUtilityButton.setAttribute(
-      "aria-label",
-      (collapsed ? "Show " : "Hide ") + (chatOpen ? "Chat" : "People and tools")
-    );
+  if (!shellLayout || !shellStage || !shellUtilityHost) return;
+  if (syncingClubhouseUtility) return;
+  syncingClubhouseUtility = true;
+  try {
+    var isV2 = document.documentElement.dataset.uiShell === "v2";
+    var mode = document.documentElement.dataset.uiMode;
+    var collapsed = shellLayout.classList.contains("utility-collapsed");
+    var overlaysStage = mode === "lounge" || mode === "compact" || mode === "mini";
+
+    if (!isV2) {
+      if (!collapsed) activeUtilityTool = inferVisibleUtilityTool();
+      delete document.documentElement.dataset.uiUtility;
+      delete shellLayout.dataset.activeUtility;
+      if (shellLayout.classList.contains("jam-open")) shellLayout.classList.remove("jam-open");
+      shellStage.inert = false;
+      shellUtilityHost.inert = false;
+      shellUtilityHost.removeAttribute("aria-hidden");
+      shellPeoplePanel?.classList.remove("hidden");
+      if (shellPeoplePanel) {
+        shellPeoplePanel.inert = false;
+        shellPeoplePanel.removeAttribute("aria-hidden");
+      }
+      if (chatPanel) {
+        chatPanel.inert = false;
+        chatPanel.removeAttribute("aria-hidden");
+      }
+      if (shellJamPanel) {
+        shellJamPanel.inert = false;
+        shellJamPanel.removeAttribute("aria-hidden");
+        shellJamPanel.classList.remove("clubhouse-utility-tool");
+      }
+      shellUtilityScrim?.classList.add("hidden");
+      if (closeChatButton) {
+        closeChatButton.textContent = "Close";
+        closeChatButton.removeAttribute("aria-label");
+      }
+      if (shellCloseJamButton) {
+        shellCloseJamButton.textContent = "Close";
+        shellCloseJamButton.removeAttribute("aria-label");
+      }
+      return;
+    }
+
+    var externallyVisibleTool = inferVisibleUtilityTool();
+    if (externallyVisibleTool !== "people") {
+      activeUtilityTool = externallyVisibleTool;
+    } else if (!collapsed && activeUtilityTool !== "people") {
+      activeUtilityTool = "people";
+    }
+    activeUtilityTool = normalizeUtilityTool(activeUtilityTool);
+    shellUtilityHost.dataset.activeTool = activeUtilityTool;
+    shellLayout.dataset.activeUtility = activeUtilityTool;
+    document.documentElement.dataset.uiUtility = activeUtilityTool;
+    shellLayout.classList.toggle("chat-open", activeUtilityTool === "chat");
+    shellLayout.classList.toggle("jam-open", activeUtilityTool === "jam");
+
+    if (shellPeoplePanel) {
+      var peopleActive = activeUtilityTool === "people";
+      shellPeoplePanel.classList.toggle("hidden", !peopleActive);
+      shellPeoplePanel.inert = !peopleActive || collapsed || settingsModalActive;
+      shellPeoplePanel.setAttribute("aria-hidden", peopleActive && !collapsed ? "false" : "true");
+    }
+    if (chatPanel) {
+      var chatActive = activeUtilityTool === "chat";
+      chatPanel.classList.toggle("hidden", !chatActive);
+      chatPanel.inert = !chatActive || collapsed || settingsModalActive;
+      chatPanel.setAttribute("aria-hidden", chatActive && !collapsed ? "false" : "true");
+    }
+    if (shellJamPanel) {
+      var jamActive = activeUtilityTool === "jam";
+      shellJamPanel.classList.toggle("hidden", !jamActive || collapsed);
+      shellJamPanel.classList.add("clubhouse-utility-tool");
+      shellJamPanel.inert = !jamActive || collapsed || settingsModalActive;
+      shellJamPanel.setAttribute("aria-hidden", jamActive && !collapsed ? "false" : "true");
+    }
+
+    shellUtilityHost.inert = collapsed || settingsModalActive;
+    shellUtilityHost.setAttribute("aria-hidden", collapsed ? "true" : "false");
+    shellStage.inert = !!(overlaysStage && !collapsed && !settingsModalActive);
+    shellUtilityScrim?.classList.toggle("hidden", !overlaysStage || collapsed || settingsModalActive);
+    if (closeChatButton) {
+      closeChatButton.textContent = "People";
+      closeChatButton.setAttribute("aria-label", "Back to People");
+    }
+    if (shellCloseJamButton) {
+      shellCloseJamButton.textContent = "People";
+      shellCloseJamButton.setAttribute("aria-label", "Back to People");
+    }
+
+    if (shellUtilityButton) {
+      var label = utilityToolLabel(activeUtilityTool);
+      shellUtilityButton.textContent = label;
+      shellUtilityButton.setAttribute("aria-expanded", collapsed ? "false" : "true");
+      shellUtilityButton.setAttribute("aria-label", (collapsed ? "Show " : "Hide ") + label);
+    }
+  } finally {
+    syncingClubhouseUtility = false;
   }
 }
+
+function setClubhouseUtilityCollapsed(collapsed, options) {
+  if (!shellLayout) return false;
+  shellLayout.classList.toggle("utility-collapsed", !!collapsed);
+  // Collapsing hides the active tool. Restore its presentation before syncing
+  // on reopen so visibility inference does not accidentally reset it to People.
+  if (!collapsed && document.documentElement.dataset.uiShell === "v2") {
+    chatPanel?.classList.toggle("hidden", activeUtilityTool !== "chat");
+    shellJamPanel?.classList.toggle("hidden", activeUtilityTool !== "jam");
+  }
+  syncClubhouseUtilityPresentation();
+  if (!collapsed && activeUtilityTool === "chat" && typeof clearUnreadChat === "function") {
+    clearUnreadChat();
+  }
+  if (collapsed && options && options.restoreFocus) {
+    requestAnimationFrame(function() { focusUtilityReturnTarget(shellUtilityButton); });
+  }
+  return true;
+}
+
+function openClubhouseUtility(tool, opener, options) {
+  activeUtilityTool = normalizeUtilityTool(tool);
+  if (isRenderedFocusable(opener)) utilityReturnFocus[activeUtilityTool] = opener;
+  if (document.documentElement.dataset.uiShell !== "v2") return false;
+  shellLayout?.classList.remove("utility-collapsed");
+  shellLayout?.classList.toggle("chat-open", activeUtilityTool === "chat");
+  shellLayout?.classList.toggle("jam-open", activeUtilityTool === "jam");
+  chatPanel?.classList.toggle("hidden", activeUtilityTool !== "chat");
+  shellJamPanel?.classList.toggle("hidden", activeUtilityTool !== "jam");
+  syncClubhouseUtilityPresentation();
+  if (!options || options.focus !== false) {
+    requestAnimationFrame(function() { focusActiveUtilityTool(activeUtilityTool); });
+  }
+  return true;
+}
+
+function closeClubhouseUtility(tool, options) {
+  var closingTool = normalizeUtilityTool(tool || activeUtilityTool);
+  var returnTarget = utilityReturnFocus[closingTool];
+  if (document.documentElement.dataset.uiShell !== "v2") {
+    activeUtilityTool = inferVisibleUtilityTool();
+    return false;
+  }
+  activeUtilityTool = "people";
+  if (shellJamPanel) shellJamPanel.classList.add("hidden");
+  if (chatPanel) chatPanel.classList.add("hidden");
+  syncClubhouseUtilityPresentation();
+  if (!options || options.restoreFocus !== false) {
+    requestAnimationFrame(function() { focusUtilityReturnTarget(returnTarget); });
+  }
+  return true;
+}
+
+function hasHigherPriorityEscapeSurface() {
+  if (document.fullscreenElement) return true;
+  var candidates = document.querySelectorAll([
+    ".image-lightbox",
+    "#capture-picker-overlay",
+    ".modal-overlay",
+    ".whats-new-overlay",
+    '[role="dialog"]:not(#chat-panel):not(#jam-panel):not(#settings-panel)',
+  ].join(","));
+  return Array.from(candidates).some(function(element) {
+    return element.getClientRects().length > 0 && getComputedStyle(element).visibility !== "hidden";
+  });
+}
+
+function keepFocusedUtilityControlVisible() {
+  if (document.documentElement.dataset.uiShell !== "v2" ||
+      shellLayout?.classList.contains("utility-collapsed") ||
+      settingsModalActive) return;
+  var active = document.activeElement;
+  var activePanel = activeUtilityTool === "chat"
+    ? chatPanel
+    : activeUtilityTool === "jam"
+      ? shellJamPanel
+      : shellPeoplePanel;
+  if (!active || !activePanel?.contains(active) || typeof active.scrollIntoView !== "function") return;
+  requestAnimationFrame(function() {
+    if (document.activeElement === active) {
+      active.scrollIntoView({ block: "nearest", inline: "nearest" });
+    }
+  });
+}
+
+window.EchoClubhouseUtility = Object.freeze({
+  activeTool: function() { return activeUtilityTool; },
+  close: closeClubhouseUtility,
+  collapse: setClubhouseUtilityCollapsed,
+  open: openClubhouseUtility,
+  sync: syncClubhouseUtilityPresentation,
+});
 
 if (dockOutputButton && settingsPanel) {
   dockOutputButton.addEventListener("click", function() {
@@ -263,16 +486,20 @@ if (shellOverflowMenu) {
 
 if (shellUtilityButton && shellLayout) {
   shellUtilityButton.addEventListener("click", function() {
-    shellLayout.classList.toggle("utility-collapsed");
-    syncClubhouseUtilityPresentation();
+    setClubhouseUtilityCollapsed(!shellLayout.classList.contains("utility-collapsed"));
   });
 }
 
-if (openChatButton) openChatButton.addEventListener("click", syncClubhouseUtilityPresentation);
-if (closeChatButton) closeChatButton.addEventListener("click", syncClubhouseUtilityPresentation);
+if (shellUtilityScrim) {
+  shellUtilityScrim.addEventListener("click", function() {
+    setClubhouseUtilityCollapsed(true, { restoreFocus: true });
+  });
+}
+
 window.addEventListener("echo:ui-shell-change", function() {
   syncClubhouseUtilityPresentation();
   syncSettingsModalPresentation();
+  keepFocusedUtilityControlVisible();
   if (!shellHeader?.classList.contains("shell-overflow-open")) return;
   var canRestoreMoreFocus = document.documentElement.dataset.uiShell === "v2"
     && shellMoreButton
@@ -313,9 +540,29 @@ document.addEventListener("keydown", function(event) {
     }
     return;
   }
-  if (event.key !== "Escape" || !shellHeader?.classList.contains("shell-overflow-open")) return;
-  event.preventDefault();
-  setShellOverflowOpen(false, { restoreFocus: true });
+  if (event.key !== "Escape") return;
+  if (shellHeader?.classList.contains("shell-overflow-open")) {
+    event.preventDefault();
+    setShellOverflowOpen(false, { restoreFocus: true });
+    return;
+  }
+  // A single Escape dismisses only the topmost surface. Dynamic lightboxes,
+  // capture pickers, fullscreen media, and feature dialogs own it before the
+  // underlying People / Chat / Jam utility presentation.
+  if (hasHigherPriorityEscapeSurface()) return;
+  if (document.documentElement.dataset.uiShell !== "v2" || shellLayout?.classList.contains("utility-collapsed")) {
+    return;
+  }
+  if (activeUtilityTool !== "people") {
+    event.preventDefault();
+    closeClubhouseUtility(activeUtilityTool);
+    return;
+  }
+  var mode = document.documentElement.dataset.uiMode;
+  if (mode === "lounge" || mode === "compact" || mode === "mini") {
+    event.preventDefault();
+    setClubhouseUtilityCollapsed(true, { restoreFocus: true });
+  }
 });
 
 syncClubhouseUtilityPresentation();
@@ -490,7 +737,7 @@ window.addEventListener("beforeunload", () => {
 // ── Jam Session ──
 
 var openJamButton = document.getElementById("open-jam");
-if (openJamButton) openJamButton.addEventListener("click", function() { openJamPanel(); });
+if (openJamButton) openJamButton.addEventListener("click", function() { openJamPanel(openJamButton); });
 
 // Start Who's Online polling on page load (only while not connected)
 startOnlineUsersPolling();

--- a/core/viewer/app.js
+++ b/core/viewer/app.js
@@ -116,6 +116,7 @@ var shellStage = document.querySelector('[data-ui-region="primary-stage"]');
 var shellUtilityHost = document.getElementById("utility-host");
 var shellUtilityScrim = document.getElementById("utility-scrim");
 var shellPeoplePanel = document.getElementById("room-sidebar");
+var shellPeopleHeading = shellPeoplePanel?.querySelector(".sidebar-title-row h2");
 var shellJamPanel = document.getElementById("jam-panel");
 var shellOpenJamButton = document.getElementById("open-jam");
 var shellCloseJamButton = document.getElementById("close-jam");
@@ -224,12 +225,6 @@ function normalizeUtilityTool(tool) {
   return tool === "chat" || tool === "jam" ? tool : "people";
 }
 
-function utilityToolLabel(tool) {
-  if (tool === "chat") return "Chat";
-  if (tool === "jam") return "Jam";
-  return "People";
-}
-
 function focusUtilityReturnTarget(preferred) {
   var candidates = [preferred, shellUtilityButton, shellMoreButton, connectBtn];
   var target = candidates.find(isRenderedFocusable);
@@ -274,9 +269,11 @@ function syncClubhouseUtilityPresentation() {
       shellUtilityHost.removeAttribute("aria-hidden");
       shellPeoplePanel?.classList.remove("hidden");
       if (shellPeoplePanel) {
+        shellPeoplePanel.setAttribute("aria-label", "People");
         shellPeoplePanel.inert = false;
         shellPeoplePanel.removeAttribute("aria-hidden");
       }
+      if (shellPeopleHeading) shellPeopleHeading.textContent = "Active Users";
       if (chatPanel) {
         chatPanel.inert = false;
         chatPanel.removeAttribute("aria-hidden");
@@ -313,10 +310,12 @@ function syncClubhouseUtilityPresentation() {
 
     if (shellPeoplePanel) {
       var peopleActive = activeUtilityTool === "people";
+      shellPeoplePanel.setAttribute("aria-label", "People and tools");
       shellPeoplePanel.classList.toggle("hidden", !peopleActive);
       shellPeoplePanel.inert = !peopleActive || collapsed || settingsModalActive;
       shellPeoplePanel.setAttribute("aria-hidden", peopleActive && !collapsed ? "false" : "true");
     }
+    if (shellPeopleHeading) shellPeopleHeading.textContent = "People & tools";
     if (chatPanel) {
       var chatActive = activeUtilityTool === "chat";
       chatPanel.classList.toggle("hidden", !chatActive);
@@ -336,19 +335,18 @@ function syncClubhouseUtilityPresentation() {
     shellStage.inert = !!(overlaysStage && !collapsed && !settingsModalActive);
     shellUtilityScrim?.classList.toggle("hidden", !overlaysStage || collapsed || settingsModalActive);
     if (closeChatButton) {
-      closeChatButton.textContent = "People";
-      closeChatButton.setAttribute("aria-label", "Back to People");
+      closeChatButton.textContent = "All tools";
+      closeChatButton.setAttribute("aria-label", "Back to People and tools");
     }
     if (shellCloseJamButton) {
-      shellCloseJamButton.textContent = "People";
-      shellCloseJamButton.setAttribute("aria-label", "Back to People");
+      shellCloseJamButton.textContent = "All tools";
+      shellCloseJamButton.setAttribute("aria-label", "Back to People and tools");
     }
 
     if (shellUtilityButton) {
-      var label = utilityToolLabel(activeUtilityTool);
-      shellUtilityButton.textContent = label;
+      shellUtilityButton.textContent = "Tools";
       shellUtilityButton.setAttribute("aria-expanded", collapsed ? "false" : "true");
-      shellUtilityButton.setAttribute("aria-label", (collapsed ? "Show " : "Hide ") + label);
+      shellUtilityButton.setAttribute("aria-label", (collapsed ? "Show" : "Hide") + " clubhouse tools");
     }
   } finally {
     syncingClubhouseUtility = false;

--- a/core/viewer/camera-lobby-layout.js
+++ b/core/viewer/camera-lobby-layout.js
@@ -1,0 +1,189 @@
+// Responsive Camera Lobby layout wiring.
+//
+// EchoLayoutPolicy owns the grid choice. This module only measures the live
+// lobby and applies presentation geometry to its existing tiles; it never
+// replaces, reparents, or reattaches camera media elements.
+(function () {
+  "use strict";
+
+  var _resizeObserver = null;
+  var _gridObserver = null;
+  var _panelObserver = null;
+  var _rafPending = false;
+  var _managedTiles = new Set();
+
+  function setStyleValue(element, property, value) {
+    if (!element || element.style[property] === value) return;
+    element.style[property] = value;
+  }
+
+  function directVisibleTiles(grid) {
+    return Array.from(grid.querySelectorAll(":scope > .camera-lobby-tile")).filter(function (tile) {
+      var style = getComputedStyle(tile);
+      return tile.offsetParent !== null && style.display !== "none" && style.visibility !== "hidden";
+    });
+  }
+
+  function numericStyle(style, property) {
+    var value = Number.parseFloat(style[property]);
+    return Number.isFinite(value) ? value : 0;
+  }
+
+  function contentGeometry(grid) {
+    var style = getComputedStyle(grid);
+    return {
+      width: Math.max(
+        0,
+        grid.clientWidth - numericStyle(style, "paddingLeft") - numericStyle(style, "paddingRight")
+      ),
+      height: Math.max(
+        0,
+        grid.clientHeight - numericStyle(style, "paddingTop") - numericStyle(style, "paddingBottom")
+      ),
+      gap: Math.max(
+        numericStyle(style, "columnGap"),
+        numericStyle(style, "rowGap")
+      ),
+    };
+  }
+
+  function pixelTrack(value) {
+    return Math.max(0, Number(value) || 0).toFixed(3).replace(/\.?0+$/, "") + "px";
+  }
+
+  function clearManagedTileSizing() {
+    _managedTiles.forEach(function (tile) {
+      setStyleValue(tile, "width", "");
+      setStyleValue(tile, "height", "");
+    });
+    _managedTiles.clear();
+  }
+
+  function clearManagedGridSizing(grid) {
+    if (!grid) return;
+    setStyleValue(grid, "gridTemplateColumns", "");
+    setStyleValue(grid, "gridTemplateRows", "");
+    grid.removeAttribute("data-layout-columns");
+    grid.removeAttribute("data-layout-rows");
+    grid.removeAttribute("data-layout-count");
+    clearManagedTileSizing();
+  }
+
+  function updateCameraLobbyLayout() {
+    var panel = document.getElementById("camera-lobby");
+    var grid = document.getElementById("camera-lobby-grid");
+    if (!panel || !grid) return;
+
+    if (
+      document.documentElement.dataset.uiShell !== "v2" ||
+      panel.classList.contains("hidden")
+    ) {
+      clearManagedGridSizing(grid);
+      return;
+    }
+
+    var tiles = directVisibleTiles(grid);
+    var geometry = contentGeometry(grid);
+    var policy = window.EchoLayoutPolicy;
+    if (
+      tiles.length === 0 ||
+      geometry.width < 10 ||
+      geometry.height < 10 ||
+      !policy ||
+      typeof policy.chooseOptimalGrid !== "function"
+    ) {
+      clearManagedGridSizing(grid);
+      return;
+    }
+
+    var layout = policy.chooseOptimalGrid({
+      width: geometry.width,
+      height: geometry.height,
+      tileCount: tiles.length,
+      gap: geometry.gap,
+      aspectRatio: policy.DEFAULT_TILE_ASPECT_RATIO,
+    });
+    if (
+      !layout ||
+      !layout.valid ||
+      layout.columns < 1 ||
+      layout.rows < 1 ||
+      layout.tileWidth <= 0 ||
+      layout.tileHeight <= 0
+    ) {
+      clearManagedGridSizing(grid);
+      return;
+    }
+
+    setStyleValue(
+      grid,
+      "gridTemplateColumns",
+      "repeat(" + layout.columns + ", " + pixelTrack(layout.tileWidth) + ")"
+    );
+    setStyleValue(
+      grid,
+      "gridTemplateRows",
+      "repeat(" + layout.rows + ", " + pixelTrack(layout.tileHeight) + ")"
+    );
+    grid.dataset.layoutColumns = String(layout.columns);
+    grid.dataset.layoutRows = String(layout.rows);
+    grid.dataset.layoutCount = String(tiles.length);
+
+    var visibleSet = new Set(tiles);
+    _managedTiles.forEach(function (tile) {
+      if (!visibleSet.has(tile)) {
+        setStyleValue(tile, "width", "");
+        setStyleValue(tile, "height", "");
+        _managedTiles.delete(tile);
+      }
+    });
+    tiles.forEach(function (tile) {
+      setStyleValue(tile, "width", "100%");
+      setStyleValue(tile, "height", "100%");
+      _managedTiles.add(tile);
+    });
+  }
+
+  function scheduleCameraLobbyLayout() {
+    if (_rafPending) return;
+    _rafPending = true;
+    requestAnimationFrame(function () {
+      _rafPending = false;
+      updateCameraLobbyLayout();
+    });
+  }
+
+  function initCameraLobbyLayout() {
+    var panel = document.getElementById("camera-lobby");
+    var grid = document.getElementById("camera-lobby-grid");
+    if (!panel || !grid || _resizeObserver) return;
+
+    if (typeof ResizeObserver === "function") {
+      _resizeObserver = new ResizeObserver(scheduleCameraLobbyLayout);
+      _resizeObserver.observe(panel);
+      _resizeObserver.observe(grid);
+    } else {
+      _resizeObserver = { disconnect: function () {} };
+      window.addEventListener("resize", scheduleCameraLobbyLayout, { passive: true });
+    }
+
+    if (typeof MutationObserver === "function") {
+      _gridObserver = new MutationObserver(scheduleCameraLobbyLayout);
+      _gridObserver.observe(grid, { childList: true });
+
+      _panelObserver = new MutationObserver(scheduleCameraLobbyLayout);
+      _panelObserver.observe(panel, { attributes: true, attributeFilter: ["class"] });
+    }
+
+    window.addEventListener("echo:ui-shell-change", scheduleCameraLobbyLayout);
+    scheduleCameraLobbyLayout();
+  }
+
+  window._echoRecalcCameraLobby = scheduleCameraLobbyLayout;
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", initCameraLobbyLayout, { once: true });
+  } else {
+    initCameraLobbyLayout();
+  }
+})();

--- a/core/viewer/capture-picker.js
+++ b/core/viewer/capture-picker.js
@@ -7,6 +7,19 @@ var _capturePickerReject = null;
 var _selectedSource = null;
 var _capturePickerSupport = null;
 
+var UNSUPPORTED_SYSTEM_CAPTURE_TITLES = Object.freeze([
+    'program manager',
+    'windows input experience',
+    'msctfime ui',
+    'default ime',
+]);
+
+function isUnsupportedSystemCaptureSource(source) {
+    if (!source) return false;
+    var title = String(source.title || '').trim().toLowerCase();
+    return UNSUPPORTED_SYSTEM_CAPTURE_TITLES.indexOf(title) !== -1;
+}
+
 function isTauriCommandMissingError(err, commandName) {
     var msg = (err && err.message) ? err.message : String(err || '');
     return msg.indexOf('Command ' + commandName + ' not found') !== -1;
@@ -125,6 +138,13 @@ async function _loadSources() {
             body.innerHTML = '<div class="capture-source-empty">No capture sources found</div>';
             return;
         }
+
+        // Windows exposes several shell/IME surfaces as ordinary top-level
+        // windows even though WGC can only produce black frames for them.
+        // Never offer those dead sources in Echo's picker.
+        sources = sources.filter(function(source) {
+            return !isUnsupportedSystemCaptureSource(source);
+        });
 
         // Categorize
         var monitors = sources.filter(function(s) { return s.source_type === 'monitor'; });
@@ -293,5 +313,5 @@ function _escHtml(s) {
 }
 
 if (typeof module !== "undefined" && module.exports) {
-    module.exports = { isTauriCommandMissingError };
+    module.exports = { isTauriCommandMissingError, isUnsupportedSystemCaptureSource };
 }

--- a/core/viewer/capture-picker.test.js
+++ b/core/viewer/capture-picker.test.js
@@ -1,0 +1,32 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  isUnsupportedSystemCaptureSource,
+} = require("./capture-picker.js");
+
+test("capture picker rejects Windows shell surfaces that only produce black frames", () => {
+  assert.equal(isUnsupportedSystemCaptureSource({
+    source_type: "window",
+    title: "Windows Input Experience",
+  }), true);
+  assert.equal(isUnsupportedSystemCaptureSource({
+    source_type: "window",
+    title: "MSCTFIME UI",
+  }), true);
+  assert.equal(isUnsupportedSystemCaptureSource({
+    source_type: "game",
+    title: "Default IME",
+  }), true);
+});
+
+test("capture picker keeps monitor and normal application sources", () => {
+  assert.equal(isUnsupportedSystemCaptureSource({
+    source_type: "monitor",
+    title: "Monitor 1 (\\\\.\\DISPLAY1)",
+  }), false);
+  assert.equal(isUnsupportedSystemCaptureSource({
+    source_type: "window",
+    title: "PowerPoint - Quarterly Review",
+  }), false);
+});

--- a/core/viewer/chat.js
+++ b/core/viewer/chat.js
@@ -440,8 +440,14 @@ function updateChatBadge() {
 }
 
 function incrementUnreadChat() {
-  // Only increment if chat is closed
-  if (chatPanel && chatPanel.classList.contains("hidden")) {
+  // A collapsed V2 utility keeps the active Chat node mounted so drafts and
+  // scroll state survive. Treat inert/aria-hidden Chat as closed to the user.
+  var chatIsClosed = chatPanel && (
+    chatPanel.classList.contains("hidden") ||
+    chatPanel.inert ||
+    chatPanel.getAttribute("aria-hidden") === "true"
+  );
+  if (chatIsClosed) {
     unreadChatCount++;
     updateChatBadge();
 
@@ -465,8 +471,12 @@ function clearUnreadChat() {
 
 function openChat() {
   if (!chatPanel) return;
-  chatPanel.classList.remove("hidden");
-  document.querySelector(".room-layout")?.classList.add("chat-open");
+  var handledByClubhouse = window.EchoClubhouseUtility &&
+    window.EchoClubhouseUtility.open("chat", openChatButton, { focus: false });
+  if (!handledByClubhouse) {
+    chatPanel.classList.remove("hidden");
+    document.querySelector(".room-layout")?.classList.add("chat-open");
+  }
   chatMessages.scrollTop = chatMessages.scrollHeight;
   chatInput.focus();
   clearUnreadChat();
@@ -474,6 +484,7 @@ function openChat() {
 
 function closeChat() {
   if (!chatPanel) return;
+  if (window.EchoClubhouseUtility && window.EchoClubhouseUtility.close("chat")) return;
   chatPanel.classList.add("hidden");
   document.querySelector(".room-layout")?.classList.remove("chat-open");
 }

--- a/core/viewer/clubhouse-shell.css
+++ b/core/viewer/clubhouse-shell.css
@@ -1139,3 +1139,328 @@
     transition-duration: 0.001ms !important;
   }
 }
+
+/* --------------------------------------------------------------------------
+   Phase 2 — one logical People / Chat / Jam utility host
+
+   Jam remains portaled under #shell-overlay-root while the legacy rollback is
+   available. The legacy .panel backdrop filter creates a fixed-position
+   containing block, so physically nesting Jam under the room panel would move
+   the centered legacy dialog offscreen. V2 gives that same node the exact
+   geometry of the active utility region without recreating or reparenting it.
+   -------------------------------------------------------------------------- */
+
+.utility-host {
+  display: contents;
+}
+
+:root[data-ui-shell="v2"] {
+  --club-safe-top: max(var(--club-shell-padding), env(safe-area-inset-top));
+  --club-safe-right: max(var(--club-shell-padding), env(safe-area-inset-right));
+  --club-safe-bottom: max(var(--club-shell-padding), env(safe-area-inset-bottom));
+  --club-safe-left: max(var(--club-shell-padding), env(safe-area-inset-left));
+  --club-workspace-top: calc(var(--club-safe-top) + var(--club-header-size) + var(--club-shell-gap));
+  --club-workspace-bottom: calc(var(--club-safe-bottom) + var(--club-dock-size) + var(--club-shell-gap));
+}
+
+:root[data-ui-shell="v2"] :where(button, input, select, textarea, [tabindex]):focus-visible {
+  outline: 2px solid var(--club-brass-bright);
+  outline-offset: 2px;
+}
+
+:root[data-ui-shell="v2"] .room-layout::after {
+  display: none;
+}
+
+:root[data-ui-shell="v2"] .utility-scrim {
+  position: absolute;
+  inset: 0;
+  z-index: var(--club-layer-utility-scrim);
+  width: 100%;
+  height: 100%;
+  padding: 0;
+  display: block !important;
+  border: 0;
+  border-radius: 0;
+  background: rgba(5, 7, 10, 0.42);
+  cursor: default;
+}
+
+:root[data-ui-shell="v2"] .utility-scrim.hidden {
+  display: none !important;
+}
+
+:root[data-ui-shell="v2"] .utility-host {
+  position: relative;
+  z-index: var(--club-layer-region);
+  width: 100%;
+  height: 100%;
+  min-width: 0;
+  min-height: 0;
+  display: grid;
+  grid-column: 2;
+  grid-row: 1;
+  container-type: inline-size;
+}
+
+:root[data-ui-shell="v2"] .utility-host > [data-ui-tool] {
+  min-width: 0;
+  min-height: 0;
+  grid-area: 1 / 1;
+}
+
+:root[data-ui-shell="v2"] .utility-host > .room-sidebar,
+:root[data-ui-shell="v2"] .utility-host > .chat-panel {
+  position: relative;
+  inset: auto;
+  width: 100%;
+  height: 100%;
+  grid-column: auto;
+  grid-row: auto;
+  visibility: visible;
+}
+
+:root[data-ui-shell="v2"] .room-layout.utility-collapsed .utility-host {
+  visibility: hidden;
+  pointer-events: none;
+}
+
+:root[data-ui-shell="v2"] .utility-host[data-active-tool="jam"] {
+  pointer-events: none;
+}
+
+:root[data-ui-shell="v2"][data-ui-mode="lounge"] .utility-host {
+  position: absolute;
+  inset-block: 0;
+  right: 0;
+  width: clamp(320px, 42vw, 380px);
+  height: 100%;
+  z-index: var(--club-layer-utility);
+}
+
+:root[data-ui-shell="v2"][data-ui-mode="compact"] .utility-host,
+:root[data-ui-shell="v2"][data-ui-mode="mini"] .utility-host {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: min(240px, 78%);
+  z-index: var(--club-layer-utility);
+}
+
+:root[data-ui-shell="v2"][data-ui-mode="mini"] .utility-host {
+  height: min(220px, 78%);
+}
+
+:root[data-ui-shell="v2"][data-ui-mode="compact"] .utility-host[data-active-tool="chat"],
+:root[data-ui-shell="v2"][data-ui-mode="mini"] .utility-host[data-active-tool="chat"] {
+  top: 0;
+  height: 100%;
+}
+
+:root[data-ui-shell="v2"][data-ui-mode="compact"] .utility-host > .room-sidebar,
+:root[data-ui-shell="v2"][data-ui-mode="mini"] .utility-host > .room-sidebar {
+  border-radius: 16px 16px 12px 12px;
+}
+
+:root[data-ui-shell="v2"][data-ui-mode="compact"] .utility-host > .chat-panel,
+:root[data-ui-shell="v2"][data-ui-mode="mini"] .utility-host > .chat-panel {
+  border-radius: var(--club-radius-panel);
+}
+
+/* Portaled Jam follows the same rail / drawer / full-workspace geometry. */
+:root[data-ui-shell="v2"] .jam-panel.clubhouse-utility-tool {
+  position: fixed;
+  top: var(--club-workspace-top);
+  right: var(--club-safe-right);
+  bottom: var(--club-workspace-bottom);
+  left: auto;
+  z-index: var(--club-layer-utility);
+  width: clamp(320px, 24vw, 360px);
+  height: auto;
+  max-height: none;
+  margin: 0;
+  padding: 12px;
+  gap: 10px;
+  transform: none;
+  container-type: inline-size;
+  overflow: hidden;
+  border: 1px solid var(--club-border-strong);
+  border-radius: var(--club-radius-panel);
+  color: var(--club-text);
+  background: linear-gradient(160deg, rgba(25, 32, 42, 0.995), rgba(13, 17, 23, 0.99));
+  box-shadow: 0 20px 55px rgba(0, 0, 0, 0.42), inset 0 1px rgba(255, 255, 255, 0.035);
+  backdrop-filter: none;
+}
+
+:root[data-ui-shell="v2"][data-ui-mode="lounge"] .jam-panel.clubhouse-utility-tool {
+  width: clamp(320px, 42vw, 380px);
+}
+
+:root[data-ui-shell="v2"][data-ui-mode="compact"] .jam-panel.clubhouse-utility-tool,
+:root[data-ui-shell="v2"][data-ui-mode="mini"] .jam-panel.clubhouse-utility-tool {
+  right: var(--club-safe-right);
+  left: var(--club-safe-left);
+  width: auto;
+}
+
+:root[data-ui-shell="v2"] .jam-panel.clubhouse-utility-tool .jam-header {
+  min-width: 0;
+  min-height: 40px;
+  padding-bottom: 10px;
+  border-color: var(--club-border);
+}
+
+:root[data-ui-shell="v2"] .jam-panel.clubhouse-utility-tool .jam-header h3 {
+  margin: 0;
+  color: var(--club-text-muted);
+  font-size: 11px;
+  font-weight: 650;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+:root[data-ui-shell="v2"] .jam-panel.clubhouse-utility-tool .jam-header button,
+:root[data-ui-shell="v2"] .jam-panel.clubhouse-utility-tool .jam-host-controls button,
+:root[data-ui-shell="v2"] .jam-panel.clubhouse-utility-tool .jam-actions button,
+:root[data-ui-shell="v2"] .jam-panel.clubhouse-utility-tool .jam-connect-btn,
+:root[data-ui-shell="v2"] .jam-panel.clubhouse-utility-tool .jam-result-add {
+  min-width: 40px;
+  min-height: 40px;
+}
+
+:root[data-ui-shell="v2"] .jam-panel.clubhouse-utility-tool .jam-body {
+  min-width: 0;
+  min-height: 0;
+  padding: 1px 4px 8px 1px;
+  gap: 12px;
+  overflow-x: hidden;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+}
+
+:root[data-ui-shell="v2"] .utility-host :where(button, input, textarea, select),
+:root[data-ui-shell="v2"] .jam-panel.clubhouse-utility-tool :where(button, input, textarea, select) {
+  scroll-margin-block: 12px;
+}
+
+:root[data-ui-shell="v2"] .jam-panel.clubhouse-utility-tool .jam-source-local-card {
+  min-width: 0;
+  padding: 11px;
+  gap: 9px;
+  border-color: rgba(76, 195, 138, 0.28);
+  border-radius: var(--club-radius-card);
+  background: rgba(76, 195, 138, 0.055);
+}
+
+:root[data-ui-shell="v2"] .jam-panel.clubhouse-utility-tool .jam-source-local-heading,
+:root[data-ui-shell="v2"] .jam-panel.clubhouse-utility-tool .jam-source-local-switch-row,
+:root[data-ui-shell="v2"] .jam-panel.clubhouse-utility-tool .jam-spotify-row,
+:root[data-ui-shell="v2"] .jam-panel.clubhouse-utility-tool .jam-actions {
+  min-width: 0;
+  flex-wrap: wrap;
+}
+
+:root[data-ui-shell="v2"] .jam-panel.clubhouse-utility-tool .jam-source-local-heading > div,
+:root[data-ui-shell="v2"] .jam-panel.clubhouse-utility-tool .jam-source-local-copy,
+:root[data-ui-shell="v2"] .jam-panel.clubhouse-utility-tool .jam-now-playing-info,
+:root[data-ui-shell="v2"] .jam-panel.clubhouse-utility-tool .jam-result-info {
+  min-width: 0;
+}
+
+:root[data-ui-shell="v2"] .jam-panel.clubhouse-utility-tool .jam-host-controls {
+  min-width: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+}
+
+:root[data-ui-shell="v2"] .jam-panel.clubhouse-utility-tool .jam-host-controls button {
+  flex: 1 1 112px;
+}
+
+:root[data-ui-shell="v2"] .jam-panel.clubhouse-utility-tool .jam-stop-btn {
+  color: #fff4f4;
+  border: 1px solid rgba(229, 106, 106, 0.42);
+  background: rgba(121, 52, 59, 0.88);
+}
+
+:root[data-ui-shell="v2"] .jam-panel.clubhouse-utility-tool .jam-end-btn {
+  color: var(--club-danger);
+  border-color: rgba(229, 106, 106, 0.5);
+  background: transparent;
+}
+
+:root[data-ui-shell="v2"] .jam-panel.clubhouse-utility-tool .jam-now-playing {
+  min-width: 0;
+  padding: 11px;
+  border-color: var(--club-border);
+  border-radius: var(--club-radius-card);
+  background: rgba(255, 255, 255, 0.025);
+}
+
+:root[data-ui-shell="v2"] .jam-panel.clubhouse-utility-tool .jam-search-queue-row {
+  min-width: 0;
+  flex-direction: column;
+}
+
+:root[data-ui-shell="v2"] .jam-panel.clubhouse-utility-tool .jam-results,
+:root[data-ui-shell="v2"] .jam-panel.clubhouse-utility-tool .jam-queue-list {
+  max-height: none;
+  overflow: visible;
+}
+
+:root[data-ui-shell="v2"] .jam-panel.clubhouse-utility-tool .jam-result-item,
+:root[data-ui-shell="v2"] .jam-panel.clubhouse-utility-tool .jam-queue-item {
+  min-width: 0;
+  padding: 8px;
+}
+
+:root[data-ui-shell="v2"] .jam-panel.clubhouse-utility-tool .jam-result-name,
+:root[data-ui-shell="v2"] .jam-panel.clubhouse-utility-tool .jam-result-artist,
+:root[data-ui-shell="v2"] .jam-panel.clubhouse-utility-tool .jam-now-playing-name,
+:root[data-ui-shell="v2"] .jam-panel.clubhouse-utility-tool .jam-now-playing-artist {
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+:root[data-ui-shell="v2"] .jam-panel.clubhouse-utility-tool .jam-result-add {
+  width: 40px;
+  height: 40px;
+  flex: 0 0 40px;
+}
+
+:root[data-ui-shell="v2"] .jam-toast {
+  bottom: calc(var(--club-workspace-bottom) + 8px);
+  z-index: var(--club-layer-notification);
+}
+
+:root[data-ui-shell="v2"][data-ui-short] .jam-panel.clubhouse-utility-tool,
+:root[data-ui-shell="v2"][data-ui-short] .room-sidebar,
+:root[data-ui-shell="v2"][data-ui-short] .chat-panel {
+  padding: 9px;
+}
+
+:root[data-ui-shell="v2"][data-ui-very-short] .jam-panel.clubhouse-utility-tool .jam-body {
+  gap: 8px;
+}
+
+@container (min-width: 620px) {
+  :root[data-ui-shell="v2"] .jam-panel.clubhouse-utility-tool .jam-search-queue-row {
+    flex-direction: row;
+  }
+}
+
+@media (hover: none), (pointer: coarse) {
+  :root[data-ui-shell="v2"] .jam-panel.clubhouse-utility-tool .jam-header button,
+  :root[data-ui-shell="v2"] .jam-panel.clubhouse-utility-tool .jam-host-controls button,
+  :root[data-ui-shell="v2"] .jam-panel.clubhouse-utility-tool .jam-actions button,
+  :root[data-ui-shell="v2"] .jam-panel.clubhouse-utility-tool .jam-connect-btn,
+  :root[data-ui-shell="v2"] .jam-panel.clubhouse-utility-tool .jam-result-add {
+    min-width: 44px;
+    min-height: 44px;
+  }
+}

--- a/core/viewer/clubhouse-shell.css
+++ b/core/viewer/clubhouse-shell.css
@@ -560,17 +560,23 @@
 }
 
 :root[data-ui-shell="v2"] .sidebar-actions {
+  width: 100%;
   min-width: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(58px, 100%), 1fr));
+  align-items: stretch;
   gap: 5px;
 }
 
 :root[data-ui-shell="v2"] .sidebar-actions button {
+  width: 100%;
   min-width: 0;
-  min-height: 32px;
+  min-height: 40px;
   padding: 5px 6px;
   overflow: hidden;
   color: var(--club-text-muted);
   font-size: 11px;
+  line-height: 1.1;
   text-overflow: ellipsis;
   border-color: var(--club-border);
   border-radius: 8px;
@@ -992,29 +998,51 @@
 
 :root[data-ui-shell="v2"][data-ui-mode="compact"] .sidebar-title-row,
 :root[data-ui-shell="v2"][data-ui-mode="mini"] .sidebar-title-row {
-  display: flex;
-  align-items: center;
-  gap: 7px;
-  overflow-x: auto;
-  scrollbar-width: none;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  align-items: stretch;
+  gap: 5px;
+  overflow: visible;
 }
 
 :root[data-ui-shell="v2"][data-ui-mode="compact"] .sidebar-title-row h2,
 :root[data-ui-shell="v2"][data-ui-mode="mini"] .sidebar-title-row h2 {
-  flex: 0 0 auto;
+  width: 100%;
 }
 
 :root[data-ui-shell="v2"][data-ui-mode="compact"] .sidebar-actions,
 :root[data-ui-shell="v2"][data-ui-mode="mini"] .sidebar-actions {
-  flex: 0 0 auto;
+  width: 100%;
 }
 
 :root[data-ui-shell="v2"][data-ui-mode="compact"] .sidebar-actions button,
 :root[data-ui-shell="v2"][data-ui-mode="mini"] .sidebar-actions button {
-  width: auto;
-  min-width: 38px;
-  flex: 0 0 auto;
-  padding-inline: 8px;
+  width: 100%;
+  min-width: 0;
+  min-height: 40px;
+  padding-inline: 5px;
+}
+
+/* Keep the two longest labels readable in the 320px rail and 360px app shell. */
+@container (max-width: 360px) {
+  :root[data-ui-shell="v2"] #open-soundboard,
+  :root[data-ui-shell="v2"] #open-camera-lobby {
+    font-size: 0;
+  }
+
+  :root[data-ui-shell="v2"] #open-soundboard::before,
+  :root[data-ui-shell="v2"] #open-camera-lobby::before {
+    font-size: 11px;
+    line-height: 1.1;
+  }
+
+  :root[data-ui-shell="v2"] #open-soundboard::before {
+    content: "Sounds";
+  }
+
+  :root[data-ui-shell="v2"] #open-camera-lobby::before {
+    content: "Cameras";
+  }
 }
 
 :root[data-ui-shell="v2"][data-ui-mode="compact"] .user-list,
@@ -1343,6 +1371,21 @@
 :root[data-ui-shell="v2"] .utility-host :where(button, input, textarea, select),
 :root[data-ui-shell="v2"] .jam-panel.clubhouse-utility-tool :where(button, input, textarea, select) {
   scroll-margin-block: 12px;
+}
+
+/* Two action rows need more participant space than the old scroller header. */
+:root[data-ui-shell="v2"][data-ui-mode="compact"] .utility-host[data-active-tool="people"] {
+  height: min(310px, 88%);
+}
+
+:root[data-ui-shell="v2"][data-ui-mode="compact"][data-ui-very-short] .utility-host[data-active-tool="people"] {
+  top: 0;
+  height: 100%;
+}
+
+:root[data-ui-shell="v2"][data-ui-mode="mini"] .utility-host[data-active-tool="people"] {
+  top: 0;
+  height: 100%;
 }
 
 :root[data-ui-shell="v2"] .jam-panel.clubhouse-utility-tool .jam-source-local-card {

--- a/core/viewer/clubhouse-shell.css
+++ b/core/viewer/clubhouse-shell.css
@@ -70,6 +70,7 @@
   --club-shell-gap: 16px;
   --club-header-size: 56px;
   --club-dock-size: 64px;
+  --club-people-rail-size: clamp(300px, 21vw, 328px);
   --club-layer-region: 0;
   --club-layer-sticky: 20;
   --club-layer-utility-scrim: 25;
@@ -431,6 +432,10 @@
   grid-template-columns: minmax(0, 1fr) clamp(320px, 24vw, 360px);
 }
 
+:root[data-ui-shell="v2"][data-ui-mode="theater"] .room-layout[data-active-utility="people"]:not(.utility-collapsed) {
+  grid-template-columns: minmax(0, 1fr) var(--club-people-rail-size);
+}
+
 :root[data-ui-shell="v2"] .room-main {
   position: relative;
   padding: 12px;
@@ -519,9 +524,10 @@
 :root[data-ui-shell="v2"] .screens-grid:empty::before {
   content: "No one is sharing\A Use Share Screen when you are ready to take the stage.";
   width: min(440px, calc(100% - 32px));
-  min-height: 150px;
+  min-height: min(240px, calc(100% - 16px));
   margin: auto;
-  padding: 88px 24px 22px;
+  padding: 142px 24px 24px;
+  box-sizing: border-box;
   display: grid;
   place-items: center;
   align-self: center;
@@ -534,7 +540,7 @@
   border: 1px dashed rgba(201, 168, 106, 0.2);
   border-radius: var(--club-radius-panel);
   background:
-    url("badge.jpg") center 18px / 58px 58px no-repeat,
+    url("badge.jpg") center 22px / min(208px, 64%) auto no-repeat,
     linear-gradient(145deg, rgba(201, 168, 106, 0.045), rgba(255, 255, 255, 0.012));
   opacity: 0.78;
 }
@@ -735,8 +741,8 @@
 :root[data-ui-shell="v2"] .user-card:not(.has-camera) .user-name {
   position: absolute;
   top: 10px;
-  left: 64px;
-  right: 10px;
+  left: 74px;
+  right: 58px;
   min-width: 0;
   overflow: hidden;
   color: var(--club-text);
@@ -746,13 +752,13 @@
 }
 
 :root[data-ui-shell="v2"] .user-card:not(.has-camera) .user-header {
-  grid-template-columns: 44px minmax(0, 1fr);
+  grid-template-columns: 54px minmax(0, 1fr);
   gap: 10px;
 }
 
 :root[data-ui-shell="v2"] .user-card:not(.has-camera) .user-avatar {
-  width: 44px;
-  height: 44px;
+  width: 54px;
+  height: 54px;
   border-radius: 10px;
   color: var(--club-brass);
   font-size: 13px;
@@ -761,8 +767,7 @@
 }
 
 :root[data-ui-shell="v2"] .user-card:not(.has-camera) .user-meta {
-  padding-top: 22px;
-  gap: 6px;
+  display: none;
 }
 
 :root[data-ui-shell="v2"] .user-indicators {
@@ -811,6 +816,174 @@
   display: grid;
 }
 
+:root[data-ui-shell="v2"] .participant-settings-toggle {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  z-index: 4;
+  width: 40px;
+  min-width: 40px;
+  height: 40px;
+  min-height: 40px;
+  padding: 0;
+  display: inline-grid !important;
+  place-items: center;
+  color: var(--club-text-muted);
+  border: 1px solid var(--club-border);
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.035);
+}
+
+:root[data-ui-shell="v2"] .participant-settings-toggle svg {
+  width: 19px;
+  height: 19px;
+  fill: currentColor;
+}
+
+:root[data-ui-shell="v2"] .participant-settings-toggle:hover,
+:root[data-ui-shell="v2"] .participant-settings-toggle:focus-visible,
+:root[data-ui-shell="v2"] .participant-settings-toggle[aria-expanded="true"] {
+  color: var(--club-brass-bright);
+  border-color: rgba(201, 168, 106, 0.38);
+  background: rgba(201, 168, 106, 0.1);
+}
+
+:root[data-ui-shell="v2"] .participant-settings-popover {
+  position: relative;
+  z-index: 6;
+  width: 100%;
+  min-width: 0;
+  margin-top: 8px;
+  padding: 10px;
+  display: none !important;
+  gap: 8px;
+  color: var(--club-text);
+  border: 1px solid var(--club-border-strong);
+  border-radius: 12px;
+  background: rgba(12, 16, 22, 0.985);
+  box-shadow: 0 16px 34px rgba(0, 0, 0, 0.42);
+}
+
+:root[data-ui-shell="v2"] .participant-settings-popover.is-open {
+  display: grid !important;
+}
+
+:root[data-ui-shell="v2"] .participant-settings-heading,
+:root[data-ui-shell="v2"] .participant-settings-section-header,
+:root[data-ui-shell="v2"] .participant-settings-slider-row,
+:root[data-ui-shell="v2"] .participant-settings-footer {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+}
+
+:root[data-ui-shell="v2"] .participant-settings-heading {
+  justify-content: space-between;
+  gap: 10px;
+}
+
+:root[data-ui-shell="v2"] .participant-settings-heading > div {
+  min-width: 0;
+  display: grid;
+  gap: 2px;
+}
+
+:root[data-ui-shell="v2"] .participant-settings-heading strong {
+  overflow: hidden;
+  font-size: 13px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+:root[data-ui-shell="v2"] .participant-settings-heading span {
+  color: var(--club-text-faint);
+  font-size: 10px;
+}
+
+:root[data-ui-shell="v2"] .participant-settings-close {
+  width: 32px;
+  min-width: 32px;
+  height: 32px;
+  min-height: 32px;
+  padding: 0;
+  display: inline-grid;
+  place-items: center;
+  color: var(--club-text-muted);
+  font-size: 20px;
+  line-height: 1;
+  border-color: transparent;
+  background: transparent;
+}
+
+:root[data-ui-shell="v2"] .participant-settings-section {
+  min-width: 0;
+  padding: 8px;
+  display: grid;
+  gap: 7px;
+  border: 1px solid var(--club-border);
+  border-radius: 9px;
+  background: rgba(255, 255, 255, 0.025);
+}
+
+:root[data-ui-shell="v2"] .participant-settings-section-header {
+  justify-content: space-between;
+  gap: 8px;
+  color: var(--club-text-muted);
+  font-size: 11px;
+  font-weight: 650;
+}
+
+:root[data-ui-shell="v2"] .participant-settings-mute,
+:root[data-ui-shell="v2"] .participant-settings-watch,
+:root[data-ui-shell="v2"] .participant-settings-footer button {
+  min-height: 30px;
+  padding: 4px 9px;
+  color: var(--club-text-muted);
+  font-size: 10px;
+  border-color: var(--club-border);
+  border-radius: 7px;
+  background: rgba(255, 255, 255, 0.035);
+}
+
+:root[data-ui-shell="v2"] .participant-settings-mute.is-muted {
+  color: #ff9aa1;
+  border-color: rgba(229, 106, 106, 0.38);
+  background: rgba(229, 106, 106, 0.12);
+}
+
+:root[data-ui-shell="v2"] .participant-settings-slider-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 38px;
+  gap: 8px;
+}
+
+:root[data-ui-shell="v2"] .participant-settings-slider-row input[type="range"] {
+  width: 100%;
+  min-width: 0;
+  margin: 0;
+  accent-color: var(--club-brass);
+}
+
+:root[data-ui-shell="v2"] .participant-settings-slider-row .vol-pct {
+  color: var(--club-text-faint);
+  font-size: 10px;
+  text-align: right;
+}
+
+:root[data-ui-shell="v2"] .participant-settings-footer {
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+:root[data-ui-shell="v2"] .participant-settings-footer:not(:has(button:not(.hidden))) {
+  display: none;
+}
+
+:root[data-ui-shell="v2"] .participant-settings-footer .danger {
+  color: #ff9aa1;
+  border-color: rgba(229, 106, 106, 0.28);
+}
+
 :root[data-ui-shell="v2"] .user-card.has-camera {
   min-height: 140px;
   aspect-ratio: 16 / 9;
@@ -834,7 +1007,7 @@
 
 :root[data-ui-shell="v2"] .user-card.has-camera .cam-overlay {
   min-width: 0;
-  padding: 28px 9px 8px;
+  padding: 28px 56px 8px 9px;
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
   opacity: 1;
@@ -852,8 +1025,66 @@
 }
 
 :root[data-ui-shell="v2"] .user-card.has-camera .cam-overlay-controls {
-  min-width: 0;
-  gap: 3px;
+  display: none;
+}
+
+:root[data-ui-shell="v2"] .user-card.has-camera > .participant-settings-toggle {
+  top: auto;
+  right: 8px;
+  bottom: 8px;
+  color: var(--club-text);
+  border-color: rgba(255, 255, 255, 0.16);
+  background: rgba(5, 7, 10, 0.68);
+  backdrop-filter: blur(8px);
+}
+
+:root[data-ui-shell="v2"] .user-card.has-camera > .participant-settings-popover {
+  position: relative;
+  inset: auto;
+  width: calc(100% - 16px);
+  max-height: none;
+  margin: 8px;
+  overflow: visible;
+}
+
+:root[data-ui-shell="v2"] .user-card.has-camera:has(> .participant-settings-popover.is-open) {
+  min-height: 0;
+  aspect-ratio: auto;
+}
+
+:root[data-ui-shell="v2"] .user-card.has-camera:has(> .participant-settings-popover.is-open) .user-header {
+  height: auto;
+  aspect-ratio: 16 / 9;
+}
+
+:root[data-ui-shell="v2"] .user-card.has-camera > .participant-settings-toggle[aria-expanded="true"] {
+  display: none !important;
+}
+
+:root[data-ui-shell="v2"][data-ui-mode="compact"] .participant-settings-popover,
+:root[data-ui-shell="v2"][data-ui-mode="mini"] .participant-settings-popover,
+:root[data-ui-shell="v2"][data-ui-mode="compact"] .user-card.has-camera > .participant-settings-popover,
+:root[data-ui-shell="v2"][data-ui-mode="mini"] .user-card.has-camera > .participant-settings-popover {
+  position: fixed;
+  inset: auto auto calc(var(--club-dock-size) + var(--club-shell-padding) + 12px) 50%;
+  z-index: var(--club-layer-modal);
+  width: min(320px, calc(100vw - 32px));
+  max-height: min(360px, calc(100dvh - var(--club-header-size) - var(--club-dock-size) - 48px));
+  margin: 0;
+  overflow-y: auto;
+  transform: translateX(-50%);
+}
+
+:root[data-ui-shell="v2"][data-ui-mode="compact"] .user-card.has-camera:has(> .participant-settings-popover.is-open),
+:root[data-ui-shell="v2"][data-ui-mode="mini"] .user-card.has-camera:has(> .participant-settings-popover.is-open) {
+  min-height: 140px;
+  aspect-ratio: 16 / 9;
+}
+
+:root[data-ui-shell="v2"][data-ui-mode="compact"] .user-card.has-camera:has(> .participant-settings-popover.is-open) .user-header,
+:root[data-ui-shell="v2"][data-ui-mode="mini"] .user-card.has-camera:has(> .participant-settings-popover.is-open) .user-header {
+  height: 100%;
+  aspect-ratio: auto;
 }
 
 :root[data-ui-shell="v2"] .cam-overlay-controls .icon-button,
@@ -1206,20 +1437,6 @@
 }
 
 @container (max-width: 303px) {
-  :root[data-ui-shell="v2"] .user-card:not(.has-camera) .user-name {
-    left: 58px;
-  }
-
-  :root[data-ui-shell="v2"] .user-card:not(.has-camera) .user-header {
-    grid-template-columns: 38px minmax(0, 1fr);
-    gap: 9px;
-  }
-
-  :root[data-ui-shell="v2"] .user-card:not(.has-camera) .user-avatar {
-    width: 38px;
-    height: 38px;
-  }
-
   :root[data-ui-shell="v2"] .participant-chime-toggle {
     width: 30px;
     padding: 0;
@@ -1369,6 +1586,10 @@
   width: clamp(320px, 42vw, 380px);
   height: 100%;
   z-index: var(--club-layer-utility);
+}
+
+:root[data-ui-shell="v2"][data-ui-mode="lounge"] .utility-host[data-active-tool="people"] {
+  width: clamp(300px, 40vw, 360px);
 }
 
 :root[data-ui-shell="v2"][data-ui-mode="compact"] .utility-host,

--- a/core/viewer/clubhouse-shell.css
+++ b/core/viewer/clubhouse-shell.css
@@ -95,6 +95,28 @@
   --club-header-size: 48px;
 }
 
+/* A live solo share is the clubhouse's primary surface. Tighten only that
+   presentation; the empty Stage and multi-share layouts keep their spacing. */
+:root[data-ui-shell="v2"]:has(#screen-grid[data-visible-tiles="1"]) {
+  --club-shell-padding: 12px;
+  --club-shell-gap: 10px;
+}
+
+:root[data-ui-shell="v2"][data-ui-mode="lounge"]:has(#screen-grid[data-visible-tiles="1"]) {
+  --club-shell-padding: 10px;
+  --club-shell-gap: 8px;
+}
+
+:root[data-ui-shell="v2"][data-ui-mode="compact"]:has(#screen-grid[data-visible-tiles="1"]) {
+  --club-shell-padding: 8px;
+  --club-shell-gap: 8px;
+}
+
+:root[data-ui-shell="v2"][data-ui-mode="mini"]:has(#screen-grid[data-visible-tiles="1"]) {
+  --club-shell-padding: 6px;
+  --club-shell-gap: 6px;
+}
+
 :root[data-ui-shell="v2"] body {
   height: 100vh;
   height: 100dvh;
@@ -422,6 +444,38 @@
   box-shadow: inset 0 1px rgba(255, 255, 255, 0.025), 0 16px 42px rgba(0, 0, 0, 0.22);
 }
 
+:root[data-ui-shell="v2"] .room-main:has(> .screens-grid[data-visible-tiles="1"]) {
+  grid-template-rows: minmax(0, 1fr);
+  padding: 6px;
+  gap: 0;
+}
+
+:root[data-ui-shell="v2"] .room-main:has(> .screens-grid[data-visible-tiles="1"]) > .grid-header {
+  position: absolute;
+  top: 56px;
+  right: 8px;
+  left: 8px;
+  z-index: 7;
+  justify-content: flex-end;
+  pointer-events: none;
+}
+
+:root[data-ui-shell="v2"] .room-main:has(> .screens-grid[data-visible-tiles="1"]) > .grid-header > * {
+  pointer-events: auto;
+}
+
+:root[data-ui-shell="v2"] .room-main:has(> .screens-grid[data-visible-tiles="1"]) > .grid-header h2 {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 :root[data-ui-shell="v2"] body[data-theme="ultra-instinct"] .room-main {
   background:
     radial-gradient(circle at 50% 0%, rgba(200, 206, 216, 0.035), transparent 42%),
@@ -453,6 +507,13 @@
   width: 100%;
   height: 100%;
   overflow: hidden;
+}
+
+:root[data-ui-shell="v2"] .screens-grid[data-visible-tiles="1"] {
+  grid-template-columns: minmax(0, 1fr) !important;
+  grid-template-rows: minmax(0, 1fr) !important;
+  align-content: stretch;
+  justify-content: stretch;
 }
 
 :root[data-ui-shell="v2"] .screens-grid:empty::before {
@@ -488,6 +549,24 @@
   box-shadow: 0 16px 38px rgba(0, 0, 0, 0.34);
 }
 
+:root[data-ui-shell="v2"] .screens-grid[data-visible-tiles="1"] > .tile[data-grid-visible] {
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  max-height: none;
+  aspect-ratio: auto;
+  justify-self: stretch;
+  align-self: stretch;
+}
+
+:root[data-ui-shell="v2"] .screens-grid[data-visible-tiles="1"] > .tile[data-grid-visible] > video.screen-video-surface {
+  width: 100%;
+  height: 100%;
+  min-width: 0;
+  min-height: 0;
+  object-fit: contain !important;
+}
+
 :root[data-ui-shell="v2"] .screens-grid .tile h3 {
   position: absolute;
   top: 8px;
@@ -509,6 +588,15 @@
 }
 
 :root[data-ui-shell="v2"] .tile-fullscreen-btn {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  z-index: 7;
+  width: 40px;
+  height: 40px;
+  padding: 0;
+  display: grid;
+  place-items: center;
   opacity: 1;
 }
 
@@ -930,7 +1018,8 @@
 }
 
 :root[data-ui-shell="v2"] .room-layout.utility-collapsed {
-  grid-template-columns: minmax(0, 1fr);
+  grid-template-columns: minmax(0, 1fr) 0;
+  gap: 0;
 }
 
 :root[data-ui-shell="v2"] .room-layout.utility-collapsed .room-sidebar,

--- a/core/viewer/clubhouse-shell.css
+++ b/core/viewer/clubhouse-shell.css
@@ -122,6 +122,14 @@
   mask-image: linear-gradient(to bottom, black, transparent 82%);
 }
 
+/* Preserve Ultra Instinct's WebView2-safe body GIF under the clubhouse shell. */
+:root[data-ui-shell="v2"] body[data-theme="ultra-instinct"] {
+  background:
+    linear-gradient(rgba(8, 10, 18, 0.55), rgba(8, 10, 18, 0.55)),
+    url("ultrainstinct.gif") center center / cover no-repeat,
+    #080a12;
+}
+
 :root[data-ui-shell="v2"] .shell-v2-only {
   display: inline-flex !important;
 }
@@ -414,6 +422,14 @@
   box-shadow: inset 0 1px rgba(255, 255, 255, 0.025), 0 16px 42px rgba(0, 0, 0, 0.22);
 }
 
+:root[data-ui-shell="v2"] body[data-theme="ultra-instinct"] .room-main {
+  background:
+    radial-gradient(circle at 50% 0%, rgba(200, 206, 216, 0.035), transparent 42%),
+    rgba(8, 10, 16, calc(0.68 * var(--ui-bg-alpha, 1)));
+  backdrop-filter: blur(2px);
+  -webkit-backdrop-filter: blur(2px);
+}
+
 :root[data-ui-shell="v2"] .grid-header h2,
 :root[data-ui-shell="v2"] .sidebar-title-row h2,
 :root[data-ui-shell="v2"] .chat-header h3 {
@@ -555,7 +571,7 @@
 }
 
 :root[data-ui-shell="v2"] .sidebar-title-row h2::before {
-  content: "PEOPLE";
+  content: "PEOPLE & TOOLS";
   font-size: 11px;
 }
 
@@ -1366,6 +1382,7 @@
   overflow-x: hidden;
   overflow-y: auto;
   overscroll-behavior: contain;
+  scroll-padding-top: 58px;
 }
 
 :root[data-ui-shell="v2"] .utility-host :where(button, input, textarea, select),
@@ -1398,11 +1415,15 @@
 }
 
 :root[data-ui-shell="v2"] .jam-panel.clubhouse-utility-tool .jam-source-local-heading,
-:root[data-ui-shell="v2"] .jam-panel.clubhouse-utility-tool .jam-source-local-switch-row,
 :root[data-ui-shell="v2"] .jam-panel.clubhouse-utility-tool .jam-spotify-row,
 :root[data-ui-shell="v2"] .jam-panel.clubhouse-utility-tool .jam-actions {
   min-width: 0;
   flex-wrap: wrap;
+}
+
+:root[data-ui-shell="v2"] .jam-panel.clubhouse-utility-tool .jam-source-local-switch-row {
+  min-width: 0;
+  flex-wrap: nowrap;
 }
 
 :root[data-ui-shell="v2"] .jam-panel.clubhouse-utility-tool .jam-source-local-heading > div,
@@ -1412,15 +1433,27 @@
   min-width: 0;
 }
 
+:root[data-ui-shell="v2"] .jam-panel.clubhouse-utility-tool .jam-source-local-copy {
+  flex: 1 1 auto;
+}
+
 :root[data-ui-shell="v2"] .jam-panel.clubhouse-utility-tool .jam-host-controls {
+  position: sticky;
+  top: 0;
+  z-index: 2;
   min-width: 0;
   display: flex;
   flex-wrap: wrap;
   gap: 7px;
+  padding: 5px 0 7px;
+  border-bottom: 1px solid var(--club-border);
+  background: rgba(17, 22, 29, 0.97);
 }
 
 :root[data-ui-shell="v2"] .jam-panel.clubhouse-utility-tool .jam-host-controls button {
-  flex: 1 1 112px;
+  min-width: 0;
+  padding-inline: 8px;
+  flex: 1 1 80px;
 }
 
 :root[data-ui-shell="v2"] .jam-panel.clubhouse-utility-tool .jam-stop-btn {

--- a/core/viewer/connect.js
+++ b/core/viewer/connect.js
@@ -950,8 +950,7 @@ async function connectToRoom({ controlUrl, sfuUrl, roomId, identity, name, reuse
       const cardRef = participantCards.get(participant.identity);
       if (!cardRef) return;
       const label = participant.name || "Guest";
-      const nameEl = cardRef.card.querySelector(".user-name");
-      if (nameEl) nameEl.textContent = label;
+      if (cardRef.setParticipantDisplayName) cardRef.setParticipantDisplayName(label);
       if (!cardRef.avatar.querySelector("video")) {
         cardRef.avatar.textContent = getInitials(label);
         updateAvatarDisplay(participant.identity);

--- a/core/viewer/grid-layout.js
+++ b/core/viewer/grid-layout.js
@@ -1,102 +1,150 @@
-// ─── Optimal Screen Grid Layout Engine ───
-// Calculates the best column/row arrangement to maximize tile size
-// while filling available space. Uses both width AND height to decide.
+// Production screen-grid layout wiring.
+// EchoLayoutPolicy owns the grid-selection algorithm; this module only measures
+// the rendered grid, applies the selected multi-share geometry, and keeps it in
+// sync as the viewer changes size or visible screen tiles change.
 
 (function () {
   "use strict";
 
-  var ASPECT = 16 / 9;
-  var GAP = 12; // matches CSS gap
   var _resizeObserver = null;
+  var _mutationObserver = null;
   var _rafPending = false;
+  var _managedTiles = new Set();
 
-  /**
-   * Given a container and N tiles, find the column count (1..N)
-   * that maximizes the tile area, biased toward balanced (square-ish)
-   * grids. The bias prevents the visually-bad case where 3 tiles end up
-   * in a single horizontal row just because the container is wide and
-   * short — with the bias, 3 tiles default to 2x2 (2 top + 1 bottom)
-   * like every modern video conferencing app does.
-   */
-  function computeOptimalColumns(containerW, containerH, tileCount) {
-    if (tileCount <= 0) return 1;
-    if (tileCount === 1) return 1;
+  function setStyleValue(element, property, value) {
+    if (!element || element.style[property] === value) return;
+    element.style[property] = value;
+  }
 
-    var bestCols = 1;
-    var bestScore = 0;
+  function clearManagedTileSizing() {
+    _managedTiles.forEach(function (tile) {
+      setStyleValue(tile, "width", "");
+      setStyleValue(tile, "height", "");
+    });
+    _managedTiles.clear();
+  }
 
-    for (var cols = 1; cols <= tileCount; cols++) {
-      var rows = Math.ceil(tileCount / cols);
+  function clearManagedGridSizing(grid) {
+    setStyleValue(grid, "gridTemplateColumns", "");
+    setStyleValue(grid, "gridTemplateRows", "");
+    clearManagedTileSizing();
+  }
 
-      // Available space after gaps
-      var availW = containerW - GAP * (cols - 1);
-      var availH = containerH - GAP * (rows - 1);
-      if (availW <= 0 || availH <= 0) continue;
+  function directTiles(grid) {
+    return Array.from(grid.querySelectorAll(":scope > .tile"));
+  }
 
-      // Max tile dimensions constrained by both axes
-      var tileW = availW / cols;
-      var tileH = availH / rows;
+  function visibleTiles(grid) {
+    return directTiles(grid).filter(function (tile) {
+      return tile.offsetParent !== null && getComputedStyle(tile).visibility !== "hidden";
+    });
+  }
 
-      // Constrain to 16:9 aspect ratio
-      var fitW, fitH;
-      if (tileW / tileH > ASPECT) {
-        // Container cell is wider than 16:9 — height is the constraint
-        fitH = tileH;
-        fitW = fitH * ASPECT;
-      } else {
-        // Container cell is taller than 16:9 — width is the constraint
-        fitW = tileW;
-        fitH = fitW / ASPECT;
-      }
+  function clearVisibleTileState(grid) {
+    grid.removeAttribute("data-visible-tiles");
+    directTiles(grid).forEach(function (tile) {
+      tile.removeAttribute("data-grid-visible");
+    });
+  }
 
-      var area = fitW * fitH;
-      // Balance bias: prefer near-square grids when areas are comparable.
-      // For 2x2 (3 tiles): aspectBalance = 1.0 → multiplier = 1.0
-      // For 3x1 (3 tiles): aspectBalance = 0.333 → multiplier = 0.8
-      // Area still dominates but balanced grids win ties and near-ties.
-      var aspectBalance = Math.min(cols, rows) / Math.max(cols, rows);
-      var score = area * (0.7 + 0.3 * aspectBalance);
-
-      if (score > bestScore) {
-        bestScore = score;
-        bestCols = cols;
-      }
+  function publishVisibleTileState(grid, tiles) {
+    var count = String(tiles.length);
+    if (grid.getAttribute("data-visible-tiles") !== count) {
+      grid.setAttribute("data-visible-tiles", count);
     }
 
-    return bestCols;
+    var visibleSet = new Set(tiles);
+    directTiles(grid).forEach(function (tile) {
+      var isVisible = visibleSet.has(tile);
+      if (isVisible && !tile.hasAttribute("data-grid-visible")) {
+        tile.setAttribute("data-grid-visible", "");
+      } else if (!isVisible && tile.hasAttribute("data-grid-visible")) {
+        tile.removeAttribute("data-grid-visible");
+      }
+    });
+  }
+
+  function numericGap(grid, policy) {
+    var style = getComputedStyle(grid);
+    var measured = Number.parseFloat(style.columnGap || style.gap);
+    if (Number.isFinite(measured) && measured >= 0) return measured;
+    return Number(policy.DEFAULT_GRID_GAP) || 12;
+  }
+
+  function pixelTrack(value) {
+    return Math.max(0, Number(value) || 0).toFixed(3).replace(/\.?0+$/, "") + "px";
   }
 
   function updateGridLayout() {
     var grid = document.getElementById("screen-grid");
     if (!grid) return;
 
-    // Don't override focused mode — it has its own layout
-    if (grid.classList.contains("is-focused")) return;
-
-    // Count visible tiles
-    var tiles = grid.querySelectorAll(".tile");
-    var visibleCount = 0;
-    for (var i = 0; i < tiles.length; i++) {
-      if (tiles[i].offsetParent !== null) visibleCount++;
-    }
-
-    if (visibleCount === 0) {
-      grid.style.gridTemplateColumns = "";
-      grid.style.gridTemplateRows = "";
+    // Phase 2 must remain a live presentation-only variant. Rolling back to
+    // legacy removes every inline grid decision made here.
+    if (document.documentElement.dataset.uiShell !== "v2") {
+      clearVisibleTileState(grid);
+      clearManagedGridSizing(grid);
       return;
     }
 
-    var containerW = grid.clientWidth;
-    var containerH = grid.clientHeight;
+    // Single-share immersion and focused mode have purpose-built CSS layouts.
+    // Remove our multi-share inline geometry so those rules retain ownership.
+    var tiles = visibleTiles(grid);
+    publishVisibleTileState(grid, tiles);
+    if (grid.classList.contains("is-focused") || tiles.length <= 1) {
+      clearManagedGridSizing(grid);
+      return;
+    }
 
-    // If container isn't measured yet, bail and retry
-    if (containerW < 10 || containerH < 10) return;
+    var policy = window.EchoLayoutPolicy;
+    if (!policy || typeof policy.chooseOptimalGrid !== "function") {
+      clearManagedGridSizing(grid);
+      return;
+    }
 
-    var cols = computeOptimalColumns(containerW, containerH, visibleCount);
-    var rows = Math.ceil(visibleCount / cols);
+    var width = grid.clientWidth;
+    var height = grid.clientHeight;
+    if (width < 10 || height < 10) return;
 
-    grid.style.gridTemplateColumns = "repeat(" + cols + ", 1fr)";
-    grid.style.gridTemplateRows = "repeat(" + rows + ", 1fr)";
+    var layout = policy.chooseOptimalGrid({
+      width: width,
+      height: height,
+      tileCount: tiles.length,
+      gap: numericGap(grid, policy),
+      aspectRatio: policy.DEFAULT_TILE_ASPECT_RATIO,
+    });
+    if (!layout || !layout.valid || layout.columns < 1 || layout.rows < 1 ||
+        layout.tileWidth <= 0 || layout.tileHeight <= 0) {
+      clearManagedGridSizing(grid);
+      return;
+    }
+
+    setStyleValue(
+      grid,
+      "gridTemplateColumns",
+      "repeat(" + layout.columns + ", " + pixelTrack(layout.tileWidth) + ")"
+    );
+    setStyleValue(
+      grid,
+      "gridTemplateRows",
+      "repeat(" + layout.rows + ", " + pixelTrack(layout.tileHeight) + ")"
+    );
+
+    // The selected tracks are the canonical tile bounds. Filling those tracks
+    // prevents decoded WebRTC resolution changes from resizing the UI.
+    var visibleSet = new Set(tiles);
+    _managedTiles.forEach(function (tile) {
+      if (!visibleSet.has(tile)) {
+        setStyleValue(tile, "width", "");
+        setStyleValue(tile, "height", "");
+        _managedTiles.delete(tile);
+      }
+    });
+    tiles.forEach(function (tile) {
+      setStyleValue(tile, "width", "100%");
+      setStyleValue(tile, "height", "100%");
+      _managedTiles.add(tile);
+    });
   }
 
   function scheduleUpdate() {
@@ -108,37 +156,53 @@
     });
   }
 
-  // Watch the grid container for size changes
   function initGridObserver() {
     var grid = document.getElementById("screen-grid");
     if (!grid || _resizeObserver) return;
 
-    _resizeObserver = new ResizeObserver(function () {
-      scheduleUpdate();
-    });
-    _resizeObserver.observe(grid);
+    if (typeof ResizeObserver === "function") {
+      _resizeObserver = new ResizeObserver(scheduleUpdate);
+      _resizeObserver.observe(grid);
+    } else {
+      _resizeObserver = { disconnect: function () {} };
+      window.addEventListener("resize", scheduleUpdate, { passive: true });
+    }
 
-    // Also watch for child additions/removals (tiles being added/removed).
-    // Some tiles are added invisibly (e.g. before subscription completes)
-    // and become visible later without firing a mutation. We schedule
-    // delayed recalcs as well to catch the deferred-visibility case.
-    var mutObs = new MutationObserver(function () {
-      scheduleUpdate();
-      setTimeout(scheduleUpdate, 250);
-      setTimeout(scheduleUpdate, 1000);
-    });
-    mutObs.observe(grid, { childList: true, subtree: false });
+    if (typeof MutationObserver === "function") {
+      _mutationObserver = new MutationObserver(function (records) {
+        var childListChanged = false;
+        var relevant = records.some(function (record) {
+          if (record.type === "childList" && record.target === grid) {
+            childListChanged = true;
+            return true;
+          }
+          return record.type === "attributes" &&
+            (record.target === grid || record.target.parentElement === grid);
+        });
+        if (!relevant) return;
+        scheduleUpdate();
+        if (childListChanged) {
+          // A tile can be inserted before its subscription becomes visible.
+          setTimeout(scheduleUpdate, 250);
+          setTimeout(scheduleUpdate, 1000);
+        }
+      });
+      _mutationObserver.observe(grid, {
+        attributes: true,
+        attributeFilter: ["class", "hidden", "style"],
+        childList: true,
+        subtree: true,
+      });
+    }
 
-    // Initial layout
+    window.addEventListener("echo:ui-shell-change", scheduleUpdate);
     scheduleUpdate();
   }
 
-  // Expose for external triggers (focus/unfocus, window resize, etc.)
   window._echoRecalcGrid = scheduleUpdate;
 
-  // Init on DOM ready
   if (document.readyState === "loading") {
-    document.addEventListener("DOMContentLoaded", initGridObserver);
+    document.addEventListener("DOMContentLoaded", initGridObserver, { once: true });
   } else {
     initGridObserver();
   }

--- a/core/viewer/index.html
+++ b/core/viewer/index.html
@@ -540,6 +540,7 @@
     <script src="screen-share-native.js?v=0.6.11.1777930912"></script>
     <script src="participants-grid.js?v=0.6.11.1777930912"></script>
     <script src="grid-layout.js?v=0.6.11.1777930912"></script>
+    <script src="camera-lobby-layout.js?v=0.6.11.1777930912"></script>
     <script src="participants-avatar.js?v=0.6.11.1777930912"></script>
     <script src="participants-fullscreen.js?v=0.6.11.1777930912"></script>
     <script src="participants.js?v=0.6.11.1777930912"></script>

--- a/core/viewer/index.html
+++ b/core/viewer/index.html
@@ -157,7 +157,7 @@
               <button id="debug-toggle" type="button">Debug</button>
             </div>
             <button id="disconnect-top" type="button" disabled>Disconnect</button>
-            <button id="shell-toggle-utility" type="button" class="shell-v2-only" aria-controls="room-sidebar chat-panel" aria-expanded="true" aria-label="Hide People and tools">People</button>
+            <button id="shell-toggle-utility" type="button" class="shell-v2-only" aria-controls="utility-host" aria-expanded="true" aria-label="Hide People and tools">People</button>
             <button id="shell-more-actions" type="button" class="shell-v2-only" aria-controls="shell-overflow-menu" aria-expanded="false" aria-label="More clubhouse actions">More</button>
           </div>
         </div>
@@ -170,7 +170,9 @@
             </div>
             <div id="screen-grid" class="media-grid screens-grid"></div>
           </div>
-          <aside id="room-sidebar" class="room-sidebar" data-ui-region="utility-host" data-ui-tool="people">
+          <button id="utility-scrim" type="button" class="utility-scrim shell-v2-only" aria-label="Close utility panel" tabindex="-1"></button>
+          <aside id="utility-host" class="utility-host" data-ui-region="utility-host" data-active-tool="people" aria-label="Clubhouse tools" aria-owns="jam-panel">
+            <section id="room-sidebar" class="room-sidebar" data-ui-tool="people" aria-label="People">
             <div class="sidebar-header">
               <div class="sidebar-title-row">
                 <h2>Active Users</h2>
@@ -189,8 +191,8 @@
               </div>
             </div>
             <div id="user-list" class="user-list"></div>
-          </aside>
-          <div id="chat-panel" class="chat-panel hidden" data-ui-tool="chat" role="dialog" aria-label="Chat">
+            </section>
+            <div id="chat-panel" class="chat-panel hidden" data-ui-tool="chat" role="dialog" aria-label="Chat">
             <div class="chat-header">
               <h3>Chat</h3>
               <div class="chat-actions">
@@ -203,10 +205,11 @@
               <button id="chat-emoji-btn" type="button" class="chat-emoji-btn" title="Add emoji">😊</button>
               <input type="file" id="chat-file-input" class="hidden" accept="image/*,audio/*,video/*,.pdf,.doc,.docx,.txt" />
               <div id="chat-emoji-picker" class="chat-emoji-picker hidden"></div>
-              <textarea id="chat-input" class="chat-input" placeholder="Type a message... (Enter to send, Shift+Enter for new line)" rows="2"></textarea>
+              <textarea id="chat-input" class="chat-input" placeholder="Message the clubhouse…" aria-label="Chat message. Enter to send; Shift+Enter for a new line." rows="2"></textarea>
               <button id="chat-send-btn" type="button" class="chat-send-btn">Send</button>
             </div>
-          </div>
+            </div>
+          </aside>
         </div>
         <nav id="call-controls" class="actions publish-actions hidden shell-control-dock" data-ui-region="control-dock" aria-label="Call controls">
           <button id="toggle-mic" type="button" data-control="microphone" aria-pressed="false" title="Enable microphone" disabled>Enable Mic</button>
@@ -394,7 +397,7 @@
       </div>
     </div>
   </div>
-      <div id="jam-panel" class="jam-panel hidden" role="dialog" aria-label="Jam Session">
+      <div id="jam-panel" class="jam-panel hidden" data-ui-tool="jam" role="dialog" aria-label="Jam Session">
         <div class="jam-header">
           <h3>Jam Session</h3>
           <button id="close-jam" type="button">Close</button>
@@ -425,7 +428,7 @@
             <label class="jam-source-local-switch-row">
               <span class="jam-source-local-copy">
                 <strong>Hear Jam on this PC</strong>
-                <small>When this Echo client joins the Jam, Jam Volume controls how loud it is here.</small>
+                <small>When this Echo client joins the Jam, your Jam volume controls how loud it is here.</small>
               </span>
               <span class="jam-source-local-switch">
                 <input type="checkbox" role="switch" data-jam-source-monitor-toggle aria-label="Hear Jam on this PC" />
@@ -449,7 +452,7 @@
             <span id="jam-listener-count" class="jam-listener-count">0 listening</span>
           </div>
           <div class="jam-volume-section">
-            <label class="jam-volume-label">Jam Volume</label>
+            <label class="jam-volume-label" for="jam-volume-slider">Your Jam volume</label>
             <div class="jam-volume-row">
               <input id="jam-volume-slider" type="range" min="0" max="100" value="50" />
               <span id="jam-volume-value" class="jam-volume-value">50%</span>

--- a/core/viewer/index.html
+++ b/core/viewer/index.html
@@ -165,7 +165,7 @@
         <div class="room-layout" data-ui-region="workspace">
           <div class="room-main" data-ui-region="primary-stage">
             <div class="grid-header">
-              <h2>Screens</h2>
+              <h2 aria-label="The Stage">Screens</h2>
               <button id="echo-display-status" type="button" class="echo-display-status hidden"></button>
             </div>
             <div id="screen-grid" class="media-grid screens-grid"></div>
@@ -539,6 +539,7 @@
     <script src="screen-share-adaptive.js?v=0.6.11.1777930912"></script>
     <script src="screen-share-native.js?v=0.6.11.1777930912"></script>
     <script src="participants-grid.js?v=0.6.11.1777930912"></script>
+    <script src="grid-layout.js?v=0.6.11.1777930912"></script>
     <script src="participants-avatar.js?v=0.6.11.1777930912"></script>
     <script src="participants-fullscreen.js?v=0.6.11.1777930912"></script>
     <script src="participants.js?v=0.6.11.1777930912"></script>

--- a/core/viewer/index.html
+++ b/core/viewer/index.html
@@ -157,7 +157,7 @@
               <button id="debug-toggle" type="button">Debug</button>
             </div>
             <button id="disconnect-top" type="button" disabled>Disconnect</button>
-            <button id="shell-toggle-utility" type="button" class="shell-v2-only" aria-controls="utility-host" aria-expanded="true" aria-label="Hide People and tools">People</button>
+            <button id="shell-toggle-utility" type="button" class="shell-v2-only" aria-controls="utility-host" aria-expanded="true" aria-label="Hide clubhouse tools">Tools</button>
             <button id="shell-more-actions" type="button" class="shell-v2-only" aria-controls="shell-overflow-menu" aria-expanded="false" aria-label="More clubhouse actions">More</button>
           </div>
         </div>
@@ -407,42 +407,49 @@
             <span id="jam-spotify-status" class="jam-spotify-status">Not Connected</span>
             <button id="jam-connect-spotify" type="button" class="jam-connect-btn">Connect Spotify</button>
           </div>
-          <section class="jam-source-local-card hidden" data-jam-source-local-card hidden aria-label="Spotify Jam controls for this PC">
-            <div class="jam-source-local-heading">
-              <div>
-                <div class="jam-source-local-title">Spotify Jam on this PC</div>
-                <div class="jam-source-local-status" data-jam-source-local-status role="status" aria-live="polite">Checking this PC…</div>
-              </div>
-              <span class="jam-source-local-badge">Source PC</span>
-            </div>
-            <label class="jam-source-local-switch-row">
-              <span class="jam-source-local-copy">
-                <strong>Allow Echo Jam to use Spotify on this PC</strong>
-                <small>Lets Echo control the configured Spotify desktop device while a Jam is active.</small>
-              </span>
-              <span class="jam-source-local-switch">
-                <input type="checkbox" role="switch" data-jam-source-takeover-toggle aria-label="Allow Echo Jam to use Spotify on this PC" />
-                <span aria-hidden="true"></span>
-              </span>
-            </label>
-            <label class="jam-source-local-switch-row">
-              <span class="jam-source-local-copy">
-                <strong>Hear Jam on this PC</strong>
-                <small>When this Echo client joins the Jam, your Jam volume controls how loud it is here.</small>
-              </span>
-              <span class="jam-source-local-switch">
-                <input type="checkbox" role="switch" data-jam-source-monitor-toggle aria-label="Hear Jam on this PC" />
-                <span aria-hidden="true"></span>
-              </span>
-            </label>
-            <div class="jam-source-local-error hidden" data-jam-source-local-error role="alert"></div>
-          </section>
           <div id="jam-host-controls" class="jam-host-controls" style="display:none">
             <button id="jam-start-btn" type="button" class="jam-start-btn">Start Jam</button>
             <button id="jam-stop-music-btn" type="button" class="jam-stop-btn" style="display:none" title="Stops Spotify playback for everyone; the Jam stays open">Stop Music</button>
             <button id="jam-end-btn" type="button" class="jam-end-btn" style="display:none" title="Ends the Jam for everyone and clears its queue">End Jam</button>
             <button id="jam-skip-btn" type="button" class="jam-skip-btn" style="display:none">Skip</button>
           </div>
+          <section class="jam-source-local-card hidden" data-jam-source-local-card hidden aria-label="Spotify Jam controls for this PC">
+            <details class="jam-source-local-details">
+              <summary class="jam-source-local-heading jam-source-local-summary">
+                <div>
+                  <div class="jam-source-local-title">Spotify on this PC</div>
+                  <div class="jam-source-local-status" data-jam-source-local-status role="status" aria-live="polite">Checking this PC…</div>
+                </div>
+                <span class="jam-source-local-summary-meta">
+                  <span class="jam-source-local-badge">Source PC</span>
+                  <span class="jam-source-local-chevron" aria-hidden="true"></span>
+                </span>
+              </summary>
+              <div class="jam-source-local-controls">
+                <label class="jam-source-local-switch-row">
+                  <span class="jam-source-local-copy">
+                    <strong>Allow Echo Jam to use Spotify on this PC</strong>
+                    <small>Lets Echo control the configured Spotify desktop device while a Jam is active.</small>
+                  </span>
+                  <span class="jam-source-local-switch">
+                    <input type="checkbox" role="switch" data-jam-source-takeover-toggle aria-label="Allow Echo Jam to use Spotify on this PC" />
+                    <span aria-hidden="true"></span>
+                  </span>
+                </label>
+                <label class="jam-source-local-switch-row">
+                  <span class="jam-source-local-copy">
+                    <strong>Hear Jam on this PC</strong>
+                    <small>When this Echo client joins the Jam, your Jam volume controls how loud it is here.</small>
+                  </span>
+                  <span class="jam-source-local-switch">
+                    <input type="checkbox" role="switch" data-jam-source-monitor-toggle aria-label="Hear Jam on this PC" />
+                    <span aria-hidden="true"></span>
+                  </span>
+                </label>
+                <div class="jam-source-local-error hidden" data-jam-source-local-error role="alert"></div>
+              </div>
+            </details>
+          </section>
           <div id="jam-now-playing" class="jam-now-playing">
             <div class="jam-now-playing-empty">No music playing</div>
           </div>

--- a/core/viewer/jam-source-local-control.test.js
+++ b/core/viewer/jam-source-local-control.test.js
@@ -31,6 +31,28 @@ test("source-PC switches appear in synchronized portal and Jam cards", () => {
   );
 });
 
+test("Jam prioritizes playback controls and collapses source-PC settings by default", () => {
+  const jamStart = indexSource.indexOf('id="jam-panel"');
+  const jamEnd = indexSource.indexOf("<!-- Dashboard Panel", jamStart);
+  const jamPanelSource = indexSource.slice(jamStart, jamEnd);
+  const portalSource = indexSource.slice(0, indexSource.indexOf('<div class="portal-form">'));
+
+  assert.notEqual(jamStart, -1, "Jam panel is present");
+  assert.notEqual(jamEnd, -1, "Jam panel boundary is present");
+  assert.match(jamPanelSource, /<details class="jam-source-local-details">/);
+  assert.doesNotMatch(jamPanelSource, /<details class="jam-source-local-details"[^>]*\sopen(?:\s|>)/);
+  assert.ok(
+    jamPanelSource.indexOf('id="jam-host-controls"') < jamPanelSource.indexOf("data-jam-source-local-card"),
+    "playback controls precede the source-PC disclosure",
+  );
+  assert.doesNotMatch(portalSource, /jam-source-local-details/);
+});
+
+test("the collapsed source-PC summary surfaces local control errors", () => {
+  const render = functionSource("renderJamSourceLocalControl", "currentJamRelayGain");
+  assert.match(render, /else if \(state\.last_error\)\s*{\s*status = state\.last_error;\s*tone = "warning";/);
+});
+
 test("source-PC controls boot before login and refresh with Jam polling", () => {
   assert.match(jamSource, /DOMContentLoaded", initJamSourceLocalControlUi/);
   assert.match(jamSource, /else\s*{\s*initJamSourceLocalControlUi\(\);\s*}/);

--- a/core/viewer/jam.css
+++ b/core/viewer/jam.css
@@ -148,6 +148,61 @@
   gap: 14px;
 }
 
+.jam-source-local-details {
+  min-width: 0;
+}
+
+.jam-source-local-summary {
+  min-width: 0;
+  min-height: 40px;
+  list-style: none;
+  cursor: pointer;
+  user-select: none;
+}
+
+.jam-source-local-summary::-webkit-details-marker {
+  display: none;
+}
+
+.jam-source-local-summary::marker {
+  content: "";
+}
+
+.jam-source-local-summary:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
+  border-radius: var(--radius-sm);
+}
+
+.jam-source-local-summary-meta {
+  display: inline-flex;
+  align-items: center;
+  gap: 9px;
+  flex: 0 0 auto;
+}
+
+.jam-source-local-chevron {
+  width: 8px;
+  height: 8px;
+  margin: 0 3px 4px 1px;
+  border-right: 2px solid var(--muted);
+  border-bottom: 2px solid var(--muted);
+  transform: rotate(45deg);
+  transition: transform 160ms ease, margin 160ms ease;
+}
+
+.jam-source-local-details[open] .jam-source-local-chevron {
+  margin-top: 4px;
+  margin-bottom: 0;
+  transform: rotate(225deg);
+}
+
+.jam-source-local-controls {
+  display: grid;
+  gap: 10px;
+  margin-top: 10px;
+}
+
 .jam-source-local-title {
   color: var(--text);
   font-size: 13px;

--- a/core/viewer/jam.js
+++ b/core/viewer/jam.js
@@ -84,6 +84,9 @@ function renderJamSourceLocalControl() {
     } else if (_jamSourceLocalControlLegacy) {
       status = "Echo update required for local Spotify controls";
       tone = "warning";
+    } else if (state.last_error) {
+      status = state.last_error;
+      tone = "warning";
     } else if (state.takeover_active && !state.takeover_enabled) {
       status = "Stopping the Jam and returning Spotify to this PC...";
       tone = "warning";

--- a/core/viewer/jam.js
+++ b/core/viewer/jam.js
@@ -617,17 +617,22 @@ function escapeHtml(str) {
 // Panel Open / Close
 // ──────────────────────────────────────────
 
-function openJamPanel() {
+function openJamPanel(opener) {
   var panel = document.getElementById("jam-panel");
   if (panel) {
-    panel.classList.remove("hidden");
+    var handledByClubhouse = window.EchoClubhouseUtility &&
+      window.EchoClubhouseUtility.open("jam", opener || document.activeElement);
+    if (!handledByClubhouse) panel.classList.remove("hidden");
     initJam();
   }
 }
 
-function closeJamPanel() {
+function closeJamPanel(options) {
   var panel = document.getElementById("jam-panel");
-  if (panel) panel.classList.add("hidden");
+  if (!panel) return;
+  var handledByClubhouse = window.EchoClubhouseUtility &&
+    window.EchoClubhouseUtility.close("jam", options);
+  if (!handledByClubhouse) panel.classList.add("hidden");
 }
 
 // ──────────────────────────────────────────
@@ -967,6 +972,11 @@ function renderSearchResults(tracks) {
       '</div>' +
       '<button class="jam-result-add" title="Add to queue">+</button>';
     var addBtn = item.querySelector(".jam-result-add");
+    var resultName = item.querySelector(".jam-result-name");
+    var resultArtist = item.querySelector(".jam-result-artist");
+    if (resultName) resultName.title = t.name || "";
+    if (resultArtist) resultArtist.title = t.artist || "";
+    addBtn.setAttribute("aria-label", "Add " + (t.name || "track") + " by " + (t.artist || "unknown artist") + " to queue");
     addBtn.onclick = function() { addToQueue(t); };
     addBtn.disabled = !_jamContract || !_jamContract.canControl;
     container.appendChild(item);
@@ -1246,6 +1256,13 @@ function renderNowPlaying(np) {
   if (!container) return;
   if (!np || !np.name || !np.is_playing) {
     container.innerHTML = '<div class="jam-now-playing-empty">No music playing</div>';
+    container.removeAttribute("role");
+    container.removeAttribute("tabindex");
+    container.removeAttribute("aria-label");
+    container.style.cursor = "";
+    container.title = "";
+    container.onclick = null;
+    container.onkeydown = null;
     return;
   }
   var progress = np.duration_ms > 0 ? Math.min(100, (np.progress_ms / np.duration_ms) * 100) : 0;
@@ -1256,16 +1273,32 @@ function renderNowPlaying(np) {
       '<div class="jam-now-playing-artist">' + escapeHtml(np.artist) + '</div>' +
     '</div>' +
     '<div class="jam-progress"><div class="jam-progress-bar" style="width:' + progress.toFixed(1) + '%"></div></div>';
+  var nowPlayingName = container.querySelector(".jam-now-playing-name");
+  var nowPlayingArtist = container.querySelector(".jam-now-playing-artist");
+  if (nowPlayingName) nowPlayingName.title = np.name || "";
+  if (nowPlayingArtist) nowPlayingArtist.title = np.artist || "";
 
   // Click now-playing card to join jam if not already listening
   if (!_jamAudioWs && _jamState && _jamState.active) {
     container.style.cursor = "pointer";
-    container.title = "Click to join the Jam";
+    container.title = "Join the Jam";
+    container.setAttribute("role", "button");
+    container.setAttribute("tabindex", "0");
+    container.setAttribute("aria-label", "Join Jam — " + np.name + " by " + np.artist + " is playing");
     container.onclick = function() { joinJam(); };
+    container.onkeydown = function(event) {
+      if (event.key !== "Enter" && event.key !== " ") return;
+      event.preventDefault();
+      joinJam();
+    };
   } else {
     container.style.cursor = "";
     container.title = "";
+    container.removeAttribute("role");
+    container.removeAttribute("tabindex");
+    container.removeAttribute("aria-label");
     container.onclick = null;
+    container.onkeydown = null;
   }
 }
 
@@ -1286,6 +1319,10 @@ function renderQueue(queue) {
         '<div class="jam-result-name">' + escapeHtml(t.name) + '</div>' +
         '<div class="jam-result-artist">' + escapeHtml(t.artist) + ' \u00b7 Added by ' + escapeHtml(t.added_by) + '</div>' +
       '</div>';
+    var queueName = item.querySelector(".jam-result-name");
+    var queueArtist = item.querySelector(".jam-result-artist");
+    if (queueName) queueName.title = t.name || "";
+    if (queueArtist) queueArtist.title = (t.artist || "") + (t.added_by ? " · Added by " + t.added_by : "");
     container.appendChild(item);
   });
 }
@@ -1685,7 +1722,7 @@ function cleanupJam() {
     syncJamButtonsFromState();
   }
   stopJamAudioStream();
-  closeJamPanel();
+  closeJamPanel({ restoreFocus: false });
 }
 
 // ──────────────────────────────────────────
@@ -1698,6 +1735,9 @@ function updateNowPlayingBanner(state) {
 
   if ((_jamContract && !_jamContract.compatible) || !state || !state.active || !state.now_playing || !state.now_playing.name || !state.now_playing.is_playing) {
     banner.classList.add("hidden");
+    banner.removeAttribute("role");
+    banner.removeAttribute("tabindex");
+    banner.removeAttribute("aria-label");
     return;
   }
 
@@ -1710,14 +1750,22 @@ function updateNowPlayingBanner(state) {
     '</div>' +
     '<span class="jam-banner-live">JAM</span>';
   banner.classList.remove("hidden");
+  banner.setAttribute("role", "button");
+  banner.setAttribute("tabindex", "0");
+  banner.setAttribute("aria-label", "Open Jam — now playing " + np.name + " by " + np.artist);
 
   // Click banner to open jam panel and auto-join
   if (!banner._jamClickBound) {
     banner.style.cursor = "pointer";
     banner.addEventListener("click", function() {
-      openJamPanel();
+      openJamPanel(banner);
       // Auto-join if not already listening
       if (_jamState && _jamState.active && !_jamAudioWs) joinJam();
+    });
+    banner.addEventListener("keydown", function(event) {
+      if (event.key !== "Enter" && event.key !== " ") return;
+      event.preventDefault();
+      banner.click();
     });
     banner._jamClickBound = true;
   }

--- a/core/viewer/media-controls.js
+++ b/core/viewer/media-controls.js
@@ -271,6 +271,9 @@ function populateCameraLobby() {
   });
 
   cameraLobbyGrid.dataset.count = Math.min(count, 6);
+  if (typeof window._echoRecalcCameraLobby === "function") {
+    window._echoRecalcCameraLobby();
+  }
 }
 
 function createCameraTile(participant) {

--- a/core/viewer/participants-avatar.js
+++ b/core/viewer/participants-avatar.js
@@ -17,6 +17,12 @@ function iconSvg(name) {
         <path d="M17 10.5V6c0-1.1-.9-2-2-2H4C2.9 4 2 4.9 2 6v12c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2v-4.5l5 4v-11l-5 4z"/>
       </svg>`;
   }
+  if (name === "settings") {
+    return `
+      <svg viewBox="0 0 24 24" aria-hidden="true">
+        <path d="M4 7h10.2a3 3 0 1 0 0-2H4v2zm0 6h3.2a3 3 0 1 0 0-2H4v2zm0 6h10.2a3 3 0 1 0 0-2H4v2zm13-14a1 1 0 1 1 0 2 1 1 0 0 1 0-2zM10 11a1 1 0 1 1 0 2 1 1 0 0 1 0-2zm7 6a1 1 0 1 1 0 2 1 1 0 0 1 0-2z"/>
+      </svg>`;
+  }
   return `
     <svg viewBox="0 0 24 24" aria-hidden="true">
       <path d="M3 5h18v14H3zM5 7v10h14V7H5zm2 12h10v2H7z"/>
@@ -28,6 +34,42 @@ function iconSvg(name) {
 // ── Participant card ──
 
 var participantControlIdSequence = 0;
+var activeParticipantSettings = null;
+
+function closeParticipantSettings(restoreFocus) {
+  if (!activeParticipantSettings) return;
+  var current = activeParticipantSettings;
+  activeParticipantSettings = null;
+  current.popup.classList.remove("is-open");
+  current.button.setAttribute("aria-expanded", "false");
+  if (restoreFocus && current.button.isConnected) current.button.focus();
+}
+
+function toggleParticipantSettings(button, popup) {
+  var opening = !popup.classList.contains("is-open");
+  if (activeParticipantSettings && activeParticipantSettings.popup !== popup) {
+    closeParticipantSettings(false);
+  }
+  popup.classList.toggle("is-open", opening);
+  button.setAttribute("aria-expanded", opening ? "true" : "false");
+  activeParticipantSettings = opening ? { button: button, popup: popup } : null;
+}
+
+if (typeof document.addEventListener === "function") {
+  document.addEventListener("click", function(event) {
+    if (!activeParticipantSettings) return;
+    if (activeParticipantSettings.button.contains(event.target) ||
+        activeParticipantSettings.popup.contains(event.target)) return;
+    closeParticipantSettings(false);
+  });
+
+  document.addEventListener("keydown", function(event) {
+    if (event.key !== "Escape" || !activeParticipantSettings) return;
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    closeParticipantSettings(true);
+  });
+}
 
 function getRemoteParticipantsForScreenIdentity(identity) {
   var matches = [];
@@ -255,7 +297,17 @@ function ensureParticipantCard(participant, isLocal = false) {
   let popScreenPct = null;
   let popChimeSlider = null;
   let popChimePct = null;
-  let chimeToggleButton = null;
+  let participantSettingsButton = null;
+  let participantSettingsPopup = null;
+  let settingsMicMute = null;
+  let settingsScreenMute = null;
+  let settingsMicSlider = null;
+  let settingsMicPct = null;
+  let settingsScreenSlider = null;
+  let settingsScreenPct = null;
+  let settingsChimeSlider = null;
+  let settingsChimePct = null;
+  let settingsWatchButton = null;
   if (!isLocal) {
     const indicators = document.createElement("div");
     indicators.className = "user-indicators";
@@ -497,19 +549,6 @@ function ensureParticipantCard(participant, isLocal = false) {
     chimePct.className = "vol-pct";
     chimePct.textContent = "50%";
     chimeRow.append(chimeLabel, chimeSlider, chimePct);
-    chimeToggleButton = document.createElement("button");
-    chimeToggleButton.type = "button";
-    chimeToggleButton.className = "participant-chime-toggle shell-v2-only";
-    chimeToggleButton.textContent = "Chime volume";
-    chimeToggleButton.setAttribute("aria-label", "Chime volume for " + participantDisplayName);
-    chimeToggleButton.setAttribute("aria-controls", chimeRow.id);
-    chimeToggleButton.setAttribute("aria-expanded", "false");
-    chimeToggleButton.addEventListener("click", function() {
-      const open = !chimeRow.classList.contains("is-open");
-      chimeRow.classList.toggle("is-open", open);
-      chimeToggleButton.setAttribute("aria-expanded", open ? "true" : "false");
-    });
-    indicators.append(chimeToggleButton);
     audioControls.append(micRow, screenRow, chimeRow);
     meta.append(indicators, audioControls);
 
@@ -678,9 +717,155 @@ function ensureParticipantCard(participant, isLocal = false) {
       debugLog("[cam-overlay] ERROR creating overlay for " + key + ": " + overlayErr.message);
       camOverlay = null;
     }
+
+    participantSettingsButton = document.createElement("button");
+    participantSettingsButton.type = "button";
+    participantSettingsButton.className = "participant-settings-toggle shell-v2-only";
+    participantSettingsButton.innerHTML = iconSvg("settings");
+    participantSettingsButton.setAttribute("aria-label", "Audio settings for " + participantDisplayName);
+    participantSettingsButton.setAttribute("aria-haspopup", "dialog");
+    participantSettingsButton.setAttribute("aria-expanded", "false");
+    participantSettingsButton.title = "Audio settings for " + participantDisplayName;
+
+    participantSettingsPopup = document.createElement("div");
+    participantSettingsPopup.id = "participant-settings-" + participantControlId;
+    participantSettingsPopup.className = "participant-settings-popover shell-v2-only";
+    participantSettingsPopup.setAttribute("role", "dialog");
+    participantSettingsPopup.setAttribute("aria-label", "Audio settings for " + participantDisplayName);
+    participantSettingsButton.setAttribute("aria-controls", participantSettingsPopup.id);
+
+    var settingsHeading = document.createElement("div");
+    settingsHeading.className = "participant-settings-heading";
+    var settingsHeadingCopy = document.createElement("div");
+    var settingsHeadingTitle = document.createElement("strong");
+    settingsHeadingTitle.textContent = participantDisplayName;
+    var settingsHeadingHint = document.createElement("span");
+    settingsHeadingHint.textContent = "Adjust what you hear";
+    settingsHeadingCopy.append(settingsHeadingTitle, settingsHeadingHint);
+    var settingsClose = document.createElement("button");
+    settingsClose.type = "button";
+    settingsClose.className = "participant-settings-close";
+    settingsClose.textContent = "\u00d7";
+    settingsClose.setAttribute("aria-label", "Close audio settings for " + participantDisplayName);
+    settingsClose.addEventListener("click", function(event) {
+      event.stopPropagation();
+      closeParticipantSettings(true);
+    });
+    settingsHeading.append(settingsHeadingCopy, settingsClose);
+
+    function createParticipantSettingsSection(labelText, sliderLabel, min, max, step, value, includeMute) {
+      var section = document.createElement("div");
+      section.className = "participant-settings-section";
+      var sectionHeader = document.createElement("div");
+      sectionHeader.className = "participant-settings-section-header";
+      var label = document.createElement("span");
+      label.textContent = labelText;
+      var mute = null;
+      if (includeMute) {
+        mute = document.createElement("button");
+        mute.type = "button";
+        mute.className = "participant-settings-mute";
+        mute.textContent = "Mute";
+        mute.setAttribute("aria-label", "Mute " + sliderLabel.toLowerCase() + " from " + participantDisplayName);
+        sectionHeader.append(label, mute);
+      } else {
+        sectionHeader.append(label);
+      }
+      var sliderRow = document.createElement("div");
+      sliderRow.className = "participant-settings-slider-row";
+      var slider = document.createElement("input");
+      slider.type = "range";
+      slider.min = min;
+      slider.max = max;
+      slider.step = step;
+      slider.value = value;
+      slider.setAttribute("aria-label", sliderLabel + " for " + participantDisplayName);
+      var pct = document.createElement("span");
+      pct.className = "vol-pct";
+      pct.textContent = Math.round(Number(value) * 100) + "%";
+      sliderRow.append(slider, pct);
+      section.append(sectionHeader, sliderRow);
+      return { section: section, slider: slider, pct: pct, mute: mute };
+    }
+
+    var settingsMic = createParticipantSettingsSection(
+      "Voice", "Microphone volume", "0", "3", "0.01", micSlider.value, true
+    );
+    settingsMicSlider = settingsMic.slider;
+    settingsMicPct = settingsMic.pct;
+    settingsMicMute = settingsMic.mute;
+    settingsMicMute.setAttribute("aria-label", "Mute microphone audio from " + participantDisplayName);
+    var settingsScreen = createParticipantSettingsSection(
+      "Shared audio", "Screen volume", "0", "3", "0.01", screenSlider.value, true
+    );
+    settingsScreenSlider = settingsScreen.slider;
+    settingsScreenPct = settingsScreen.pct;
+    settingsScreenMute = settingsScreen.mute;
+    settingsScreenMute.setAttribute("aria-label", "Mute screen audio from " + participantDisplayName);
+    var settingsChime = createParticipantSettingsSection(
+      "Join chime", "Chime volume", "0", "1", "0.01", chimeSlider.value, false
+    );
+    settingsChimeSlider = settingsChime.slider;
+    settingsChimePct = settingsChime.pct;
+
+    settingsWatchButton = document.createElement("button");
+    settingsWatchButton.type = "button";
+    settingsWatchButton.className = "participant-settings-watch hidden";
+    settingsWatchButton.textContent = watchToggleBtn.textContent;
+    settingsWatchButton.addEventListener("click", function(event) {
+      event.stopPropagation();
+      watchToggleBtn.click();
+    });
+    function syncSettingsWatchButton() {
+      settingsWatchButton.textContent = watchToggleBtn.textContent;
+      settingsWatchButton.classList.toggle("hidden", watchToggleBtn.style.display === "none");
+    }
+    if (typeof MutationObserver !== "undefined") {
+      new MutationObserver(syncSettingsWatchButton).observe(watchToggleBtn, {
+        attributes: true,
+        childList: true,
+        subtree: true,
+      });
+    }
+    syncSettingsWatchButton();
+
+    var settingsFooter = document.createElement("div");
+    settingsFooter.className = "participant-settings-footer";
+    settingsFooter.append(settingsWatchButton);
+    if (isAdminMode()) {
+      var settingsServerMute = document.createElement("button");
+      settingsServerMute.type = "button";
+      settingsServerMute.textContent = "Server mute";
+      settingsServerMute.addEventListener("click", function() {
+        adminMuteParticipant(participant.identity);
+      });
+      var settingsKick = document.createElement("button");
+      settingsKick.type = "button";
+      settingsKick.className = "danger";
+      settingsKick.textContent = "Remove";
+      settingsKick.addEventListener("click", function() {
+        adminKickParticipant(participant.identity);
+      });
+      settingsFooter.append(settingsServerMute, settingsKick);
+    }
+
+    participantSettingsPopup.append(
+      settingsHeading,
+      settingsMic.section,
+      settingsScreen.section,
+      settingsChime.section,
+      settingsFooter
+    );
+    participantSettingsButton.addEventListener("click", function(event) {
+      event.stopPropagation();
+      toggleParticipantSettings(participantSettingsButton, participantSettingsPopup);
+    });
   }
   header.append(avatar, meta);
   card.append(header);
+  if (participantSettingsButton && participantSettingsPopup) {
+    card.append(participantSettingsButton, participantSettingsPopup);
+  }
 
   let controls = null;
   let micStatusEl = micIndicator;
@@ -807,7 +992,8 @@ function ensureParticipantCard(participant, isLocal = false) {
     });
   }
   if (micMuteButton) {
-    micMuteButton.addEventListener("click", () => {
+    micMuteButton.addEventListener("click", (event) => {
+      event.stopPropagation();
       state.micUserMuted = !state.micUserMuted;
       micMuteButton.textContent = state.micUserMuted ? "Unmute" : "Mute";
       micMuteButton.setAttribute("aria-label", (state.micUserMuted ? "Unmute" : "Mute") + " microphone audio from " + participantDisplayName);
@@ -818,12 +1004,18 @@ function ensureParticipantCard(participant, isLocal = false) {
         ovMicMute.setAttribute("aria-label", (state.micUserMuted ? "Unmute" : "Mute") + " microphone audio from " + participantDisplayName);
         ovMicMute.classList.toggle("is-muted", state.micUserMuted);
       }
+      if (settingsMicMute) {
+        settingsMicMute.textContent = state.micUserMuted ? "Unmute" : "Mute";
+        settingsMicMute.setAttribute("aria-label", (state.micUserMuted ? "Unmute" : "Mute") + " microphone audio from " + participantDisplayName);
+        settingsMicMute.classList.toggle("is-muted", state.micUserMuted);
+      }
       applyParticipantAudioVolumes(state);
       updateActiveSpeakerUi();
     });
   }
   if (screenMuteButton) {
-    screenMuteButton.addEventListener("click", () => {
+    screenMuteButton.addEventListener("click", (event) => {
+      event.stopPropagation();
       state.screenUserMuted = !state.screenUserMuted;
       screenMuteButton.textContent = state.screenUserMuted ? "Unmute" : "Mute";
       screenMuteButton.setAttribute("aria-label", (state.screenUserMuted ? "Unmute" : "Mute") + " screen audio from " + participantDisplayName);
@@ -833,6 +1025,11 @@ function ensureParticipantCard(participant, isLocal = false) {
         ovScreenMute.textContent = state.screenUserMuted ? "Unmute" : "Mute";
         ovScreenMute.setAttribute("aria-label", (state.screenUserMuted ? "Unmute" : "Mute") + " screen audio from " + participantDisplayName);
         ovScreenMute.classList.toggle("is-muted", state.screenUserMuted);
+      }
+      if (settingsScreenMute) {
+        settingsScreenMute.textContent = state.screenUserMuted ? "Unmute" : "Mute";
+        settingsScreenMute.setAttribute("aria-label", (state.screenUserMuted ? "Unmute" : "Mute") + " screen audio from " + participantDisplayName);
+        settingsScreenMute.classList.toggle("is-muted", state.screenUserMuted);
       }
       applyParticipantAudioVolumes(state);
     });
@@ -845,6 +1042,8 @@ function ensureParticipantCard(participant, isLocal = false) {
       // Sync popup slider
       if (popMicSlider) popMicSlider.value = state.micVolume;
       if (popMicPct) { popMicPct.textContent = Math.round(state.micVolume * 100) + "%"; popMicPct.classList.toggle("boosted", state.micVolume > 1); }
+      if (settingsMicSlider) settingsMicSlider.value = state.micVolume;
+      if (settingsMicPct) { settingsMicPct.textContent = Math.round(state.micVolume * 100) + "%"; settingsMicPct.classList.toggle("boosted", state.micVolume > 1); }
       applyParticipantAudioVolumes(state);
       saveParticipantVolume(key, state.micVolume, state.screenVolume, state.chimeVolume);
     });
@@ -857,6 +1056,8 @@ function ensureParticipantCard(participant, isLocal = false) {
       // Sync popup slider
       if (popScreenSlider) popScreenSlider.value = state.screenVolume;
       if (popScreenPct) { popScreenPct.textContent = Math.round(state.screenVolume * 100) + "%"; popScreenPct.classList.toggle("boosted", state.screenVolume > 1); }
+      if (settingsScreenSlider) settingsScreenSlider.value = state.screenVolume;
+      if (settingsScreenPct) { settingsScreenPct.textContent = Math.round(state.screenVolume * 100) + "%"; settingsScreenPct.classList.toggle("boosted", state.screenVolume > 1); }
       applyParticipantAudioVolumes(state);
       saveParticipantVolume(key, state.micVolume, state.screenVolume, state.chimeVolume);
     });
@@ -867,6 +1068,61 @@ function ensureParticipantCard(participant, isLocal = false) {
       if (chimePct) chimePct.textContent = Math.round(state.chimeVolume * 100) + "%";
       if (popChimeSlider) popChimeSlider.value = state.chimeVolume;
       if (popChimePct) popChimePct.textContent = Math.round(state.chimeVolume * 100) + "%";
+      if (settingsChimeSlider) settingsChimeSlider.value = state.chimeVolume;
+      if (settingsChimePct) settingsChimePct.textContent = Math.round(state.chimeVolume * 100) + "%";
+      saveParticipantVolume(key, state.micVolume, state.screenVolume, state.chimeVolume);
+    });
+  }
+  if (settingsMicMute) {
+    settingsMicMute.addEventListener("click", function(event) {
+      event.stopPropagation();
+      micMuteButton.click();
+    });
+  }
+  if (settingsScreenMute) {
+    settingsScreenMute.addEventListener("click", function(event) {
+      event.stopPropagation();
+      screenMuteButton.click();
+    });
+  }
+  if (settingsMicSlider) {
+    settingsMicSlider.addEventListener("input", function() {
+      var val = Number(settingsMicSlider.value);
+      state.micVolume = val;
+      if (micSlider) micSlider.value = val;
+      if (popMicSlider) popMicSlider.value = val;
+      var pctText = Math.round(val * 100) + "%";
+      if (settingsMicPct) { settingsMicPct.textContent = pctText; settingsMicPct.classList.toggle("boosted", val > 1); }
+      if (micPct) { micPct.textContent = pctText; micPct.classList.toggle("boosted", val > 1); }
+      if (popMicPct) { popMicPct.textContent = pctText; popMicPct.classList.toggle("boosted", val > 1); }
+      applyParticipantAudioVolumes(state);
+      saveParticipantVolume(key, state.micVolume, state.screenVolume, state.chimeVolume);
+    });
+  }
+  if (settingsScreenSlider) {
+    settingsScreenSlider.addEventListener("input", function() {
+      var val = Number(settingsScreenSlider.value);
+      state.screenVolume = val;
+      if (screenSlider) screenSlider.value = val;
+      if (popScreenSlider) popScreenSlider.value = val;
+      var pctText = Math.round(val * 100) + "%";
+      if (settingsScreenPct) { settingsScreenPct.textContent = pctText; settingsScreenPct.classList.toggle("boosted", val > 1); }
+      if (screenPct) { screenPct.textContent = pctText; screenPct.classList.toggle("boosted", val > 1); }
+      if (popScreenPct) { popScreenPct.textContent = pctText; popScreenPct.classList.toggle("boosted", val > 1); }
+      applyParticipantAudioVolumes(state);
+      saveParticipantVolume(key, state.micVolume, state.screenVolume, state.chimeVolume);
+    });
+  }
+  if (settingsChimeSlider) {
+    settingsChimeSlider.addEventListener("input", function() {
+      var val = Number(settingsChimeSlider.value);
+      state.chimeVolume = val;
+      if (chimeSlider) chimeSlider.value = val;
+      if (popChimeSlider) popChimeSlider.value = val;
+      var pctText = Math.round(val * 100) + "%";
+      if (settingsChimePct) settingsChimePct.textContent = pctText;
+      if (chimePct) chimePct.textContent = pctText;
+      if (popChimePct) popChimePct.textContent = pctText;
       saveParticipantVolume(key, state.micVolume, state.screenVolume, state.chimeVolume);
     });
   }
@@ -879,6 +1135,8 @@ function ensureParticipantCard(participant, isLocal = false) {
       var pctText = Math.round(val * 100) + "%";
       if (popMicPct) { popMicPct.textContent = pctText; popMicPct.classList.toggle("boosted", val > 1); }
       if (micPct) { micPct.textContent = pctText; micPct.classList.toggle("boosted", val > 1); }
+      if (settingsMicSlider) settingsMicSlider.value = val;
+      if (settingsMicPct) { settingsMicPct.textContent = pctText; settingsMicPct.classList.toggle("boosted", val > 1); }
       applyParticipantAudioVolumes(state);
       saveParticipantVolume(key, state.micVolume, state.screenVolume, state.chimeVolume);
     });
@@ -891,6 +1149,8 @@ function ensureParticipantCard(participant, isLocal = false) {
       var pctText = Math.round(val * 100) + "%";
       if (popScreenPct) { popScreenPct.textContent = pctText; popScreenPct.classList.toggle("boosted", val > 1); }
       if (screenPct) { screenPct.textContent = pctText; screenPct.classList.toggle("boosted", val > 1); }
+      if (settingsScreenSlider) settingsScreenSlider.value = val;
+      if (settingsScreenPct) { settingsScreenPct.textContent = pctText; settingsScreenPct.classList.toggle("boosted", val > 1); }
       applyParticipantAudioVolumes(state);
       saveParticipantVolume(key, state.micVolume, state.screenVolume, state.chimeVolume);
     });
@@ -903,6 +1163,8 @@ function ensureParticipantCard(participant, isLocal = false) {
       var pctText = Math.round(val * 100) + "%";
       if (popChimePct) popChimePct.textContent = pctText;
       if (chimePct) chimePct.textContent = pctText;
+      if (settingsChimeSlider) settingsChimeSlider.value = val;
+      if (settingsChimePct) settingsChimePct.textContent = pctText;
       saveParticipantVolume(key, state.micVolume, state.screenVolume, state.chimeVolume);
     });
   }
@@ -918,6 +1180,8 @@ function ensureParticipantCard(participant, isLocal = false) {
         // Sync popup slider
         if (popMicSlider) popMicSlider.value = savedVol.mic;
         if (popMicPct) { popMicPct.textContent = Math.round(savedVol.mic * 100) + "%"; popMicPct.classList.toggle("boosted", savedVol.mic > 1); }
+        if (settingsMicSlider) settingsMicSlider.value = savedVol.mic;
+        if (settingsMicPct) { settingsMicPct.textContent = Math.round(savedVol.mic * 100) + "%"; settingsMicPct.classList.toggle("boosted", savedVol.mic > 1); }
       }
       if (savedVol.screen != null && screenSlider) {
         state.screenVolume = savedVol.screen;
@@ -927,6 +1191,8 @@ function ensureParticipantCard(participant, isLocal = false) {
         // Sync popup slider
         if (popScreenSlider) popScreenSlider.value = savedVol.screen;
         if (popScreenPct) { popScreenPct.textContent = Math.round(savedVol.screen * 100) + "%"; popScreenPct.classList.toggle("boosted", savedVol.screen > 1); }
+        if (settingsScreenSlider) settingsScreenSlider.value = savedVol.screen;
+        if (settingsScreenPct) { settingsScreenPct.textContent = Math.round(savedVol.screen * 100) + "%"; settingsScreenPct.classList.toggle("boosted", savedVol.screen > 1); }
       }
       if (savedVol.chime != null && chimeSlider) {
         state.chimeVolume = savedVol.chime;
@@ -934,10 +1200,53 @@ function ensureParticipantCard(participant, isLocal = false) {
         if (chimePct) chimePct.textContent = Math.round(savedVol.chime * 100) + "%";
         if (popChimeSlider) popChimeSlider.value = savedVol.chime;
         if (popChimePct) popChimePct.textContent = Math.round(savedVol.chime * 100) + "%";
+        if (settingsChimeSlider) settingsChimeSlider.value = savedVol.chime;
+        if (settingsChimePct) settingsChimePct.textContent = Math.round(savedVol.chime * 100) + "%";
       }
       applyParticipantAudioVolumes(state);
       debugLog("[vol-prefs] restored " + key + " mic=" + (savedVol.mic || 1) + " screen=" + (savedVol.screen || 1) + " chime=" + (savedVol.chime != null ? savedVol.chime : 0.5));
     }
+  }
+
+  function setParticipantDisplayName(nextName) {
+    participantDisplayName = nextName || "Guest";
+    title.textContent = participantDisplayName;
+    title.title = participantDisplayName;
+
+    if (overlayName) {
+      overlayName.textContent = participantDisplayName;
+      overlayName.title = participantDisplayName;
+    }
+    if (micIndicator) micIndicator.setAttribute("aria-label", "Microphone audio settings for " + participantDisplayName);
+    if (screenIndicator) screenIndicator.setAttribute("aria-label", "Screen audio settings for " + participantDisplayName);
+    if (micSlider) micSlider.setAttribute("aria-label", "Microphone volume for " + participantDisplayName);
+    if (screenSlider) screenSlider.setAttribute("aria-label", "Screen volume for " + participantDisplayName);
+    if (chimeSlider) chimeSlider.setAttribute("aria-label", "Chime volume for " + participantDisplayName);
+    if (ovMicBtn) ovMicBtn.setAttribute("aria-label", "Microphone volume for " + participantDisplayName);
+    if (ovScreenBtn) ovScreenBtn.setAttribute("aria-label", "Screen volume for " + participantDisplayName);
+    if (popMicSlider) popMicSlider.setAttribute("aria-label", "Microphone volume for " + participantDisplayName);
+    if (popScreenSlider) popScreenSlider.setAttribute("aria-label", "Screen volume for " + participantDisplayName);
+    if (popChimeSlider) popChimeSlider.setAttribute("aria-label", "Chime volume for " + participantDisplayName);
+
+    var micAction = state.micUserMuted ? "Unmute" : "Mute";
+    var screenAction = state.screenUserMuted ? "Unmute" : "Mute";
+    [micMuteButton, ovMicMute, settingsMicMute].forEach(function(button) {
+      if (button) button.setAttribute("aria-label", micAction + " microphone audio from " + participantDisplayName);
+    });
+    [screenMuteButton, ovScreenMute, settingsScreenMute].forEach(function(button) {
+      if (button) button.setAttribute("aria-label", screenAction + " screen audio from " + participantDisplayName);
+    });
+
+    if (participantSettingsButton) {
+      participantSettingsButton.setAttribute("aria-label", "Audio settings for " + participantDisplayName);
+      participantSettingsButton.title = "Audio settings for " + participantDisplayName;
+    }
+    if (participantSettingsPopup) participantSettingsPopup.setAttribute("aria-label", "Audio settings for " + participantDisplayName);
+    if (settingsHeadingTitle) settingsHeadingTitle.textContent = participantDisplayName;
+    if (settingsClose) settingsClose.setAttribute("aria-label", "Close audio settings for " + participantDisplayName);
+    if (settingsMicSlider) settingsMicSlider.setAttribute("aria-label", "Microphone volume for " + participantDisplayName);
+    if (settingsScreenSlider) settingsScreenSlider.setAttribute("aria-label", "Screen volume for " + participantDisplayName);
+    if (settingsChimeSlider) settingsChimeSlider.setAttribute("aria-label", "Chime volume for " + participantDisplayName);
   }
 
   participantCards.set(key, {
@@ -967,7 +1276,15 @@ function ensureParticipantCard(participant, isLocal = false) {
     popScreenPct,
     popChimeSlider,
     popChimePct,
-    chimeToggleButton
+    participantSettingsButton,
+    participantSettingsPopup,
+    settingsMicMute,
+    settingsScreenMute,
+    settingsMicSlider,
+    settingsScreenSlider,
+    settingsChimeSlider,
+    settingsWatchButton,
+    setParticipantDisplayName
   });
   participantState.set(key, state);
   debugLog(`participant card created and added to DOM for ${key}, card.isConnected=${card.isConnected}, avatar exists=${!!avatar}`);

--- a/core/viewer/style.css
+++ b/core/viewer/style.css
@@ -2914,6 +2914,111 @@ video {
   color: rgba(226, 232, 240, 0.9);
 }
 
+/* Phase 2 Camera Lobby: let the shared layout policy size the existing camera
+   tiles against both available axes. The inline tracks are presentation only;
+   camera videos remain attached to their original tiles. */
+:root[data-ui-shell="v2"] .camera-lobby {
+  min-width: 0;
+  min-height: 0;
+  grid-template-rows: auto minmax(0, 1fr);
+}
+
+:root[data-ui-shell="v2"] .camera-lobby-header,
+:root[data-ui-shell="v2"] .camera-lobby-actions {
+  min-width: 0;
+}
+
+:root[data-ui-shell="v2"] .camera-lobby-grid {
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+  align-content: center;
+  justify-content: center;
+  grid-auto-flow: row;
+}
+
+:root[data-ui-shell="v2"] .camera-lobby-tile {
+  min-width: 0;
+  max-width: 100%;
+  max-height: 100%;
+  justify-self: center;
+  align-self: center;
+}
+
+:root[data-ui-shell="v2"] .camera-lobby-tile.enlarged {
+  width: auto !important;
+  height: auto !important;
+  max-width: none;
+  max-height: none;
+  justify-self: stretch;
+  align-self: stretch;
+}
+
+@media (max-width: 639px) {
+  :root[data-ui-shell="v2"] .camera-lobby {
+    inset: 8px;
+    padding: 10px;
+    gap: 8px;
+    border-radius: 14px;
+  }
+
+  :root[data-ui-shell="v2"] .camera-lobby-header {
+    align-items: flex-start;
+    flex-wrap: wrap;
+    gap: 7px;
+    padding-bottom: 8px;
+  }
+
+  :root[data-ui-shell="v2"] .camera-lobby-header h3 {
+    flex: 1 0 100%;
+  }
+
+  :root[data-ui-shell="v2"] .camera-lobby-actions {
+    width: 100%;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) auto;
+    gap: 5px;
+  }
+
+  :root[data-ui-shell="v2"] .lobby-control-btn,
+  :root[data-ui-shell="v2"] #close-camera-lobby {
+    min-width: 0;
+    padding: 7px 6px;
+    justify-content: center;
+    overflow: hidden;
+    font-size: 11px;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  :root[data-ui-shell="v2"] .camera-lobby-grid {
+    gap: 8px;
+    padding: 2px;
+  }
+}
+
+@media (max-height: 519px) {
+  :root[data-ui-shell="v2"] .camera-lobby {
+    inset: 6px;
+    padding: 8px;
+    gap: 6px;
+  }
+
+  :root[data-ui-shell="v2"] .camera-lobby-header {
+    gap: 6px;
+    padding-bottom: 6px;
+  }
+
+  :root[data-ui-shell="v2"] .camera-lobby-header h3 {
+    font-size: 12px;
+  }
+
+  :root[data-ui-shell="v2"] .camera-lobby-grid {
+    gap: 6px;
+    padding: 2px;
+  }
+}
+
 /* ─── Room Selector ─── */
 
 

--- a/docs/UI-RESPONSIVE-CONTRACT.md
+++ b/docs/UI-RESPONSIVE-CONTRACT.md
@@ -167,9 +167,12 @@ JavaScript must not write per-breakpoint pixel widths, move feature nodes betwee
 alternate parents, or decide which text happens to fit. A component that needs
 local adaptation declares a containment boundary and uses container queries.
 
-The existing screen-grid allocator may continue calculating media tile geometry
-inside the stage. It receives the stage's available rectangle; it must not
-duplicate shell breakpoints or control utility-panel behavior.
+The screen-grid allocator calculates media tile geometry inside the stage. It
+receives the stage's available rectangle; it must not duplicate shell
+breakpoints or control utility-panel behavior. A single visible share owns the
+full grid independently of the currently decoded media resolution. Two or more
+shares use the canonical grid policy, and every video preserves its source with
+`object-fit: contain`.
 
 A no-JavaScript/failure fallback may use media queries at the canonical
 thresholds. The supported runtime, however, uses the named root mode so behavior
@@ -190,6 +193,12 @@ and geometry change together.
   the viewport.
 - Shell padding is `24px` in `theater`, `16px` in `lounge`, `12px` in
   `compact`, and `8px` in `mini`, before safe-area additions.
+- While exactly one share is visible, Stage-First presentation may tighten the
+  shell padding and inter-region gap for immersion. The empty Stage and
+  multi-share layouts retain their normal mode spacing.
+- Solo-share labels and media controls overlay the tile instead of
+  consuming grid tracks. Overlay controls remain keyboard focusable and must
+  not change the video's fitted geometry.
 - The ordinary region gap is `16px`. Components may use smaller values from the
   shared spacing scale; they must not introduce arbitrary shell gaps.
 

--- a/docs/UI-RESPONSIVE-CONTRACT.md
+++ b/docs/UI-RESPONSIVE-CONTRACT.md
@@ -1,6 +1,7 @@
 # Echo Chamber Responsive UI Contract
 
-Status: Phase 0 contract landed; Phase 1 Clubhouse shell is implemented behind an off-by-default flag
+Status: Phase 0 contract landed; Phase 1 Clubhouse shell and Phase 2 utility
+host are implemented and verified behind the off-by-default flag
 
 Applies to: `core/viewer/` in the browser and Windows desktop shell
 
@@ -497,10 +498,27 @@ host in Phase 2.
 
 ### Phase 2 - Dock and Utility Host
 
-- Move existing primary call controls into the stable dock without changing
-  their state owners.
-- Migrate People first, then Chat and Jam, into the single utility host.
-- Ship each migration independently under the same flag with legacy fallback.
+- People, Chat, and Jam are presented as one logical utility host with exactly
+  one active tool. People and Chat are physical descendants of the host. Jam
+  intentionally remains the single portaled feature node under
+  `shell-overlay-root`, linked to the host with `aria-owns`, because nesting its
+  fixed legacy panel inside the filtered shell changes its containing block and
+  breaks legacy positioning.
+- One shell controller owns active-tool presentation, open/collapsed state,
+  inertness, Escape behavior, and focus restoration. The People, Chat, and Jam
+  feature modules retain ownership of their participants, drafts, search,
+  queue, playback, and other feature state.
+- The same utility nodes present as a pinned rail in `theater`, a
+  workspace-bounded drawer in `lounge`, and a sheet or full-workspace surface
+  above the dock in `compact` and `mini`.
+- Resize and live flag changes must restyle the mounted nodes in place. The
+  legacy fallback must remain a one-switch rollback with tool-local state and
+  node identity preserved; it must not duplicate IDs, listeners, or feature
+  state machines.
+- Phase 2 verification covers node and input-state preservation across modes
+  and flag rollback, populated utility geometry and overflow, pointer-target
+  sizing, keyboard/Escape/focus behavior, modal inertness for the portaled Jam,
+  and the distinction between Jam Stop Music and End Jam actions.
 
 ### Phase 3 - Canary Default-On
 

--- a/docs/UI-RESPONSIVE-CONTRACT.md
+++ b/docs/UI-RESPONSIVE-CONTRACT.md
@@ -160,7 +160,7 @@ interactive surface, they do not have independent hysteresis.
 | Width/height mode selection and hysteresis | One JavaScript mode controller |
 | Active utility tool, panel open state, and return focus | JavaScript UI state |
 | Modal focus containment and background inertness | JavaScript behavior plus CSS presentation |
-| Media tile allocation inside the stage | Existing media-grid layout owner |
+| Media tile allocation inside the stage or Camera Lobby | Existing media-grid layout owners |
 | Room, publication, subscription, Jam, and participant truth | Existing feature state owners |
 
 JavaScript must not write per-breakpoint pixel widths, move feature nodes between
@@ -173,6 +173,10 @@ breakpoints or control utility-panel behavior. A single visible share owns the
 full grid independently of the currently decoded media resolution. Two or more
 shares use the canonical grid policy, and every video preserves its source with
 `object-fit: contain`.
+
+The Camera Lobby uses the same canonical grid policy against the lobby's own
+available rectangle. Resizing may change only grid tracks and tile geometry; it
+must preserve each mounted camera tile, video element, stream, and track.
 
 A no-JavaScript/failure fallback may use media queries at the canonical
 thresholds. The supported runtime, however, uses the named root mode so behavior


### PR DESCRIPTION
## Summary

- presents People, Chat, and Jam as one stable responsive utility system
- gives the shared stage priority and keeps camera/screen layouts contained from theater through mini sizes
- consolidates each remote participant's voice, shared-audio, and join-chime controls into one accessible settings menu
- keeps the People rail compact with larger avatars and fixes the naturally proportioned empty-stage crest
- restores the Ultra Instinct GIF and improves Camera Lobby stacking and source-picker reliability
- integrates Spotify takeover, local Jam monitoring, Stop Music, and host-only End Jam
- excludes the active Echo desktop process tree from monitor-audio capture to prevent Echo playback feedback
- aligns the Windows desktop and control packages at 0.6.33

## Stack / dependencies

- Base: #214 (Phase 1 Clubhouse shell)
- Includes the approved Jam controls from #212
- #213, #214, and this PR remain a stacked rollout until the final live validation is accepted

## Verification

- `npm run verify:quick` - 166/166 viewer tests
- `npm run verify:viewer:layout` - 62/62 Chromium layout tests
- `cargo check --locked --manifest-path core/Cargo.toml -p echo-core-client --tests`
- focused Rust playback-exclusion test - 1/1
- control viewer-cache stamping test - 1/1
- `core/deploy/test-viewer-runtime-lib.ps1`
- `core/deploy/test-local-release-lib.ps1`
- independent visual/code audit - no blocking findings
- live monitor and Megabonk capture validated by Brad
- live 71-file viewer snapshot verified after restart at server 0.6.33

## Release impact

- `release-impact:both`
- Viewer/server snapshot is live for validation.
- The native playback-exclusion fix requires the Windows 0.6.33 desktop release and is not live until that updater is published and installed.

The PR remains draft pending final live UI/audio validation.