### PR TITLE
Sync v0.6.33 updater manifest

### DIFF
--- a/core/deploy/latest.json
+++ b/core/deploy/latest.json
@@ -1,11 +1,11 @@
 {
     "platforms":  {
                       "windows-x86_64":  {
-                                             "signature":  "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVSQ3ByNFJuZlpjMEpvQnVOaXpOdFRJWjRLQkJMUWhuaGUrRjlHVENKU210MVF4Q0RCU1RldkNic1FEdHF5Sys1UGx4RkNqaW14OTBCMmJmTjZMbWxXbjlYMEI2d0p1UkFjPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzg0MTM3NDEzCWZpbGU6RWNobyBDaGFtYmVyXzAuNi4zMF94NjQtc2V0dXAuZXhlCjRHdkFxMGVrb1JuS2hSVWcwaWQrNzdXSFJnYUF0SHZYcUs2Qi9WUU4zdGd5cmhVQnJvQ0swa25hOUgrTVlaR2FGb0VUWTBiamxTbFdrZVROYnJDdUJRPT0K",
-                                             "url":  "https://github.com/SamWatson86/echo-chamber/releases/download/v0.6.30/Echo.Chamber_0.6.30_x64-setup.exe"
+                                             "signature":  "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVSQ3ByNFJuZlpjMEl2aTRWMElxNmU2S1lZVG9mNXA2MGYyT2x6aGtYaDVTVjU3TU9GQWQ5M1dDRXZkbVdVTmxJdUJuSlJBa29Kd1piK2VlVGFpVkwrMjgyK1VFVGg3ckFVPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzg0MzI1Mjk1CWZpbGU6RWNobyBDaGFtYmVyXzAuNi4zM194NjQtc2V0dXAuZXhlCkpTQlM5ZlhWVEtDNEFUL0k3ZnM4T1Z0L2Qxc3dralZLcVRxd0hkUU1LYjJCQkpNL2c1TmNGWjAvRFdaNG95RVg0cmh4OHlhMkNaV1pINDlQVXR1ZkFnPT0K",
+                                             "url":  "https://github.com/SamWatson86/echo-chamber/releases/download/v0.6.33/Echo.Chamber_0.6.33_x64-setup.exe"
                                          }
                   },
-    "pub_date":  "2026-07-15T17:43:33Z",
-    "version":  "0.6.30",
-    "notes":  "Echo Chamber v0.6.30"
+    "pub_date":  "2026-07-17T21:54:55Z",
+    "version":  "0.6.33",
+    "notes":  "Echo Chamber v0.6.33"
 }


### PR DESCRIPTION
## Summary
- publish the signed Windows v0.6.33 updater metadata
- point clients at the v0.6.33 NSIS installer

## Verification
- GitHub release v0.6.33 is published with installer, signature, and latest.json assets
- installer SHA-256 matches the uploaded release asset digest
- live /api/update/latest.json reports 0.6.33
- live /api/version reports server 0.6.33 / latest client 0.6.33
- live /health is OK