### PR TITLE
Fix native Stop Sharing ownership

### DIFF
--- a/core/client/src/capture_health.rs
+++ b/core/client/src/capture_health.rs
@@ -93,6 +93,10 @@ pub struct CaptureHealthSnapshot {
     pub consecutive_timeouts_max_5m: u32,
     pub encoder_skip_rate_pct: f32,
     pub shader_errors_5m: u32,
+    /// Correlates the active native capture with lifecycle events and the
+    /// value returned by the Tauri start command. Absent on older binaries.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub capture_session_id: Option<u64>,
     /// Seconds since capture became active. Used by the classifier to
     /// suppress fps-based checks during the cold-start grace window.
     /// Zero when capture is inactive.
@@ -119,9 +123,63 @@ pub struct CaptureSenderDiagnostics {
     pub encoder: Option<String>,
 }
 
+/// Monotonic lease for one native capture attempt. Window WGC, monitor WGC,
+/// and DXGI all draw from the same sequence so a task from an older backend
+/// cannot deactivate or complete a newer capture.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct CaptureSessionId(u64);
+
+impl CaptureSessionId {
+    pub fn as_u64(self) -> u64 {
+        self.0
+    }
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CaptureStoppedEvent {
+    pub session_id: u64,
+}
+
+impl CaptureStoppedEvent {
+    pub fn new(session: CaptureSessionId) -> Self {
+        Self {
+            session_id: session.as_u64(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CaptureErrorEvent {
+    pub session_id: u64,
+    pub message: String,
+}
+
+impl CaptureErrorEvent {
+    pub fn new(session: CaptureSessionId, message: String) -> Self {
+        Self {
+            session_id: session.as_u64(),
+            message,
+        }
+    }
+}
+
+#[derive(Default)]
+struct CaptureSessionState {
+    next_id: u64,
+    current: Option<CaptureSessionId>,
+    stopping: bool,
+}
+
 // ── State ───────────────────────────────────────────────────────────
 
 pub struct CaptureHealthState {
+    /// Serializes capture-session replacement and completion. The health
+    /// fields below use atomics/locks for cheap sampling, but lifecycle writes
+    /// must be ordered as one transition so a stale task cannot win a race
+    /// after merely checking a generation number.
+    capture_session: Mutex<CaptureSessionState>,
     consecutive_timeouts: AtomicU32,
     consecutive_timeouts_max_5m: AtomicU32,
     encoder_skipped_total: AtomicU64,
@@ -146,6 +204,7 @@ pub struct CaptureHealthState {
 impl CaptureHealthState {
     pub fn new() -> Self {
         Self {
+            capture_session: Mutex::new(CaptureSessionState::default()),
             consecutive_timeouts: AtomicU32::new(0),
             consecutive_timeouts_max_5m: AtomicU32::new(0),
             encoder_skipped_total: AtomicU64::new(0),
@@ -173,50 +232,158 @@ impl CaptureHealthState {
         events.retain(|(t, _)| *t >= cutoff);
     }
 
-    pub fn record_reinit(&self) {
-        let now = Instant::now();
-        let mut e = self.reinit_events.lock();
-        Self::prune(&mut e, now);
-        e.push(now);
+    pub fn record_reinit(&self, session: CaptureSessionId) {
+        self.with_current_capture_session(session, || {
+            let now = Instant::now();
+            let mut e = self.reinit_events.lock();
+            Self::prune(&mut e, now);
+            e.push(now);
+        });
     }
 
-    pub fn record_consecutive_timeout(&self, current: u32) {
-        self.consecutive_timeouts.store(current, Ordering::Relaxed);
-        let now = Instant::now();
-        let mut e = self.timeout_max_events.lock();
-        Self::prune_pairs(&mut e, now);
-        e.push((now, current));
-        let max = e.iter().map(|(_, n)| *n).max().unwrap_or(0);
-        self.consecutive_timeouts_max_5m
-            .store(max, Ordering::Relaxed);
+    pub fn record_consecutive_timeout(&self, session: CaptureSessionId, current: u32) {
+        self.with_current_capture_session(session, || {
+            self.consecutive_timeouts.store(current, Ordering::Relaxed);
+            let now = Instant::now();
+            let mut e = self.timeout_max_events.lock();
+            Self::prune_pairs(&mut e, now);
+            e.push((now, current));
+            let max = e.iter().map(|(_, n)| *n).max().unwrap_or(0);
+            self.consecutive_timeouts_max_5m
+                .store(max, Ordering::Relaxed);
+        });
     }
 
-    pub fn reset_consecutive_timeouts(&self) {
-        self.consecutive_timeouts.store(0, Ordering::Relaxed);
+    pub fn reset_consecutive_timeouts(&self, session: CaptureSessionId) {
+        self.with_current_capture_session(session, || {
+            self.consecutive_timeouts.store(0, Ordering::Relaxed);
+        });
     }
 
-    pub fn record_encoder_status(&self, skipped_total: u64, sent_total: u64) {
-        self.encoder_skipped_total
-            .store(skipped_total, Ordering::Relaxed);
-        self.encoder_sent_total.store(sent_total, Ordering::Relaxed);
+    pub fn record_encoder_status(
+        &self,
+        session: CaptureSessionId,
+        skipped_total: u64,
+        sent_total: u64,
+    ) {
+        self.with_current_capture_session(session, || {
+            self.encoder_skipped_total
+                .store(skipped_total, Ordering::Relaxed);
+            self.encoder_sent_total.store(sent_total, Ordering::Relaxed);
+        });
     }
 
-    pub fn record_shader_error(&self) {
-        let now = Instant::now();
-        let mut e = self.shader_error_events.lock();
-        Self::prune(&mut e, now);
-        e.push(now);
+    pub fn record_shader_error(&self, session: CaptureSessionId) {
+        self.with_current_capture_session(session, || {
+            let now = Instant::now();
+            let mut e = self.shader_error_events.lock();
+            Self::prune(&mut e, now);
+            e.push(now);
+        });
     }
 
-    pub fn record_capture_fps(&self, fps: u32) {
-        self.last_capture_fps.store(fps, Ordering::Relaxed);
+    pub fn record_capture_fps(&self, session: CaptureSessionId, fps: u32) {
+        self.with_current_capture_session(session, || {
+            self.last_capture_fps.store(fps, Ordering::Relaxed);
+        });
     }
 
-    pub fn record_sender_diagnostics(&self, diagnostics: CaptureSenderDiagnostics) {
-        *self.sender_diagnostics.write() = Some(diagnostics);
+    pub fn record_sender_diagnostics(
+        &self,
+        session: CaptureSessionId,
+        diagnostics: CaptureSenderDiagnostics,
+    ) {
+        self.with_current_capture_session(session, || {
+            *self.sender_diagnostics.write() = Some(diagnostics);
+        });
     }
 
-    pub fn set_active(&self, active: bool, mode: CaptureMode, encoder: EncoderType, target: u32) {
+    /// Start a new cross-backend capture session and invalidate every older
+    /// task. Health is reset while the new task connects to the SFU.
+    pub fn begin_capture_session_with<T, F>(&self, install: F) -> (CaptureSessionId, T)
+    where
+        F: FnOnce(CaptureSessionId) -> T,
+    {
+        let mut state = self.capture_session.lock();
+        state.next_id = state.next_id.wrapping_add(1).max(1);
+        let session = CaptureSessionId(state.next_id);
+        state.current = Some(session);
+        state.stopping = false;
+        self.set_active_inner(false, CaptureMode::None, EncoderType::None, 0);
+        let installed = install(session);
+        (session, installed)
+    }
+
+    #[cfg(test)]
+    fn begin_capture_session(&self) -> CaptureSessionId {
+        self.begin_capture_session_with(|_| ()).0
+    }
+
+    /// Mark a capture session active only if it is still the newest native
+    /// capture attempt. Returns false when a replacement already owns health.
+    pub fn activate_capture_session(
+        &self,
+        session: CaptureSessionId,
+        mode: CaptureMode,
+        encoder: EncoderType,
+        target: u32,
+    ) -> bool {
+        let state = self.capture_session.lock();
+        if state.current != Some(session) || state.stopping {
+            return false;
+        }
+        self.set_active_inner(true, mode, encoder, target);
+        true
+    }
+
+    /// Run a short ownership transition only while this session is current.
+    /// Start paths use this to stop the opposite backend without allowing a
+    /// concurrent newer start to be mistaken for the backend being retired.
+    pub fn with_current_capture_session<F>(&self, session: CaptureSessionId, action: F) -> bool
+    where
+        F: FnOnce(),
+    {
+        let state = self.capture_session.lock();
+        if state.current != Some(session) || state.stopping {
+            return false;
+        }
+        action();
+        true
+    }
+
+    /// Cancel a current session before its async connection/publisher task has
+    /// necessarily started. A cancelled lease can complete and emit its final
+    /// stop event, but it can never activate or publish live metrics again.
+    pub fn cancel_capture_session(&self, session: CaptureSessionId) -> bool {
+        let mut state = self.capture_session.lock();
+        if state.current != Some(session) {
+            return false;
+        }
+        state.stopping = true;
+        self.set_active_inner(false, CaptureMode::None, EncoderType::None, 0);
+        true
+    }
+
+    /// Complete the current capture and run its notification while session
+    /// replacement is serialized. This makes stop/error events truthful: a
+    /// newer start either happens before this call (and suppresses the stale
+    /// callback) or after the current stop notification has been emitted.
+    pub fn complete_capture_session<F>(&self, session: CaptureSessionId, on_current: F) -> bool
+    where
+        F: FnOnce(),
+    {
+        let mut state = self.capture_session.lock();
+        if state.current != Some(session) {
+            return false;
+        }
+        self.set_active_inner(false, CaptureMode::None, EncoderType::None, 0);
+        on_current();
+        state.current = None;
+        state.stopping = false;
+        true
+    }
+
+    fn set_active_inner(&self, active: bool, mode: CaptureMode, encoder: EncoderType, target: u32) {
         let was_active = self.capture_active.swap(active, Ordering::Relaxed);
         *self.capture_mode.write() = mode;
         // Use the caller's encoder hint, but OVERRIDE to OpenH264 if we
@@ -255,9 +422,9 @@ impl CaptureHealthState {
     /// libwebrtc actually selected for encoderImplementation. The viewer
     /// reads this from getStats() which is the canonical source — Rust
     /// side has no easy way to know which encoder libwebrtc chose at
-    /// publish time. We default-assume Nvenc in set_active() and let the
+    /// publish time. We default-assume Nvenc when capture activates and let the
     /// viewer correct us if WebRTC picked OpenH264 or anything else.
-    pub fn set_encoder_type_from_string(&self, raw: &str) {
+    pub fn set_encoder_type_from_string(&self, session_id: u64, raw: &str) -> bool {
         let lower = raw.to_lowercase();
         let new_type =
             if lower.contains("openh264") || lower == "open h264" || lower.contains("software") {
@@ -271,12 +438,22 @@ impl CaptureHealthState {
                 EncoderType::Nvenc
             } else {
                 // Unknown encoder string — leave whatever set_active put there.
-                return;
+                return false;
             };
+        let state = self.capture_session.lock();
+        if state.current.map(CaptureSessionId::as_u64) != Some(session_id) || state.stopping {
+            return false;
+        }
         *self.encoder_type.write() = new_type;
+        true
     }
 
     pub fn snapshot(&self) -> CaptureHealthSnapshot {
+        // Lifecycle writers always lock session first, then individual health
+        // fields. Hold that same guard through sampling so one snapshot cannot
+        // combine session A's ID with session B's active/mode/counters.
+        let session_state = self.capture_session.lock();
+        let capture_session_id = session_state.current.map(CaptureSessionId::as_u64);
         let now = Instant::now();
         let reinit_count_5m = {
             let mut e = self.reinit_events.lock();
@@ -328,6 +505,7 @@ impl CaptureHealthState {
             consecutive_timeouts_max_5m,
             encoder_skip_rate_pct,
             shader_errors_5m,
+            capture_session_id,
             seconds_since_capture_started: {
                 let started = *self.capture_started_at.lock();
                 started.map(|t| t.elapsed().as_secs()).unwrap_or(0)
@@ -346,6 +524,7 @@ impl CaptureHealthState {
                 .as_ref()
                 .and_then(|diag| diag.encoder.clone()),
         };
+        drop(session_state);
         let (level, reasons) = classify(&snap);
         snap.level = level;
         snap.reasons = reasons;
@@ -490,6 +669,7 @@ mod tests {
             consecutive_timeouts_max_5m: 0,
             encoder_skip_rate_pct: 0.0,
             shader_errors_5m: 0,
+            capture_session_id: None,
             // Past the 10s cold-start grace by default so existing tests
             // exercise the steady-state classifier behavior. Tests that
             // need to verify cold-start suppression set this to a small
@@ -501,6 +681,80 @@ mod tests {
             sender_quality_limitation: None,
             sender_encoder: None,
         }
+    }
+
+    #[test]
+    fn cancelled_connect_cannot_activate_or_write_metrics_but_completes_once() {
+        let state = CaptureHealthState::new();
+        let session = state.begin_capture_session();
+
+        assert!(state.cancel_capture_session(session));
+        assert!(!state.activate_capture_session(session, CaptureMode::Wgc, EncoderType::Nvenc, 30));
+        state.record_capture_fps(session, 99);
+
+        let cancelled = state.snapshot();
+        assert!(!cancelled.capture_active);
+        assert_eq!(cancelled.current_fps, 0);
+        assert_eq!(cancelled.capture_session_id, Some(session.as_u64()));
+
+        let completions = std::sync::atomic::AtomicU32::new(0);
+        assert!(state.complete_capture_session(session, || {
+            completions.fetch_add(1, Ordering::SeqCst);
+        }));
+        assert!(!state.complete_capture_session(session, || {
+            completions.fetch_add(1, Ordering::SeqCst);
+        }));
+        assert_eq!(completions.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn stale_completion_and_metrics_cannot_supersede_newest_session() {
+        let state = CaptureHealthState::new();
+        let old = state.begin_capture_session();
+        assert!(state.activate_capture_session(old, CaptureMode::DxgiDd, EncoderType::Nvenc, 60));
+        state.record_capture_fps(old, 12);
+
+        let newest = state.begin_capture_session();
+        assert!(state.activate_capture_session(newest, CaptureMode::Wgc, EncoderType::Nvenc, 30));
+        state.record_capture_fps(newest, 27);
+
+        state.record_capture_fps(old, 1);
+        assert!(!state.set_encoder_type_from_string(old.as_u64(), "OpenH264"));
+        let stale_callback_ran = std::sync::atomic::AtomicBool::new(false);
+        assert!(!state.complete_capture_session(old, || {
+            stale_callback_ran.store(true, Ordering::SeqCst);
+        }));
+
+        let snapshot = state.snapshot();
+        assert!(snapshot.capture_active);
+        assert_eq!(snapshot.capture_mode, "WGC");
+        assert_eq!(snapshot.current_fps, 27);
+        assert_eq!(snapshot.capture_session_id, Some(newest.as_u64()));
+        assert!(!stale_callback_ran.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn newest_cross_backend_claim_exclusively_runs_replacement_transition() {
+        let state = CaptureHealthState::new();
+        let installed = Mutex::new(None::<(CaptureSessionId, &'static str)>);
+
+        let (wgc, retired) =
+            state.begin_capture_session_with(|session| installed.lock().replace((session, "WGC")));
+        assert!(retired.is_none());
+
+        let (dxgi, retired) =
+            state.begin_capture_session_with(|session| installed.lock().replace((session, "DXGI")));
+        assert_eq!(retired, Some((wgc, "WGC")));
+        assert_eq!(*installed.lock(), Some((dxgi, "DXGI")));
+
+        let transitions = std::sync::atomic::AtomicU32::new(0);
+        assert!(!state.with_current_capture_session(wgc, || {
+            transitions.fetch_add(1, Ordering::SeqCst);
+        }));
+        assert!(state.with_current_capture_session(dxgi, || {
+            transitions.fetch_add(1, Ordering::SeqCst);
+        }));
+        assert_eq!(transitions.load(Ordering::SeqCst), 1);
     }
 
     #[test]
@@ -645,14 +899,23 @@ mod tests {
     #[test]
     fn snapshot_includes_sender_diagnostics_and_clears_when_inactive() {
         let state = CaptureHealthState::new();
-        state.set_active(true, CaptureMode::DxgiDd, EncoderType::Nvenc, 60);
-        state.record_sender_diagnostics(CaptureSenderDiagnostics {
-            fps: Some(8.0),
-            target_bitrate_kbps: Some(5520),
-            available_outgoing_bitrate_kbps: Some(5615),
-            quality_limitation: Some("Cpu".into()),
-            encoder: Some("NVIDIA H264 Encoder".into()),
-        });
+        let session = state.begin_capture_session();
+        assert!(state.activate_capture_session(
+            session,
+            CaptureMode::DxgiDd,
+            EncoderType::Nvenc,
+            60
+        ));
+        state.record_sender_diagnostics(
+            session,
+            CaptureSenderDiagnostics {
+                fps: Some(8.0),
+                target_bitrate_kbps: Some(5520),
+                available_outgoing_bitrate_kbps: Some(5615),
+                quality_limitation: Some("Cpu".into()),
+                encoder: Some("NVIDIA H264 Encoder".into()),
+            },
+        );
 
         let active = state.snapshot();
         assert_eq!(active.sender_fps, Some(8.0));
@@ -664,7 +927,7 @@ mod tests {
             Some("NVIDIA H264 Encoder")
         );
 
-        state.set_active(false, CaptureMode::None, EncoderType::None, 0);
+        assert!(state.complete_capture_session(session, || {}));
         let inactive = state.snapshot();
         assert_eq!(inactive.sender_fps, None);
         assert_eq!(inactive.sender_target_bitrate_kbps, None);

--- a/core/client/src/capture_pipeline.rs
+++ b/core/client/src/capture_pipeline.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Emitter};
 use tokio::sync::mpsc::UnboundedReceiver;
 
-use crate::capture_health::{CaptureHealthState, CaptureSenderDiagnostics};
+use crate::capture_health::{CaptureHealthState, CaptureSenderDiagnostics, CaptureSessionId};
 use crate::file_debug_log;
 use livekit::options::{TrackPublishOptions, VideoCodec, VideoEncoding};
 use livekit::prelude::*;
@@ -513,7 +513,11 @@ impl CapturePublisher {
         self.start_time.elapsed()
     }
 
-    pub async fn log_sender_stats(&self, log_prefix: &str, health: Option<&CaptureHealthState>) {
+    pub async fn log_sender_stats(
+        &self,
+        log_prefix: &str,
+        health: Option<(&CaptureHealthState, CaptureSessionId)>,
+    ) {
         match self.track.get_stats().await {
             Ok(stats) => {
                 let transport = stats.iter().find_map(|stat| match stat {
@@ -736,8 +740,8 @@ impl CapturePublisher {
                     eprintln!("[{}] transport stats missing", log_prefix);
                     file_debug_log::append(&format!("[{}] transport stats missing", log_prefix));
                 }
-                if let (Some(health), Some(diagnostics)) = (health, sender_diagnostics) {
-                    health.record_sender_diagnostics(diagnostics);
+                if let (Some((health, session)), Some(diagnostics)) = (health, sender_diagnostics) {
+                    health.record_sender_diagnostics(session, diagnostics);
                 }
             }
             Err(e) => {
@@ -751,7 +755,7 @@ impl CapturePublisher {
         &self,
         rt: &tokio::runtime::Handle,
         log_prefix: &str,
-        health: Option<&CaptureHealthState>,
+        health: Option<(&CaptureHealthState, CaptureSessionId)>,
     ) {
         rt.block_on(self.log_sender_stats(log_prefix, health));
     }

--- a/core/client/src/desktop_capture.rs
+++ b/core/client/src/desktop_capture.rs
@@ -51,7 +51,10 @@ use windows::Win32::UI::WindowsAndMessaging::{
     WS_EX_NOACTIVATE, WS_EX_TOOLWINDOW, WS_EX_TOPMOST, WS_EX_TRANSPARENT, WS_POPUP,
 };
 
-use crate::capture_health::{CaptureHealthState, CaptureMode, EncoderType};
+use crate::capture_health::{
+    CaptureErrorEvent, CaptureHealthState, CaptureMode, CaptureSessionId, CaptureStoppedEvent,
+    EncoderType,
+};
 use crate::capture_pipeline::{CapturePublisher, PublishProfile};
 use crate::file_debug_log;
 
@@ -62,12 +65,58 @@ use crate::gpu_converter::GpuConverter;
 // ── Global State ──
 
 struct DesktopShareHandle {
+    session: CaptureSessionId,
     running: Arc<AtomicBool>,
+    health: Arc<CaptureHealthState>,
 }
 
 fn global_state() -> &'static Mutex<Option<DesktopShareHandle>> {
     static STATE: OnceLock<Mutex<Option<DesktopShareHandle>>> = OnceLock::new();
     STATE.get_or_init(|| Mutex::new(None))
+}
+
+fn request_stop(state: &Mutex<Option<DesktopShareHandle>>, cancel_session: bool) -> bool {
+    let current = {
+        let state = state.lock().unwrap();
+        state.as_ref().map(|handle| {
+            (
+                handle.session,
+                Arc::clone(&handle.running),
+                Arc::clone(&handle.health),
+            )
+        })
+    };
+    let Some((session, running, health)) = current else {
+        return false;
+    };
+    if cancel_session {
+        health.cancel_capture_session(session);
+    }
+    running.store(false, Ordering::SeqCst);
+    true
+}
+
+fn replace_handle(
+    state: &Mutex<Option<DesktopShareHandle>>,
+    replacement: DesktopShareHandle,
+) -> Option<DesktopShareHandle> {
+    state.lock().unwrap().replace(replacement)
+}
+
+fn clear_if_owner(
+    state: &Mutex<Option<DesktopShareHandle>>,
+    session: CaptureSessionId,
+    running: &Arc<AtomicBool>,
+) -> bool {
+    let mut state = state.lock().unwrap();
+    let owns_handle = state
+        .as_ref()
+        .map(|handle| handle.session == session && Arc::ptr_eq(&handle.running, running))
+        .unwrap_or(false);
+    if owns_handle {
+        *state = None;
+    }
+    owns_handle
 }
 
 fn should_emit_frame_count_stats(frame_count: u64, last_stats_frame_count: &mut u64) -> bool {
@@ -82,6 +131,47 @@ fn should_emit_frame_count_stats(frame_count: u64, last_stats_frame_count: &mut 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn stale_dxgi_completion_cannot_clear_replacement_handle() {
+        let health = Arc::new(CaptureHealthState::new());
+        let state = Mutex::new(None);
+
+        let old_running = Arc::new(AtomicBool::new(true));
+        let old_for_handle = Arc::clone(&old_running);
+        let old_health = Arc::clone(&health);
+        let (old_session, retired) = health.begin_capture_session_with(|session| {
+            replace_handle(
+                &state,
+                DesktopShareHandle {
+                    session,
+                    running: old_for_handle,
+                    health: old_health,
+                },
+            )
+        });
+        assert!(retired.is_none());
+
+        let new_running = Arc::new(AtomicBool::new(true));
+        let new_for_handle = Arc::clone(&new_running);
+        let new_health = Arc::clone(&health);
+        let (new_session, retired) = health.begin_capture_session_with(|session| {
+            replace_handle(
+                &state,
+                DesktopShareHandle {
+                    session,
+                    running: new_for_handle,
+                    health: new_health,
+                },
+            )
+        });
+        let retired = retired.expect("the replacement must retire the old handle");
+        retired.running.store(false, Ordering::SeqCst);
+
+        assert!(!clear_if_owner(&state, old_session, &old_running));
+        assert!(new_running.load(Ordering::SeqCst));
+        assert!(clear_if_owner(&state, new_session, &new_running));
+    }
 
     #[test]
     fn frame_count_stats_gate_only_emits_once_per_60_frame_boundary() {
@@ -205,16 +295,31 @@ pub async fn start(
     publish_profile: PublishProfile,
     app: AppHandle,
     health: Arc<CaptureHealthState>,
-) -> Result<(), String> {
-    stop();
-
+) -> Result<u64, String> {
     let running = Arc::new(AtomicBool::new(true));
-
-    {
-        let mut state = global_state().lock().unwrap();
-        *state = Some(DesktopShareHandle {
-            running: running.clone(),
-        });
+    let running_for_handle = Arc::clone(&running);
+    let health_for_handle = Arc::clone(&health);
+    let (session, retired) = health.begin_capture_session_with(|session| {
+        replace_handle(
+            global_state(),
+            DesktopShareHandle {
+                session,
+                running: running_for_handle,
+                health: health_for_handle,
+            },
+        )
+    });
+    if let Some(retired) = retired {
+        retired.running.store(false, Ordering::SeqCst);
+    }
+    if !health.with_current_capture_session(session, crate::screen_capture::stop_for_replacement) {
+        running.store(false, Ordering::SeqCst);
+        if clear_if_owner(global_state(), session, &running) {
+            health.complete_capture_session(session, || {
+                let _ = app.emit("desktop-capture-stopped", CaptureStoppedEvent::new(session));
+            });
+        }
+        return Err("desktop capture start cancelled or superseded".to_string());
     }
 
     // Get game PID for audio capture
@@ -225,46 +330,68 @@ pub async fn start(
         pid
     };
 
-    let _ = app.emit("desktop-capture-started", target_pid);
-
-    let r2 = running.clone();
-    let health_clone = Arc::clone(&health);
+    let r2 = Arc::clone(&running);
+    let running_for_loop = Arc::clone(&running);
+    let health_for_loop = Arc::clone(&health);
+    let app_for_capture = app.clone();
     tokio::spawn(async move {
         // Run DXGI capture on a blocking thread — it uses COM and blocking waits
-        let result = tokio::task::spawn_blocking(move || {
+        let result = match tokio::task::spawn_blocking(move || {
             capture_loop_blocking(
                 &sfu_url,
                 &token,
                 publish_profile,
-                &app,
-                &r2,
+                &app_for_capture,
+                &running_for_loop,
                 hwnd,
                 fullscreen,
-                health_clone,
+                target_pid,
+                health_for_loop,
+                session,
             )
         })
         .await
-        .map_err(|e| format!("spawn_blocking: {e}"))?;
+        {
+            Ok(result) => result,
+            Err(error) => Err(format!("spawn_blocking: {error}")),
+        };
 
-        if let Err(e) = result {
-            eprintln!("[desktop-capture] error: {e}");
-            file_debug_log::append(&format!("[desktop-capture] task error: {}", e));
+        if !clear_if_owner(global_state(), session, &r2) {
+            eprintln!("[desktop-capture] stale task exited after replacement");
+            return;
         }
 
-        let mut state = global_state().lock().unwrap();
-        *state = None;
-        Ok::<(), String>(())
+        let error = result.err();
+        if !health.complete_capture_session(session, || {
+            if let Some(error) = error.as_ref() {
+                eprintln!("[desktop-capture] error: {error}");
+                file_debug_log::append(&format!("[desktop-capture] task error: {}", error));
+                let _ = app.emit(
+                    "desktop-capture-error",
+                    CaptureErrorEvent::new(session, error.to_string()),
+                );
+            }
+            let _ = app.emit("desktop-capture-stopped", CaptureStoppedEvent::new(session));
+        }) {
+            eprintln!("[desktop-capture] task exited after a newer backend took ownership");
+            return;
+        }
+        eprintln!("[desktop-capture] task exited");
     });
 
-    Ok(())
+    Ok(session.as_u64())
 }
 
 /// Stop the current desktop capture.
 pub fn stop() {
-    let mut state = global_state().lock().unwrap();
-    if let Some(handle) = state.take() {
-        handle.running.store(false, Ordering::SeqCst);
+    if request_stop(global_state(), true) {
         eprintln!("[desktop-capture] stop requested");
+    }
+}
+
+pub(crate) fn stop_for_replacement() {
+    if request_stop(global_state(), false) {
+        eprintln!("[desktop-capture] replacement stop requested");
     }
 }
 
@@ -457,6 +584,32 @@ unsafe fn create_anti_mpo_window(monitor_rect: &RECT) -> Option<HWND> {
     } else {
         eprintln!("[anti-mpo] CreateWindowExW failed: {:?}", hwnd.err());
         None
+    }
+}
+
+/// Owns the anti-MPO overlay on the capture thread. DXGI setup has many fallible
+/// steps after the window is created, so RAII is required to restore normal DWM
+/// behavior on every early return as well as the normal stop path.
+struct AntiMpoWindow(Option<HWND>);
+
+impl AntiMpoWindow {
+    fn new(hwnd: Option<HWND>) -> Self {
+        Self(hwnd)
+    }
+
+    fn hwnd(&self) -> Option<HWND> {
+        self.0
+    }
+}
+
+impl Drop for AntiMpoWindow {
+    fn drop(&mut self) {
+        if let Some(hwnd) = self.0.take() {
+            unsafe {
+                let _ = DestroyWindow(hwnd);
+            }
+            eprintln!("[anti-mpo] overlay window destroyed");
+        }
     }
 }
 
@@ -679,7 +832,9 @@ fn capture_loop_blocking(
     running: &Arc<AtomicBool>,
     hwnd: u64,
     fullscreen: bool,
+    target_pid: u32,
     health: Arc<CaptureHealthState>,
+    session: CaptureSessionId,
 ) -> Result<(), String> {
     eprintln!("[desktop-capture] initializing DXGI Desktop Duplication...");
     file_debug_log::append(&format!(
@@ -696,7 +851,7 @@ fn capture_loop_blocking(
     // 1b. Create anti-MPO overlay to force DWM Composed Flip.
     // Without this, borderless windowed games trigger Independent Flip / MPO,
     // causing DXGI DD to capture at 5-15fps instead of the game's native framerate.
-    let anti_mpo_hwnd = unsafe {
+    let anti_mpo_window = AntiMpoWindow::new(unsafe {
         let monitor = if fullscreen {
             use windows::Win32::Graphics::Gdi::HMONITOR;
             HMONITOR(hwnd as *mut _)
@@ -714,7 +869,7 @@ fn capture_loop_blocking(
             eprintln!("[anti-mpo] GetMonitorInfoW failed, skipping overlay");
             None
         }
-    };
+    });
 
     // 2. Create D3D11 device on the same adapter
     let adapter_base: windows::Win32::Graphics::Dxgi::IDXGIAdapter = adapter
@@ -849,6 +1004,9 @@ fn capture_loop_blocking(
     ));
 
     // 4. Connect to LiveKit and publish track via shared pipeline
+    if !running.load(Ordering::SeqCst) {
+        return Ok(());
+    }
     let rt = tokio::runtime::Handle::current();
     let mut publisher = CapturePublisher::connect_and_publish_blocking(
         &rt,
@@ -862,12 +1020,28 @@ fn capture_loop_blocking(
         true,
     )?;
 
-    health.set_active(
-        true,
+    if !running.load(Ordering::SeqCst) {
+        publisher.shutdown_blocking(&rt);
+        return Ok(());
+    }
+
+    if !health.activate_capture_session(
+        session,
         CaptureMode::DxgiDd,
         EncoderType::Nvenc,
         publish_profile.target_fps(),
-    );
+    ) {
+        running.store(false, Ordering::SeqCst);
+        publisher.shutdown_blocking(&rt);
+        return Ok(());
+    }
+    if !health.with_current_capture_session(session, || {
+        let _ = app.emit("desktop-capture-started", target_pid);
+    }) {
+        running.store(false, Ordering::SeqCst);
+        publisher.shutdown_blocking(&rt);
+        return Ok(());
+    }
 
     // 6. Prepare GPU converter (shader pipeline) or CPU fallback
     let mut gpu_converter: Option<GpuConverter> = None;
@@ -981,7 +1155,7 @@ fn capture_loop_blocking(
                     // encode load, driver hiccups, UAC intrusions, display mode
                     // changes, etc. Reinit typically recovers immediately.
                     consecutive_timeouts += 1;
-                    health.record_consecutive_timeout(consecutive_timeouts);
+                    health.record_consecutive_timeout(session, consecutive_timeouts);
                     if consecutive_timeouts >= 50 {
                         eprintln!(
                             "[desktop-capture] 50 consecutive timeouts (~5s stall) \
@@ -998,8 +1172,8 @@ fn capture_loop_blocking(
                             Some(new_dup) => {
                                 duplication = new_dup;
                                 consecutive_timeouts = 0;
-                                health.reset_consecutive_timeouts();
-                                health.record_reinit();
+                                health.reset_consecutive_timeouts(session);
+                                health.record_reinit(session);
                                 continue;
                             }
                             None => break,
@@ -1037,8 +1211,8 @@ fn capture_loop_blocking(
                         Some(new_dup) => {
                             duplication = new_dup;
                             consecutive_timeouts = 0;
-                            health.reset_consecutive_timeouts();
-                            health.record_reinit();
+                            health.reset_consecutive_timeouts(session);
+                            health.record_reinit(session);
                             continue;
                         }
                         None => break,
@@ -1050,7 +1224,7 @@ fn capture_loop_blocking(
                         e
                     ));
                     consecutive_timeouts += 1;
-                    health.record_consecutive_timeout(consecutive_timeouts);
+                    health.record_consecutive_timeout(session, consecutive_timeouts);
                     if consecutive_timeouts >= 10 {
                         break;
                     }
@@ -1059,7 +1233,7 @@ fn capture_loop_blocking(
             }
             Ok(()) => {
                 consecutive_timeouts = 0;
-                health.reset_consecutive_timeouts();
+                health.reset_consecutive_timeouts(session);
             }
         }
 
@@ -1197,7 +1371,7 @@ fn capture_loop_blocking(
                     crop_y,
                     crop_w,
                     crop_h,
-                    Some(&*health),
+                    Some((&*health, session)),
                 ) {
                     Ok((bgra_ptr, stride, w, h)) => {
                         duplication.ReleaseFrame().ok();
@@ -1324,7 +1498,7 @@ fn capture_loop_blocking(
         // Reassert anti-MPO overlay topmost status every 60 frames (~1s).
         // Games can temporarily promote themselves above our overlay.
         if frame_count % 60 == 0 {
-            if let Some(h) = anti_mpo_hwnd {
+            if let Some(h) = anti_mpo_window.hwnd() {
                 unsafe {
                     refresh_anti_mpo_window(h);
                 }
@@ -1347,13 +1521,15 @@ fn capture_loop_blocking(
                     "[desktop-capture] stats {}x{} fps={} frames={}",
                     enc_w, enc_h, fps, frame_count
                 ));
-                health.record_capture_fps(fps);
+                health.record_capture_fps(session, fps);
             }
-            publisher.log_sender_stats_blocking(&rt, "desktop-capture", Some(health.as_ref()));
+            publisher.log_sender_stats_blocking(
+                &rt,
+                "desktop-capture",
+                Some((health.as_ref(), session)),
+            );
         }
     }
-
-    health.set_active(false, CaptureMode::None, EncoderType::None, 0);
 
     running.store(false, Ordering::SeqCst);
     eprintln!(
@@ -1365,14 +1541,7 @@ fn capture_loop_blocking(
         publisher.frame_count()
     ));
 
-    // Destroy anti-MPO overlay -- restore normal DWM flip behavior
-    if let Some(h) = anti_mpo_hwnd {
-        unsafe {
-            let _ = DestroyWindow(h);
-        }
-        eprintln!("[anti-mpo] overlay window destroyed");
-    }
-
+    drop(anti_mpo_window);
     publisher.shutdown_blocking(&rt);
     eprintln!("[desktop-capture] SFU room closed");
 

--- a/core/client/src/gpu_converter.rs
+++ b/core/client/src/gpu_converter.rs
@@ -5,7 +5,7 @@
 //! applies HDR→SDR tonemap + downscale via compute shader, outputs
 //! BGRA8 at the target encode resolution.
 
-use crate::capture_health::CaptureHealthState;
+use crate::capture_health::{CaptureHealthState, CaptureSessionId};
 use windows::core::PCSTR;
 use windows::Win32::Graphics::Direct3D::Fxc::D3DCompile;
 use windows::Win32::Graphics::Direct3D::ID3DBlob;
@@ -328,7 +328,7 @@ impl GpuConverter {
         crop_y: u32,
         crop_w: u32,
         crop_h: u32,
-        health: Option<&CaptureHealthState>,
+        health: Option<(&CaptureHealthState, CaptureSessionId)>,
     ) -> Result<(*const u8, u32, u32, u32), String> {
         // 1. Copy captured frame → gpu_src (GPU→GPU, preserves format)
         context.CopyResource(&self.gpu_src, frame_texture);
@@ -384,8 +384,8 @@ impl GpuConverter {
         context
             .Map(&self.staging, 0, D3D11_MAP_READ, 0, Some(&mut mapped))
             .map_err(|e| {
-                if let Some(h) = health {
-                    h.record_shader_error();
+                if let Some((health, session)) = health {
+                    health.record_shader_error(session);
                 }
                 format!("map staging: {e}")
             })?;

--- a/core/client/src/main.rs
+++ b/core/client/src/main.rs
@@ -534,7 +534,7 @@ async fn start_screen_share(
     publish_profile: Option<capture_pipeline::PublishProfile>,
     app: tauri::AppHandle,
     health: tauri::State<'_, std::sync::Arc<CaptureHealthState>>,
-) -> Result<(), String> {
+) -> Result<u64, String> {
     let health_arc = std::sync::Arc::clone(&*health);
     screen_capture::start_share(
         source_id,
@@ -583,7 +583,7 @@ async fn start_desktop_capture(
     publish_profile: Option<capture_pipeline::PublishProfile>,
     app: tauri::AppHandle,
     health: tauri::State<'_, std::sync::Arc<CaptureHealthState>>,
-) -> Result<(), String> {
+) -> Result<u64, String> {
     let health_arc = std::sync::Arc::clone(&*health);
     desktop_capture::start(
         hwnd,
@@ -608,7 +608,7 @@ async fn start_screen_share_monitor(
     token: String,
     app: tauri::AppHandle,
     health: tauri::State<'_, std::sync::Arc<CaptureHealthState>>,
-) -> Result<(), String> {
+) -> Result<u64, String> {
     let health_arc = std::sync::Arc::clone(&*health);
     screen_capture::start_share_monitor(hmonitor, sfu_url, token, app, health_arc).await
 }
@@ -634,8 +634,12 @@ fn get_capture_health(
 
 #[cfg(target_os = "windows")]
 #[tauri::command]
-fn report_encoder_implementation(state: tauri::State<Arc<CaptureHealthState>>, encoder: String) {
-    state.set_encoder_type_from_string(&encoder);
+fn report_encoder_implementation(
+    state: tauri::State<Arc<CaptureHealthState>>,
+    encoder: String,
+    capture_session_id: u64,
+) {
+    state.set_encoder_type_from_string(capture_session_id, &encoder);
 }
 
 fn main() {

--- a/core/client/src/screen_capture.rs
+++ b/core/client/src/screen_capture.rs
@@ -17,7 +17,10 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 use tauri::{AppHandle, Emitter};
 
-use crate::capture_health::{CaptureHealthState, CaptureMode, EncoderType};
+use crate::capture_health::{
+    CaptureErrorEvent, CaptureHealthState, CaptureMode, CaptureSessionId, CaptureStoppedEvent,
+    EncoderType,
+};
 use crate::capture_pipeline::{
     CapturePublisher, PublishProfile, StaticFrameHeartbeat, STATIC_FRAME_HEARTBEAT_INTERVAL,
 };
@@ -63,7 +66,9 @@ impl CaptureWindowStatus {
 // ── Global State ──
 
 struct ShareHandle {
+    session: CaptureSessionId,
     running: Arc<AtomicBool>,
+    health: Arc<CaptureHealthState>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -232,6 +237,50 @@ fn window_is_above(
 fn global_state() -> &'static Mutex<Option<ShareHandle>> {
     static STATE: OnceLock<Mutex<Option<ShareHandle>>> = OnceLock::new();
     STATE.get_or_init(|| Mutex::new(None))
+}
+
+fn request_stop(state: &Mutex<Option<ShareHandle>>, cancel_session: bool) -> bool {
+    let current = {
+        let state = state.lock().unwrap();
+        state.as_ref().map(|handle| {
+            (
+                handle.session,
+                Arc::clone(&handle.running),
+                Arc::clone(&handle.health),
+            )
+        })
+    };
+    let Some((session, running, health)) = current else {
+        return false;
+    };
+    if cancel_session {
+        health.cancel_capture_session(session);
+    }
+    running.store(false, Ordering::SeqCst);
+    true
+}
+
+fn replace_handle(
+    state: &Mutex<Option<ShareHandle>>,
+    replacement: ShareHandle,
+) -> Option<ShareHandle> {
+    state.lock().unwrap().replace(replacement)
+}
+
+fn clear_if_owner(
+    state: &Mutex<Option<ShareHandle>>,
+    session: CaptureSessionId,
+    running: &Arc<AtomicBool>,
+) -> bool {
+    let mut state = state.lock().unwrap();
+    let owns_handle = state
+        .as_ref()
+        .map(|handle| handle.session == session && Arc::ptr_eq(&handle.running, running))
+        .unwrap_or(false);
+    if owns_handle {
+        *state = None;
+    }
+    owns_handle
 }
 
 #[cfg(target_os = "windows")]
@@ -514,54 +563,88 @@ pub async fn start_share(
     publish_profile: PublishProfile,
     app: AppHandle,
     health: Arc<CaptureHealthState>,
-) -> Result<(), String> {
+) -> Result<u64, String> {
     // The source may have closed or its HWND may have been reused since the
     // picker was rendered. Revalidate the live window before interrupting an
     // existing share or spawning a new capture task.
     validate_capture_window(source_id)?;
-    stop_share();
-
     let running = Arc::new(AtomicBool::new(true));
-
-    {
-        let mut state = global_state().lock().unwrap();
-        *state = Some(ShareHandle {
-            running: running.clone(),
-        });
+    let running_for_handle = Arc::clone(&running);
+    let health_for_handle = Arc::clone(&health);
+    let (session, retired) = health.begin_capture_session_with(|session| {
+        replace_handle(
+            global_state(),
+            ShareHandle {
+                session,
+                running: running_for_handle,
+                health: health_for_handle,
+            },
+        )
+    });
+    if let Some(retired) = retired {
+        retired.running.store(false, Ordering::SeqCst);
+    }
+    if !health.with_current_capture_session(session, crate::desktop_capture::stop_for_replacement) {
+        running.store(false, Ordering::SeqCst);
+        if clear_if_owner(global_state(), session, &running) {
+            health.complete_capture_session(session, || {
+                let _ = app.emit("screen-capture-stopped", CaptureStoppedEvent::new(session));
+            });
+        }
+        return Err("screen capture start cancelled or superseded".to_string());
     }
 
     let app2 = app.clone();
     let r2 = running.clone();
+    let health_for_loop = Arc::clone(&health);
     tokio::spawn(async move {
-        if let Err(e) = share_loop(
+        let result = share_loop(
             source_id,
             &sfu_url,
             &token,
             publish_profile,
             &app2,
             &r2,
-            health,
+            health_for_loop,
+            session,
         )
-        .await
-        {
-            eprintln!("[screen-capture] error: {}", e);
-            let _ = app2.emit("screen-capture-error", format!("{}", e));
+        .await;
+
+        if !clear_if_owner(global_state(), session, &r2) {
+            eprintln!("[screen-capture] stale task exited after replacement");
+            return;
         }
-        let _ = app2.emit("screen-capture-stopped", ());
+
+        let error = result.err();
+        if !health.complete_capture_session(session, || {
+            if let Some(error) = error.as_ref() {
+                eprintln!("[screen-capture] error: {}", error);
+                let _ = app2.emit(
+                    "screen-capture-error",
+                    CaptureErrorEvent::new(session, error.to_string()),
+                );
+            }
+            let _ = app2.emit("screen-capture-stopped", CaptureStoppedEvent::new(session));
+        }) {
+            eprintln!("[screen-capture] task exited after a newer backend took ownership");
+            return;
+        }
         eprintln!("[screen-capture] task exited");
-        let mut state = global_state().lock().unwrap();
-        *state = None;
     });
 
-    Ok(())
+    Ok(session.as_u64())
 }
 
 /// Stop the current screen share.
 pub fn stop_share() {
-    let mut state = global_state().lock().unwrap();
-    if let Some(handle) = state.take() {
-        handle.running.store(false, Ordering::SeqCst);
+    if request_stop(global_state(), true) {
         eprintln!("[screen-capture] stop requested");
+    }
+}
+
+pub(crate) fn stop_for_replacement() {
+    if request_stop(global_state(), false) {
+        eprintln!("[screen-capture] replacement stop requested");
     }
 }
 
@@ -840,6 +923,7 @@ async fn share_loop(
     app: &AppHandle,
     running: &Arc<AtomicBool>,
     health: Arc<CaptureHealthState>,
+    session: CaptureSessionId,
 ) -> Result<(), String> {
     // 1. Connect to SFU and publish track via shared pipeline
     let publish_settings = wgc_publish_settings(publish_profile);
@@ -855,6 +939,11 @@ async fn share_loop(
     )
     .await?;
 
+    if !running.load(Ordering::SeqCst) {
+        publisher.shutdown().await;
+        return Ok(());
+    }
+
     // Resolve HWND -> PID for WASAPI audio auto-start
     let target_pid = unsafe {
         use windows::Win32::Foundation::HWND;
@@ -866,14 +955,29 @@ async fn share_loop(
         pid
     };
 
-    eprintln!("[screen-capture] starting WGC capture");
-    let _ = app.emit("screen-capture-started", target_pid);
-    health.set_active(
-        true,
+    if !running.load(Ordering::SeqCst) {
+        publisher.shutdown().await;
+        return Ok(());
+    }
+
+    if !health.activate_capture_session(
+        session,
         CaptureMode::Wgc,
         EncoderType::Nvenc,
         publish_profile.target_fps(),
-    );
+    ) {
+        running.store(false, Ordering::SeqCst);
+        publisher.shutdown().await;
+        return Ok(());
+    }
+    eprintln!("[screen-capture] starting WGC capture");
+    if !health.with_current_capture_session(session, || {
+        let _ = app.emit("screen-capture-started", target_pid);
+    }) {
+        running.store(false, Ordering::SeqCst);
+        publisher.shutdown().await;
+        return Ok(());
+    }
 
     // 2. Start WGC capture -- callback sends BGRA frames via channel
     // Channel sends 1080p BGRA frames (8MB each, GPU-downscaled from 4K)
@@ -1139,7 +1243,7 @@ async fn share_loop(
                 pushed,
                 from_heartbeat
             ));
-            health.record_capture_fps(pushed_fps.round() as u32);
+            health.record_capture_fps(session, pushed_fps.round() as u32);
             last_publish_log_at = now;
             last_publish_attempt_count = publish_attempt_count;
             last_publish_frame_count = fc;
@@ -1149,7 +1253,7 @@ async fn share_loop(
 
         if now.duration_since(last_sender_stats_at) >= std::time::Duration::from_secs(5) {
             publisher
-                .log_sender_stats("screen-capture", Some(health.as_ref()))
+                .log_sender_stats("screen-capture", Some((health.as_ref(), session)))
                 .await;
             last_sender_stats_at = now;
         }
@@ -1173,7 +1277,7 @@ async fn share_loop(
             if let Some(emit_fps) =
                 publisher.maybe_emit_stats(app, "screen-capture-stats", "wgc", *width, *height, 30)
             {
-                health.record_capture_fps(emit_fps);
+                health.record_capture_fps(session, emit_fps);
             }
         }
     }
@@ -1183,7 +1287,6 @@ async fn share_loop(
         "[screen-capture] shutting down, {} frames captured",
         publisher.frame_count()
     );
-    health.set_active(false, CaptureMode::None, EncoderType::None, 0);
     publisher.shutdown().await;
     Ok(())
 }
@@ -1201,32 +1304,71 @@ pub async fn start_share_monitor(
     token: String,
     app: AppHandle,
     health: Arc<CaptureHealthState>,
-) -> Result<(), String> {
-    stop_share();
-
+) -> Result<u64, String> {
     let running = Arc::new(AtomicBool::new(true));
-
-    {
-        let mut state = global_state().lock().unwrap();
-        *state = Some(ShareHandle {
-            running: running.clone(),
-        });
+    let running_for_handle = Arc::clone(&running);
+    let health_for_handle = Arc::clone(&health);
+    let (session, retired) = health.begin_capture_session_with(|session| {
+        replace_handle(
+            global_state(),
+            ShareHandle {
+                session,
+                running: running_for_handle,
+                health: health_for_handle,
+            },
+        )
+    });
+    if let Some(retired) = retired {
+        retired.running.store(false, Ordering::SeqCst);
+    }
+    if !health.with_current_capture_session(session, crate::desktop_capture::stop_for_replacement) {
+        running.store(false, Ordering::SeqCst);
+        if clear_if_owner(global_state(), session, &running) {
+            health.complete_capture_session(session, || {
+                let _ = app.emit("screen-capture-stopped", CaptureStoppedEvent::new(session));
+            });
+        }
+        return Err("monitor capture start cancelled or superseded".to_string());
     }
 
     let app2 = app.clone();
     let r2 = running.clone();
+    let health_for_loop = Arc::clone(&health);
     tokio::spawn(async move {
-        if let Err(e) = share_loop_monitor(hmonitor, &sfu_url, &token, &app2, &r2, health).await {
-            eprintln!("[screen-capture-monitor] error: {}", e);
-            let _ = app2.emit("screen-capture-error", format!("{}", e));
+        let result = share_loop_monitor(
+            hmonitor,
+            &sfu_url,
+            &token,
+            &app2,
+            &r2,
+            health_for_loop,
+            session,
+        )
+        .await;
+
+        if !clear_if_owner(global_state(), session, &r2) {
+            eprintln!("[screen-capture-monitor] stale task exited after replacement");
+            return;
         }
-        let _ = app2.emit("screen-capture-stopped", ());
+
+        let error = result.err();
+        if !health.complete_capture_session(session, || {
+            if let Some(error) = error.as_ref() {
+                eprintln!("[screen-capture-monitor] error: {}", error);
+                let _ = app2.emit(
+                    "screen-capture-error",
+                    CaptureErrorEvent::new(session, error.to_string()),
+                );
+            }
+            let _ = app2.emit("screen-capture-stopped", CaptureStoppedEvent::new(session));
+        }) {
+            eprintln!("[screen-capture-monitor] task exited after a newer backend took ownership");
+            return;
+        }
         eprintln!("[screen-capture-monitor] task exited");
-        let mut state = global_state().lock().unwrap();
-        *state = None;
     });
 
-    Ok(())
+    Ok(session.as_u64())
 }
 
 async fn share_loop_monitor(
@@ -1236,6 +1378,7 @@ async fn share_loop_monitor(
     app: &AppHandle,
     running: &Arc<AtomicBool>,
     health: Arc<CaptureHealthState>,
+    session: CaptureSessionId,
 ) -> Result<(), String> {
     // 1. Connect to SFU and publish track via shared pipeline
     let publish_settings = wgc_monitor_publish_settings();
@@ -1251,18 +1394,33 @@ async fn share_loop_monitor(
     )
     .await?;
 
+    if !running.load(Ordering::SeqCst) {
+        publisher.shutdown().await;
+        return Ok(());
+    }
+
+    if !health.activate_capture_session(
+        session,
+        CaptureMode::Wgc,
+        EncoderType::Nvenc,
+        PublishProfile::Desktop.target_fps(),
+    ) {
+        running.store(false, Ordering::SeqCst);
+        publisher.shutdown().await;
+        return Ok(());
+    }
     eprintln!(
         "[screen-capture-monitor] starting WGC monitor capture for HMONITOR {}",
         hmonitor
     );
     // No PID for monitor capture — system-wide audio not per-process
-    let _ = app.emit("screen-capture-started", 0u32);
-    health.set_active(
-        true,
-        CaptureMode::Wgc,
-        EncoderType::Nvenc,
-        PublishProfile::Desktop.target_fps(),
-    );
+    if !health.with_current_capture_session(session, || {
+        let _ = app.emit("screen-capture-started", 0u32);
+    }) {
+        running.store(false, Ordering::SeqCst);
+        publisher.shutdown().await;
+        return Ok(());
+    }
 
     let (frame_tx, frame_rx) = std::sync::mpsc::sync_channel::<(Vec<u8>, u32, u32)>(4);
     let capture_running = running.clone();
@@ -1498,7 +1656,7 @@ async fn share_loop_monitor(
                 pushed,
                 from_heartbeat
             ));
-            health.record_capture_fps(pushed_fps.round() as u32);
+            health.record_capture_fps(session, pushed_fps.round() as u32);
             last_publish_log_at = now;
             last_publish_attempt_count = publish_attempt_count;
             last_publish_frame_count = fc;
@@ -1508,7 +1666,7 @@ async fn share_loop_monitor(
 
         if now.duration_since(last_sender_stats_at) >= std::time::Duration::from_secs(5) {
             publisher
-                .log_sender_stats("screen-capture-monitor", Some(health.as_ref()))
+                .log_sender_stats("screen-capture-monitor", Some((health.as_ref(), session)))
                 .await;
             last_sender_stats_at = now;
         }
@@ -1537,7 +1695,7 @@ async fn share_loop_monitor(
                 *height,
                 30,
             ) {
-                health.record_capture_fps(emit_fps);
+                health.record_capture_fps(session, emit_fps);
             }
         }
     }
@@ -1547,7 +1705,6 @@ async fn share_loop_monitor(
         "[screen-capture-monitor] shutting down, {} frames captured",
         publisher.frame_count()
     );
-    health.set_active(false, CaptureMode::None, EncoderType::None, 0);
     publisher.shutdown().await;
     Ok(())
 }
@@ -1555,6 +1712,54 @@ async fn share_loop_monitor(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn replacement_owns_handle_and_explicit_stop_targets_latest_wgc_session() {
+        let health = Arc::new(CaptureHealthState::new());
+        let state = Mutex::new(None);
+
+        let old_running = Arc::new(AtomicBool::new(true));
+        let old_for_handle = Arc::clone(&old_running);
+        let old_health = Arc::clone(&health);
+        let (old_session, retired) = health.begin_capture_session_with(|session| {
+            replace_handle(
+                &state,
+                ShareHandle {
+                    session,
+                    running: old_for_handle,
+                    health: old_health,
+                },
+            )
+        });
+        assert!(retired.is_none());
+
+        let new_running = Arc::new(AtomicBool::new(true));
+        let new_for_handle = Arc::clone(&new_running);
+        let new_health = Arc::clone(&health);
+        let (new_session, retired) = health.begin_capture_session_with(|session| {
+            replace_handle(
+                &state,
+                ShareHandle {
+                    session,
+                    running: new_for_handle,
+                    health: new_health,
+                },
+            )
+        });
+        let retired = retired.expect("the replacement must retire the old handle");
+        retired.running.store(false, Ordering::SeqCst);
+
+        assert!(!old_running.load(Ordering::SeqCst));
+        assert!(!clear_if_owner(&state, old_session, &old_running));
+        assert!(request_stop(&state, true));
+        assert!(!new_running.load(Ordering::SeqCst));
+        assert!(
+            state.lock().unwrap().is_some(),
+            "stop must retain ownership"
+        );
+        assert!(clear_if_owner(&state, new_session, &new_running));
+        assert!(state.lock().unwrap().is_none());
+    }
 
     #[test]
     fn source_visibility_warning_flags_minimized_window() {

--- a/core/viewer-tests/tests/shell.phase1.spec.js
+++ b/core/viewer-tests/tests/shell.phase1.spec.js
@@ -947,6 +947,91 @@ test("room switching freezes local publish controls and rejects user media toggl
   expect(result.localDisabled).toBe(true);
 });
 
+test("Stop Sharing recovers a native companion after viewer capture flags are lost", async ({ page }) => {
+  await page.setViewportSize({ width: 1024, height: 768 });
+  await openPhaseOneViewer(page, {
+    participants: 2,
+    cameras: 0,
+    screenShares: 1,
+    screenOwners: [1],
+  });
+
+  const localCard = page.locator(".user-card.is-local");
+  const sharingBadge = localCard.locator(".participant-screen-state");
+  await expect(localCard).toHaveClass(/is-screen-sharing/);
+  await expect(sharingBadge).toBeVisible();
+  await expect(page.locator("#screen-grid > .tile")).toHaveCount(1);
+
+  await page.evaluate(() => {
+    window.__echoNativeStopCalls = [];
+    window.__echoNativeStopFetches = [];
+    window.__ECHO_NATIVE__ = true;
+    window.__TAURI__ = {
+      core: {
+        invoke: async function(command) {
+          window.__echoNativeStopCalls.push(command);
+          if (command === "get_capture_health") {
+            return {
+              capture_active: true,
+              capture_mode: "WGC",
+              captureSessionId: 73,
+            };
+          }
+          return null;
+        },
+      },
+    };
+    window.fetch = async function(input, options) {
+      window.__echoNativeStopFetches.push({
+        url: String(input),
+        method: options && options.method,
+      });
+      return new Response("{}", { status: 200, headers: { "content-type": "application/json" } });
+    };
+    adminToken = "fixture-admin-token";
+    screenEnabled = true;
+    window._echoNativeCaptureActive = false;
+    window._echoNativeCaptureMode = null;
+    _nativeAudioActive = true;
+    renderPublishButtons();
+    screenBtn.disabled = false;
+  });
+
+  const stopButton = page.locator("#toggle-screen");
+  await expect(stopButton).toHaveText("Stop Sharing");
+  await expect(stopButton).toHaveAttribute("aria-pressed", "true");
+  await stopButton.click();
+
+  await expect(stopButton).toHaveText("Share Screen");
+  await expect(stopButton).toHaveAttribute("aria-pressed", "false");
+  await expect(page.locator("#screen-grid > .tile")).toHaveCount(0);
+  await expect(localCard).not.toHaveClass(/is-screen-sharing/);
+  await expect(sharingBadge).toBeHidden();
+  await expect(localCard.locator(".participant-settings-toggle")).toBeHidden();
+
+  const cleanup = await page.evaluate(() => ({
+    calls: window.__echoNativeStopCalls,
+    fetches: window.__echoNativeStopFetches,
+    parentMapped: screenTileByIdentity.has(room.localParticipant.identity),
+    companionMapped: screenTileByIdentity.has(room.localParticipant.identity + "$screen"),
+    nativeSessionId: window._echoNativeCaptureSessionId,
+    screenEnabled: screenEnabled,
+  }));
+  expect(cleanup.calls).toEqual([
+    "get_capture_health",
+    "stop_screen_share",
+    "stop_audio_capture",
+  ]);
+  expect(cleanup.fetches).toEqual([{
+    url: "/v1/rooms/main/kick/layout-fixture-1%24screen",
+    method: "POST",
+  }]);
+  expect(cleanup.parentMapped).toBe(false);
+  expect(cleanup.companionMapped).toBe(false);
+  expect(cleanup.nativeSessionId).toBe(null);
+  expect(cleanup.screenEnabled).toBe(false);
+});
+
 test("room switching waits for an in-flight mic toggle and preserves its intent", async ({ page }) => {
   await page.setViewportSize({ width: 1024, height: 768 });
   await openPhaseOneViewer(page, {

--- a/core/viewer/screen-share-native.js
+++ b/core/viewer/screen-share-native.js
@@ -12,6 +12,60 @@ function _sourceVisibilityToastCooldownMs() {
   return typeof SOURCE_VISIBILITY_TOAST_COOLDOWN_MS === 'number' ? SOURCE_VISIBILITY_TOAST_COOLDOWN_MS : 10000;
 }
 
+function _normalizeNativeCaptureSessionId(value) {
+  if (value && typeof value === 'object') {
+    value = value.sessionId !== undefined ? value.sessionId : value.session_id;
+  }
+  if (value === undefined || value === null || value === '') return null;
+  return String(value);
+}
+
+function _nativeCaptureLifecycleVersion() {
+  return Number(window._echoNativeLifecycleVersion) || 0;
+}
+
+function _rememberNativeCaptureSessionId(startResult, lifecycleVersionAtStart) {
+  var sessionId = _normalizeNativeCaptureSessionId(startResult);
+  var stoppedSessionId = _normalizeNativeCaptureSessionId(
+    window._echoLastStoppedNativeCaptureSessionId
+  );
+  if (sessionId && sessionId === stoppedSessionId) {
+    window._echoNativeCaptureSessionId = null;
+    throw new Error('Native capture ended before startup completed');
+  }
+  // Older binaries return no session ID. A lifecycle event accepted while the
+  // invoke was in flight is the only authoritative signal available; never
+  // mark that already-ended attempt active just because the void invoke later
+  // resolved.
+  if (!sessionId && lifecycleVersionAtStart !== undefined &&
+      _nativeCaptureLifecycleVersion() !== lifecycleVersionAtStart) {
+    window._echoNativeCaptureSessionId = null;
+    throw new Error('Native capture ended before startup completed');
+  }
+  window._echoNativeCaptureSessionId = sessionId;
+  return window._echoNativeCaptureSessionId;
+}
+
+function _nativeEncoderReportArgs(encoder) {
+  var args = { encoder: encoder };
+  var sessionId = _normalizeNativeCaptureSessionId(window._echoNativeCaptureSessionId);
+  if (sessionId !== null) args.captureSessionId = Number(sessionId);
+  return args;
+}
+
+function _nativeCaptureEventDetails(event) {
+  var payload = event && Object.prototype.hasOwnProperty.call(event, 'payload')
+    ? event.payload
+    : event;
+  var structured = !!(payload && typeof payload === 'object');
+  return {
+    message: structured ? payload.message : (typeof payload === 'string' ? payload : null),
+    // Older binaries emitted unit stop payloads and plain-string errors. Only
+    // the new structured payload is trustworthy capture-session evidence.
+    sessionId: structured ? _normalizeNativeCaptureSessionId(payload) : null,
+  };
+}
+
 function _shouldMonitorNativeCaptureSource(source, mode) {
   return !!(
     source &&
@@ -163,7 +217,110 @@ function _stopNativeCaptureStopListeners() {
   }
 }
 
-async function _finalizeNativeCaptureStop(stopMessage) {
+function _nativeCaptureStopCommands(captureMode) {
+  var normalizedMode = String(captureMode || '').trim().toLowerCase();
+  if (normalizedMode === 'desktop-dd' || normalizedMode === 'dxgi-dd') {
+    return ['stop_desktop_capture'];
+  }
+  if (normalizedMode === 'wgc' || normalizedMode === 'wgc-monitor' ||
+      normalizedMode === 'wgc-game-monitor') {
+    return ['stop_screen_share'];
+  }
+  // A reloaded viewer may know that its native companion is still live but no
+  // longer know which Rust capture route created it. Both stop commands are
+  // intentionally idempotent, so cover both routes before removing the share.
+  return ['stop_screen_share', 'stop_desktop_capture'];
+}
+
+function _hasOwnNativeScreenCompanion() {
+  var localIdentity = room && room.localParticipant ? room.localParticipant.identity : null;
+  if (!localIdentity) return false;
+  var parentIdentity = localIdentity.endsWith('$screen')
+    ? localIdentity.slice(0, -'$screen'.length)
+    : localIdentity;
+  var companionIdentity = parentIdentity + '$screen';
+  var remotes = room && room.remoteParticipants;
+
+  if (remotes) {
+    if (typeof remotes.get === 'function' && remotes.get(companionIdentity)) return true;
+    if (typeof remotes.forEach === 'function') {
+      var companionFound = false;
+      remotes.forEach(function(participant) {
+        if (participant && participant.identity === companionIdentity) companionFound = true;
+      });
+      if (companionFound) return true;
+    }
+  }
+
+  if (typeof screenTileByIdentity !== 'undefined' && screenTileByIdentity) {
+    if (screenTileByIdentity.has(companionIdentity)) return true;
+    // Native shares have no browser LocalVideoTrack. In that case the parent
+    // tile is sufficient fallback evidence for older companion bookkeeping.
+    if ((!_screenShareVideoTrack) && screenTileByIdentity.has(parentIdentity)) return true;
+  }
+  if (typeof screenTrackMeta !== 'undefined' && screenTrackMeta && screenTrackMeta.forEach) {
+    var metadataFound = false;
+    screenTrackMeta.forEach(function(meta) {
+      if (!meta) return;
+      if (meta.identity === companionIdentity ||
+          ((!_screenShareVideoTrack) && meta.identity === parentIdentity)) {
+        metadataFound = true;
+      }
+    });
+    if (metadataFound) return true;
+  }
+  return false;
+}
+
+async function _resolveNativeCaptureStopCommands() {
+  if (window._echoNativeCaptureActive || window._echoNativeCaptureMode) {
+    return _nativeCaptureStopCommands(window._echoNativeCaptureMode);
+  }
+
+  // The native publisher runs in a separate companion participant. A viewer
+  // reload can lose these JavaScript flags while Rust is still publishing, so
+  // ask the desktop capture engine before falling through to browser cleanup.
+  if (!window.__ECHO_NATIVE__ || typeof tauriInvoke !== 'function') return null;
+  var hasCompanion = _hasOwnNativeScreenCompanion();
+  try {
+    var health = await tauriInvoke('get_capture_health');
+    if (health && health.capture_active) {
+      var healthSessionId = health.capture_session_id !== undefined
+        ? health.capture_session_id
+        : health.captureSessionId;
+      if (healthSessionId !== undefined && healthSessionId !== null) {
+        _rememberNativeCaptureSessionId(healthSessionId);
+      }
+      return _nativeCaptureStopCommands(health.capture_mode);
+    }
+    // Older WGC completion paths can report health inactive while the native
+    // companion is still publishing. Companion/tile evidence is authoritative
+    // for this explicit user-requested stop.
+    return hasCompanion ? _nativeCaptureStopCommands(null) : null;
+  } catch (err) {
+    if (typeof debugLog === 'function') {
+      debugLog('[screen-share] get_capture_health failed during stop: ' + (err.message || err));
+    }
+    if (hasCompanion) return _nativeCaptureStopCommands(null);
+    // A native shell can intentionally fall back to getDisplayMedia when its
+    // capture commands are unavailable. Only that known browser-track case may
+    // continue through browser cleanup; otherwise preserve the truthful
+    // "Stop Sharing" state and let the caller surface the failed transition.
+    if (typeof _screenShareVideoTrack !== 'undefined' && _screenShareVideoTrack) return null;
+    throw new Error('Unable to verify the active native screen share: ' + (err.message || err));
+  }
+}
+
+async function _finalizeNativeCaptureStop(stopMessage, stoppedSessionId) {
+  var normalizedStoppedSessionId = _normalizeNativeCaptureSessionId(stoppedSessionId);
+  var currentSessionId = _normalizeNativeCaptureSessionId(window._echoNativeCaptureSessionId);
+  if (normalizedStoppedSessionId && currentSessionId &&
+      normalizedStoppedSessionId !== currentSessionId) {
+    if (typeof debugLog === 'function') {
+      debugLog('[screen-share] ignored stale finalize for native session ' + normalizedStoppedSessionId);
+    }
+    return false;
+  }
   var wasActive = !!(window._echoNativeCaptureActive || window._echoNativeCaptureMode || screenEnabled);
   window._echoNativeCaptureActive = false;
   window._echoNativeCaptureMode = null;
@@ -175,13 +332,31 @@ async function _finalizeNativeCaptureStop(stopMessage) {
   _stopQualityWarnListener();
   await stopNativeAudioCapture();
   renderPublishButtons();
+  var latestSessionId = _normalizeNativeCaptureSessionId(window._echoNativeCaptureSessionId);
+  if ((normalizedStoppedSessionId && latestSessionId === normalizedStoppedSessionId) ||
+      (!normalizedStoppedSessionId && !currentSessionId && !latestSessionId)) {
+    window._echoNativeCaptureSessionId = null;
+  }
+  if (normalizedStoppedSessionId) {
+    window._echoLastStoppedNativeCaptureSessionId = normalizedStoppedSessionId;
+  }
   if (stopMessage && wasActive) showToast(stopMessage, 3000);
+  return true;
+}
+
+async function _cleanupStoppedNativePublication() {
+  var localIdentity = room && room.localParticipant ? room.localParticipant.identity : null;
+  var roomName = currentRoomName || 'main';
+  _clearNativeScreenTilesForIdentity(localIdentity);
+  await _removeNativeScreenCompanion(localIdentity, roomName);
 }
 
 function _clearNativeScreenTilesForIdentity(identity) {
   if (!identity) return;
-  var identities = [identity];
-  if (!identity.endsWith('$screen')) identities.push(identity + '$screen');
+  var parentIdentity = identity.endsWith('$screen')
+    ? identity.slice(0, -'$screen'.length)
+    : identity;
+  var identities = [parentIdentity, parentIdentity + '$screen'];
 
   function removeTile(tile, trackSid) {
     if (trackSid && typeof removeScreenTile === 'function') {
@@ -262,6 +437,8 @@ async function _startNativeCaptureStopListeners() {
   var stopEvents = {
     'screen-capture-stopped': 'Screen capture ended',
     'desktop-capture-stopped': 'Desktop capture ended',
+    'screen-capture-error': 'Screen capture failed',
+    'desktop-capture-error': 'Desktop capture failed',
   };
   var unlisteners = [];
 
@@ -269,10 +446,43 @@ async function _startNativeCaptureStopListeners() {
     for (var eventName in stopEvents) {
       if (!Object.prototype.hasOwnProperty.call(stopEvents, eventName)) continue;
       var unlisten = await tauriListen(eventName, function(name) {
-        return function() {
-          debugLog('[' + name + '] stopped by Rust');
-          _finalizeNativeCaptureStop(stopEvents[name]).catch(function(err) {
+        return function(event) {
+          var details = _nativeCaptureEventDetails(event);
+          var currentSessionId = _normalizeNativeCaptureSessionId(window._echoNativeCaptureSessionId);
+          var lastStoppedSessionId = _normalizeNativeCaptureSessionId(
+            window._echoLastStoppedNativeCaptureSessionId
+          );
+          if (details.sessionId && details.sessionId === lastStoppedSessionId) {
+            debugLog('[' + name + '] ignored duplicate native session ' + details.sessionId);
+            return Promise.resolve(false);
+          }
+          // New binaries identify every native attempt. A queued event from an
+          // older attempt must never clear or kick the replacement share.
+          if (currentSessionId && details.sessionId !== currentSessionId) {
+            debugLog('[' + name + '] ignored stale native session ' + (details.sessionId || 'legacy'));
+            return Promise.resolve(false);
+          }
+
+          debugLog('[' + name + '] stopped by Rust' +
+            (details.sessionId ? ' session=' + details.sessionId : ''));
+          window._echoNativeLifecycleVersion = _nativeCaptureLifecycleVersion() + 1;
+          if (details.sessionId) {
+            // Mark completion before any awaited cleanup. The start invoke can
+            // resolve after Rust has already emitted this event; its returned
+            // session ID must not resurrect the dead attempt.
+            window._echoLastStoppedNativeCaptureSessionId = details.sessionId;
+            // The session-correlated Rust task has already disconnected its SFU
+            // companion. Clear only its local presentation; do not issue a kick
+            // that could race a just-started replacement using the same identity.
+            var localIdentity = room && room.localParticipant ? room.localParticipant.identity : null;
+            _clearNativeScreenTilesForIdentity(localIdentity);
+          }
+          var message = details.message
+            ? stopEvents[name] + ': ' + details.message
+            : stopEvents[name];
+          return _finalizeNativeCaptureStop(message, details.sessionId).catch(function(err) {
             debugLog('[screen-share] native stop cleanup failed: ' + (err.message || err));
+            return false;
           });
         };
       }(eventName));
@@ -385,12 +595,14 @@ async function startScreenShareManual() {
         if (!captureStarted && gameCaptureMode !== 'desktop-dd' && wgcSupported) {
           try {
             debugLog('[wgc] trying WGC window capture for HWND ' + source.id + ' (build ' + osBuild + ')');
-            await tauriInvoke('start_screen_share', {
+            var wgcLifecycleVersion = _nativeCaptureLifecycleVersion();
+            var wgcSessionId = await tauriInvoke('start_screen_share', {
               sourceId: source.id,
               sfuUrl: sfuUrl,
               token: screenToken,
               publishProfile: publishProfile,
             });
+            _rememberNativeCaptureSessionId(wgcSessionId, wgcLifecycleVersion);
             window._echoNativeCaptureMode = 'wgc';
             captureStarted = true;
           } catch (wgcErr) {
@@ -407,13 +619,15 @@ async function startScreenShareManual() {
             var ddResult = await tauriInvoke('check_desktop_capture_available');
             if (ddResult && ddResult[0]) {
               debugLog('[desktop-dd] available: ' + ddResult[1]);
-              await tauriInvoke('start_desktop_capture', {
+              var desktopLifecycleVersion = _nativeCaptureLifecycleVersion();
+              var desktopSessionId = await tauriInvoke('start_desktop_capture', {
                 hwnd: source.id,
                 fullscreen: source.isMonitor || false,
                 sfuUrl: sfuUrl,
                 token: screenToken,
                 publishProfile: publishProfile,
               });
+              _rememberNativeCaptureSessionId(desktopSessionId, desktopLifecycleVersion);
               window._echoNativeCaptureMode = 'desktop-dd';
               captureStarted = true;
             } else {
@@ -441,24 +655,28 @@ async function startScreenShareManual() {
           debugLog('[monitor] using DXGI DD for monitor capture');
           var ddResult = await tauriInvoke('check_desktop_capture_available');
           if (ddResult && ddResult[0]) {
-            await tauriInvoke('start_desktop_capture', {
+            var monitorLifecycleVersion = _nativeCaptureLifecycleVersion();
+            var monitorSessionId = await tauriInvoke('start_desktop_capture', {
               hwnd: source.id,
               fullscreen: true,
               sfuUrl: sfuUrl,
               token: screenToken,
               publishProfile: 'desktop',
             });
+            _rememberNativeCaptureSessionId(monitorSessionId, monitorLifecycleVersion);
             window._echoNativeCaptureMode = 'desktop-dd';
           } else {
             throw new Error('Desktop capture not available: ' + (ddResult ? ddResult[1] : 'unknown'));
           }
         } else if (wgcSupported) {
-          await tauriInvoke('start_screen_share', {
+          var fallbackLifecycleVersion = _nativeCaptureLifecycleVersion();
+          var fallbackSessionId = await tauriInvoke('start_screen_share', {
             sourceId: source.id,
             sfuUrl: sfuUrl,
             token: screenToken,
             publishProfile: 'desktop',
           });
+          _rememberNativeCaptureSessionId(fallbackSessionId, fallbackLifecycleVersion);
           window._echoNativeCaptureMode = 'wgc';
         } else {
           throw new Error('Window capture requires Windows 11 24H2+ (current build: ' + osBuild + ')');
@@ -892,9 +1110,20 @@ async function startScreenShareManual() {
               // the classifier will turn the chip Red.
               if (codec && codec !== "unknown" && typeof tauriInvoke === "function") {
                 try {
-                  if (window._lastReportedEncoder !== codec) {
+                  var encoderSessionId = _normalizeNativeCaptureSessionId(
+                    window._echoNativeCaptureSessionId
+                  );
+                  if (window._lastReportedEncoder !== codec ||
+                      window._lastReportedEncoderSessionId !== encoderSessionId) {
                     window._lastReportedEncoder = codec;
-                    tauriInvoke("report_encoder_implementation", { encoder: codec }).catch(function(){});
+                    window._lastReportedEncoderSessionId = encoderSessionId;
+                    // New binaries require the capture lease so late stats from
+                    // an old sender cannot overwrite the replacement session.
+                    // Omit it only for the browser fallback / older binaries.
+                    tauriInvoke(
+                      "report_encoder_implementation",
+                      _nativeEncoderReportArgs(codec)
+                    ).catch(function(){});
                   }
                 } catch (e) { /* IPC unavailable, ignore */ }
               }
@@ -1205,21 +1434,34 @@ async function startScreenShareManual() {
 
 async function stopScreenShareManual() {
   // ── Native capture stop path ──
-  if (window._echoNativeCaptureActive || window._echoNativeCaptureMode) {
-    var stopCommand = window._echoNativeCaptureMode === 'desktop-dd'
-      ? 'stop_desktop_capture'
-      : 'stop_screen_share';
-    var localIdentity = room && room.localParticipant ? room.localParticipant.identity : null;
-    var roomName = currentRoomName || 'main';
+  var stopCommands = await _resolveNativeCaptureStopCommands();
+  if (stopCommands && stopCommands.length) {
+    var stoppingSessionId = _normalizeNativeCaptureSessionId(window._echoNativeCaptureSessionId);
     _stopNativeCaptureStopListeners();
-    try {
-      await tauriInvoke(stopCommand);
-    } catch (e) {
-      console.error('[screen-share] native stop error:', e);
+    var stopErrors = [];
+    for (var commandIndex = 0; commandIndex < stopCommands.length; commandIndex += 1) {
+      var stopCommand = stopCommands[commandIndex];
+      try {
+        await tauriInvoke(stopCommand);
+      } catch (e) {
+        stopErrors.push(e);
+        if (typeof debugLog === 'function') {
+          debugLog('[screen-share] ' + stopCommand + ' failed: ' + (e.message || e));
+        }
+      }
     }
-    _clearNativeScreenTilesForIdentity(localIdentity);
-    await _removeNativeScreenCompanion(localIdentity, roomName);
-    await _finalizeNativeCaptureStop(null);
+    if (stopErrors.length > 0) {
+      try {
+        await _startNativeCaptureStopListeners();
+      } catch (listenErr) {
+        if (typeof debugLog === 'function') {
+          debugLog('[screen-share] native stop listener rollback failed: ' + (listenErr.message || listenErr));
+        }
+      }
+      throw stopErrors[0];
+    }
+    await _cleanupStoppedNativePublication();
+    await _finalizeNativeCaptureStop(null, stoppingSessionId);
     return; // Don't fall through to browser path
   }
 

--- a/core/viewer/screen-share-native.test.js
+++ b/core/viewer/screen-share-native.test.js
@@ -218,6 +218,7 @@ test("manual WGC game capture keeps the WGC path available", async () => {
   context.tauriInvoke = async (command, args) => {
     calls.push({ command, args });
     if (command === "get_os_build_number") return 26100;
+    if (command === "start_screen_share") return 73;
     return null;
   };
 
@@ -229,6 +230,56 @@ test("manual WGC game capture keeps the WGC path available", async () => {
   assert.equal(wgcStart.args.publishProfile, "game");
   assert.equal(calls.some((call) => call.command === "start_desktop_capture"), false);
   assert.equal(context.window._echoNativeCaptureMode, "wgc");
+  assert.equal(context.window._echoNativeCaptureSessionId, "73");
+});
+
+test("native lifecycle completion before start resolves cannot resurrect the dead session", async () => {
+  const { context, calls } = loadScreenShareNative();
+  const listeners = new Map();
+  let lifecyclePromise = null;
+  context.showCapturePicker = async () => ({
+    sourceType: "game",
+    id: 4242,
+    pid: 0,
+    isMonitor: false,
+    captureMode: "wgc",
+  });
+  context.tauriListen = async (eventName, callback) => {
+    listeners.set(eventName, callback);
+    return () => { listeners.delete(eventName); };
+  };
+  context.tauriInvoke = async (command, args) => {
+    calls.push({ command, args });
+    if (command === "get_os_build_number") return 26100;
+    if (command === "start_screen_share") {
+      lifecyclePromise = listeners.get("screen-capture-stopped")({
+        payload: { sessionId: 91 },
+      });
+      return 91;
+    }
+    return null;
+  };
+
+  await context.startScreenShareManual();
+  await lifecyclePromise;
+
+  assert.equal(context.window._echoLastStoppedNativeCaptureSessionId, "91");
+  assert.equal(context.window._echoNativeCaptureSessionId, null);
+  assert.equal(context.window._echoNativeCaptureActive, false);
+  assert.equal(context.window._echoNativeCaptureMode, null);
+  assert.equal(context.screenEnabled, false);
+  assert.equal(calls.filter((call) => call.command === "start_screen_share").length, 1);
+
+  // Older binaries return void instead of a session ID. Their accepted
+  // lifecycle event still prevents the late invoke resolution from reviving
+  // an already-ended capture attempt.
+  context.window._echoLastStoppedNativeCaptureSessionId = null;
+  context.window._echoNativeLifecycleVersion = 4;
+  assert.throws(
+    () => context._rememberNativeCaptureSessionId(null, 3),
+    /ended before startup completed/
+  );
+  assert.equal(context.window._echoNativeCaptureSessionId, null);
 });
 
 test("source visibility warning tells the publisher to keep the shared window visible", () => {
@@ -256,6 +307,22 @@ test("source visibility monitor is only enabled for native window-like sources",
   assert.equal(
     context._shouldMonitorNativeCaptureSource({ id: 789, sourceType: "monitor" }, "desktop-dd"),
     false
+  );
+});
+
+test("encoder reports are leased to the native capture session", () => {
+  const { context } = loadScreenShareNative();
+  context.window._echoNativeCaptureSessionId = "73";
+
+  assert.deepEqual(
+    JSON.parse(JSON.stringify(context._nativeEncoderReportArgs("NVENC"))),
+    { encoder: "NVENC", captureSessionId: 73 }
+  );
+
+  context.window._echoNativeCaptureSessionId = null;
+  assert.deepEqual(
+    JSON.parse(JSON.stringify(context._nativeEncoderReportArgs("OpenH264"))),
+    { encoder: "OpenH264" }
   );
 });
 
@@ -378,6 +445,326 @@ test("native stop clears local screen tile and removes the screen companion", as
   assert.match(fetches[0].url, /\/v1\/rooms\/main\/kick\/Sam%24screen$/);
   assert.equal(fetches[0].opts.method, "POST");
   assert.equal(fetches[0].opts.headers.Authorization, "Bearer admin-token");
+});
+
+for (const [captureMode, expectedCommand] of [
+  ["WGC", "stop_screen_share"],
+  ["DXGI-DD", "stop_desktop_capture"],
+]) {
+  test(`native stop recovers ${captureMode} capture after viewer state flags are lost`, async () => {
+    const { context, calls, fetches } = loadScreenShareNative();
+    const screenAvailability = [];
+    let removed = false;
+    let renderCount = 0;
+    let nativeAudioStops = 0;
+    const tile = {
+      dataset: { trackSid: "TR_RECOVERED" },
+      classList: { contains: () => false },
+      remove() { removed = true; },
+    };
+
+    context.window._echoNativeCaptureActive = false;
+    context.window._echoNativeCaptureMode = null;
+    context.screenEnabled = true;
+    context.stopNativeAudioCapture = async () => { nativeAudioStops += 1; };
+    context.screenTileByIdentity = new Map([["Sam$screen", tile]]);
+    context.screenTileBySid = new Map([["TR_RECOVERED", tile]]);
+    context.screenTrackMeta = new Map([["TR_RECOVERED", { identity: "Sam$screen" }]]);
+    context.screenRecoveryAttempts = new Map([["TR_RECOVERED", 1]]);
+    context.screenResubscribeIntent = new Map([["TR_RECOVERED", 1]]);
+    context.hiddenScreens = new Set(["Sam", "Sam$screen"]);
+    context.watchedScreens = new Set(["Sam", "Sam$screen"]);
+    context._pubBitrateControl = new Map([["Sam$screen", {}]]);
+    context.removeScreenTile = (sid) => {
+      assert.equal(sid, "TR_RECOVERED");
+      removed = true;
+      context.screenTileBySid.delete(sid);
+    };
+    context.unregisterScreenTrack = (sid) => {
+      context.screenTrackMeta.delete(sid);
+    };
+    context.setParticipantScreenWatchAvailable = (identity, available) => {
+      screenAvailability.push([identity, available]);
+    };
+    context.renderPublishButtons = () => { renderCount += 1; };
+    context.tauriInvoke = async (command, args) => {
+      calls.push({ command, args });
+      if (command === "get_capture_health") {
+        return { capture_active: true, capture_mode: captureMode };
+      }
+      return null;
+    };
+
+    await context.stopScreenShareManual();
+
+    assert.deepEqual(
+      calls.map((call) => call.command),
+      ["get_capture_health", expectedCommand]
+    );
+    assert.equal(nativeAudioStops, 1);
+    assert.equal(removed, true);
+    assert.equal(context.screenEnabled, false);
+    assert.equal(context.window._echoNativeCaptureActive, false);
+    assert.equal(context.window._echoNativeCaptureMode, null);
+    assert.equal(context.screenTileByIdentity.has("Sam"), false);
+    assert.equal(context.screenTileByIdentity.has("Sam$screen"), false);
+    assert.equal(context.screenTrackMeta.size, 0);
+    assert.equal(context.hiddenScreens.size, 0);
+    assert.equal(context.watchedScreens.size, 0);
+    assert.equal(context._pubBitrateControl.size, 0);
+    assert.deepEqual(screenAvailability, [["Sam", false], ["Sam$screen", false]]);
+    assert.equal(renderCount, 1);
+    assert.equal(fetches.length, 1);
+    assert.match(fetches[0].url, /\/v1\/rooms\/main\/kick\/Sam%24screen$/);
+  });
+}
+
+test("native stop failure preserves the published UI state for a retry", async () => {
+  const { context, calls, fetches } = loadScreenShareNative();
+  const tile = {
+    dataset: { trackSid: "TR_STILL_LIVE" },
+    classList: { contains: () => false },
+    remove() { throw new Error("live tile must not be removed"); },
+  };
+  context.window._echoNativeCaptureActive = false;
+  context.window._echoNativeCaptureMode = null;
+  context.screenEnabled = true;
+  context.screenTileByIdentity = new Map([["Sam$screen", tile]]);
+  context.screenTileBySid = new Map([["TR_STILL_LIVE", tile]]);
+  context.setParticipantScreenWatchAvailable = () => {
+    throw new Error("sharing badge must remain visible");
+  };
+  context.tauriInvoke = async (command, args) => {
+    calls.push({ command, args });
+    if (command === "get_capture_health") {
+      return { capture_active: true, capture_mode: "WGC" };
+    }
+    if (command === "stop_screen_share") throw new Error("native stop rejected");
+    return null;
+  };
+
+  await assert.rejects(context.stopScreenShareManual(), /native stop rejected/);
+
+  assert.deepEqual(calls.map((call) => call.command), ["get_capture_health", "stop_screen_share"]);
+  assert.equal(context.screenEnabled, true);
+  assert.equal(context.screenTileByIdentity.get("Sam$screen"), tile);
+  assert.equal(context.screenTileBySid.get("TR_STILL_LIVE"), tile);
+  assert.equal(fetches.length, 0);
+});
+
+test("inactive health with a live companion stops both native capture routes", async () => {
+  const { context, calls, fetches } = loadScreenShareNative();
+  const screenAvailability = [];
+  const companion = { identity: "Sam$screen", trackPublications: new Map() };
+  const tile = {
+    dataset: { trackSid: "TR_INACTIVE_HEALTH" },
+    classList: { contains: () => false },
+    remove() {},
+  };
+  context.room.remoteParticipants = new Map([[companion.identity, companion]]);
+  context.window._echoNativeCaptureActive = false;
+  context.window._echoNativeCaptureMode = null;
+  context.screenEnabled = true;
+  context.screenTileByIdentity = new Map([["Sam$screen", tile]]);
+  context.screenTileBySid = new Map([["TR_INACTIVE_HEALTH", tile]]);
+  context.removeScreenTile = (sid) => { context.screenTileBySid.delete(sid); };
+  context.setParticipantScreenWatchAvailable = (identity, available) => {
+    screenAvailability.push([identity, available]);
+  };
+  context.tauriInvoke = async (command, args) => {
+    calls.push({ command, args });
+    if (command === "get_capture_health") return null;
+    return null;
+  };
+
+  await context.stopScreenShareManual();
+
+  assert.deepEqual(calls.map((call) => call.command), [
+    "get_capture_health",
+    "stop_screen_share",
+    "stop_desktop_capture",
+  ]);
+  assert.equal(context.screenEnabled, false);
+  assert.equal(context.screenTileByIdentity.size, 0);
+  assert.deepEqual(screenAvailability, [["Sam", false], ["Sam$screen", false]]);
+  assert.equal(fetches.length, 1);
+});
+
+test("unknown native route keeps the published UI when either stop command fails", async () => {
+  const { context, calls, fetches } = loadScreenShareNative();
+  const tile = {
+    dataset: { trackSid: "TR_UNKNOWN_ROUTE" },
+    classList: { contains: () => false },
+    remove() { throw new Error("uncertain capture tile must remain"); },
+  };
+  context.room.remoteParticipants = new Map([[
+    "Sam$screen",
+    { identity: "Sam$screen", trackPublications: new Map() },
+  ]]);
+  context.screenEnabled = true;
+  context.screenTileByIdentity = new Map([["Sam$screen", tile]]);
+  context.screenTileBySid = new Map([["TR_UNKNOWN_ROUTE", tile]]);
+  context.setParticipantScreenWatchAvailable = () => {
+    throw new Error("uncertain sharing badge must remain");
+  };
+  context.tauriInvoke = async (command, args) => {
+    calls.push({ command, args });
+    if (command === "get_capture_health") return null;
+    if (command === "stop_desktop_capture") throw new Error("desktop stop rejected");
+    return null;
+  };
+
+  await assert.rejects(context.stopScreenShareManual(), /desktop stop rejected/);
+
+  assert.deepEqual(calls.map((call) => call.command), [
+    "get_capture_health",
+    "stop_screen_share",
+    "stop_desktop_capture",
+  ]);
+  assert.equal(context.screenEnabled, true);
+  assert.equal(context.screenTileByIdentity.get("Sam$screen"), tile);
+  assert.equal(fetches.length, 0);
+});
+
+test("matching structured native stop event clears only its published presentation", async () => {
+  const { context, fetches } = loadScreenShareNative();
+  const listeners = new Map();
+  const screenAvailability = [];
+  let removed = false;
+  context.tauriListen = async (eventName, callback) => {
+    listeners.set(eventName, callback);
+    return () => { listeners.delete(eventName); };
+  };
+  context.window._echoNativeCaptureActive = true;
+  context.window._echoNativeCaptureMode = "wgc";
+  context.window._echoNativeCaptureSessionId = "41";
+  context.screenEnabled = true;
+  const tile = {
+    dataset: { trackSid: "TR_SESSION_41" },
+    classList: { contains: () => false },
+    remove() { removed = true; },
+  };
+  context.screenTileByIdentity = new Map([["Sam$screen", tile]]);
+  context.screenTileBySid = new Map([["TR_SESSION_41", tile]]);
+  context.screenTrackMeta = new Map([["TR_SESSION_41", { identity: "Sam$screen" }]]);
+  context.removeScreenTile = (sid) => {
+    removed = true;
+    context.screenTileBySid.delete(sid);
+  };
+  context.unregisterScreenTrack = (sid) => { context.screenTrackMeta.delete(sid); };
+  context.setParticipantScreenWatchAvailable = (identity, available) => {
+    screenAvailability.push([identity, available]);
+  };
+
+  await context._startNativeCaptureStopListeners();
+  await listeners.get("screen-capture-stopped")({ payload: { sessionId: 41 } });
+
+  assert.equal(removed, true);
+  assert.equal(context.screenEnabled, false);
+  assert.equal(context.window._echoNativeCaptureSessionId, null);
+  assert.equal(context.window._echoLastStoppedNativeCaptureSessionId, "41");
+  assert.equal(context.screenTileByIdentity.size, 0);
+  assert.equal(context.screenTrackMeta.size, 0);
+  assert.deepEqual(screenAvailability, [["Sam", false], ["Sam$screen", false]]);
+  // Rust owns and disconnects the session-correlated companion. The viewer
+  // deliberately avoids a late HTTP kick that could hit a replacement.
+  assert.equal(fetches.length, 0);
+});
+
+test("stale and legacy native stop events cannot clear a newer capture session", async () => {
+  const { context, fetches } = loadScreenShareNative();
+  const listeners = new Map();
+  let renderCount = 0;
+  let nativeAudioStops = 0;
+  const tile = {
+    dataset: { trackSid: "TR_NEW_SESSION" },
+    classList: { contains: () => false },
+    remove() { throw new Error("new capture tile must survive stale events"); },
+  };
+  context.tauriListen = async (eventName, callback) => {
+    listeners.set(eventName, callback);
+    return () => { listeners.delete(eventName); };
+  };
+  context.window._echoNativeCaptureActive = true;
+  context.window._echoNativeCaptureMode = "desktop-dd";
+  context.window._echoNativeCaptureSessionId = "52";
+  context.screenEnabled = true;
+  context.screenTileByIdentity = new Map([["Sam$screen", tile]]);
+  context.screenTileBySid = new Map([["TR_NEW_SESSION", tile]]);
+  context.renderPublishButtons = () => { renderCount += 1; };
+  context.stopNativeAudioCapture = async () => { nativeAudioStops += 1; };
+
+  await context._startNativeCaptureStopListeners();
+  const stopped = listeners.get("desktop-capture-stopped");
+  const failed = listeners.get("desktop-capture-error");
+  assert.equal(await stopped({ payload: { sessionId: 51 } }), false);
+  assert.equal(await stopped({ payload: null }), false);
+  assert.equal(await failed({ payload: "old desktop capture error" }), false);
+
+  assert.equal(context.screenEnabled, true);
+  assert.equal(context.window._echoNativeCaptureActive, true);
+  assert.equal(context.window._echoNativeCaptureMode, "desktop-dd");
+  assert.equal(context.window._echoNativeCaptureSessionId, "52");
+  assert.equal(context.screenTileByIdentity.get("Sam$screen"), tile);
+  assert.equal(context.screenTileBySid.get("TR_NEW_SESSION"), tile);
+  assert.equal(renderCount, 0);
+  assert.equal(nativeAudioStops, 0);
+  assert.equal(fetches.length, 0);
+});
+
+test("legacy spontaneous stop events cannot tear down a possible replacement companion", async () => {
+  const { context, calls, fetches } = loadScreenShareNative();
+  const listeners = new Map();
+  const screenAvailability = [];
+  let removed = false;
+  let renderCount = 0;
+  let nativeAudioStops = 0;
+  context.tauriListen = async (eventName, callback) => {
+    listeners.set(eventName, callback);
+    return () => { listeners.delete(eventName); };
+  };
+  context.window._echoNativeCaptureActive = true;
+  context.window._echoNativeCaptureMode = "desktop-dd";
+  context.screenEnabled = true;
+  context.stopNativeAudioCapture = async () => { nativeAudioStops += 1; };
+  const tile = {
+    dataset: { trackSid: "TR_SPONTANEOUS" },
+    classList: { contains: () => false },
+    remove() { removed = true; },
+  };
+  context.screenTileByIdentity = new Map([["Sam$screen", tile]]);
+  context.screenTileBySid = new Map([["TR_SPONTANEOUS", tile]]);
+  context.screenTrackMeta = new Map([["TR_SPONTANEOUS", { identity: "Sam$screen" }]]);
+  context.removeScreenTile = (sid) => {
+    removed = true;
+    context.screenTileBySid.delete(sid);
+  };
+  context.unregisterScreenTrack = (sid) => {
+    context.screenTrackMeta.delete(sid);
+  };
+  context.setParticipantScreenWatchAvailable = (identity, available) => {
+    screenAvailability.push([identity, available]);
+  };
+  context.renderPublishButtons = () => { renderCount += 1; };
+
+  await context._startNativeCaptureStopListeners();
+  const stopped = listeners.get("desktop-capture-stopped");
+  assert.equal(typeof stopped, "function");
+  await stopped();
+
+  assert.equal(removed, false);
+  assert.equal(context.screenEnabled, false);
+  assert.equal(context.window._echoNativeCaptureActive, false);
+  assert.equal(context.window._echoNativeCaptureMode, null);
+  assert.equal(context.window._echoNativeLifecycleVersion, 1);
+  assert.equal(context.screenTileByIdentity.get("Sam$screen"), tile);
+  assert.equal(context.screenTileBySid.get("TR_SPONTANEOUS"), tile);
+  assert.equal(context.screenTrackMeta.size, 1);
+  assert.deepEqual(screenAvailability, []);
+  assert.equal(renderCount, 1);
+  assert.equal(fetches.length, 0);
+  assert.equal(nativeAudioStops, 1);
+  assert.deepEqual(calls.map((call) => call.command), []);
 });
 
 test("native audio worklet downmixes multichannel WASAPI frames to stereo", () => {

--- a/docs/eli5/stop-sharing-native-capture-ownership.md
+++ b/docs/eli5/stop-sharing-native-capture-ownership.md
@@ -1,0 +1,58 @@
+# Native Stop Sharing reliability
+
+## The simple version
+
+Echo Desktop publishes a native screen share through a separate hidden
+`$screen` participant. The viewer shows that publication on the Stage and marks
+the owner's People card as **Sharing**.
+
+Previously, a retiring Windows capture task could finish after its replacement
+had started. That old task erased the replacement's native-capture handle and
+sent an unversioned "capture stopped" event. The screen publisher could keep
+running, but the viewer forgot that Rust owned it. Clicking **Stop Sharing**
+then stopped only the browser-side audio and left the video, Stage tile, and
+Sharing badge alive.
+
+Native capture attempts now receive one cross-backend session ID. Replacing a
+share atomically installs the new owner before the old task is stopped. Only
+the current owner may update capture health, clear the native handle, or emit a
+stop/error event. WGC and Desktop Duplication also retire each other so only
+one native video publisher can own the screen companion.
+
+The viewer remembers the session ID returned by Echo Desktop and ignores late
+events from older sessions. If its in-memory flags are ever lost, the Stop
+button can recover ownership from native health or from the user's live
+`$screen` companion. It stops the applicable native capture engine—or both
+idempotent engines when the mode is unknown—removes the companion, and clears
+the Stage tile and Sharing indicator together.
+
+## How we know it works
+
+- Rust ownership tests cover replacement, stale completion, cross-backend
+  exclusion, and stop-during-start behavior.
+- Viewer unit tests reproduce the lost-flag state for both WGC and Desktop
+  Duplication and verify stale session events cannot tear down a replacement.
+- A browser layout test clicks the real **Stop Sharing** control and verifies
+  the native stop commands, companion removal, Stage cleanup, Sharing badge,
+  settings control, and dock state.
+
+## Release boundary
+
+This fix needs both pieces:
+
+- the control-plane viewer bundle supplies the recovery behavior and truthful
+  UI cleanup; and
+- a new Windows Echo Desktop binary supplies session-owned native capture.
+
+Updating only the server does not repair the old native handle race. Updating
+only Echo Desktop leaves older served viewer code unable to recover when its
+volatile flags are missing.
+
+## What could still go wrong?
+
+- An old Echo Desktop binary can still lose its capture handle. The new viewer
+  can remove the server-side companion, but fully stopping an already orphaned
+  local encoder may require exiting that old client.
+- If both native stop commands and the authenticated companion-removal request
+  fail, Echo deliberately keeps the Sharing UI visible so the user can retry
+  instead of falsely claiming the stream is gone.


### PR DESCRIPTION
## What changed

- give every native WGC/DXGI capture attempt a cross-backend session lease
- make handle replacement, cancellation, health/metrics writes, and stop/error events session-owned
- prevent retired capture tasks from clearing or deactivating their replacement
- recover Stop Sharing from native health or the local `$screen` companion when viewer flags are stale
- remove the companion, Stage tile, Sharing badge, and local controls together
- ignore stale lifecycle events and cover completion-before-start-response races
- add native ownership tests, viewer unit regressions, a real dock-click Playwright regression, and an ELI5 operating note

## Root cause

A retiring Windows capture task could finish after a replacement had installed its handle. The old task unconditionally cleared the shared native handle, marked capture health inactive, and emitted an unversioned stopped event. The Rust publisher could keep sending video while the viewer forgot native capture was active. The Stop Sharing button then took the browser cleanup path, stopped only screen audio, and left the `$screen` video participant, Stage tile, and Sharing badge alive.

## User and release impact

Stop Sharing now stops the active native publisher even after volatile viewer state is lost, and stale capture completions cannot damage a replacement share.

This crosses both release boundaries: deploy the updated control-plane viewer bundle and ship a new Windows Echo Desktop binary. No macOS build is needed. An already-orphaned publisher from the old binary may still require fully exiting that old client once.

## Validation

- `npm run verify:quick` — guardrails + 182/182 viewer tests passed
- `npm --prefix core/viewer-tests test` — 69/69 Playwright tests passed
- `cargo fmt --manifest-path core/client/Cargo.toml --check` — passed
- `cargo check --manifest-path core/client/Cargo.toml --tests` — passed
- local in-app browser sanity check — viewer loaded cleanly with no console errors
- `git diff --check` — passed

`cargo test ... capture_health` compiled the Rust test code but the final executable link remains blocked by the checkout's existing WebRTC MSVC CRT mismatch (`MT_StaticRelease` vs `MD_DynamicRelease`, LNK2038/LNK1169). A real Windows WGC/DXGI stop-and-immediate-restart smoke test remains the release gate.
