### PR TITLE
Restore per-stream Stage visibility controls

### DIFF
--- a/core/viewer-tests/fixtures/install-scenario.js
+++ b/core/viewer-tests/fixtures/install-scenario.js
@@ -434,6 +434,14 @@
     updateActiveSpeakerUi();
   }
 
+  function setParticipantScreenShareAvailable(identity, available) {
+    const cardRef = participantCards.get(identity);
+    if (!cardRef?.setScreenWatchAvailable) {
+      throw new Error("participant screen-share state is unavailable for " + identity);
+    }
+    cardRef.setScreenWatchAvailable(available);
+  }
+
   window.EchoLayoutTestScenario = Object.freeze({
     captureCameraLobbySnapshot: captureCameraLobbySnapshot,
     captureIdentitySnapshot: captureIdentitySnapshot,
@@ -442,6 +450,7 @@
     install: install,
     installCameraLobby: installCameraLobby,
     setParticipantMicrophoneState: setParticipantMicrophoneState,
+    setParticipantScreenShareAvailable: setParticipantScreenShareAvailable,
     unbrokenDisplayName: unbrokenDisplayName,
   });
 })();

--- a/core/viewer-tests/fixtures/install-scenario.js
+++ b/core/viewer-tests/fixtures/install-scenario.js
@@ -35,6 +35,11 @@
     if (typeof participantCards !== "undefined") participantCards.clear();
     if (typeof participantState !== "undefined") participantState.clear();
     if (typeof screenTileBySid !== "undefined") screenTileBySid.clear();
+    if (typeof screenTileByIdentity !== "undefined") screenTileByIdentity.clear();
+    if (typeof hiddenScreens !== "undefined") hiddenScreens.clear();
+    if (typeof watchedScreens !== "undefined") watchedScreens.clear();
+    if (typeof room !== "undefined") room = null;
+    window.__echoLayoutFixtureSubscriptions = [];
   }
 
   function createVideoTrackStub(label, aspectRatio) {
@@ -101,10 +106,14 @@
     }
 
     let attachedCameras = 0;
+    const participants = [];
     for (let index = 1; index <= count; index += 1) {
       const isLocal = index === 1;
+      const participant = makeParticipant(index, longNames, unbrokenNames);
+      participant.trackPublications = new Map();
+      participants.push(participant);
       const cardRef = ensureParticipantCard(
-        makeParticipant(index, longNames, unbrokenNames),
+        participant,
         isLocal,
       );
       const shouldAttachCamera = isLocal ? !!localCamera : attachedCameras < cameraCount;
@@ -119,9 +128,10 @@
       video.setAttribute("aria-label", `${cardRef.card.dataset.identity} camera fixture`);
       if (!isLocal) attachedCameras += 1;
     }
+    return participants;
   }
 
-  function addScreenShares(count, aspectRatios) {
+  function addScreenShares(count, aspectRatios, screenOwners, participants) {
     if (typeof addScreenTile !== "function" || typeof createLockedVideoElement !== "function") {
       throw new Error("production screen renderer is unavailable");
     }
@@ -133,7 +143,51 @@
       exposeFixtureDimensions(video, media);
       video.classList.add("layout-fixture-screen");
       video.setAttribute("aria-label", `screen share ${index + 1}`);
-      addScreenTile(`Shared by Friend ${index + 2}`, video, media.track.sid);
+      const ownerIndex = Number(Array.isArray(screenOwners) ? screenOwners[index] : 0);
+      const owner = Number.isInteger(ownerIndex) && ownerIndex > 0
+        ? participants[ownerIndex - 1]
+        : null;
+      const ownerName = owner ? owner.name : `Friend ${index + 2}`;
+      const tile = addScreenTile(`Shared by ${ownerName}`, video, media.track.sid);
+
+      if (owner) {
+        const LK = getLiveKitClient();
+        tile.dataset.identity = owner.identity;
+        screenTileByIdentity.set(owner.identity, tile);
+
+        const subscriptionLog = window.__echoLayoutFixtureSubscriptions;
+        function makePublication(suffix, source, kind) {
+          const publication = {
+            isSubscribed: true,
+            kind: kind,
+            source: source,
+            track: null,
+            trackSid: `${media.track.sid}-${suffix}`,
+            setSubscribed: function(value) {
+              publication.isSubscribed = !!value;
+              subscriptionLog.push({
+                identity: owner.identity,
+                source: source,
+                subscribed: !!value,
+              });
+            },
+          };
+          owner.trackPublications.set(publication.trackSid, publication);
+        }
+        makePublication("video", LK.Track.Source.ScreenShare, LK.Track.Kind.Video);
+        makePublication("audio", LK.Track.Source.ScreenShareAudio, LK.Track.Kind.Audio);
+
+        const state = participantState.get(owner.identity);
+        if (state) {
+          const audio = document.createElement("audio");
+          audio.muted = false;
+          state.screenAudioEls.add(audio);
+          state.screenGainNodes.set(audio, { gain: { gain: { value: 1 } } });
+        }
+
+        const cardRef = participantCards.get(owner.identity);
+        if (cardRef?.setScreenWatchAvailable) cardRef.setScreenWatchAvailable(true);
+      }
     }
   }
 
@@ -164,18 +218,27 @@
       chatOpen: false,
       longNames: false,
       localCamera: false,
+      screenOwners: [],
       unbrokenNames: false,
     }, options || {});
 
     resetRoom();
