### PR TITLE
Fix truthful microphone and camera presence

### DIFF
--- a/core/viewer-tests/fixtures/install-scenario.js
+++ b/core/viewer-tests/fixtures/install-scenario.js
@@ -92,7 +92,7 @@
     };
   }
 
-  function addParticipants(count, cameraCount, longNames, unbrokenNames) {
+  function addParticipants(count, cameraCount, longNames, unbrokenNames, localCamera) {
     if (typeof ensureParticipantCard !== "function") {
       throw new Error("production ensureParticipantCard renderer is unavailable");
     }
@@ -107,7 +107,8 @@
         makeParticipant(index, longNames, unbrokenNames),
         isLocal,
       );
-      if (!cardRef || isLocal || attachedCameras >= cameraCount) continue;
+      const shouldAttachCamera = isLocal ? !!localCamera : attachedCameras < cameraCount;
+      if (!cardRef || !shouldAttachCamera) continue;
 
       const media = createVideoTrackStub(`fixture-camera-${index}`, 16 / 9);
       updateAvatarVideo(cardRef, media.track);
@@ -116,7 +117,7 @@
       exposeFixtureDimensions(video, media);
       video.classList.add("layout-fixture-camera");
       video.setAttribute("aria-label", `${cardRef.card.dataset.identity} camera fixture`);
-      attachedCameras += 1;
+      if (!isLocal) attachedCameras += 1;
     }
   }
 
@@ -162,6 +163,7 @@
       shareAspects: [16 / 9],
       chatOpen: false,
       longNames: false,
+      localCamera: false,
       unbrokenNames: false,
     }, options || {});
 
@@ -171,6 +173,7 @@
       scenario.cameras,
       scenario.longNames,
       scenario.unbrokenNames,
+      scenario.localCamera,
     );
     addScreenShares(scenario.screenShares, scenario.shareAspects);
     populateChat(scenario.chatOpen);
@@ -358,6 +361,16 @@
     };
   }
 
+  function setParticipantMicrophoneState(identity, options) {
+    const state = participantState.get(identity);
+    if (!state) throw new Error("participant state is unavailable for " + identity);
+    const next = Object.assign({ published: false, muted: true }, options || {});
+    state.micPublished = !!next.published;
+    state.micPublisherMuted = !!next.muted;
+    state.micMuted = !!next.muted;
+    updateActiveSpeakerUi();
+  }
+
   window.EchoLayoutTestScenario = Object.freeze({
     captureCameraLobbySnapshot: captureCameraLobbySnapshot,
     captureIdentitySnapshot: captureIdentitySnapshot,
@@ -365,6 +378,7 @@
     inspectIdentitySnapshot: inspectIdentitySnapshot,
     install: install,
     installCameraLobby: installCameraLobby,
+    setParticipantMicrophoneState: setParticipantMicrophoneState,
     unbrokenDisplayName: unbrokenDisplayName,
   });
 })();

