### PR TITLE
Make the clubhouse shell the production default

### DIFF
--- a/core/viewer-tests/tests/shell.phase1.spec.js
+++ b/core/viewer-tests/tests/shell.phase1.spec.js
@@ -135,10 +135,10 @@ async function expectCanonicalStructure(page) {
 
 const flagCases = [
   {
-    title: "defaults to legacy when neither storage nor query overrides the shell",
+    title: "defaults to V2 when neither storage nor query overrides the shell",
     persisted: null,
     query: "",
-    expected: "legacy",
+    expected: "v2",
   },
   {
     title: "uses the persisted V2 shell when the query is absent",

--- a/core/viewer/ui-shell.js
+++ b/core/viewer/ui-shell.js
@@ -57,7 +57,7 @@
 
     const storedOverride = parseFlagValue(input.storedValue);
     if (storedOverride != null) return storedOverride ? V2_VARIANT : LEGACY_VARIANT;
-    return LEGACY_VARIANT;
+    return V2_VARIANT;
   }
 
   function normalizeVariant(value) {

--- a/core/viewer/ui-shell.test.js
+++ b/core/viewer/ui-shell.test.js
@@ -99,9 +99,10 @@ test("flag parsing accepts explicit on and off values without guessing", () => {
   }
 });
 
-test("query override wins over storage and absence defaults to legacy", () => {
-  assert.equal(resolveShellVariant({ search: "", storedValue: null }), "legacy");
+test("query override wins over storage and absence defaults to v2", () => {
+  assert.equal(resolveShellVariant({ search: "", storedValue: null }), "v2");
   assert.equal(resolveShellVariant({ search: "", storedValue: "1" }), "v2");
+  assert.equal(resolveShellVariant({ search: "", storedValue: "0" }), "legacy");
   assert.equal(resolveShellVariant({ search: "?echo-ui-shell-v2=1", storedValue: "0" }), "v2");
   assert.equal(resolveShellVariant({ search: "?echo-ui-shell-v2=0", storedValue: "1" }), "legacy");
 });

--- a/docs/UI-RESPONSIVE-CONTRACT.md
+++ b/docs/UI-RESPONSIVE-CONTRACT.md
@@ -548,6 +548,10 @@ host in Phase 2.
 - Remove legacy layout CSS, the flag, and dual-path tests in a focused cleanup
   PR after the rollback window closes.
 
+The general rollout now defaults clients with no stored preference to the V2
+shell. Explicit query or stored `0` values continue to select the legacy shell
+for rollback validation during the normal-release safety window.
+
 ## Foundation PR Non-Goals
 
 The foundation PR must not:


### PR DESCRIPTION
## What changed

- default clients without a stored shell preference to the responsive V2 clubhouse UI
- preserve explicit query and stored legacy overrides for rollback
- update unit, browser-layout, and rollout-contract coverage

## Root cause

The v0.6.33 desktop update was successful, but the desktop shell always loads the server viewer. Sam's canary WebView had `echo-ui-shell-v2=1`; Brad and David had no flag, and the viewer still defaulted missing flags to the legacy presentation.

## Impact

Server/viewer-only. No new desktop installer is required. After the production viewer reload, normal clients receive V2 by default.

## Verification

- `npm run verify:quick` — 166 passed
- `npm run verify:viewer:layout` — 62 passed
- `git diff --check` — clean
- explicit stored/query `0` rollback remains covered