-    addParticipants(
+    const participants = addParticipants(
       scenario.participants,
       scenario.cameras,
       scenario.longNames,
       scenario.unbrokenNames,
       scenario.localCamera,
     );
-    addScreenShares(scenario.screenShares, scenario.shareAspects);
+    if (participants.length > 0 && scenario.screenOwners.length > 0) {
+      room = {
+        localParticipant: participants[0],
+        remoteParticipants: new Map(participants.slice(1).map(function(participant) {
+          return [participant.identity, participant];
+        })),
+      };
+    }
+    addScreenShares(scenario.screenShares, scenario.shareAspects, scenario.screenOwners, participants);
     populateChat(scenario.chatOpen);
     await nextFrame();
 

--- a/core/viewer-tests/tests/shell.phase1.spec.js
+++ b/core/viewer-tests/tests/shell.phase1.spec.js
@@ -1544,13 +1544,62 @@ test("every member can hide and restore any shared screen on their own Stage", a
   const remoteIdentity = "layout-fixture-2";
   const localCard = page.locator(`.user-card[data-identity="${localIdentity}"]`);
   const remoteCard = page.locator(`.user-card[data-identity="${remoteIdentity}"]`);
+  const nonSharingCard = page.locator('.user-card[data-identity="layout-fixture-3"]');
   const localTile = page.locator(`#screen-grid > .tile[data-identity="${localIdentity}"]`);
   const remoteTile = page.locator(`#screen-grid > .tile[data-identity="${remoteIdentity}"]`);
+  const localSharingBadge = localCard.locator(".participant-screen-state");
+  const remoteSharingBadge = remoteCard.locator(".participant-screen-state");
+
+  await page.evaluate(() => updateActiveSpeakerUi());
 
   await expect(localTile).toBeVisible();
   await expect(remoteTile).toBeVisible();
   await expect(localCard.locator(".participant-settings-toggle")).toBeVisible();
   await expect(remoteCard.locator(".participant-settings-toggle")).toBeVisible();
+  await expect(localCard).toHaveClass(/is-screen-sharing/);
+  await expect(remoteCard).toHaveClass(/is-screen-sharing/);
+  await expect(nonSharingCard).not.toHaveClass(/is-screen-sharing/);
+  await expect(localSharingBadge).toBeVisible();
+  await expect(localSharingBadge).toHaveText("Sharing");
+  await expect(localSharingBadge).toHaveAccessibleName(/Sharing screen from Friend 1/i);
+  await expect(remoteSharingBadge).toBeVisible();
+  await expect(remoteSharingBadge).toHaveText("Sharing");
+  await expect(remoteSharingBadge).toHaveAccessibleName(/Sharing screen from Friend 2/i);
+  await expect(nonSharingCard.locator(".participant-screen-state")).toBeHidden();
+  await expectContained(localSharingBadge, localCard);
+  await expectContained(remoteSharingBadge, remoteCard);
+  await expectNoOverlap(localSharingBadge, localCard.locator(".participant-mic-state"));
+  await expectNoOverlap(localSharingBadge, localCard.locator(".participant-settings-toggle"));
+  await expectNoOverlap(remoteSharingBadge, remoteCard.locator(".participant-mic-state"));
+  await expectNoOverlap(remoteSharingBadge, remoteCard.locator(".participant-settings-toggle"));
+
+  await page.evaluate((identity) => {
+    window.EchoLayoutTestScenario.setParticipantMicrophoneState(identity, {
+      published: true,
+      muted: false,
+    });
+  }, remoteIdentity);
+  await expect(remoteCard).toHaveCSS("border-color", "rgba(201, 168, 106, 0.72)");
+
+  await page.evaluate((identity) => {
+    const state = participantState.get(identity);
+    state.micActive = true;
+    lastActiveSpeakerEvent = Number.NEGATIVE_INFINITY;
+    updateActiveSpeakerUi();
+  }, remoteIdentity);
+  await expect(remoteCard).toHaveCSS("border-color", "rgba(79, 195, 200, 0.72)");
+
+  await page.evaluate((identity) => {
+    window.EchoLayoutTestScenario.setParticipantMicrophoneState(identity, {
+      published: true,
+      muted: true,
+    });
+  }, remoteIdentity);
+  await expect(remoteCard).toHaveClass(/is-publisher-mic-off/);
+  await expect(remoteCard).toHaveClass(/is-screen-sharing/);
+  await expect(remoteCard).toHaveCSS("border-color", "rgba(229, 106, 106, 0.58)");
+  await expect(remoteSharingBadge).toBeVisible();
+  await expectNoOverlap(remoteSharingBadge, remoteCard.locator(".participant-mic-state"));
 
   async function openScreenAction(card, participantName, action) {
     const toggle = card.locator(".participant-settings-toggle");
@@ -1568,6 +1617,10 @@ test("every member can hide and restore any shared screen on their own Stage", a
   await expect(localTile).toBeHidden();
   await expect(remoteTile).toBeVisible();
   await expect(localCard.locator(".participant-settings-toggle")).toBeVisible();
+  await expect(localCard).toHaveClass(/is-screen-sharing/);
+  await expect(localSharingBadge).toBeVisible();
+  await expectContained(localSharingBadge, localCard);
+  await expectNoOverlap(localSharingBadge, localCard.locator(".participant-settings-toggle"));
 
   const localHiddenState = await page.evaluate((identity) => {
     const state = participantState.get(identity);
@@ -1609,6 +1662,8 @@ test("every member can hide and restore any shared screen on their own Stage", a
   await hideRemote.click();
   await expect(remoteTile).toBeHidden();
   await expect(localTile).toBeVisible();
+  await expect(remoteCard).toHaveClass(/is-screen-sharing/);
+  await expect(remoteSharingBadge).toBeVisible();
 
   const remoteHiddenState = await page.evaluate((identity) => {
     const state = participantState.get(identity);
@@ -1646,7 +1701,19 @@ test("every member can hide and restore any shared screen on their own Stage", a
     getComputedStyle(grid, "::before").content
   )).toContain("All shared screens are hidden");
   await expect(localCard.locator(".participant-settings-toggle")).toBeVisible();
+  await expect(localSharingBadge).toBeVisible();
+  await expect(remoteSharingBadge).toBeVisible();
   await expect(remoteCard.locator(".participant-settings-popover").getByRole("button", {
     name: /Show the shared screen from Friend 2 on my Stage/i,
   })).toBeVisible();
+
+  await page.evaluate(({ localIdentity, remoteIdentity }) => {
+    window.EchoLayoutTestScenario.setParticipantScreenShareAvailable(localIdentity, false);
+    window.EchoLayoutTestScenario.setParticipantScreenShareAvailable(remoteIdentity, false);
+  }, { localIdentity, remoteIdentity });
+  await expect(localCard).not.toHaveClass(/is-screen-sharing/);
+  await expect(remoteCard).not.toHaveClass(/is-screen-sharing/);
+  await expect(localSharingBadge).toBeHidden();
+  await expect(remoteSharingBadge).toBeHidden();
+  await expect(localCard.locator(".participant-settings-toggle")).toBeHidden();
 });

--- a/core/viewer-tests/tests/shell.phase1.spec.js
+++ b/core/viewer-tests/tests/shell.phase1.spec.js
@@ -1530,3 +1530,123 @@ test("one participant audio menu owns voice, shared-audio, and chime controls", 
     await expect(nonCameraCard.locator(".user-indicators .mute-button").nth(muteIndex)).toBeVisible();
   }
 });
+
+test("every member can hide and restore any shared screen on their own Stage", async ({ page }) => {
+  await page.setViewportSize({ width: 1024, height: 768 });
+  await openPhaseOneViewer(page, {
+    participants: 3,
+    cameras: 1,
+    screenShares: 2,
+    screenOwners: [1, 2],
+  });
+
+  const localIdentity = "layout-fixture-1";
+  const remoteIdentity = "layout-fixture-2";
+  const localCard = page.locator(`.user-card[data-identity="${localIdentity}"]`);
+  const remoteCard = page.locator(`.user-card[data-identity="${remoteIdentity}"]`);
+  const localTile = page.locator(`#screen-grid > .tile[data-identity="${localIdentity}"]`);
+  const remoteTile = page.locator(`#screen-grid > .tile[data-identity="${remoteIdentity}"]`);
+
+  await expect(localTile).toBeVisible();
+  await expect(remoteTile).toBeVisible();
+  await expect(localCard.locator(".participant-settings-toggle")).toBeVisible();
+  await expect(remoteCard.locator(".participant-settings-toggle")).toBeVisible();
+
+  async function openScreenAction(card, participantName, action) {
+    const toggle = card.locator(".participant-settings-toggle");
+    const popup = card.locator(".participant-settings-popover");
+    if (!(await popup.isVisible())) await toggle.click();
+    await expect(popup).toBeVisible();
+    return popup.getByRole("button", {
+      name: new RegExp(`${action} the shared screen from ${participantName} on my Stage`, "i"),
+    });
+  }
+
+  const hideLocal = await openScreenAction(localCard, "Friend 1", "Hide");
+  await expect(hideLocal).toHaveText("Hide from my Stage");
+  await hideLocal.click();
+  await expect(localTile).toBeHidden();
+  await expect(remoteTile).toBeVisible();
+  await expect(localCard.locator(".participant-settings-toggle")).toBeVisible();
+
+  const localHiddenState = await page.evaluate((identity) => {
+    const state = participantState.get(identity);
+    const audio = Array.from(state.screenAudioEls)[0];
+    const gainNode = state.screenGainNodes.get(audio);
+    return {
+      gain: gainNode.gain.gain.value,
+      hidden: hiddenScreens.has(identity),
+      muted: audio.muted,
+      subscriptions: window.__echoLayoutFixtureSubscriptions.filter((entry) => entry.identity === identity),
+    };
+  }, localIdentity);
+  expect(localHiddenState).toEqual({ gain: 0, hidden: true, muted: true, subscriptions: [] });
+
+  await page.setViewportSize({ width: 560, height: 640 });
+  await expect(page.locator("html")).toHaveAttribute("data-ui-mode", "mini");
+  const showLocal = await openScreenAction(localCard, "Friend 1", "Show");
+  await expect(showLocal).toHaveText("Show on my Stage");
+  const restoreGeometry = await showLocal.evaluate((button) => {
+    const rect = button.getBoundingClientRect();
+    return {
+      bottom: rect.bottom,
+      left: rect.left,
+      right: rect.right,
+      top: rect.top,
+      viewportHeight: window.innerHeight,
+      viewportWidth: window.innerWidth,
+    };
+  });
+  expect(restoreGeometry.left).toBeGreaterThanOrEqual(0);
+  expect(restoreGeometry.top).toBeGreaterThanOrEqual(0);
+  expect(restoreGeometry.right).toBeLessThanOrEqual(restoreGeometry.viewportWidth);
+  expect(restoreGeometry.bottom).toBeLessThanOrEqual(restoreGeometry.viewportHeight);
+  await showLocal.click();
+  await expect(localTile).toBeVisible();
+
+  await page.setViewportSize({ width: 1024, height: 768 });
+  const hideRemote = await openScreenAction(remoteCard, "Friend 2", "Hide");
+  await hideRemote.click();
+  await expect(remoteTile).toBeHidden();
+  await expect(localTile).toBeVisible();
+
+  const remoteHiddenState = await page.evaluate((identity) => {
+    const state = participantState.get(identity);
+    const audio = Array.from(state.screenAudioEls)[0];
+    const gainNode = state.screenGainNodes.get(audio);
+    return {
+      gain: gainNode.gain.gain.value,
+      hidden: hiddenScreens.has(identity),
+      muted: audio.muted,
+      unsubscribedSources: window.__echoLayoutFixtureSubscriptions
+        .filter((entry) => entry.identity === identity && !entry.subscribed)
+        .map((entry) => entry.source)
+        .sort(),
+    };
+  }, remoteIdentity);
+  expect(remoteHiddenState.hidden).toBe(true);
+  expect(remoteHiddenState.muted).toBe(true);
+  expect(remoteHiddenState.gain).toBe(0);
+  expect(remoteHiddenState.unsubscribedSources).toEqual(["screen_share", "screen_share_audio"]);
+
+  const showRemote = await openScreenAction(remoteCard, "Friend 2", "Show");
+  await showRemote.click();
+  await expect(remoteTile).toBeVisible();
+  await expect.poll(() => page.evaluate((identity) => ({
+    hidden: hiddenScreens.has(identity),
+    resubscribed: window.__echoLayoutFixtureSubscriptions.some((entry) =>
+      entry.identity === identity && entry.subscribed
+    ),
+  }), remoteIdentity)).toEqual({ hidden: false, resubscribed: true });
+
+  await (await openScreenAction(localCard, "Friend 1", "Hide")).click();
+  await (await openScreenAction(remoteCard, "Friend 2", "Hide")).click();
+  await expect(page.locator("#screen-grid")).toHaveAttribute("data-visible-tiles", "0");
+  await expect.poll(() => page.locator("#screen-grid").evaluate((grid) =>
+    getComputedStyle(grid, "::before").content
+  )).toContain("All shared screens are hidden");
+  await expect(localCard.locator(".participant-settings-toggle")).toBeVisible();
+  await expect(remoteCard.locator(".participant-settings-popover").getByRole("button", {
+    name: /Show the shared screen from Friend 2 on my Stage/i,
+  })).toBeVisible();
+});

--- a/core/viewer/audio-routing.js
+++ b/core/viewer/audio-routing.js
@@ -415,11 +415,7 @@ function handleTrackSubscribed(track, publication, participant) {
     var _isLocalScreen = room && room.localParticipant && effectiveParticipant.identity === room.localParticipant.identity;
     if (!_isLocalScreen && isUnwatchedScreenShare(publication, participant)) {
       if (publication?.setSubscribed) publication.setSubscribed(false);
-      if (cardRef && cardRef.watchToggleBtn) {
-        cardRef.watchToggleBtn.style.display = "";
-        cardRef.watchToggleBtn.textContent = "Start Watching";
-        if (cardRef.ovWatchClone) { cardRef.ovWatchClone.style.display = ""; cardRef.ovWatchClone.textContent = "Start Watching"; }
-      }
+      setParticipantScreenWatchAvailable(effectiveParticipant.identity, true);
       debugLog("[opt-in] auto-unsubscribed unwatched screen " + effectiveParticipant.identity);
       return;
     }
@@ -432,11 +428,7 @@ function handleTrackSubscribed(track, publication, participant) {
       if (!hiddenScreens.has(identity)) {
         existingTile.style.display = "";
       }
-      if (cardRef && cardRef.watchToggleBtn) {
-        cardRef.watchToggleBtn.style.display = "";
-        cardRef.watchToggleBtn.textContent = hiddenScreens.has(identity) ? "Start Watching" : "Stop Watching";
-        if (cardRef.ovWatchClone) { cardRef.ovWatchClone.style.display = ""; cardRef.ovWatchClone.textContent = cardRef.watchToggleBtn.textContent; }
-      }
+      setParticipantScreenWatchAvailable(identity, true);
       // If same track object, NEVER replace the element — just ensure it plays.
       // SDP renegotiations fire unsub/resub for the same track every ~2s. Replacing
       // the video element interrupts play(), creating a loop of "interrupted by new load".
@@ -517,11 +509,7 @@ function handleTrackSubscribed(track, publication, participant) {
     if (!_isLocalTile) startInboundScreenStatsMonitor();
     // Opt-in screen shares: tile was created because user is watching (or it's local)
     // No need to hide — the intercept at the top of this function already unsubscribed unwatched screens
-    if (cardRef && cardRef.watchToggleBtn) {
-      cardRef.watchToggleBtn.style.display = "";
-      cardRef.watchToggleBtn.textContent = hiddenScreens.has(effectiveParticipant.identity) ? "Start Watching" : "Stop Watching";
-      if (cardRef.ovWatchClone) { cardRef.ovWatchClone.style.display = ""; cardRef.ovWatchClone.textContent = cardRef.watchToggleBtn.textContent; }
-    }
+    setParticipantScreenWatchAvailable(effectiveParticipant.identity, true);
     var _pState = participantState.get(effectiveParticipant.identity);
     if (_pState) _pState.screenTrackSid = screenTrackSid;
     forceVideoLayer(publication, element);
@@ -762,12 +750,7 @@ function handleTrackUnsubscribed(track, publication, participant) {
           _pubBitrateControl.delete(identity);
           debugLog("[bitrate-ctrl] cleared AIMD state for " + identity + " (screen share ended)");
         }
-        var cardRef2 = participantCards.get(identity);
-        if (cardRef2 && cardRef2.watchToggleBtn) {
-          cardRef2.watchToggleBtn.style.display = "none";
-          cardRef2.watchToggleBtn.textContent = "Stop Watching";
-          if (cardRef2.ovWatchClone) { cardRef2.ovWatchClone.style.display = "none"; cardRef2.ovWatchClone.textContent = "Stop Watching"; }
-        }
+        setParticipantScreenWatchAvailable(identity, false);
       }
       // If still publishing but user unsubscribed, keep hiddenScreens and button as-is
     }

--- a/core/viewer/clubhouse-shell.css
+++ b/core/viewer/clubhouse-shell.css
@@ -521,7 +521,8 @@
   justify-content: stretch;
 }
 
-:root[data-ui-shell="v2"] .screens-grid:empty::before {
+:root[data-ui-shell="v2"] .screens-grid:empty::before,
+:root[data-ui-shell="v2"] #screen-grid[data-visible-tiles="0"]:not(:empty)::before {
   content: "No one is sharing\A Use Share Screen when you are ready to take the stage.";
   width: min(440px, calc(100% - 32px));
   min-height: min(240px, calc(100% - 16px));
@@ -543,6 +544,10 @@
     url("badge.jpg") center 22px / min(208px, 64%) auto no-repeat,
     linear-gradient(145deg, rgba(201, 168, 106, 0.045), rgba(255, 255, 255, 0.012));
   opacity: 0.78;
+}
+
+:root[data-ui-shell="v2"] #screen-grid[data-visible-tiles="0"]:not(:empty)::before {
+  content: "All shared screens are hidden\A Open People and choose Show on my Stage to restore one.";
 }
 
 :root[data-ui-shell="v2"] .screens-grid .tile {
@@ -861,6 +866,10 @@
   background: rgba(201, 168, 106, 0.1);
 }
 
+:root[data-ui-shell="v2"] .participant-settings-toggle.is-stream-control-unavailable {
+  display: none !important;
+}
+
 :root[data-ui-shell="v2"] .participant-settings-popover {
   position: relative;
   z-index: 6;
@@ -962,6 +971,19 @@
   color: #ff9aa1;
   border-color: rgba(229, 106, 106, 0.38);
   background: rgba(229, 106, 106, 0.12);
+}
+
+:root[data-ui-shell="v2"] .participant-settings-watch {
+  width: 100%;
+  min-height: 38px;
+  justify-content: center;
+  font-size: 11px;
+}
+
+:root[data-ui-shell="v2"] .participant-settings-watch.is-screen-hidden {
+  color: var(--club-brass-bright);
+  border-color: rgba(201, 168, 106, 0.38);
+  background: rgba(201, 168, 106, 0.1);
 }
 
 :root[data-ui-shell="v2"] .participant-settings-slider-row {

--- a/core/viewer/clubhouse-shell.css
+++ b/core/viewer/clubhouse-shell.css
@@ -733,9 +733,16 @@
   box-shadow: none;
 }
 
-:root[data-ui-shell="v2"] .user-card:not(.is-publisher-mic-off):has(.icon-button.is-active) {
+:root[data-ui-shell="v2"] .user-card:not(.is-publisher-mic-off):has(.participant-mic-activity.is-active) {
   border-color: rgba(79, 195, 200, 0.72);
   box-shadow: 0 0 0 2px rgba(79, 195, 200, 0.1), 0 12px 28px rgba(0, 0, 0, 0.2);
+}
+
+:root[data-ui-shell="v2"] .user-card.is-screen-sharing:not(.is-publisher-mic-off) {
+  border-color: rgba(201, 168, 106, 0.72);
+  box-shadow:
+    inset 0 0 0 1px rgba(201, 168, 106, 0.08),
+    0 0 18px rgba(201, 168, 106, 0.14);
 }
 
 :root[data-ui-shell="v2"] .user-card.is-publisher-mic-off {
@@ -764,6 +771,7 @@
 }
 
 :root[data-ui-shell="v2"] .user-card:not(.has-camera) .user-header {
+  position: relative;
   grid-template-columns: 54px minmax(0, 1fr);
   gap: 10px;
 }
@@ -786,6 +794,55 @@
   right: auto;
   bottom: 10px;
   left: 74px;
+}
+
+:root[data-ui-shell="v2"] .participant-screen-state {
+  position: absolute;
+  right: 48px;
+  bottom: 0;
+  z-index: 5;
+  min-width: 0;
+  min-height: 26px;
+  padding: 4px 8px;
+  display: inline-flex !important;
+  align-items: center;
+  gap: 5px;
+  overflow: hidden;
+  color: var(--club-brass-bright);
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 1;
+  letter-spacing: 0.02em;
+  border: 1px solid rgba(201, 168, 106, 0.46);
+  border-radius: var(--club-radius-pill);
+  background: rgba(68, 49, 17, 0.9);
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.28);
+  backdrop-filter: blur(8px);
+  pointer-events: none;
+}
+
+:root[data-ui-shell="v2"] .participant-screen-state[hidden] {
+  display: none !important;
+}
+
+:root[data-ui-shell="v2"] .participant-screen-state-icon {
+  width: 14px;
+  height: 14px;
+  display: inline-grid;
+  flex: 0 0 14px;
+  place-items: center;
+}
+
+:root[data-ui-shell="v2"] .participant-screen-state-icon svg {
+  width: 14px;
+  height: 14px;
+  fill: currentColor;
+}
+
+:root[data-ui-shell="v2"] .participant-screen-state-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 :root[data-ui-shell="v2"] .user-indicators {
@@ -1032,6 +1089,12 @@
   right: auto;
   bottom: auto;
   left: 8px;
+}
+
+:root[data-ui-shell="v2"] .user-card.has-camera .participant-screen-state {
+  top: 8px;
+  right: 8px;
+  bottom: auto;
 }
 
 :root[data-ui-shell="v2"] .user-card.is-local.has-camera .user-name {
@@ -1497,6 +1560,16 @@
   :root[data-ui-shell="v2"] .participant-chime-toggle::before {
     content: "♪";
     font-size: 13px;
+  }
+}
+
+@container (max-width: 280px) {
+  :root[data-ui-shell="v2"] .participant-screen-state {
+    padding-inline: 6px;
+  }
+
+  :root[data-ui-shell="v2"] .participant-screen-state-label {
+    display: none;
   }
 }
 

--- a/core/viewer/connect.js
+++ b/core/viewer/connect.js
@@ -769,12 +769,7 @@ async function connectToRoom({ controlUrl, sfuUrl, roomId, identity, name, reuse
           playScreenShareChime(ssVol);
         }
         if (hiddenScreens.has(_pubIdentity)) {
-          var cardRef = participantCards.get(_pubIdentity);
-          if (cardRef && cardRef.watchToggleBtn) {
-            cardRef.watchToggleBtn.style.display = "";
-            cardRef.watchToggleBtn.textContent = "Start Watching";
-            if (cardRef.ovWatchClone) { cardRef.ovWatchClone.style.display = ""; cardRef.ovWatchClone.textContent = "Start Watching"; }
-          }
+          setParticipantScreenWatchAvailable(_pubIdentity, true);
           debugLog(`[opt-in] track published (screen, user-hidden) ${_pubIdentity} src=${pubSource}`);
           // Still hook so we can subscribe later when user opts in
           if (participant) hookPublication(publication, participant);
@@ -876,12 +871,7 @@ async function connectToRoom({ controlUrl, sfuUrl, roomId, identity, name, reuse
           hiddenScreens.delete(identity);
           watchedScreens.delete(identity);
           _pubBitrateControl.delete(identity);
-          var cardRef = participantCards.get(identity);
-          if (cardRef?.watchToggleBtn) {
-            cardRef.watchToggleBtn.style.display = "none";
-            cardRef.watchToggleBtn.textContent = "Stop Watching";
-            if (cardRef.ovWatchClone) { cardRef.ovWatchClone.style.display = "none"; cardRef.ovWatchClone.textContent = "Stop Watching"; }
-          }
+          setParticipantScreenWatchAvailable(identity, false);
         }
       }
 
@@ -1260,12 +1250,7 @@ async function connectToRoom({ controlUrl, sfuUrl, roomId, identity, name, reuse
         if (publication.trackSid) {
           registerScreenTrack(publication.trackSid, publication, tile, localIdentity);
         }
-        // Show "Stop Watching" button for local screen share
-        const localCardRef = participantCards.get(localIdentity);
-        if (localCardRef && localCardRef.watchToggleBtn) {
-          localCardRef.watchToggleBtn.style.display = "";
-          localCardRef.watchToggleBtn.textContent = hiddenScreens.has(localIdentity) ? "Start Watching" : "Stop Watching";
-        }
+        setParticipantScreenWatchAvailable(localIdentity, true);
       } else if (publication.track?.kind === "video" && source === LK.Track.Source.Camera) {
         updateAvatarVideo(ensureParticipantCard(local, true), publication.track);
       } else if (publication.track?.kind === "audio") {
@@ -1295,16 +1280,12 @@ async function connectToRoom({ controlUrl, sfuUrl, roomId, identity, name, reuse
         if (publication.trackSid === localScreenTrackSid) {
           localScreenTrackSid = "";
         }
-        // Hide "Stop Watching" button when local screen share ends
+        // Remove the local Stage-view action when the share itself ends.
         const localId = room?.localParticipant?.identity;
         if (localId) {
           hiddenScreens.delete(localId);
           screenTileByIdentity.delete(localId);
-          const localCard = participantCards.get(localId);
-          if (localCard && localCard.watchToggleBtn) {
-            localCard.watchToggleBtn.style.display = "none";
-            localCard.watchToggleBtn.textContent = "Stop Watching";
-          }
+          setParticipantScreenWatchAvailable(localId, false);
         }
       } else if (publication.track?.kind === "video" && source === LK.Track.Source.Camera) {
         const cardRef = participantCards.get(room?.localParticipant?.identity || "");
@@ -1420,7 +1401,7 @@ async function connectToRoom({ controlUrl, sfuUrl, roomId, identity, name, reuse
   remoteList.forEach((participant) => {
     ensureParticipantCard(participant);
     attachParticipantTracks(participant);
-    // Opt-in: detect existing screen shares and show "Start Watching" button
+    // Detect existing screen shares and expose the viewer-local Stage action.
     var pubs = getParticipantPublications(participant);
     pubs.forEach(function(pub) {
       patchScreenCompanionSource(pub, pub?.track, participant);
@@ -1433,19 +1414,8 @@ async function connectToRoom({ controlUrl, sfuUrl, roomId, identity, name, reuse
         ? getParentIdentity(participant.identity)
         : participant.identity;
       // Auto-subscribe to existing screen shares — don't force opt-in for late joiners.
-      // The "Stop Watching" button is available if they want to unsubscribe later.
+      // The Stage-view action remains available if they want to hide it later.
       startWatchingScreenIdentity(effectiveIdentity, "late-join");
-      return;
-      hiddenScreens.delete(effectiveIdentity);
-      watchedScreens.add(effectiveIdentity);
-      resubscribeParticipantTracks(participant);
-      reconcileParticipantMedia(participant);
-      var cardRef = participantCards.get(effectiveIdentity);
-      if (cardRef && cardRef.watchToggleBtn) {
-        cardRef.watchToggleBtn.style.display = "";
-        cardRef.watchToggleBtn.textContent = "Stop Watching";
-        if (cardRef.ovWatchClone) { cardRef.ovWatchClone.style.display = ""; cardRef.ovWatchClone.textContent = "Stop Watching"; }
-      }
     }
   });
   // Retry existing participants — fast on room switch, full on first connect

--- a/core/viewer/participants-avatar.js
+++ b/core/viewer/participants-avatar.js
@@ -55,6 +55,14 @@ function toggleParticipantSettings(button, popup) {
   activeParticipantSettings = opening ? { button: button, popup: popup } : null;
 }
 
+function setParticipantScreenWatchAvailable(identity, available) {
+  if (!identity) return;
+  var cardRef = participantCards.get(identity);
+  if (cardRef && typeof cardRef.setScreenWatchAvailable === "function") {
+    cardRef.setScreenWatchAvailable(available);
+  }
+}
+
 if (typeof document.addEventListener === "function") {
   document.addEventListener("click", function(event) {
     if (!activeParticipantSettings) return;
@@ -104,15 +112,7 @@ function startWatchingScreenIdentity(identity, reason) {
   hiddenScreens.delete(identity);
   watchedScreens.add(identity);
 
-  var cardRef = participantCards.get(identity);
-  if (cardRef && cardRef.watchToggleBtn) {
-    cardRef.watchToggleBtn.style.display = "";
-    cardRef.watchToggleBtn.textContent = "Stop Watching";
-    if (cardRef.ovWatchClone) {
-      cardRef.ovWatchClone.style.display = "";
-      cardRef.ovWatchClone.textContent = "Stop Watching";
-    }
-  }
+  setParticipantScreenWatchAvailable(identity, true);
 
   var tile = screenTileByIdentity.get(identity);
   if (tile) tile.style.display = "";
@@ -339,6 +339,39 @@ function ensureParticipantCard(participant, isLocal = false) {
   let settingsChimeSlider = null;
   let settingsChimePct = null;
   let settingsWatchButton = null;
+  let screenWatchAvailable = false;
+
+  function syncScreenWatchControls() {
+    var screenHidden = hiddenScreens.has(key);
+    var actionText = screenHidden ? "Show on my Stage" : "Hide from my Stage";
+    var actionLabel = (screenHidden ? "Show" : "Hide") +
+      " the shared screen from " + participantDisplayName + " on my Stage";
+
+    [watchToggleBtn, ovWatchClone, settingsWatchButton].forEach(function(button) {
+      if (!button) return;
+      button.textContent = actionText;
+      button.setAttribute("aria-label", actionLabel);
+      button.title = actionLabel;
+      button.classList.toggle("is-screen-hidden", screenHidden);
+    });
+
+    if (watchToggleBtn) watchToggleBtn.style.display = screenWatchAvailable ? "" : "none";
+    if (ovWatchClone) ovWatchClone.style.display = screenWatchAvailable ? "" : "none";
+    if (settingsWatchButton) settingsWatchButton.classList.toggle("hidden", !screenWatchAvailable);
+
+    if (isLocal && participantSettingsButton) {
+      participantSettingsButton.classList.toggle("is-stream-control-unavailable", !screenWatchAvailable);
+      if (!screenWatchAvailable && participantSettingsPopup?.classList.contains("is-open")) {
+        closeParticipantSettings(false);
+      }
+    }
+  }
+
+  function setScreenWatchAvailable(available) {
+    screenWatchAvailable = !!available;
+    syncScreenWatchControls();
+  }
+
   if (!isLocal) {
     const indicators = document.createElement("div");
     indicators.className = "user-indicators";
@@ -371,7 +404,7 @@ function ensureParticipantCard(participant, isLocal = false) {
     var watchToggleBtn = document.createElement("button");
     watchToggleBtn.type = "button";
     watchToggleBtn.className = "watch-toggle-btn";
-    watchToggleBtn.textContent = "Stop Watching";
+    watchToggleBtn.textContent = "Hide from my Stage";
     watchToggleBtn.style.display = "none";
     watchToggleBtn.addEventListener("click", function(e) {
       e.stopPropagation();
@@ -384,97 +417,12 @@ function ensureParticipantCard(participant, isLocal = false) {
       }
 
       if (hiddenScreens.has(identity)) {
-        // === START WATCHING: subscribe to screen share tracks ===
         startWatchingScreenIdentity(identity, "manual-click");
         return;
-        hiddenScreens.delete(identity);
-        watchedScreens.add(identity);
-        watchToggleBtn.textContent = "Stop Watching";
-        if (ovWatchClone) ovWatchClone.textContent = "Stop Watching";
-        debugLog("[opt-in] user opted in to watch " + identity);
-
-        // Find the remote participant and subscribe to their screen share tracks
-        var remotes = getRemoteParticipantsForScreenIdentity(identity);
-        if (remotes.length > 0) {
-          remotes.forEach(function(remote) {
-            var pubs = getParticipantPublications(remote);
-            pubs.forEach(function(pub) {
-              var src = getWatchSource(pub, remote);
-              if (src === LK_wt.Track.Source.ScreenShare || src === LK_wt.Track.Source.ScreenShareAudio) {
-                // Subscribe to the track on the SFU
-                if (pub.setSubscribed) pub.setSubscribed(true);
-                // Ensure publication is hooked (event listeners registered)
-                hookPublication(pub, remote);
-                // If the track is already available (SDK cached it), process immediately
-                if (pub.track && pub.isSubscribed) {
-                  debugLog("[opt-in] track already available for " + src + " " + remote.identity + " → " + identity + " — processing immediately");
-                  handleTrackSubscribed(pub.track, pub, remote);
-                } else {
-                  debugLog("[opt-in] subscribed to " + src + " for " + remote.identity + " → " + identity + " — waiting for track (subscribed=" + (pub.isSubscribed ?? "?") + " hasTrack=" + !!pub.track + ")");
-                }
-              }
-            });
-          });
-          // Fallback at 500ms: check if tracks arrived and process them
-          setTimeout(function() {
-            var remoteFbs = getRemoteParticipantsForScreenIdentity(identity);
-            if (remoteFbs.length === 0) return;
-            remoteFbs.forEach(function(remoteFb) {
-              var fbPubs = getParticipantPublications(remoteFb);
-              fbPubs.forEach(function(pub) {
-                var src = getWatchSource(pub, remoteFb);
-                if (src === LK_wt.Track.Source.ScreenShare) {
-                  if (pub.track && pub.isSubscribed && !screenTileByIdentity.has(identity)) {
-                    debugLog("[opt-in] fallback@500ms: processing screen track for " + remoteFb.identity + " → " + identity);
-                    handleTrackSubscribed(pub.track, pub, remoteFb);
-                  }
-                  if (!pub.isSubscribed && pub.setSubscribed) {
-                    debugLog("[opt-in] fallback@500ms: re-subscribing screen for " + remoteFb.identity + " → " + identity);
-                    pub.setSubscribed(true);
-                  }
-                }
-                if (src === LK_wt.Track.Source.ScreenShareAudio) {
-                  var fbState = participantState.get(identity);
-                  if (pub.track && pub.isSubscribed && fbState && fbState.screenAudioEls.size === 0) {
-                    debugLog("[opt-in] fallback@500ms: processing screen audio for " + remoteFb.identity + " → " + identity);
-                    handleTrackSubscribed(pub.track, pub, remoteFb);
-                  }
-                  if (!pub.isSubscribed && pub.setSubscribed) {
-                    debugLog("[opt-in] fallback@500ms: re-subscribing screen audio for " + remoteFb.identity + " → " + identity);
-                    pub.setSubscribed(true);
-                  }
-                }
-              });
-            });
-          }, 500);
-          // Fallback at 1500ms: full reconcile to catch anything still missing
-          setTimeout(function() {
-            var remoteFb2s = getRemoteParticipantsForScreenIdentity(identity);
-            remoteFb2s.forEach(function(remoteFb2) {
-              debugLog("[opt-in] fallback@1500ms: full reconcile for " + remoteFb2.identity + " → " + identity);
-              reconcileParticipantMedia(remoteFb2);
-            });
-          }, 1500);
-          // Schedule reconcile waves to ensure everything settles
-          scheduleReconcileWaves("opt-in-watch");
-        }
-        // Show existing tile if it was created
-        var tile = screenTileByIdentity.get(identity);
-        if (tile) tile.style.display = "";
-        // Unmute screen share audio
-        if (pState && pState.screenAudioEls) {
-          pState.screenAudioEls.forEach(function(el) {
-            el.muted = false;
-            var gn = pState.screenGainNodes?.get(el);
-            if (gn) gn.gain.gain.value = pState.screenVolume || 1;
-          });
-        }
       } else {
         // === STOP WATCHING: unsubscribe from screen share tracks ===
         hiddenScreens.add(identity);
         watchedScreens.delete(identity);
-        watchToggleBtn.textContent = "Start Watching";
-        if (ovWatchClone) ovWatchClone.textContent = "Start Watching";
         debugLog("[opt-in] user stopped watching " + identity);
 
         // Find the remote participant and unsubscribe from their screen share tracks
@@ -505,6 +453,7 @@ function ensureParticipantCard(participant, isLocal = false) {
             if (gn) gn.gain.gain.value = 0;
           });
         }
+        syncScreenWatchControls();
       }
     });
     screenIndicatorRow.append(watchToggleBtn);
@@ -753,16 +702,16 @@ function ensureParticipantCard(participant, isLocal = false) {
     participantSettingsButton.type = "button";
     participantSettingsButton.className = "participant-settings-toggle shell-v2-only";
     participantSettingsButton.innerHTML = iconSvg("settings");
-    participantSettingsButton.setAttribute("aria-label", "Audio settings for " + participantDisplayName);
+    participantSettingsButton.setAttribute("aria-label", "Controls for " + participantDisplayName);
     participantSettingsButton.setAttribute("aria-haspopup", "dialog");
     participantSettingsButton.setAttribute("aria-expanded", "false");
-    participantSettingsButton.title = "Audio settings for " + participantDisplayName;
+    participantSettingsButton.title = "Controls for " + participantDisplayName;
 
     participantSettingsPopup = document.createElement("div");
     participantSettingsPopup.id = "participant-settings-" + participantControlId;
     participantSettingsPopup.className = "participant-settings-popover shell-v2-only";
     participantSettingsPopup.setAttribute("role", "dialog");
-    participantSettingsPopup.setAttribute("aria-label", "Audio settings for " + participantDisplayName);
+    participantSettingsPopup.setAttribute("aria-label", "Controls for " + participantDisplayName);
     participantSettingsButton.setAttribute("aria-controls", participantSettingsPopup.id);
 
     var settingsHeading = document.createElement("div");
@@ -771,13 +720,13 @@ function ensureParticipantCard(participant, isLocal = false) {
     var settingsHeadingTitle = document.createElement("strong");
     settingsHeadingTitle.textContent = participantDisplayName;
     var settingsHeadingHint = document.createElement("span");
-    settingsHeadingHint.textContent = "Adjust what you hear";
+    settingsHeadingHint.textContent = "Choose what you see and hear";
     settingsHeadingCopy.append(settingsHeadingTitle, settingsHeadingHint);
     var settingsClose = document.createElement("button");
     settingsClose.type = "button";
     settingsClose.className = "participant-settings-close";
     settingsClose.textContent = "\u00d7";
-    settingsClose.setAttribute("aria-label", "Close audio settings for " + participantDisplayName);
+    settingsClose.setAttribute("aria-label", "Close controls for " + participantDisplayName);
     settingsClose.addEventListener("click", function(event) {
       event.stopPropagation();
       closeParticipantSettings(true);
@@ -847,18 +796,6 @@ function ensureParticipantCard(participant, isLocal = false) {
       event.stopPropagation();
       watchToggleBtn.click();
     });
-    function syncSettingsWatchButton() {
-      settingsWatchButton.textContent = watchToggleBtn.textContent;
-      settingsWatchButton.classList.toggle("hidden", watchToggleBtn.style.display === "none");
-    }
-    if (typeof MutationObserver !== "undefined") {
-      new MutationObserver(syncSettingsWatchButton).observe(watchToggleBtn, {
-        attributes: true,
-        childList: true,
-        subtree: true,
-      });
-    }
-    syncSettingsWatchButton();
 
     var settingsFooter = document.createElement("div");
     settingsFooter.className = "participant-settings-footer";
@@ -894,9 +831,6 @@ function ensureParticipantCard(participant, isLocal = false) {
   }
   header.append(avatar, meta);
   card.append(header);
-  if (participantSettingsButton && participantSettingsPopup) {
-    card.append(participantSettingsButton, participantSettingsPopup);
-  }
 
   let controls = null;
   let micStatusEl = micIndicator;
@@ -931,11 +865,11 @@ function ensureParticipantCard(participant, isLocal = false) {
     screenControl.addEventListener("click", () => toggleScreen().catch(() => {}));
     row.append(micControl, camControl, screenControl);
     controls.append(enableAll, row);
-    // Add watch toggle button for local user's own screen share
+    // Local-only Stage visibility. This never stops the published screen share.
     var watchToggleBtn = document.createElement("button");
     watchToggleBtn.type = "button";
     watchToggleBtn.className = "watch-toggle-btn";
-    watchToggleBtn.textContent = "Stop Watching";
+    watchToggleBtn.textContent = "Hide from my Stage";
     watchToggleBtn.style.display = "none";
     watchToggleBtn.addEventListener("click", function(e) {
       e.stopPropagation();
@@ -952,7 +886,6 @@ function ensureParticipantCard(participant, isLocal = false) {
             if (gn) gn.gain.gain.value = pState.screenVolume || 1;
           });
         }
-        watchToggleBtn.textContent = "Stop Watching";
       } else {
         hiddenScreens.add(identity);
         var tile = screenTileByIdentity.get(identity);
@@ -970,13 +903,73 @@ function ensureParticipantCard(participant, isLocal = false) {
             if (gn) gn.gain.gain.value = 0;
           });
         }
-        watchToggleBtn.textContent = "Start Watching";
       }
+      syncScreenWatchControls();
     });
     controls.append(watchToggleBtn);
     meta.append(controls);
     micStatusEl = micControl;
     screenStatusEl = screenControl;
+
+    // V2 hides the legacy local control row. Give the local card the same
+    // single settings affordance as every other member while a share exists.
+    participantSettingsButton = document.createElement("button");
+    participantSettingsButton.type = "button";
+    participantSettingsButton.className =
+      "participant-settings-toggle shell-v2-only is-stream-control-unavailable";
+    participantSettingsButton.innerHTML = iconSvg("settings");
+    participantSettingsButton.setAttribute("aria-label", "Controls for " + participantDisplayName);
+    participantSettingsButton.setAttribute("aria-haspopup", "dialog");
+    participantSettingsButton.setAttribute("aria-expanded", "false");
+    participantSettingsButton.title = "Controls for " + participantDisplayName;
+
+    participantSettingsPopup = document.createElement("div");
+    participantSettingsPopup.id = "participant-settings-" + participantControlId;
+    participantSettingsPopup.className =
+      "participant-settings-popover participant-screen-settings shell-v2-only";
+    participantSettingsPopup.setAttribute("role", "dialog");
+    participantSettingsPopup.setAttribute("aria-label", "Controls for " + participantDisplayName);
+    participantSettingsButton.setAttribute("aria-controls", participantSettingsPopup.id);
+
+    var settingsHeading = document.createElement("div");
+    settingsHeading.className = "participant-settings-heading";
+    var settingsHeadingCopy = document.createElement("div");
+    var settingsHeadingTitle = document.createElement("strong");
+    settingsHeadingTitle.textContent = participantDisplayName;
+    var settingsHeadingHint = document.createElement("span");
+    settingsHeadingHint.textContent = "Control your Stage view";
+    settingsHeadingCopy.append(settingsHeadingTitle, settingsHeadingHint);
+    var settingsClose = document.createElement("button");
+    settingsClose.type = "button";
+    settingsClose.className = "participant-settings-close";
+    settingsClose.textContent = "\u00d7";
+    settingsClose.setAttribute("aria-label", "Close controls for " + participantDisplayName);
+    settingsClose.addEventListener("click", function(event) {
+      event.stopPropagation();
+      closeParticipantSettings(true);
+    });
+    settingsHeading.append(settingsHeadingCopy, settingsClose);
+
+    settingsWatchButton = document.createElement("button");
+    settingsWatchButton.type = "button";
+    settingsWatchButton.className = "participant-settings-watch hidden";
+    settingsWatchButton.addEventListener("click", function(event) {
+      event.stopPropagation();
+      watchToggleBtn.click();
+    });
+
+    var settingsFooter = document.createElement("div");
+    settingsFooter.className = "participant-settings-footer";
+    settingsFooter.append(settingsWatchButton);
+    participantSettingsPopup.append(settingsHeading, settingsFooter);
+    participantSettingsButton.addEventListener("click", function(event) {
+      event.stopPropagation();
+      toggleParticipantSettings(participantSettingsButton, participantSettingsPopup);
+    });
+  }
+
+  if (participantSettingsButton && participantSettingsPopup) {
+    card.append(participantSettingsButton, participantSettingsPopup);
   }
   if (isLocal) {
     userListEl.prepend(card);
@@ -1272,12 +1265,12 @@ function ensureParticipantCard(participant, isLocal = false) {
     });
 
     if (participantSettingsButton) {
-      participantSettingsButton.setAttribute("aria-label", "Audio settings for " + participantDisplayName);
-      participantSettingsButton.title = "Audio settings for " + participantDisplayName;
+      participantSettingsButton.setAttribute("aria-label", "Controls for " + participantDisplayName);
+      participantSettingsButton.title = "Controls for " + participantDisplayName;
     }
-    if (participantSettingsPopup) participantSettingsPopup.setAttribute("aria-label", "Audio settings for " + participantDisplayName);
+    if (participantSettingsPopup) participantSettingsPopup.setAttribute("aria-label", "Controls for " + participantDisplayName);
     if (settingsHeadingTitle) settingsHeadingTitle.textContent = participantDisplayName;
-    if (settingsClose) settingsClose.setAttribute("aria-label", "Close audio settings for " + participantDisplayName);
+    if (settingsClose) settingsClose.setAttribute("aria-label", "Close controls for " + participantDisplayName);
     if (settingsMicSlider) settingsMicSlider.setAttribute("aria-label", "Microphone volume for " + participantDisplayName);
     if (settingsScreenSlider) settingsScreenSlider.setAttribute("aria-label", "Screen volume for " + participantDisplayName);
     if (settingsChimeSlider) settingsChimeSlider.setAttribute("aria-label", "Chime volume for " + participantDisplayName);
@@ -1287,6 +1280,7 @@ function ensureParticipantCard(participant, isLocal = false) {
         (publisherMicStateLabel?.textContent || "Mic off") + " for " + participantDisplayName
       );
     }
+    syncScreenWatchControls();
   }
 
   participantCards.set(key, {
@@ -1326,9 +1320,11 @@ function ensureParticipantCard(participant, isLocal = false) {
     settingsScreenSlider,
     settingsChimeSlider,
     settingsWatchButton,
+    setScreenWatchAvailable,
     setParticipantDisplayName
   });
   participantState.set(key, state);
+  setScreenWatchAvailable(false);
   debugLog(`participant card created and added to DOM for ${key}, card.isConnected=${card.isConnected}, avatar exists=${!!avatar}`);
   // Show avatar image if one exists for this user
   updateAvatarDisplay(key);

--- a/core/viewer/participants-avatar.js
+++ b/core/viewer/participants-avatar.js
@@ -261,6 +261,21 @@ function ensureParticipantCard(participant, isLocal = false) {
   publisherMicStateLabel.className = "participant-mic-state-label";
   publisherMicStateLabel.textContent = "Mic off";
   publisherMicState.append(publisherMicStateIcon, publisherMicStateLabel);
+
+  const publisherScreenState = document.createElement("div");
+  publisherScreenState.className = "participant-screen-state shell-v2-only";
+  publisherScreenState.hidden = true;
+  publisherScreenState.setAttribute("role", "status");
+  publisherScreenState.setAttribute("aria-label", "Sharing screen from " + participantDisplayName);
+  publisherScreenState.title = "Sharing screen";
+  const publisherScreenStateIcon = document.createElement("span");
+  publisherScreenStateIcon.className = "participant-screen-state-icon";
+  publisherScreenStateIcon.innerHTML = iconSvg("screen");
+  const publisherScreenStateLabel = document.createElement("span");
+  publisherScreenStateLabel.className = "participant-screen-state-label";
+  publisherScreenStateLabel.textContent = "Sharing";
+  publisherScreenState.append(publisherScreenStateIcon, publisherScreenStateLabel);
+
   card.append(publisherMicState);
 
   const header = document.createElement("div");
@@ -359,6 +374,9 @@ function ensureParticipantCard(participant, isLocal = false) {
     if (ovWatchClone) ovWatchClone.style.display = screenWatchAvailable ? "" : "none";
     if (settingsWatchButton) settingsWatchButton.classList.toggle("hidden", !screenWatchAvailable);
 
+    card.classList.toggle("is-screen-sharing", screenWatchAvailable);
+    publisherScreenState.hidden = !screenWatchAvailable;
+
     if (isLocal && participantSettingsButton) {
       participantSettingsButton.classList.toggle("is-stream-control-unavailable", !screenWatchAvailable);
       if (!screenWatchAvailable && participantSettingsPopup?.classList.contains("is-open")) {
@@ -381,7 +399,7 @@ function ensureParticipantCard(participant, isLocal = false) {
     screenIndicatorRow.className = "indicator-row";
     micIndicator = document.createElement("button");
     micIndicator.type = "button";
-    micIndicator.className = "icon-button indicator-only";
+    micIndicator.className = "icon-button indicator-only participant-mic-activity";
     micIndicator.innerHTML = iconSvg("mic");
     micIndicator.setAttribute("aria-label", "Microphone audio settings for " + (participant.name || "Guest"));
     micMuteButton = document.createElement("button");
@@ -829,7 +847,7 @@ function ensureParticipantCard(participant, isLocal = false) {
       toggleParticipantSettings(participantSettingsButton, participantSettingsPopup);
     });
   }
-  header.append(avatar, meta);
+  header.append(avatar, meta, publisherScreenState);
   card.append(header);
 
   let controls = null;
@@ -847,7 +865,7 @@ function ensureParticipantCard(participant, isLocal = false) {
     row.className = "control-row";
     const micControl = document.createElement("button");
     micControl.type = "button";
-    micControl.className = "icon-button";
+    micControl.className = "icon-button participant-mic-activity";
     micControl.innerHTML = iconSvg("mic");
     micControl.setAttribute("aria-label", "Toggle microphone");
     micControl.addEventListener("click", () => toggleMic().catch(() => {}));
@@ -1280,6 +1298,7 @@ function ensureParticipantCard(participant, isLocal = false) {
         (publisherMicStateLabel?.textContent || "Mic off") + " for " + participantDisplayName
       );
     }
+    publisherScreenState.setAttribute("aria-label", "Sharing screen from " + participantDisplayName);
     syncScreenWatchControls();
   }
 
@@ -1291,6 +1310,7 @@ function ensureParticipantCard(participant, isLocal = false) {
     micStatusEl,
     publisherMicStateEl: publisherMicState,
     publisherMicStateLabel,
+    publisherScreenStateEl: publisherScreenState,
     screenStatusEl,
     micSlider,
     screenSlider,

--- a/core/viewer/screen-share-native.js
+++ b/core/viewer/screen-share-native.js
@@ -212,16 +212,8 @@ function _clearNativeScreenTilesForIdentity(identity) {
     if (typeof watchedScreens !== 'undefined' && watchedScreens) watchedScreens.delete(key);
     if (typeof _pubBitrateControl !== 'undefined' && _pubBitrateControl) _pubBitrateControl.delete(key);
 
-    if (typeof participantCards !== 'undefined' && participantCards) {
-      var cardRef = participantCards.get(key);
-      if (cardRef && cardRef.watchToggleBtn) {
-        cardRef.watchToggleBtn.style.display = 'none';
-        cardRef.watchToggleBtn.textContent = 'Stop Watching';
-        if (cardRef.ovWatchClone) {
-          cardRef.ovWatchClone.style.display = 'none';
-          cardRef.ovWatchClone.textContent = 'Stop Watching';
-        }
-      }
+    if (typeof setParticipantScreenWatchAvailable === 'function') {
+      setParticipantScreenWatchAvailable(key, false);
     }
   });
 

--- a/core/viewer/screen-share-native.test.js
+++ b/core/viewer/screen-share-native.test.js
@@ -334,6 +334,7 @@ test("native stop clears local screen tile and removes the screen companion", as
   const { context, calls, fetches } = loadScreenShareNative();
   let removed = false;
   let unregisteredSid = null;
+  const screenAvailability = [];
   const tile = {
     dataset: { trackSid: "TR_SCREEN" },
     classList: { contains: () => false },
@@ -359,6 +360,9 @@ test("native stop clears local screen tile and removes the screen companion", as
     unregisteredSid = sid;
     context.screenTrackMeta.delete(sid);
   };
+  context.setParticipantScreenWatchAvailable = (identity, available) => {
+    screenAvailability.push([identity, available]);
+  };
 
   await context.stopScreenShareManual();
 
@@ -369,6 +373,7 @@ test("native stop clears local screen tile and removes the screen companion", as
   assert.equal(context.hiddenScreens.has("Sam"), false);
   assert.equal(context.watchedScreens.has("Sam"), false);
   assert.equal(context._pubBitrateControl.has("Sam"), false);
+  assert.deepEqual(screenAvailability, [["Sam", false], ["Sam$screen", false]]);
   assert.equal(fetches.length, 1);
   assert.match(fetches[0].url, /\/v1\/rooms\/main\/kick\/Sam%24screen$/);
   assert.equal(fetches[0].opts.method, "POST");


### PR DESCRIPTION
## What changed

- Gives every participant card one viewer-local **Hide from my Stage / Show on my Stage** action for an active screen share, including the current user's own share.
- Keeps self-hide separate from **Stop Sharing**: hiding your own preview never unpublishes or ends the broadcast.
- Unsubscribes remote screen video/audio only for the viewer who hides it, then resubscribes when restored.
- Shows a gold **Sharing** chip and brass card outline for every active screen publisher, on both avatar and camera cards.
- Preserves the visual state hierarchy: active speakers turn teal, muted publishers stay red, and the Sharing chip remains visible.
- Keeps the sharing indicator tied to publisher truth, so it remains visible after a viewer locally hides the stream and clears only when sharing stops.
- Centralizes visibility labels and availability across the V2 menu, legacy controls, camera overlay, reconnect paths, and native screen-share cleanup.
- Shows an explicit recovery message when every active share is hidden.

## Root cause

The V2 clubhouse shell intentionally hid the local participant's legacy control row, but the replacement participant settings menu was created only for remote members. The media behavior survived; the local control became unreachable. Participant cards also had no publisher-level screen-share state, so there was no reliable way to see who owned each active share from the People list.

## User impact

Each Echo user can independently decide which active screen shares appear on their own Stage. One viewer's choice does not change anyone else's Stage and cannot stop another person's broadcast. The People list now makes screen publishers obvious without opening a menu.

## Verification

- `npm run verify:quick` — 172/172 viewer and unit checks passed.
- `npm test` from `core/viewer-tests` — 68/68 browser layout and interaction tests passed.
- Focused coverage verifies local and remote shares, avatar and camera cards, responsive containment, gold/teal/red state priority, local hiding, remote unsubscribe/resubscribe, all-hidden recovery, and native stop cleanup.
- Captured desktop and resized browser frames were inspected for badge, settings, mic-state, and card collisions.
- Independent final review found and prompted restoration of the active-speaker highlight for screen publishers.

## Release impact

- Server-served viewer only.
- No Windows desktop binary update required.
- No live deploy or service restart performed.