--- a/core/viewer-tests/tests/shell.phase1.spec.js
+++ b/core/viewer-tests/tests/shell.phase1.spec.js
@@ -807,6 +807,237 @@ for (const viewport of [
 
 for (const viewport of [
   { width: 1280, height: 720, mode: "theater" },
+  { width: 360, height: 640, mode: "mini" },
+]) {
+  test(`local camera is promoted exactly like remote cameras in ${viewport.mode}`, async ({ page }) => {
+    await page.setViewportSize(viewport);
+    await openPhaseOneViewer(page, {
+      participants: 3,
+      cameras: 1,
+      localCamera: true,
+      screenShares: 0,
+    });
+    await expect(page.locator("html")).toHaveAttribute("data-ui-mode", viewport.mode);
+
+    const localCard = page.locator(".user-card.is-local.has-camera");
+    const remoteCard = page.locator(".user-card.is-remote.has-camera");
+    await expect(localCard).toHaveCount(1);
+    await expect(remoteCard).toHaveCount(1);
+    await expect(localCard.locator(".user-name")).toBeVisible();
+
+    for (const card of [localCard, remoteCard]) {
+      await card.evaluate((element) => element.scrollIntoView({ block: "nearest" }));
+      const geometry = await card.evaluate((element) => {
+        const cardRect = element.getBoundingClientRect();
+        const videoRect = element.querySelector("video").getBoundingClientRect();
+        return {
+          ratio: cardRect.width / cardRect.height,
+          videoHeightDelta: Math.abs(videoRect.height - cardRect.height),
+          videoWidthDelta: Math.abs(videoRect.width - cardRect.width),
+        };
+      });
+      expect.soft(geometry.ratio).toBeGreaterThan(1.73);
+      expect.soft(geometry.ratio).toBeLessThan(1.82);
+      // The card's 1px border accounts for a 2px outer-size difference.
+      expect.soft(geometry.videoHeightDelta).toBeLessThanOrEqual(2.1);
+      expect.soft(geometry.videoWidthDelta).toBeLessThanOrEqual(2.1);
+      await expectContained(card.locator("video"), card);
+    }
+
+    await page.evaluate(() => {
+      const local = document.querySelector(".user-card.is-local");
+      updateAvatarVideo(participantCards.get(local.dataset.identity), null);
+    });
+    await expect(page.locator(".user-card.is-local")).not.toHaveClass(/has-camera/);
+    await expect(page.locator(".user-card.is-local .user-avatar video")).toHaveCount(0);
+  });
+}
+
+test("publisher microphone badges stay truthful and visible in avatar and camera cards", async ({ page }) => {
+  await page.setViewportSize({ width: 360, height: 640 });
+  await openPhaseOneViewer(page, {
+    participants: 3,
+    cameras: 1,
+    screenShares: 0,
+  });
+
+  const cameraCard = page.locator(".user-card.is-remote.has-camera");
+  const avatarCard = page.locator(".user-card.is-remote:not(.has-camera)");
+  const cameraIdentity = await cameraCard.getAttribute("data-identity");
+  const avatarIdentity = await avatarCard.getAttribute("data-identity");
+
+  await page.evaluate(({ cameraIdentity, avatarIdentity }) => {
+    window.EchoLayoutTestScenario.setParticipantMicrophoneState(cameraIdentity, {
+      published: true,
+      muted: true,
+    });
+    window.EchoLayoutTestScenario.setParticipantMicrophoneState(avatarIdentity, {
+      published: false,
+      muted: true,
+    });
+  }, { cameraIdentity, avatarIdentity });
+
+  const cameraBadge = cameraCard.locator(".participant-mic-state");
+  const avatarBadge = avatarCard.locator(".participant-mic-state");
+  await expect(cameraBadge).toBeVisible();
+  await expect(cameraBadge).toContainText("Muted");
+  await expect(cameraBadge).toHaveAccessibleName(/Muted.*Friend 2/i);
+  await expect(avatarBadge).toBeVisible();
+  await expect(avatarBadge).toContainText("Mic off");
+  await expect(avatarBadge).toHaveAccessibleName(/Mic off.*Friend 3/i);
+  await expectContained(cameraBadge, cameraCard);
+  await expectContained(avatarBadge, avatarCard);
+  await expectNoOverlap(avatarBadge, avatarCard.locator(".participant-settings-toggle"));
+
+  await page.evaluate((identity) => {
+    window.EchoLayoutTestScenario.setParticipantMicrophoneState(identity, {
+      published: true,
+      muted: false,
+    });
+    const state = participantState.get(identity);
+    state.micUserMuted = true;
+    roomAudioMuted = true;
+    updateActiveSpeakerUi();
+  }, avatarIdentity);
+  await expect(avatarBadge).toBeHidden();
+});
+
+test("room switching freezes local publish controls and rejects user media toggles", async ({ page }) => {
+  await page.setViewportSize({ width: 1024, height: 768 });
+  await openPhaseOneViewer(page, {
+    participants: 2,
+    cameras: 0,
+    screenShares: 0,
+  });
+
+  const result = await page.evaluate(async () => {
+    const calls = { camera: 0, microphone: 0 };
+    room = {
+      localParticipant: {
+        async setCameraEnabled() { calls.camera += 1; },
+        async setMicrophoneEnabled() { calls.microphone += 1; },
+      },
+    };
+    switchingRoom = true;
+    setPublishButtonsEnabled(false);
+
+    const localCard = Array.from(participantCards.values()).find((cardRef) => cardRef.isLocal);
+    const localButtons = Array.from(localCard.controls.querySelectorAll("button"));
+    const dockButtons = [micBtn, camBtn, screenBtn];
+
+    await toggleMic();
+    await toggleCam();
+    await toggleScreen();
+
+    return {
+      calls,
+      dockDisabled: dockButtons.every((button) => button.disabled),
+      localDisabled: localButtons.length > 0 && localButtons.every((button) => button.disabled),
+    };
+  });
+
+  expect(result.calls).toEqual({ camera: 0, microphone: 0 });
+  expect(result.dockDisabled).toBe(true);
+  expect(result.localDisabled).toBe(true);
+});
+
+test("room switching waits for an in-flight mic toggle and preserves its intent", async ({ page }) => {
+  await page.setViewportSize({ width: 1024, height: 768 });
+  await openPhaseOneViewer(page, {
+    participants: 2,
+    cameras: 0,
+    screenShares: 0,
+  });
+
+  const result = await page.evaluate(async () => {
+    const LK = getLiveKitClient();
+    const observedAtConnect = [];
+    const originalConnectToRoom = connectToRoom;
+    connectToRoom = async function () {
+      observedAtConnect.push({
+        actual: micEnabled,
+        desired: desiredMicEnabledForRoomSwitch(),
+      });
+    };
+
+    async function runToggleThenSwitch(initialEnabled, targetRoom) {
+      roomSwitchState.forceConnected("main");
+      currentRoomName = "main";
+      _lastRoomSwitchTime = 0;
+      switchingRoom = false;
+      _isRoomSwitch = false;
+
+      const microphonePublication = {
+        source: LK.Track.Source.Microphone,
+        kind: LK.Track.Kind.Audio,
+        isMuted: !initialEnabled,
+        track: {
+          source: LK.Track.Source.Microphone,
+          kind: LK.Track.Kind.Audio,
+          isMuted: !initialEnabled,
+          mediaStreamTrack: { readyState: "live" },
+        },
+      };
+      const publications = new Map();
+      if (initialEnabled) publications.set("mic", microphonePublication);
+
+      let releaseSdkCall;
+      const sdkCall = new Promise((resolve) => {
+        releaseSdkCall = resolve;
+      });
+      const localCard = Array.from(participantCards.values()).find((cardRef) => cardRef.isLocal);
+      const localParticipant = {
+        identity: localCard.card.dataset.identity,
+        name: localCard.card.querySelector(".user-name").textContent,
+        isMicrophoneEnabled: initialEnabled,
+        isCameraEnabled: false,
+        trackPublications: publications,
+        async setMicrophoneEnabled(desired) {
+          await sdkCall;
+          this.isMicrophoneEnabled = desired;
+          microphonePublication.isMuted = !desired;
+          microphonePublication.track.isMuted = !desired;
+          if (desired) publications.set("mic", microphonePublication);
+          else publications.delete("mic");
+        },
+      };
+
+      room = { localParticipant };
+      micEnabled = initialEnabled;
+      syncDesiredMicToActual(initialEnabled);
+
+      const togglePromise = toggleMic();
+      await Promise.resolve();
+      const connectsBeforeSwitch = observedAtConnect.length;
+      const switchPromise = switchRoom(targetRoom);
+      await Promise.resolve();
+      const waitedForToggle = observedAtConnect.length === connectsBeforeSwitch;
+
+      releaseSdkCall();
+      await Promise.all([togglePromise, switchPromise]);
+      return waitedForToggle;
+    }
+
+    try {
+      const disableWaited = await runToggleThenSwitch(true, "breakout-1");
+      await new Promise((resolve) => setTimeout(resolve, 550));
+      const enableWaited = await runToggleThenSwitch(false, "breakout-2");
+      return { disableWaited, enableWaited, observedAtConnect };
+    } finally {
+      connectToRoom = originalConnectToRoom;
+    }
+  });
+
+  expect(result.disableWaited).toBe(true);
+  expect(result.enableWaited).toBe(true);
+  expect(result.observedAtConnect).toEqual([
+    { actual: false, desired: false },
+    { actual: true, desired: true },
+  ]);
+});
+
+for (const viewport of [
+  { width: 1280, height: 720, mode: "theater" },
   { width: 1024, height: 768, mode: "lounge" },
 ]) {
   test(`${viewport.mode} camera-card grid tracks prevent card overlap`, async ({ page }) => {

--- a/core/viewer-tests/tests/shell.phase1.spec.js
+++ b/core/viewer-tests/tests/shell.phase1.spec.js
@@ -879,6 +879,11 @@ test("publisher microphone badges stay truthful and visible in avatar and camera
 
   const cameraBadge = cameraCard.locator(".participant-mic-state");
   const avatarBadge = avatarCard.locator(".participant-mic-state");
+  await expect(cameraCard).toHaveClass(/is-publisher-mic-off/);
+  await expect(avatarCard).toHaveClass(/is-publisher-mic-off/);
+  await expect(cameraCard).toHaveCSS("border-color", "rgba(229, 106, 106, 0.58)");
+  await cameraCard.hover();
+  await expect(cameraCard).toHaveCSS("border-color", "rgba(229, 106, 106, 0.58)");
   await expect(cameraBadge).toBeVisible();
   await expect(cameraBadge).toContainText("Muted");
   await expect(cameraBadge).toHaveAccessibleName(/Muted.*Friend 2/i);
@@ -899,6 +904,7 @@ test("publisher microphone badges stay truthful and visible in avatar and camera
     roomAudioMuted = true;
     updateActiveSpeakerUi();
   }, avatarIdentity);
+  await expect(avatarCard).not.toHaveClass(/is-publisher-mic-off/);
   await expect(avatarBadge).toBeHidden();
 });
 

--- a/core/viewer/audio-routing.js
+++ b/core/viewer/audio-routing.js
@@ -201,6 +201,26 @@ function updateActiveSpeakerUi() {
   participantCards.forEach((cardRef, identity) => {
     const micEl = cardRef.micStatusEl;
     const state = participantState.get(identity);
+    const publisherMicOff = cardRef.isLocal
+      ? !micEnabled
+      : !state?.micPublished || !!state?.micPublisherMuted;
+    const publisherMicLabel = state?.micPublished && state?.micPublisherMuted ? "Muted" : "Mic off";
+    if (cardRef.publisherMicStateEl) {
+      const shouldHidePublisherMicState = !publisherMicOff;
+      if (cardRef.publisherMicStateEl.hidden !== shouldHidePublisherMicState) {
+        cardRef.publisherMicStateEl.hidden = shouldHidePublisherMicState;
+      }
+      const publisherMicAriaLabel = publisherMicLabel + " for " +
+        (cardRef.card?.querySelector(".user-name")?.textContent || identity);
+      if (cardRef.publisherMicStateEl.getAttribute("aria-label") !== publisherMicAriaLabel) {
+        cardRef.publisherMicStateEl.setAttribute("aria-label", publisherMicAriaLabel);
+      }
+    }
+    if (cardRef.publisherMicStateLabel && cardRef.publisherMicStateLabel.textContent !== publisherMicLabel) {
+      cardRef.publisherMicStateLabel.textContent = publisherMicLabel;
+    }
+    cardRef.card?.classList.toggle("is-publisher-mic-off", publisherMicOff);
+
     const muted = roomAudioMuted || state?.micMuted || state?.micUserMuted || (cardRef.isLocal && !micEnabled);
     if (micEl) {
       micEl.classList.toggle("is-muted", !!muted);
@@ -649,6 +669,8 @@ function handleTrackSubscribed(track, publication, participant) {
     } else {
       state.micSid = getTrackSid(publication, track, `${effectiveParticipant.identity}-mic`);
       state.micMuted = publication?.isMuted || false;
+      state.micPublished = true;
+      state.micPublisherMuted = !!publication?.isMuted;
       state.micAudioEls.add(element);
       if (!state.micAnalyser && LK?.createAudioAnalyser) {
         state.micAnalyser = LK.createAudioAnalyser(track);

--- a/core/viewer/changelog.js
+++ b/core/viewer/changelog.js
@@ -12,7 +12,7 @@ var ECHO_CHANGELOG = [
     title: "Truthful Media Presence",
     notes: [
       "Echo now shows the microphone as on only after a real, live microphone track is published; failed starts return the button to off with an actionable message.",
-      "Participant cards now show a clear Mic off or Muted badge based on the publisher's actual microphone state.",
+      "Participant cards now show a clear Mic off or Muted badge and a subtle red outline based on the publisher's actual microphone state.",
       "Your own camera now receives the same prominent 16:9 participant card as everyone else's camera."
     ]
   },

--- a/core/viewer/changelog.js
+++ b/core/viewer/changelog.js
@@ -8,6 +8,15 @@
 
 var ECHO_CHANGELOG = [
   {
+    version: "v0.6.33",
+    title: "Truthful Media Presence",
+    notes: [
+      "Echo now shows the microphone as on only after a real, live microphone track is published; failed starts return the button to off with an actionable message.",
+      "Participant cards now show a clear Mic off or Muted badge based on the publisher's actual microphone state.",
+      "Your own camera now receives the same prominent 16:9 participant card as everyone else's camera."
+    ]
+  },
+  {
     version: "v0.6.31",
     title: "Jam Source Controls",
     notes: [

--- a/core/viewer/clubhouse-shell.css
+++ b/core/viewer/clubhouse-shell.css
@@ -770,6 +770,12 @@
   display: none;
 }
 
+:root[data-ui-shell="v2"] .user-card:not(.has-camera) .participant-mic-state {
+  right: auto;
+  bottom: 10px;
+  left: 74px;
+}
+
 :root[data-ui-shell="v2"] .user-indicators {
   margin: 0;
   display: flex;
@@ -990,6 +996,21 @@
   overflow: hidden;
   border-radius: var(--club-radius-card);
   background: #06080b;
+}
+
+:root[data-ui-shell="v2"] .user-card.has-camera .participant-mic-state {
+  top: 8px;
+  right: auto;
+  bottom: auto;
+  left: 8px;
+}
+
+:root[data-ui-shell="v2"] .user-card.is-local.has-camera .user-name {
+  left: 9px;
+  bottom: 9px;
+  max-width: calc(100% - 64px);
+  color: var(--club-text);
+  font-size: 12px;
 }
 
 :root[data-ui-shell="v2"] .user-card.has-camera .user-header,

--- a/core/viewer/clubhouse-shell.css
+++ b/core/viewer/clubhouse-shell.css
@@ -728,9 +728,16 @@
   box-shadow: none;
 }
 
-:root[data-ui-shell="v2"] .user-card:has(.icon-button.is-active) {
+:root[data-ui-shell="v2"] .user-card:not(.is-publisher-mic-off):has(.icon-button.is-active) {
   border-color: rgba(79, 195, 200, 0.72);
   box-shadow: 0 0 0 2px rgba(79, 195, 200, 0.1), 0 12px 28px rgba(0, 0, 0, 0.2);
+}
+
+:root[data-ui-shell="v2"] .user-card.is-publisher-mic-off {
+  border-color: rgba(229, 106, 106, 0.58);
+  box-shadow:
+    inset 0 0 0 1px rgba(229, 106, 106, 0.08),
+    0 0 18px rgba(229, 106, 106, 0.12);
 }
 
 :root[data-ui-shell="v2"] .user-card:not(.has-camera) {

--- a/core/viewer/connect.js
+++ b/core/viewer/connect.js
@@ -6,6 +6,7 @@ function hookPublication(publication, participant) {
   if (!publication || !participant) return;
   // $screen companions publish as Camera for SFU optimization — patch to ScreenShare
   patchScreenCompanionSource(publication, publication?.track, participant);
+  updatePublisherMicrophoneState(publication, participant, true);
   if (!publication._echoHooked) {
     publication._echoHooked = true;
     if (publication.setSubscribed && !isUnwatchedScreenShare(publication, participant)) {
@@ -126,8 +127,13 @@ async function switchRoom(roomId) {
 
   switchingRoom = true;
   _isRoomSwitch = true;
+  // Freeze local publish intent until the new room is connected. This keeps a
+  // click or keyboard shortcut during the async handoff from being silently
+  // overwritten by the pre-switch microphone snapshot.
+  setPublishButtonsEnabled(false);
+  await waitForMicToggleSettled();
   // Remember mic state before switch so we can restore it
-  var wasMicEnabled = micEnabled;
+  var wasMicEnabled = desiredMicEnabledForRoomSwitch();
   debugLog(`Switching from ${fromRoom} to ${roomId} (mic was ${wasMicEnabled ? "on" : "off"})`);
 
   try {
@@ -152,6 +158,7 @@ async function switchRoom(roomId) {
     throw err;
   } finally {
     switchingRoom = false;
+    setPublishButtonsEnabled(!!room);
   }
 }
 
@@ -171,6 +178,12 @@ function setPublishButtonsEnabled(enabled) {
     // Show flip button only on mobile devices
     flipCamBtn.classList.toggle("hidden", !_isMobileDevice);
   }
+  participantCards.forEach((cardRef) => {
+    if (!cardRef?.isLocal || !cardRef.controls) return;
+    cardRef.controls.querySelectorAll("button").forEach((button) => {
+      button.disabled = !enabled;
+    });
+  });
   // Device selects stay enabled so users can choose devices before connecting
 }
 
@@ -189,15 +202,32 @@ function renderPublishButtons() {
   screenBtn.classList.toggle("is-on", screenEnabled);
 }
 
+function updatePublisherMicrophoneState(publication, participant, published) {
+  if (!publication || !participant) return false;
+  const LK = getLiveKitClient();
+  const source = publication.source || publication.track?.source;
+  const kind = publication.kind || publication.track?.kind;
+  if (source !== LK?.Track?.Source?.Microphone || kind !== LK?.Track?.Kind?.Audio) return false;
+
+  const state = participantState.get(participant.identity);
+  if (!state) return true;
+  state.micPublished = !!published;
+  state.micPublisherMuted = !published || !!publication.isMuted;
+  state.micMuted = !published || !!publication.isMuted;
+  updateActiveSpeakerUi();
+  return true;
+}
+
 function reconcileLocalPublishIndicators(reason) {
   if (!publishStateReconcile || !room || !room.localParticipant) return;
   // Skip reconciliation while a toggle is in progress — the toggle sets
-  // camEnabled from the SDK's authoritative state when it finishes.
+  // micEnabled/camEnabled from authoritative state when each toggle finishes.
   if (_camToggling || _micToggling) return;
   // Use the SDK's authoritative isCameraEnabled / isScreenShareEnabled
   // instead of checking !!pub.track. Publication objects retain muted/ended
   // tracks after setCameraEnabled(false), giving false positives.
   const cameraPublished = !!room.localParticipant.isCameraEnabled;
+  const microphonePublished = _isMicrophoneActuallyEnabled();
   const LK = getLiveKitClient();
   const pubs = getParticipantPublications(room.localParticipant);
   const screenPublished = window._echoNativeCaptureActive || pubs.some((pub) =>
@@ -209,19 +239,27 @@ function reconcileLocalPublishIndicators(reason) {
   );
 
   const out = publishStateReconcile(
-    { camEnabled, screenEnabled },
-    { cameraPublished, screenPublished }
+    { micEnabled, camEnabled, screenEnabled },
+    { microphonePublished, cameraPublished, screenPublished }
   );
 
   if (out.anyDrift) {
+    micEnabled = out.next.micEnabled;
+    if (out.drift.microphone) syncDesiredMicToActual(micEnabled);
     camEnabled = out.next.camEnabled;
     screenEnabled = out.next.screenEnabled;
+    if (!micEnabled) disableNoiseCancellation();
     renderPublishButtons();
-    debugLog(`[publish-reconcile] ${reason || "unknown"} camera=${camEnabled} screen=${screenEnabled}`);
+    updateActiveSpeakerUi();
+    debugLog(`[publish-reconcile] ${reason || "unknown"} mic=${micEnabled} camera=${camEnabled} screen=${screenEnabled}`);
   }
 }
 
 async function connectToRoom({ controlUrl, sfuUrl, roomId, identity, name, reuseAdmin }) {
+  // A newly connected LiveKit participant has no publications yet. Preserve
+  // the user's pre-switch intent separately so authoritative reconciliation
+  // can report the new room truth without cancelling mic restoration.
+  const restoreMicAfterConnect = !!(reuseAdmin && desiredMicEnabledForRoomSwitch());
   if (!controlUrl || !sfuUrl) {
     setStatus("Enter control URL and SFU URL.", true);
     return;
@@ -581,6 +619,7 @@ async function connectToRoom({ controlUrl, sfuUrl, roomId, identity, name, reuse
         debugLog("[reconnect] cancelled pending disconnect for " + pendingKey);
       }
       _pendingDisconnects.clear();
+      reconcileLocalPublishIndicators("signal-reconnected");
       // Reset adaptive layer tracker to HIGH after reconnection
       for (const [dtKey, dtVal] of _inboundDropTracker) {
         if (dtVal.currentQuality !== "HIGH" && LK?.VideoQuality) {
@@ -616,6 +655,7 @@ async function connectToRoom({ controlUrl, sfuUrl, roomId, identity, name, reuse
         debugLog("[reconnect] cancelled pending disconnect for " + pendingKey);
       }
       _pendingDisconnects.clear();
+      reconcileLocalPublishIndicators("reconnected");
       // Reset adaptive layer tracker to HIGH after reconnection so quality recovers immediately
       for (const [dtKey, dtVal] of _inboundDropTracker) {
         if (dtVal.currentQuality !== "HIGH" && LK?.VideoQuality) {
@@ -799,6 +839,11 @@ async function connectToRoom({ controlUrl, sfuUrl, roomId, identity, name, reuse
         if (!remoteP) room.remoteParticipants.forEach(function(p) { if (p.identity === publicationIdentity) remoteP = p; });
       }
       var pubs = remoteP ? getParticipantPublications(remoteP) : [];
+
+      // Publisher mute/off is independent from whether this viewer currently
+      // has the remote audio track subscribed.  Preserve that truth even when
+      // there is no track object to inspect.
+      updatePublisherMicrophoneState(publication, participant, false);
 
       // ── Screen share cleanup ──
       if (source === LK.Track.Source.ScreenShare) {
@@ -1058,6 +1103,8 @@ async function connectToRoom({ controlUrl, sfuUrl, roomId, identity, name, reuse
       if (publication?.kind === LK.Track.Kind.Audio && source === LK.Track.Source.Microphone) {
         const state = participantState.get(participant.identity);
         if (state) {
+          state.micPublished = true;
+          state.micPublisherMuted = true;
           state.micMuted = true;
           applyParticipantAudioVolumes(state);
           updateActiveSpeakerUi();
@@ -1078,6 +1125,8 @@ async function connectToRoom({ controlUrl, sfuUrl, roomId, identity, name, reuse
       if (publication?.kind === LK.Track.Kind.Audio && source === LK.Track.Source.Microphone) {
         const state = participantState.get(participant.identity);
         if (state) {
+          state.micPublished = true;
+          state.micPublisherMuted = false;
           state.micMuted = false;
           applyParticipantAudioVolumes(state);
           updateActiveSpeakerUi();
@@ -1198,6 +1247,7 @@ async function connectToRoom({ controlUrl, sfuUrl, roomId, identity, name, reuse
     newRoom.on(LK.RoomEvent.LocalTrackPublished, (publication) => {
       const local = room.localParticipant;
       if (!local || !publication) return;
+      updatePublisherMicrophoneState(publication, local, true);
       const source = publication.source;
       if (publication.track?.kind === "video" && source === LK.Track.Source.ScreenShare) {
         localScreenTrackSid = publication.trackSid || "";
@@ -1236,6 +1286,8 @@ async function connectToRoom({ controlUrl, sfuUrl, roomId, identity, name, reuse
   }
   if (LK.RoomEvent?.LocalTrackUnpublished) {
     newRoom.on(LK.RoomEvent.LocalTrackUnpublished, (publication) => {
+      const localParticipant = room?.localParticipant;
+      if (localParticipant) updatePublisherMicrophoneState(publication, localParticipant, false);
       const source = publication.source;
       if (publication.track?.kind === "video" && source === LK.Track.Source.ScreenShare) {
         removeScreenTile(publication.trackSid);
@@ -1336,15 +1388,15 @@ async function connectToRoom({ controlUrl, sfuUrl, roomId, identity, name, reuse
   } else {
     currentRoomName = roomId;
   }
-  setPublishButtonsEnabled(true);
+  setPublishButtonsEnabled(!switchingRoom);
   // Show dashboard button for all connected users
   var dashBtn = document.getElementById("open-admin-dash");
   if (dashBtn) dashBtn.classList.remove("hidden");
   reconcileLocalPublishIndicators("post-connect");
-  if (reuseAdmin && micEnabled) {
+  if (restoreMicAfterConnect) {
     // Room switch: mic was already on, re-enable immediately without permission dance
     micEnabled = false; // reset so toggleMicOn proceeds
-    toggleMicOn().catch((err) => {
+    toggleMicOn(true).catch((err) => {
       debugLog("[mic] room-switch re-enable failed: " + (err.message || err));
     });
   } else {
@@ -1768,6 +1820,7 @@ async function disconnect() {
   if (dashBtn) dashBtn.classList.add("hidden");
   if (_adminDashOpen) toggleAdminDash();
   micEnabled = false;
+  syncDesiredMicToActual(false);
   camEnabled = false;
   screenEnabled = false;
   renderPublishButtons();

--- a/core/viewer/media-controls.js
+++ b/core/viewer/media-controls.js
@@ -360,6 +360,20 @@ function updateCameraLobbySpeakingIndicators() {
 
 let _micToggling = false;
 let _camToggling = false;
+let _micDesiredEnabled = !!micEnabled;
+let _micToggleCompletion = Promise.resolve();
+
+function desiredMicEnabledForRoomSwitch() {
+  return !!_micDesiredEnabled;
+}
+
+function waitForMicToggleSettled() {
+  return _micToggleCompletion;
+}
+
+function syncDesiredMicToActual(actualEnabled) {
+  _micDesiredEnabled = !!actualEnabled;
+}
 
 // Check if camera is actually enabled using the SDK's own state.
 // Publication objects can retain muted/ended tracks — checking !!pub.track
@@ -368,10 +382,46 @@ function _isCameraActuallyEnabled() {
   return !!room?.localParticipant?.isCameraEnabled;
 }
 
-async function toggleMic() {
-  if (!room || _micToggling) return;
+// The button may only claim the microphone is live when LiveKit agrees and an
+// unmuted microphone publication still owns a live audio track.  In particular,
+// setMicrophoneEnabled(true) can resolve after a device failure without leaving
+// a usable publication behind.
+function _isMicrophoneActuallyEnabled() {
+  const local = room?.localParticipant;
+  if (!local || !local.isMicrophoneEnabled) return false;
+  const LK = getLiveKitClient();
+  const truth = window.EchoPublishStateReconcile?.isMicrophoneActuallyEnabled;
+  if (!truth) return false;
+  return truth(
+    local,
+    getParticipantPublications(local),
+    LK?.Track?.Source?.Microphone,
+    LK?.Track?.Kind?.Audio
+  );
+}
+
+function _syncLocalMicUi() {
+  renderPublishButtons();
+  if (room?.localParticipant) {
+    const cardRef = ensureParticipantCard(room.localParticipant, true);
+    if (cardRef.controls) {
+      cardRef.controls.querySelectorAll(".icon-button")[0]?.classList.toggle("is-on", micEnabled);
+    }
+  }
+  updateActiveSpeakerUi();
+}
+
+async function toggleMic(allowDuringRoomSwitch = false) {
+  if (!room || _micToggling || (switchingRoom && !allowDuringRoomSwitch)) return;
+  let settleMicToggle;
+  _micToggleCompletion = new Promise((resolve) => {
+    settleMicToggle = resolve;
+  });
   _micToggling = true;
   const desired = !micEnabled;
+  // Capture intent before the SDK call yields. A room switch that starts while
+  // this operation is pending must preserve the click, not stale rendered UI.
+  _micDesiredEnabled = desired;
   micBtn.disabled = true;
   try {
     try {
@@ -388,27 +438,36 @@ async function toggleMic() {
         throw devErr;
       }
     }
-    micEnabled = desired;
+    const actualState = _isMicrophoneActuallyEnabled();
+    micEnabled = actualState;
+
+    if (actualState !== desired) {
+      debugLog(`[mic] SDK state drift after toggle desired=${desired} actual=${actualState}`);
+      const publishErr = new Error(desired
+        ? "Microphone did not start — choose an input device in Settings and try again"
+        : "Microphone is still live — try disabling it again");
+      publishErr.name = "MicrophonePublishError";
+      throw publishErr;
+    }
 
     // Apply or remove noise cancellation
-    if (desired && noiseCancelEnabled) {
+    if (actualState && noiseCancelEnabled) {
       try { await enableNoiseCancellation(); } catch (e) {
         debugLog("[noise-cancel] Could not enable on mic toggle: " + (e.message || e));
       }
-    } else if (!desired) {
+    } else if (!actualState) {
       disableNoiseCancellation();
     }
 
-    renderPublishButtons();
-    if (room?.localParticipant) {
-      const cardRef = ensureParticipantCard(room.localParticipant, true);
-      if (cardRef.controls) {
-        cardRef.controls.querySelectorAll(".icon-button")[0]?.classList.toggle("is-on", micEnabled);
-      }
-    }
-    updateActiveSpeakerUi();
+    _syncLocalMicUi();
   } catch (err) {
     debugLog("[mic] toggle error: " + (err.message || err) + " (name=" + err.name + ")");
+    micEnabled = _isMicrophoneActuallyEnabled();
+    // A failed enable should stay visibly and intentionally off. A failed
+    // disable keeps the off intent so the next room does not republish it.
+    if (desired && !micEnabled) _micDesiredEnabled = false;
+    if (!micEnabled) disableNoiseCancellation();
+    _syncLocalMicUi();
     // Provide actionable error messages for common Mac issues
     if (err.name === "NotAllowedError" || err.name === "PermissionDeniedError") {
       setStatus("Mic permission denied — grant access in System Settings > Privacy > Microphone", true);
@@ -420,14 +479,16 @@ async function toggleMic() {
       setStatus(err.message || "Mic failed", true);
     }
   } finally {
-    micBtn.disabled = false;
+    micBtn.disabled = switchingRoom;
     _micToggling = false;
+    settleMicToggle();
+    reconcileLocalPublishIndicators("mic-toggle-complete");
   }
 }
 
 
 async function toggleCam() {
-  if (!room || _camToggling) return;
+  if (!room || _camToggling || switchingRoom) return;
   _camToggling = true;
   const desired = !camEnabled;
   camBtn.disabled = true;
@@ -486,13 +547,13 @@ async function toggleCam() {
       setStatus(err.message || "Camera failed", true);
     }
   } finally {
-    camBtn.disabled = false;
+    camBtn.disabled = switchingRoom;
     _camToggling = false;
   }
 }
 
 async function toggleScreen() {
-  if (!room) return;
+  if (!room || switchingRoom) return;
   const desired = !screenEnabled;
   debugLog("[toggleScreen] screenEnabled=" + screenEnabled + " desired=" + desired + " _nativeScreenShareActive=" + (typeof _nativeScreenShareActive !== "undefined" ? _nativeScreenShareActive : "undef"));
   screenBtn.disabled = true;
@@ -513,7 +574,7 @@ async function toggleScreen() {
   } catch (err) {
     setStatus(err.message || "Screen share failed", true);
   } finally {
-    screenBtn.disabled = false;
+    screenBtn.disabled = switchingRoom;
   }
 }
 
@@ -542,9 +603,9 @@ async function enableAllMedia() {
   await toggleScreenOn();
 }
 
-async function toggleMicOn() {
+async function toggleMicOn(allowDuringRoomSwitch = false) {
   if (micEnabled) return;
-  await toggleMic();
+  await toggleMic(allowDuringRoomSwitch);
 }
 
 async function toggleCamOn() {

--- a/core/viewer/participants-avatar.js
+++ b/core/viewer/participants-avatar.js
@@ -209,6 +209,23 @@ function startWatchingScreenIdentity(identity, reason) {
   scheduleReconcileWaves("opt-in-watch");
 }
 
+function getParticipantMicrophonePublicationState(participant) {
+  var LK = getLiveKitClient();
+  var micSource = LK?.Track?.Source?.Microphone;
+  var publications = getParticipantPublications(participant);
+  var publication = publications.find(function(pub) {
+    if (!pub) return false;
+    var source = pub.source || pub.track?.source;
+    var kind = pub.kind || pub.track?.kind;
+    return source === micSource && (!kind || kind === LK?.Track?.Kind?.Audio || kind === "audio");
+  });
+
+  return {
+    published: !!publication,
+    muted: publication ? !!publication.isMuted : true,
+  };
+}
+
 function ensureParticipantCard(participant, isLocal = false) {
   const key = participant.identity;
   // Hide ghost subscriber from UI
@@ -231,6 +248,20 @@ function ensureParticipantCard(participant, isLocal = false) {
   title.textContent = participant.name || "Guest";
   title.title = title.textContent;
   card.append(title);
+
+  const publisherMicState = document.createElement("div");
+  publisherMicState.className = "participant-mic-state";
+  publisherMicState.hidden = true;
+  publisherMicState.setAttribute("role", "status");
+  publisherMicState.setAttribute("aria-label", "Microphone off for " + participantDisplayName);
+  const publisherMicStateIcon = document.createElement("span");
+  publisherMicStateIcon.className = "participant-mic-state-icon";
+  publisherMicStateIcon.innerHTML = iconSvg("mic");
+  const publisherMicStateLabel = document.createElement("span");
+  publisherMicStateLabel.className = "participant-mic-state-label";
+  publisherMicStateLabel.textContent = "Mic off";
+  publisherMicState.append(publisherMicStateIcon, publisherMicStateLabel);
+  card.append(publisherMicState);
 
   const header = document.createElement("div");
   header.className = "user-header";
@@ -953,12 +984,15 @@ function ensureParticipantCard(participant, isLocal = false) {
     userListEl.appendChild(card);
   }
 
+  const initialMicState = getParticipantMicrophonePublicationState(participant);
   const state = {
     cameraTrackSid: null,
     screenTrackSid: null,
     micSid: null,
     screenAudioSid: null,
-    micMuted: false,
+    micMuted: initialMicState.muted,
+    micPublished: initialMicState.published,
+    micPublisherMuted: initialMicState.muted,
     micVolume: 1,
     screenVolume: 1,
     chimeVolume: 0.5,  // default 50% — halves built-in chime loudness
@@ -1247,6 +1281,12 @@ function ensureParticipantCard(participant, isLocal = false) {
     if (settingsMicSlider) settingsMicSlider.setAttribute("aria-label", "Microphone volume for " + participantDisplayName);
     if (settingsScreenSlider) settingsScreenSlider.setAttribute("aria-label", "Screen volume for " + participantDisplayName);
     if (settingsChimeSlider) settingsChimeSlider.setAttribute("aria-label", "Chime volume for " + participantDisplayName);
+    if (publisherMicState) {
+      publisherMicState.setAttribute(
+        "aria-label",
+        (publisherMicStateLabel?.textContent || "Mic off") + " for " + participantDisplayName
+      );
+    }
   }
 
   participantCards.set(key, {
@@ -1255,6 +1295,8 @@ function ensureParticipantCard(participant, isLocal = false) {
     isLocal,
     controls,
     micStatusEl,
+    publisherMicStateEl: publisherMicState,
+    publisherMicStateLabel,
     screenStatusEl,
     micSlider,
     screenSlider,
@@ -1302,7 +1344,6 @@ function updateAvatarVideo(cardRef, track) {
   }
   var avatar = cardRef.avatar;
   var card = cardRef.card;
-  var isLocal = cardRef.isLocal;
   // Preserve the hidden file input for local user avatar upload
   var fileInput = avatar.querySelector('input[type="file"]');
   avatar.innerHTML = "";
@@ -1313,20 +1354,18 @@ function updateAvatarVideo(cardRef, track) {
     startBasicVideoMonitor(element);
     avatar.appendChild(element);
     debugLog("video attached to avatar for track " + (track.sid || "unknown"));
-    // Toggle camera-first layout for remote users
-    if (!isLocal && card) {
-      card.classList.add("has-camera");
-    }
+    // Camera-on participants always use the same prominent camera-first card.
+    if (card) card.classList.add("has-camera");
+    if (cardRef.isLocal) avatar.title = "Click to view camera fullscreen";
   } else {
     avatar.textContent = getInitials(card?.querySelector(".user-name")?.textContent || "");
     if (fileInput) avatar.appendChild(fileInput);
     // Show avatar image if one exists (replaces initials)
     var identity = card?.dataset?.identity;
     if (identity) updateAvatarDisplay(identity);
-    // Revert to compact layout for remote users
-    if (!isLocal && card) {
-      card.classList.remove("has-camera");
-    }
+    // Camera-off participants return to the compact avatar card.
+    if (card) card.classList.remove("has-camera");
+    if (cardRef.isLocal) avatar.title = "Click to upload avatar";
     // Close any open volume popup
     if (cardRef.camOverlay) {
       var popup = cardRef.camOverlay.querySelector(".vol-popup");

--- a/core/viewer/participants-avatar.test.js
+++ b/core/viewer/participants-avatar.test.js
@@ -39,10 +39,16 @@ function makeAvatarElement(initials = "Z") {
   return avatar;
 }
 
-function loadParticipantsAvatar({ deviceId, imageResults } = {}) {
+function loadParticipantsAvatar({ deviceId, imageResults, isLocal = false } = {}) {
   const avatar = makeAvatarElement();
+  const classes = new Set();
   const card = {
     dataset: { identity: "z-6826" },
+    classList: {
+      add(value) { classes.add(value); },
+      remove(value) { classes.delete(value); },
+      contains(value) { return classes.has(value); },
+    },
     querySelector(selector) {
       if (selector === ".user-name") return { textContent: "Z" };
       return null;
@@ -50,7 +56,7 @@ function loadParticipantsAvatar({ deviceId, imageResults } = {}) {
   };
   const context = {
     participantCards: new Map([
-      ["z-6826", { avatar, card, isLocal: false }],
+      ["z-6826", { avatar, card, isLocal }],
     ]),
     avatarUrls: new Map(),
     deviceIdByIdentity: new Map(deviceId ? [["z", deviceId]] : []),
@@ -79,6 +85,14 @@ function loadParticipantsAvatar({ deviceId, imageResults } = {}) {
       }
     },
     Node: { TEXT_NODE: 3 },
+    createLockedVideoElement(track) {
+      return { className: "", track };
+    },
+    configureVideoElement() {},
+    startBasicVideoMonitor() {},
+    getInitials(value) {
+      return (value || "").slice(0, 2).toUpperCase();
+    },
     apiUrl(pathname) {
       return "https://echo.example.test:9443" + pathname;
     },
@@ -99,7 +113,7 @@ function loadParticipantsAvatar({ deviceId, imageResults } = {}) {
   vm.createContext(context);
   const code = fs.readFileSync(path.join(__dirname, "participants-avatar.js"), "utf8");
   vm.runInContext(code, context, { filename: "participants-avatar.js" });
-  return { context, avatar };
+  return { context, avatar, card };
 }
 
 test("remote avatar falls back to the server identity avatar when no broadcast URL arrived", () => {
@@ -145,3 +159,16 @@ test("remote avatar keeps the last good image when a replacement fails to load",
     "https://echo.example.test:9443/api/avatar/70ff47ce-0128-4d5f-a29d"
   );
 });
+
+for (const isLocal of [true, false]) {
+  test(`${isLocal ? "local" : "remote"} camera uses and restores the prominent camera card`, () => {
+    const { context, card } = loadParticipantsAvatar({ isLocal });
+    const cardRef = context.participantCards.get("z-6826");
+
+    context.updateAvatarVideo(cardRef, { sid: "camera-track" });
+    assert.equal(card.classList.contains("has-camera"), true);
+
+    context.updateAvatarVideo(cardRef, null);
+    assert.equal(card.classList.contains("has-camera"), false);
+  });
+}

--- a/core/viewer/publish-state-reconcile.js
+++ b/core/viewer/publish-state-reconcile.js
@@ -5,30 +5,61 @@
     root.EchoPublishStateReconcile = factory();
   }
 })(typeof globalThis !== "undefined" ? globalThis : this, function () {
+  function isMicrophoneActuallyEnabled(participant, publications, microphoneSource, audioKind) {
+    if (!participant || !participant.isMicrophoneEnabled) return false;
+    const pubs = Array.isArray(publications) ? publications : [];
+    return pubs.some((publication) => {
+      if (!publication) return false;
+      const track = publication.track;
+      const source = publication.source || (track && track.source);
+      const kind = publication.kind || (track && track.kind);
+      return source === microphoneSource &&
+        kind === audioKind &&
+        !publication.isMuted &&
+        !!track &&
+        !track.isMuted &&
+        (!track.mediaStreamTrack || track.mediaStreamTrack.readyState !== "ended");
+    });
+  }
+
   function reconcilePublishIndicators(current, actual) {
     const cur = current || {};
     const act = actual || {};
+    const tracksMicrophone = Object.prototype.hasOwnProperty.call(cur, "micEnabled") ||
+      Object.prototype.hasOwnProperty.call(act, "microphonePublished");
 
+    const nextMicEnabled = !!act.microphonePublished;
     const nextCamEnabled = !!act.cameraPublished;
     const nextScreenEnabled = !!act.screenPublished;
 
+    const microphoneDrift = tracksMicrophone && !!cur.micEnabled !== nextMicEnabled;
     const cameraDrift = !!cur.camEnabled !== nextCamEnabled;
     const screenDrift = !!cur.screenEnabled !== nextScreenEnabled;
 
+    const next = {
+      camEnabled: nextCamEnabled,
+      screenEnabled: nextScreenEnabled,
+    };
+    const drift = {
+      camera: cameraDrift,
+      screen: screenDrift,
+    };
+    // Preserve the helper's old camera/screen-only shape for reliability
+    // scenarios that intentionally do not model microphone state.
+    if (tracksMicrophone) {
+      next.micEnabled = nextMicEnabled;
+      drift.microphone = microphoneDrift;
+    }
+
     return {
-      next: {
-        camEnabled: nextCamEnabled,
-        screenEnabled: nextScreenEnabled,
-      },
-      drift: {
-        camera: cameraDrift,
-        screen: screenDrift,
-      },
-      anyDrift: cameraDrift || screenDrift,
+      next,
+      drift,
+      anyDrift: microphoneDrift || cameraDrift || screenDrift,
     };
   }
 
   return {
+    isMicrophoneActuallyEnabled,
     reconcilePublishIndicators,
   };
 });

--- a/core/viewer/publish-state-reconcile.test.js
+++ b/core/viewer/publish-state-reconcile.test.js
@@ -1,25 +1,79 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
-const { reconcilePublishIndicators } = require("./publish-state-reconcile.js");
+const {
+  isMicrophoneActuallyEnabled,
+  reconcilePublishIndicators,
+} = require("./publish-state-reconcile.js");
 
-test("camera/screen stale-on flags are corrected to false when unpublished", () => {
+const microphoneSource = "microphone";
+const audioKind = "audio";
+
+function microphonePublication(overrides = {}) {
+  return {
+    source: microphoneSource,
+    kind: audioKind,
+    isMuted: false,
+    track: {
+      kind: audioKind,
+      isMuted: false,
+      mediaStreamTrack: { readyState: "live" },
+    },
+    ...overrides,
+  };
+}
+
+test("microphone truth requires both SDK enabled state and a live unmuted publication", () => {
+  const livePublication = microphonePublication();
+
+  assert.equal(isMicrophoneActuallyEnabled(
+    { isMicrophoneEnabled: true }, [livePublication], microphoneSource, audioKind
+  ), true);
+  assert.equal(isMicrophoneActuallyEnabled(
+    { isMicrophoneEnabled: false }, [livePublication], microphoneSource, audioKind
+  ), false);
+  assert.equal(isMicrophoneActuallyEnabled(
+    { isMicrophoneEnabled: true }, [], microphoneSource, audioKind
+  ), false);
+});
+
+test("muted, ended, and non-microphone publications never count as a live mic", () => {
+  const participant = { isMicrophoneEnabled: true };
+
+  assert.equal(isMicrophoneActuallyEnabled(
+    participant, [microphonePublication({ isMuted: true })], microphoneSource, audioKind
+  ), false);
+  assert.equal(isMicrophoneActuallyEnabled(
+    participant,
+    [microphonePublication({ track: { kind: audioKind, isMuted: false, mediaStreamTrack: { readyState: "ended" } } })],
+    microphoneSource,
+    audioKind
+  ), false);
+  assert.equal(isMicrophoneActuallyEnabled(
+    participant, [microphonePublication({ source: "screen_share_audio" })], microphoneSource, audioKind
+  ), false);
+});
+
+test("mic/camera/screen stale-on flags are corrected to false when unpublished", () => {
   const out = reconcilePublishIndicators(
-    { camEnabled: true, screenEnabled: true },
-    { cameraPublished: false, screenPublished: false }
+    { micEnabled: true, camEnabled: true, screenEnabled: true },
+    { microphonePublished: false, cameraPublished: false, screenPublished: false }
   );
 
+  assert.equal(out.next.micEnabled, false);
   assert.equal(out.next.camEnabled, false);
   assert.equal(out.next.screenEnabled, false);
+  assert.equal(out.drift.microphone, true);
   assert.equal(out.drift.camera, true);
   assert.equal(out.drift.screen, true);
 });
 
 test("published tracks force UI truth to enabled", () => {
   const out = reconcilePublishIndicators(
-    { camEnabled: false, screenEnabled: false },
-    { cameraPublished: true, screenPublished: true }
+    { micEnabled: false, camEnabled: false, screenEnabled: false },
+    { microphonePublished: true, cameraPublished: true, screenPublished: true }
   );
 
+  assert.equal(out.next.micEnabled, true);
   assert.equal(out.next.camEnabled, true);
   assert.equal(out.next.screenEnabled, true);
   assert.equal(out.anyDrift, true);
@@ -27,12 +81,12 @@ test("published tracks force UI truth to enabled", () => {
 
 test("no drift when UI state already matches publication reality", () => {
   const out = reconcilePublishIndicators(
-    { camEnabled: true, screenEnabled: false },
-    { cameraPublished: true, screenPublished: false }
+    { micEnabled: false, camEnabled: true, screenEnabled: false },
+    { microphonePublished: false, cameraPublished: true, screenPublished: false }
   );
 
   assert.equal(out.anyDrift, false);
-  assert.deepEqual(out.next, { camEnabled: true, screenEnabled: false });
+  assert.deepEqual(out.next, { micEnabled: false, camEnabled: true, screenEnabled: false });
 });
 
 test("missing inputs default to unpublished false flags", () => {
@@ -42,13 +96,35 @@ test("missing inputs default to unpublished false flags", () => {
   assert.equal(out.anyDrift, false);
 });
 
-test("camera and screen drift are tracked independently", () => {
+test("legacy camera/screen-only callers keep their original result shape", () => {
   const out = reconcilePublishIndicators(
-    { camEnabled: false, screenEnabled: true },
-    { cameraPublished: true, screenPublished: true }
+    { camEnabled: true, screenEnabled: false },
+    { cameraPublished: false, screenPublished: true }
   );
 
+  assert.deepEqual(out.next, { camEnabled: false, screenEnabled: true });
+  assert.deepEqual(out.drift, { camera: true, screen: true });
+});
+
+test("microphone, camera, and screen drift are tracked independently", () => {
+  const out = reconcilePublishIndicators(
+    { micEnabled: true, camEnabled: false, screenEnabled: true },
+    { microphonePublished: false, cameraPublished: true, screenPublished: true }
+  );
+
+  assert.equal(out.drift.microphone, true);
   assert.equal(out.drift.camera, true);
   assert.equal(out.drift.screen, false);
+  assert.equal(out.anyDrift, true);
+});
+
+test("an unconfirmed microphone cannot remain optimistically enabled", () => {
+  const out = reconcilePublishIndicators(
+    { micEnabled: true, camEnabled: false, screenEnabled: false },
+    { microphonePublished: false, cameraPublished: false, screenPublished: false }
+  );
+
+  assert.equal(out.next.micEnabled, false);
+  assert.equal(out.drift.microphone, true);
   assert.equal(out.anyDrift, true);
 });

--- a/core/viewer/style.css
+++ b/core/viewer/style.css
@@ -1532,6 +1532,57 @@ video {
   display: block;
 }
 
+.participant-mic-state {
+  position: absolute;
+  right: 14px;
+  bottom: 14px;
+  z-index: 5;
+  min-height: 26px;
+  padding: 4px 8px;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  color: #fecaca;
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 1;
+  letter-spacing: 0.02em;
+  border: 1px solid rgba(248, 113, 113, 0.46);
+  border-radius: 999px;
+  background: rgba(69, 10, 10, 0.86);
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.28);
+  pointer-events: none;
+}
+
+.participant-mic-state[hidden] {
+  display: none !important;
+}
+
+.participant-mic-state-icon {
+  position: relative;
+  width: 14px;
+  height: 14px;
+  display: inline-grid;
+  place-items: center;
+}
+
+.participant-mic-state-icon svg {
+  width: 14px;
+  height: 14px;
+  fill: currentColor;
+}
+
+.participant-mic-state-icon::after {
+  content: "";
+  position: absolute;
+  width: 2px;
+  height: 17px;
+  border-radius: 2px;
+  background: currentColor;
+  transform: rotate(-43deg);
+  box-shadow: 0 0 0 1px rgba(69, 10, 10, 0.72);
+}
+
 .user-avatar-local:hover::after {
   content: "Upload";
   position: absolute;
@@ -1548,13 +1599,40 @@ video {
   pointer-events: none;
 }
 
-/* ─── Camera-First Card (remote users with camera ON) ─── */
+/* ─── Camera-First Card (any participant with camera ON) ─── */
 .user-card.has-camera {
   padding: 0;
   overflow: visible;
 }
 
 .user-card.has-camera .user-name {
+  display: none;
+}
+
+.user-card.is-local.has-camera .user-name {
+  position: absolute;
+  left: 12px;
+  bottom: 10px;
+  z-index: 4;
+  max-width: calc(100% - 72px);
+  display: block;
+  overflow: hidden;
+  color: #fff;
+  text-overflow: ellipsis;
+  text-shadow: 0 1px 4px rgba(0, 0, 0, 0.9);
+  white-space: nowrap;
+}
+
+.user-card.has-camera .participant-mic-state {
+  top: 10px;
+  right: auto;
+  bottom: auto;
+  left: 10px;
+  background: rgba(69, 10, 10, 0.9);
+  backdrop-filter: blur(8px);
+}
+
+.user-card.has-camera .user-avatar-local:hover::after {
   display: none;
 }
 


### PR DESCRIPTION
## What changed

- Treat a local microphone as on only when LiveKit has a live, unmuted microphone publication.
- Reconcile microphone truth after toggles, reconnects, publication changes, and room switches.
- Show a clear **Mic off** or **Muted** badge plus a subtle crimson card outline from the publisher's actual state.
- Promote the local camera to the same responsive 16:9 participant card used for remote cameras.
- Freeze local publish controls during room handoffs and preserve in-flight microphone intent safely.

## Root cause

Echo optimistically trusted the requested microphone state instead of verifying that LiveKit actually published a usable track. Remote cards also defaulted to an unmuted-looking state when no microphone publication existed, and the V2 camera styling intentionally excluded the local participant.

## User impact

A failed microphone start can no longer leave Echo claiming the user is live. Friends can see when a participant has no mic publication or has muted it, and the local camera is now as prominent as everyone else's.

## Verification

- `npm run verify:quick` — 172/172 viewer and state tests passed
- `npm run verify:viewer:layout` — 67/67 Chromium interaction and responsive-layout tests passed
- Explicit race coverage for disable→immediate room switch and enable→immediate room switch
- Browser visual QA of muted and live camera cards
- Independent final code review: clean
- `git diff --check` — clean

## Release impact

- [x] Server-only viewer deploy
- [ ] Desktop binary required
- [ ] Both

Existing Echo desktop installations receive this through the server-hosted viewer; no Windows installer update is required.
