### PR TITLE
Harden the macOS browser fallback

### DIFF
--- a/core/viewer/app.js
+++ b/core/viewer/app.js
@@ -593,7 +593,6 @@ refreshDevicesBtn.addEventListener("click", async () => {
   setDeviceStatus("Refreshing devices...");
   await ensureDevicePermissions();
   await refreshDevices();
-  setDeviceStatus("");
 });
 
 // Create Room button removed in favor of fixed rooms (Main, Breakout 1-3)
@@ -724,7 +723,7 @@ setRoomAudioMutedState(false);
 refreshDevices().catch(() => {}).then(() => {
   micSelect.disabled = false;
   camSelect.disabled = false;
-  speakerSelect.disabled = false;
+  applyAudioOutputCapability();
   refreshDevicesBtn.disabled = false;
 });
 

--- a/core/viewer/connect.js
+++ b/core/viewer/connect.js
@@ -1840,10 +1840,16 @@ function buildChimeSettingsUI() {
   var ncBtn = document.createElement("button");
   ncBtn.type = "button";
   ncBtn.id = "nc-toggle-btn";
-  ncBtn.className = "nc-toggle-btn" + (noiseCancelEnabled ? " is-on" : "");
-  ncBtn.textContent = noiseCancelEnabled ? "ON" : "OFF";
+  var ncBlockedOnPlatform = typeof isNoiseCancellationBlockedForPlatform === "function"
+    ? isNoiseCancellationBlockedForPlatform()
+    : false;
+  ncBtn.className = "nc-toggle-btn" + (!ncBlockedOnPlatform && noiseCancelEnabled ? " is-on" : "");
+  ncBtn.textContent = !ncBlockedOnPlatform && noiseCancelEnabled ? "ON" : "OFF";
+  ncBtn.disabled = ncBlockedOnPlatform;
+  ncBtn.title = ncBlockedOnPlatform ? "Unavailable on macOS while microphone stability is being hardened" : "";
 
   ncBtn.addEventListener("click", async function() {
+    if (ncBlockedOnPlatform) return;
     debugLog("[noise-cancel] Button clicked, was: " + noiseCancelEnabled + ", micEnabled: " + micEnabled + ", room: " + !!room);
     noiseCancelEnabled = !noiseCancelEnabled;
     debugLog("[noise-cancel] Now: " + noiseCancelEnabled);
@@ -1877,7 +1883,9 @@ function buildChimeSettingsUI() {
 
   var ncDesc = document.createElement("div");
   ncDesc.className = "nc-description";
-  ncDesc.textContent = "Reduces background noise like fans, AC, and keyboard sounds.";
+  ncDesc.textContent = ncBlockedOnPlatform
+    ? "Unavailable on macOS for now. Echo keeps the direct microphone path active for reliability."
+    : "Reduces background noise like fans, AC, and keyboard sounds.";
   ncSection.appendChild(ncDesc);
 
   // Suppression strength selector
@@ -1893,7 +1901,9 @@ function buildChimeSettingsUI() {
     btn.type = "button";
     btn.className = "nc-level-btn" + (ncSuppressionLevel === idx ? " is-active" : "");
     btn.textContent = label;
+    btn.disabled = ncBlockedOnPlatform;
     btn.addEventListener("click", function() {
+      if (ncBlockedOnPlatform) return;
       updateNoiseGateLevel(idx);
       ncLevelBtns.querySelectorAll(".nc-level-btn").forEach(function(b, i) {
         b.classList.toggle("is-active", i === idx);
@@ -1906,7 +1916,9 @@ function buildChimeSettingsUI() {
 
   var ncLevelDesc = document.createElement("div");
   ncLevelDesc.className = "nc-description";
-  ncLevelDesc.textContent = "Light = AI denoise only. Medium/Strong adds a noise gate that mutes silence.";
+  ncLevelDesc.textContent = ncBlockedOnPlatform
+    ? "The browser's normal microphone processing remains available."
+    : "Light = AI denoise only. Medium/Strong adds a noise gate that mutes silence.";
   ncSection.appendChild(ncLevelDesc);
 
   settingsDevicePanel.appendChild(ncSection);

--- a/core/viewer/media-controls.js
+++ b/core/viewer/media-controls.js
@@ -17,6 +17,42 @@ function setSelectOptions(select, items, placeholder) {
   });
 }
 
+function shouldEnableAudioOutputSelection(options) {
+  var opts = options || {};
+  return opts.nativeIpc === true || opts.setSinkIdSupported === true;
+}
+
+function audioOutputSelectionSupported() {
+  var nativeIpc = !!(window.__ECHO_NATIVE__ && hasTauriIPC());
+  var setSinkIdSupported = typeof HTMLMediaElement !== "undefined" &&
+    typeof HTMLMediaElement.prototype.setSinkId === "function";
+  return shouldEnableAudioOutputSelection({ nativeIpc, setSinkIdSupported });
+}
+
+function applyAudioOutputCapability() {
+  var supported = audioOutputSelectionSupported();
+  if (!speakerSelect) return supported;
+  speakerSelect.disabled = !supported;
+  speakerSelect.title = supported
+    ? "Choose Echo's audio output"
+    : "This browser uses the system audio output";
+  speakerSelect.setAttribute("aria-label", supported
+    ? "Audio output device"
+    : "Audio output is controlled by the operating system");
+  return supported;
+}
+
+function devicePermissionGuidance(options) {
+  var opts = options || {};
+  if (opts.macOS && opts.nativeShell) {
+    return "Devices detected but permissions not granted. Open macOS System Settings → Privacy & Security → Microphone/Camera, then restart Echo.";
+  }
+  if (opts.macOS) {
+    return "Devices detected but permissions not granted. Allow this Echo site in browser settings and macOS Privacy & Security, then reload.";
+  }
+  return "Devices detected but permissions not granted. Allow microphone and camera access in browser or system settings, then retry.";
+}
+
 async function ensureDevicePermissions() {
   let gotAudio = false;
   let gotVideo = false;
@@ -97,7 +133,13 @@ async function refreshDevices() {
 
   setSelectOptions(micSelect, mics, "Default mic");
   setSelectOptions(camSelect, cams, "Default camera");
-  setSelectOptions(speakerSelect, speakers, "Default output");
+  var outputSelectionSupported = audioOutputSelectionSupported();
+  setSelectOptions(
+    speakerSelect,
+    outputSelectionSupported ? speakers : [],
+    outputSelectionSupported ? "Default output" : "Use system output"
+  );
+  applyAudioOutputCapability();
   // Restore saved device selections from localStorage if not already set
   if (!selectedMicId) {
     selectedMicId = echoGet("echo-device-mic") || "";
@@ -125,7 +167,10 @@ async function refreshDevices() {
     else selectedSpeakerId = "";
   }
   if (allLabelsEmpty) {
-    setDeviceStatus("Devices detected but permissions not granted. On Mac: System Settings → Privacy & Security → Microphone/Camera, then restart the app.", true);
+    setDeviceStatus(devicePermissionGuidance({
+      macOS: typeof _isMacOSDevice !== "undefined" && _isMacOSDevice,
+      nativeShell: window.__ECHO_NATIVE__ === true,
+    }), true);
   } else if (!mics.length && !cams.length) {
     setDeviceStatus("No audio or video devices found. Check permissions.");
   } else if (!mics.length) {

--- a/core/viewer/rnnoise.js
+++ b/core/viewer/rnnoise.js
@@ -4,9 +4,25 @@
 
 // Mobile device detection — variable declared in state.js, assigned here
 var _isMobileDevice = /Android|iPhone|iPad|iPod|Mobile/i.test(navigator.userAgent);
+var _isMacOSDevice = (function() {
+  try {
+    var uaPlatform = navigator.userAgentData && navigator.userAgentData.platform;
+    if (uaPlatform && /mac/i.test(uaPlatform)) return true;
+  } catch (e) {}
+  var platform = navigator.platform || "";
+  var ua = navigator.userAgent || "";
+  return /Mac/i.test(platform) || /Macintosh|Mac OS X/i.test(ua);
+})();
+
+function isNoiseCancellationBlockedForPlatform() {
+  return _isMacOSDevice && !_isMobileDevice;
+}
 
 // ── State vars that depend on echoGet (settings.js) ──
-let noiseCancelEnabled = echoGet("echo-noise-cancel") !== "false"; // Default ON (#59)
+// Keep desktop macOS on the direct microphone publication path. Replacing the
+// sender track with the optional RNNoise Web Audio graph has historically made
+// a working Mac microphone go silent after join while video remains healthy.
+let noiseCancelEnabled = !isNoiseCancellationBlockedForPlatform() && echoGet("echo-noise-cancel") !== "false"; // Default ON (#59)
 let ncSuppressionLevel = parseInt(echoGet("echo-nc-level") || "1", 10); // 0=light, 1=medium, 2=strong
 
 // Detects SIMD support for optimal WASM variant
@@ -21,6 +37,10 @@ async function detectSimdSupport() {
 // Noise cancellation applies ONLY to the microphone track — never screen share audio
 // Skip on mobile — too CPU-heavy and .wasm fetch triggers Samsung download interceptor
 async function enableNoiseCancellation() {
+  if (isNoiseCancellationBlockedForPlatform()) {
+    debugLog("[noise-cancel] Skipped on macOS to preserve microphone stability");
+    return;
+  }
   if (_isMobileDevice) { debugLog("[noise-cancel] Skipped on mobile device"); return; }
   if (!room || !micEnabled) return;
   var LK = getLiveKitClient();
@@ -157,7 +177,10 @@ function disableNoiseCancellation() {
 function updateNoiseCancelUI() {
   var btn = document.getElementById("nc-toggle-btn");
   if (btn) {
-    btn.textContent = noiseCancelEnabled ? "ON" : "OFF";
-    btn.classList.toggle("is-on", noiseCancelEnabled);
+    var blocked = isNoiseCancellationBlockedForPlatform();
+    btn.textContent = !blocked && noiseCancelEnabled ? "ON" : "OFF";
+    btn.classList.toggle("is-on", !blocked && noiseCancelEnabled);
+    btn.disabled = blocked;
+    btn.title = blocked ? "Unavailable on macOS while microphone stability is being hardened" : "";
   }
 }

--- a/core/viewer/rnnoise.test.js
+++ b/core/viewer/rnnoise.test.js
@@ -1,0 +1,83 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const vm = require("node:vm");
+
+const source = fs.readFileSync(path.join(__dirname, "rnnoise.js"), "utf8");
+
+function loadRnnoise(options = {}) {
+  const logs = [];
+  const context = {
+    navigator: {
+      userAgent: options.userAgent || "",
+      platform: options.platform || "",
+      userAgentData: options.userAgentData,
+    },
+    echoGet(key) {
+      return key === "echo-noise-cancel" ? options.savedNoiseCancel ?? null : null;
+    },
+    debugLog(message) {
+      logs.push(message);
+    },
+  };
+  vm.createContext(context);
+  vm.runInContext(source, context, { filename: "rnnoise.js" });
+  return {
+    context,
+    logs,
+    blocked: vm.runInContext("isNoiseCancellationBlockedForPlatform()", context),
+    enabled: vm.runInContext("noiseCancelEnabled", context),
+  };
+}
+
+test("desktop macOS blocks the optional RNNoise sender-track replacement", () => {
+  const loaded = loadRnnoise({
+    platform: "MacIntel",
+    userAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_5)",
+    savedNoiseCancel: "true",
+  });
+
+  assert.equal(loaded.blocked, true);
+  assert.equal(loaded.enabled, false);
+});
+
+test("macOS detection supports Chromium userAgentData", () => {
+  const loaded = loadRnnoise({
+    platform: "",
+    userAgent: "Mozilla/5.0",
+    userAgentData: { platform: "macOS" },
+  });
+
+  assert.equal(loaded.blocked, true);
+  assert.equal(loaded.enabled, false);
+});
+
+test("Windows keeps the existing RNNoise default and saved preference", () => {
+  const defaultOn = loadRnnoise({
+    platform: "Win32",
+    userAgent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64)",
+  });
+  const savedOff = loadRnnoise({
+    platform: "Win32",
+    userAgent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64)",
+    savedNoiseCancel: "false",
+  });
+
+  assert.equal(defaultOn.blocked, false);
+  assert.equal(defaultOn.enabled, true);
+  assert.equal(savedOff.blocked, false);
+  assert.equal(savedOff.enabled, false);
+});
+
+test("macOS enable request exits before touching room or media state", async () => {
+  const loaded = loadRnnoise({
+    platform: "MacIntel",
+    userAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_5)",
+  });
+
+  await vm.runInContext("enableNoiseCancellation()", loaded.context);
+  assert.deepEqual(loaded.logs, [
+    "[noise-cancel] Skipped on macOS to preserve microphone stability",
+  ]);
+});

--- a/core/viewer/screen-share-config.js
+++ b/core/viewer/screen-share-config.js
@@ -2,7 +2,18 @@
    SCREEN SHARE — Publish options builder
    ========================================================= */
 
-function getScreenSharePublishOptions(srcW, srcH) {
+function getScreenSharePublishOptions(srcW, srcH, conservativeBrowserShare) {
+  // The Mac web canary favors a direct, single-layer 30fps publication over
+  // the Chromium/NVENC-oriented canvas and three-layer 60fps path.
+  if (conservativeBrowserShare) {
+    debugLog("[simulcast] conservative browser share — direct single layer");
+    return {
+      videoCodec: "h264",
+      simulcast: false,
+      screenShareEncoding: { maxBitrate: 5_000_000, maxFramerate: 30 },
+      degradationPreference: "balanced",
+    };
+  }
   // Performance Mode: single layer, reduced settings — saves GPU on weak hardware
   if (performanceMode) {
     debugLog("[simulcast] performance mode — single layer screen share");

--- a/core/viewer/screen-share-config.test.js
+++ b/core/viewer/screen-share-config.test.js
@@ -1,0 +1,41 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const vm = require("node:vm");
+
+function loadConfig(performanceMode) {
+  const logs = [];
+  const context = {
+    performanceMode: !!performanceMode,
+    debugLog(message) { logs.push(message); },
+  };
+  vm.createContext(context);
+  vm.runInContext(
+    fs.readFileSync(path.join(__dirname, "screen-share-config.js"), "utf8"),
+    context,
+    { filename: "screen-share-config.js" }
+  );
+  return { context, logs };
+}
+
+test("conservative browser publishing is single-layer 30fps", () => {
+  const { context } = loadConfig(false);
+  const options = context.getScreenSharePublishOptions(2560, 1440, true);
+
+  assert.equal(options.videoCodec, "h264");
+  assert.equal(options.simulcast, false);
+  assert.equal(options.screenShareEncoding.maxBitrate, 5_000_000);
+  assert.equal(options.screenShareEncoding.maxFramerate, 30);
+  assert.equal(options.degradationPreference, "balanced");
+});
+
+test("ordinary browser publishing retains the existing simulcast profile", () => {
+  const { context } = loadConfig(false);
+  const options = context.getScreenSharePublishOptions(1920, 1080, false);
+
+  assert.equal(options.simulcast, true);
+  assert.equal(options.screenShareEncoding.maxBitrate, 15_000_000);
+  assert.equal(options.screenShareEncoding.maxFramerate, 60);
+  assert.equal(options.screenShareSimulcastLayers.length, 2);
+});

--- a/core/viewer/screen-share-native.js
+++ b/core/viewer/screen-share-native.js
@@ -38,6 +38,58 @@ function _stringOrNull(value) {
   return String(value);
 }
 
+function _isDesktopMacOSBrowser(navigatorLike) {
+  var nav = navigatorLike || {};
+  var uaPlatform = "";
+  try {
+    uaPlatform = nav.userAgentData && nav.userAgentData.platform || "";
+  } catch (e) {}
+  return /mac/i.test(uaPlatform) ||
+    /Mac/i.test(nav.platform || "") ||
+    /Macintosh|Mac OS X/i.test(nav.userAgent || "");
+}
+
+function shouldUseConservativeBrowserScreenShare(options) {
+  var opts = options || {};
+  if (opts.nativeClient) return false;
+  return _isDesktopMacOSBrowser(opts.navigatorLike) ||
+    opts.canvasCaptureSupported !== true ||
+    opts.workerSupported !== true;
+}
+
+function buildBrowserDisplayMediaConstraints(conservative) {
+  if (conservative) {
+    // Safari and Mac Chromium get the standards-only, lower-cost request.
+    // System audio is intentionally not promised on the web canary.
+    return {
+      video: { frameRate: { ideal: 30 } },
+      audio: true,
+    };
+  }
+  return {
+    video: {
+      frameRate: { ideal: 60 },
+      resizeMode: "none",
+    },
+    surfaceSwitching: "exclude",
+    selfBrowserSurface: "exclude",
+    preferCurrentTab: false,
+    audio: {
+      autoGainControl: false,
+      echoCancellation: false,
+      noiseSuppression: false,
+    },
+    systemAudio: "include",
+  };
+}
+
+function stopBrowserCaptureStream(stream) {
+  if (!stream || typeof stream.getTracks !== "function") return;
+  stream.getTracks().forEach(function(track) {
+    try { track.stop(); } catch (e) {}
+  });
+}
+
 function buildCaptureSourceReport(source, captureRoute, publishProfile) {
   if (!source) return null;
   var sourceType = source.sourceType || source.source_type || null;
@@ -507,31 +559,25 @@ async function startScreenShareManual() {
   }
 
   // ── Browser path (getDisplayMedia) ──
-  var gdmConstraints = {
-    video: {
-      // Capture at native resolution — NVENC handles 4K with zero CPU cost.
-      // No width/height cap so 4K monitors capture at 3840x2160.
-      frameRate: { ideal: 60 },
-      // Don't resize window captures to monitor resolution — preserve native window size.
-      // Without this, sharing a small window on an ultrawide captures at 3432x1440 and stretches.
-      resizeMode: "none",
-    },
-    surfaceSwitching: "exclude",
-    selfBrowserSurface: "exclude",
-    preferCurrentTab: false,
-  };
-  // Always request audio from getDisplayMedia — works as baseline for all clients
-  // Native client will additionally try WASAPI per-process capture for better quality
-  gdmConstraints.audio = {
-    autoGainControl: false,
-    echoCancellation: false,
-    noiseSuppression: false,
-  };
-  gdmConstraints.systemAudio = "include";
+  if (!navigator.mediaDevices || typeof navigator.mediaDevices.getDisplayMedia !== "function") {
+    throw new Error("Screen sharing is not supported by this browser.");
+  }
+  var conservativeBrowserShare = shouldUseConservativeBrowserScreenShare({
+    nativeClient: isNativeClient,
+    navigatorLike: navigator,
+    canvasCaptureSupported: typeof HTMLCanvasElement !== "undefined" &&
+      typeof HTMLCanvasElement.prototype.captureStream === "function",
+    workerSupported: typeof Worker === "function",
+  });
+  var gdmConstraints = buildBrowserDisplayMediaConstraints(conservativeBrowserShare);
   const stream = await navigator.mediaDevices.getDisplayMedia(gdmConstraints);
 
   // Log the actual capture frame rate
   const videoMst = stream.getVideoTracks()[0];
+  if (!videoMst) {
+    stopBrowserCaptureStream(stream);
+    throw new Error("The browser did not provide a screen video track.");
+  }
   if (videoMst) {
     const settings = videoMst.getSettings();
     debugLog("Screen capture actual FPS: " + (settings.frameRate || "unknown") +
@@ -540,7 +586,7 @@ async function startScreenShareManual() {
       sourceType: "browser",
       id: "browser-picker",
       title: settings.displaySurface || videoMst.label || "Browser picker",
-    }, "browser", "desktop");
+    }, conservativeBrowserShare ? "browser-direct" : "browser-canvas", "desktop");
 
     // Set content hint for smooth motion (gaming/video)
     videoMst.contentHint = "motion";
@@ -550,9 +596,10 @@ async function startScreenShareManual() {
     // Drawing through a canvas creates a new track without this flag, unlocking 60fps.
     // With NVENC hardware encoding, the canvas drawImage overhead is trivial (GPU-composited).
     // A Web Worker timer drives requestFrame() to avoid setTimeout throttling when occluded.
-    let publishMst;
+    let publishMst = videoMst;
     let canvasW = settings.width || 1920;
     let canvasH = settings.height || 1080;
+    if (!conservativeBrowserShare) {
     // ── Smart downscaling for ultrawide/4K captures ──
     // At 15Mbps/60fps, standard 1080p (2.07M px) gets 0.12 bits/pixel — good.
     // A 3440x1440 ultrawide (4.95M px) gets only 0.05 bpp — causes encoder stalls.
@@ -709,6 +756,10 @@ async function startScreenShareManual() {
     });
     debugLog("Screen capture: canvas pipeline active (" + canvasW + "x" + canvasH + " @60fps captureStream(60), NVENC H264)");
     logEvent("screen-share-start", canvasW + "x" + canvasH + " @60fps canvas+NVENC");
+    } else {
+      debugLog("Screen capture: conservative direct-track pipeline active (" + canvasW + "x" + canvasH + " @up to 30fps)");
+      logEvent("screen-share-start", canvasW + "x" + canvasH + " @up to 30fps browser-direct");
+    }
 
     // ── Resource shedding: tear down pre-warmed room connections ──
     // Each pre-warmed room holds a WebRTC peer connection (ICE, DTLS, STUN keepalives).
@@ -724,10 +775,18 @@ async function startScreenShareManual() {
 
     // Create LiveKit LocalVideoTrack and publish
     _screenShareVideoTrack = new LK.LocalVideoTrack(publishMst, undefined, false);
-    await room.localParticipant.publishTrack(_screenShareVideoTrack, {
-      source: LK.Track.Source.ScreenShare,
-      ...getScreenSharePublishOptions(canvasW, canvasH),
-    });
+    try {
+      await room.localParticipant.publishTrack(_screenShareVideoTrack, {
+        source: LK.Track.Source.ScreenShare,
+        ...getScreenSharePublishOptions(canvasW, canvasH, conservativeBrowserShare),
+      });
+    } catch (publishError) {
+      if (conservativeBrowserShare) {
+        stopBrowserCaptureStream(stream);
+        _screenShareVideoTrack = null;
+      }
+      throw publishError;
+    }
 
     // Set initial sender parameters for simulcast screen share.
     // 3 layers: HIGH (4K@60), MEDIUM (1080p@60), LOW (720p@30).
@@ -736,7 +795,7 @@ async function startScreenShareManual() {
     debugLog("Screen share sender: " + (sender ? "found" : "NULL") +
       " track.sender=" + (typeof _screenShareVideoTrack?.sender) +
       " mediaStreamTrack=" + (publishMst ? publishMst.readyState + " " + publishMst.getSettings().width + "x" + publishMst.getSettings().height : "null"));
-    if (sender) {
+    if (sender && !conservativeBrowserShare) {
       try {
         const params = sender.getParameters();
         debugLog("Screen share encodings BEFORE override: " + JSON.stringify(params.encodings));

--- a/core/viewer/screen-share-native.test.js
+++ b/core/viewer/screen-share-native.test.js
@@ -259,6 +259,143 @@ test("source visibility monitor is only enabled for native window-like sources",
   );
 });
 
+test("Mac browser sharing selects the conservative direct-track profile", () => {
+  const { context } = loadScreenShareNative();
+
+  assert.equal(context.shouldUseConservativeBrowserScreenShare({
+    nativeClient: false,
+    navigatorLike: {
+      platform: "MacIntel",
+      userAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_5)",
+    },
+    canvasCaptureSupported: true,
+    workerSupported: true,
+  }), true);
+});
+
+test("capable Windows browser sharing keeps the existing canvas profile", () => {
+  const { context } = loadScreenShareNative();
+
+  assert.equal(context.shouldUseConservativeBrowserScreenShare({
+    nativeClient: false,
+    navigatorLike: {
+      platform: "Win32",
+      userAgent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64)",
+    },
+    canvasCaptureSupported: true,
+    workerSupported: true,
+  }), false);
+});
+
+test("missing canvas or Worker capability safely selects direct-track sharing", () => {
+  const { context } = loadScreenShareNative();
+  const navigatorLike = {
+    platform: "Linux x86_64",
+    userAgent: "Mozilla/5.0 (X11; Linux x86_64)",
+  };
+
+  assert.equal(context.shouldUseConservativeBrowserScreenShare({
+    nativeClient: false,
+    navigatorLike,
+    canvasCaptureSupported: false,
+    workerSupported: true,
+  }), true);
+  assert.equal(context.shouldUseConservativeBrowserScreenShare({
+    nativeClient: false,
+    navigatorLike,
+    canvasCaptureSupported: true,
+    workerSupported: false,
+  }), true);
+});
+
+test("conservative display request omits Chromium-only system-audio hints", () => {
+  const { context } = loadScreenShareNative();
+  const constraints = context.buildBrowserDisplayMediaConstraints(true);
+
+  assert.equal(constraints.video.frameRate.ideal, 30);
+  assert.equal(constraints.audio, true);
+  assert.equal("systemAudio" in constraints, false);
+  assert.equal("surfaceSwitching" in constraints, false);
+});
+
+test("browser capture cleanup stops every acquired track", () => {
+  const { context } = loadScreenShareNative();
+  const stopped = [];
+  context.stopBrowserCaptureStream({
+    getTracks: () => [
+      { stop: () => stopped.push("video") },
+      { stop: () => stopped.push("audio") },
+    ],
+  });
+
+  assert.deepEqual(stopped, ["video", "audio"]);
+});
+
+test("Mac browser start publishes the original display track without creating a canvas", async () => {
+  const { context } = loadScreenShareNative();
+  const published = [];
+  const optionCalls = [];
+  let canvasCreated = false;
+  const videoTrack = {
+    id: "mac-display-track",
+    readyState: "live",
+    enabled: true,
+    muted: false,
+    label: "Screen 1",
+    getSettings: () => ({ width: 1728, height: 1117, frameRate: 30, displaySurface: "monitor" }),
+    addEventListener() {},
+    stop() {},
+  };
+  const stream = {
+    getVideoTracks: () => [videoTrack],
+    getAudioTracks: () => [],
+    getTracks: () => [videoTrack],
+  };
+
+  context.window.__ECHO_NATIVE__ = false;
+  context.navigator = {
+    platform: "MacIntel",
+    userAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_5)",
+    mediaDevices: { getDisplayMedia: async () => stream },
+  };
+  context.HTMLCanvasElement = function HTMLCanvasElement() {};
+  context.HTMLCanvasElement.prototype.captureStream = function() {};
+  context.Worker = function Worker() {};
+  context.prewarmedRooms = new Map();
+  context._screenShareStatsInterval = null;
+  context.logEvent = () => {};
+  context.renderPublishButtons = () => {};
+  context.getScreenSharePublishOptions = (width, height, conservative) => {
+    optionCalls.push({ width, height, conservative });
+    return { simulcast: false };
+  };
+  context.getLiveKitClient = () => ({
+    Track: { Source: { ScreenShare: "screen_share", ScreenShareAudio: "screen_share_audio" } },
+    LocalVideoTrack: class {
+      constructor(mediaStreamTrack) {
+        this.mediaStreamTrack = mediaStreamTrack;
+        this.sender = null;
+      }
+    },
+  });
+  context.room.localParticipant.publishTrack = async (track, options) => {
+    published.push({ track, options });
+  };
+  context.document.createElement = () => {
+    canvasCreated = true;
+    throw new Error("Mac direct-track route must not create a canvas");
+  };
+
+  await context.startScreenShareManual();
+
+  assert.equal(canvasCreated, false);
+  assert.equal(published.length, 1);
+  assert.equal(published[0].track.mediaStreamTrack, videoTrack);
+  assert.equal(published[0].options.source, "screen_share");
+  assert.deepEqual(optionCalls, [{ width: 1728, height: 1117, conservative: true }]);
+  assert.equal(context.window._echoCaptureSourceReport.capture_route, "browser-direct");
+});
+
 test("monitor audio capture requests system audio with Echo playback excluded", () => {
   const { context } = loadScreenShareNative();
 

--- a/core/viewer/theme.js
+++ b/core/viewer/theme.js
@@ -4,6 +4,11 @@
 
 // ── Version info + Update button at bottom of settings ──
 // Called after room connect so it appears at the bottom (after device/NC/chime sections)
+function shouldShowDesktopUpdater(options) {
+  var opts = options || {};
+  return opts.nativeShell === true && opts.hasIpc === true;
+}
+
 function buildVersionSection() {
   if (!settingsDevicePanel) return;
   if (document.getElementById("version-settings-section")) return; // already built
@@ -25,7 +30,11 @@ function buildVersionSection() {
   updateStatus.id = "update-status";
   updateStatus.style.cssText = "font-size:12px; opacity:0.7; margin-left:4px;";
   versionRow.appendChild(versionLabel);
-  versionRow.appendChild(updateBtn);
+  var showDesktopUpdater = shouldShowDesktopUpdater({
+    nativeShell: window.__ECHO_NATIVE__ === true,
+    hasIpc: hasTauriIPC(),
+  });
+  if (showDesktopUpdater) versionRow.appendChild(updateBtn);
   versionRow.appendChild(updateStatus);
   section.appendChild(versionRow);
   settingsDevicePanel.appendChild(section);
@@ -43,6 +52,11 @@ function buildVersionSection() {
       versionLabel.textContent = "Version: unknown";
     }
   })();
+
+  if (!showDesktopUpdater) {
+    updateStatus.textContent = "Updates automatically with the Echo server.";
+    return;
+  }
 
   // Check for updates — query server /api/version then try Tauri auto-update
   updateBtn.addEventListener("click", async function() {

--- a/core/viewer/web-capabilities.test.js
+++ b/core/viewer/web-capabilities.test.js
@@ -1,0 +1,61 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const vm = require("node:vm");
+
+function loadScript(fileName, endMarker, extraContext = {}) {
+  const context = {
+    togglePg13Button: null,
+    ...extraContext,
+  };
+  let source = fs.readFileSync(path.join(__dirname, fileName), "utf8");
+  if (endMarker) source = source.slice(0, source.indexOf(endMarker));
+  vm.createContext(context);
+  vm.runInContext(
+    source,
+    context,
+    { filename: fileName }
+  );
+  return context;
+}
+
+test("browser output selection follows setSinkId capability", () => {
+  const context = loadScript("media-controls.js", "async function ensureDevicePermissions");
+
+  assert.equal(context.shouldEnableAudioOutputSelection({
+    nativeIpc: false,
+    setSinkIdSupported: true,
+  }), true);
+  assert.equal(context.shouldEnableAudioOutputSelection({
+    nativeIpc: false,
+    setSinkIdSupported: false,
+  }), false);
+});
+
+test("native IPC keeps existing Windows output controls enabled", () => {
+  const context = loadScript("media-controls.js", "async function ensureDevicePermissions");
+
+  assert.equal(context.shouldEnableAudioOutputSelection({
+    nativeIpc: true,
+    setSinkIdSupported: false,
+  }), true);
+});
+
+test("Mac browser permission guidance points to site and OS controls", () => {
+  const context = loadScript("media-controls.js", "async function ensureDevicePermissions");
+  const message = context.devicePermissionGuidance({ macOS: true, nativeShell: false });
+
+  assert.match(message, /Echo site/);
+  assert.match(message, /macOS Privacy & Security/);
+  assert.match(message, /reload/);
+  assert.doesNotMatch(message, /restart Echo/);
+});
+
+test("desktop updater action is native-shell only", () => {
+  const context = loadScript("theme.js", "function buildVersionSection");
+
+  assert.equal(context.shouldShowDesktopUpdater({ nativeShell: true, hasIpc: true }), true);
+  assert.equal(context.shouldShowDesktopUpdater({ nativeShell: false, hasIpc: true }), false);
+  assert.equal(context.shouldShowDesktopUpdater({ nativeShell: true, hasIpc: false }), false);
+});

--- a/docs/MACOS-CANARY-GATE-A.md
+++ b/docs/MACOS-CANARY-GATE-A.md
@@ -1,0 +1,162 @@
+# macOS Apple Silicon Canary: Gate A Audit
+
+Date: 2026-07-21
+
+## Baseline
+
+- Worktree: `F:\EC-worktrees\macos-client-canary`
+- Branch: `codex/macos-client-canary`
+- Baseline: `d6191a5fd212428ba4243f4e6e5af896d7dc627f` (`origin/main`)
+- Baseline desktop/control version: `0.6.33`
+- Live `/api/version`: `0.6.33`; live `/health`: healthy
+- Live `EchoCoreHost` is running the control binary from
+  `F:\EC-worktrees\main`, not this worktree. Gate A made no live changes.
+
+The historical `origin/codex/macos-build-enable` branch and
+`mac-audio-canary-0.6.11-1` tag are evidence only. Their useful implementation
+is a five-line macOS bundle override, an isolated manual workflow, and a viewer
+guard that disables RNNoise sender track replacement on macOS. The branch also
+contains dated session/changelog material and must not be merged wholesale.
+
+## Current architecture findings
+
+- `core/client/Cargo.toml` correctly limits LiveKit/libwebrtc,
+  `windows-capture`, and Windows APIs to `cfg(windows)`.
+- `main.rs` has non-Windows stubs for process/system audio capture and output
+  routing. Windows capture, presenter, placement, GPU, Spotify source-host, and
+  capture-health state are compile-gated.
+- Tauri already carries microphone/camera usage descriptions and camera/audio
+  input entitlements. Its default bundle target remains Windows `nsis`, so Mac
+  needs a separate config override rather than a default change.
+- The shell loads the bundled viewer and injects `window.__ECHO_NATIVE__`.
+  Viewer APIs are redirected to the configured Echo server.
+- Browser mic/camera publishing and all remote media receiving use WebRTC and
+  do not depend on Windows native capture.
+- Native screen publishing prefers Windows IPC, but a missing
+  `list_screen_sources` command already falls back to the browser display-media
+  picker. That fallback is not accepted as reliable Mac screen/system-audio
+  publishing without real-Mac validation.
+- Native presenter and display-placement commands are Windows-only. macOS must
+  remain on ordinary WebRTC video rendering and avoid treating missing native
+  presenter commands as a media failure.
+- Jam join/listen/control is viewer/server behavior. The Spotify source agent,
+  local source-PC switches, WASAPI capture, and Spotify routing are deliberately
+  Windows-only; `is_jam_source_host` already returns false elsewhere.
+- The non-Windows output implementation returns no devices and treats changes
+  as success. Viewer `setSinkId` support may provide routing in WKWebView, but
+  this is an unverified Phase 1 runtime item, not parity evidence.
+- The current updater endpoint is shared with the Windows release channel.
+  Ad-hoc Mac canaries must not create updater artifacts or automatically enter
+  that channel.
+- `/api/client-stats-report` provides authenticated ephemeral health reporting.
+  Calls to `/api/stats-log` are dead: no control route exists and failures are
+  swallowed. There is no durable incident store, shared sanitizer, Mac spool,
+  panic hook, exit sentinel, consent UI, or Admin Diagnostics view.
+
+## Phase 0/1 feature matrix
+
+| Capability | Gate A classification | Phase 0/1 action/evidence |
+| --- | --- | --- |
+| App bundle, launch, configured server | Needs thin Mac packaging | Separate `app,dmg` override; ad-hoc ARM64 CI build |
+| Login, rooms, room switching | Expected now | Viewer regression tests plus real-Mac canary |
+| Microphone, mute/unmute | Needs fallback | Disable RNNoise track swap on macOS; 30-minute real-Mac run |
+| Camera | Expected now | Permission denial/grant and publish tests on real Mac |
+| Remote audio/camera/screen receive | Expected now | Keep WebRTC rendering; platform-gate Windows presenter probes |
+| Chat, themes, tools | Expected now | Viewer smoke test and canary checklist |
+| Reconnect and sleep/wake | Expected, unproven on Mac | Automatic timeline plus real-Mac cycle tests |
+| Output selection | Needs fallback/validation | Use WebKit capability when available; report unsupported behavior honestly |
+| Jam join/listen/control | Expected now | Real-Mac listener/control test |
+| Spotify Jam source host | Explicitly deferred/Windows-only | No Mac source credentials or native source agent |
+| Screen publishing/system audio | Explicitly deferred | ScreenCaptureKit phase; browser picker is experimental only |
+| Intel/universal build | Explicitly deferred | Apple Silicon only |
+| Signing/notarization/Mac updater | Explicitly deferred | Ad-hoc DMG; isolated canary channel metadata |
+| Automatic diagnostics | Missing, mandatory | Complete diagnostics PR before external DMG |
+
+## Focused PR and release boundaries
+
+### PR 1: Private diagnostics foundation
+
+Release impact: **server deploy + server-served viewer update + desktop binary**.
+
+- Versioned, authenticated incident envelopes with strict 256 KiB route limit,
+  participant identity derivation/current-presence checks, rate limits,
+  idempotency, deduplication, two-pass sanitization, 14-day retention, and a
+  250 MiB cap.
+- Extend live stats with bounded platform/build/permission/media health.
+- Admin Diagnostics sessions/timelines/download/delete and explicit creation of
+  a redacted GitHub issue; raw diagnostics never publish automatically.
+- Structured viewer capture, Mac-canary consent/settings, authenticated upload,
+  native atomic spool/panic/exit lifecycle, and acceptance-focused tests.
+- Replace the dead `/api/stats-log` event path with the authenticated lane.
+
+This PR must merge and deploy during a separately approved server window before
+an external diagnostic canary can report successfully.
+
+### PR 2: Apple Silicon packaging and media fallback
+
+Release impact: **Mac desktop binary + server-served viewer update**. Windows
+NSIS behavior and the Windows release workflow remain unchanged.
+
+- macOS-only Tauri bundle override (`app`, `dmg`) with updater artifacts off.
+- Disable RNNoise track replacement on desktop macOS and expose the reason.
+- Explicit platform capability reporting/gating for presenter, screen publish,
+  audio capture/output, updater, and Jam source-host behavior.
+- Manual `workflow_dispatch` on standard `macos-latest`; read-only contents
+  permission; short-lived DMG artifact; no release upload by default.
+
+### Canary release
+
+- Current-main Apple Silicon ad-hoc DMG only after PR 1 is deployed and PR 2
+  passes GitHub compile/bundle verification.
+- No normal Windows release dependency, `latest.json` change, signing,
+  notarization, updater rollout, Intel build, or live service disruption.
+
+## Gate A completion / Gate B order
+
+1. Land diagnostics schema, sanitization, storage, abuse controls, and tests.
+2. Add authenticated viewer collection and Admin Diagnostics.
+3. Add native Mac spool, lifecycle/panic reporting, and explicit consent.
+4. Add Mac bundle override, RNNoise fallback, and isolated manual workflow.
+5. Run local Rust/viewer/control tests; run GitHub Mac workflow only when the
+   branch is ready for a meaningful compile artifact.
+6. During an approved window, deploy the server portion and validate malformed,
+   oversized, stale, unauthenticated, duplicate, over-rate, and redaction cases.
+7. Collect tester hardware facts, distribute the DMG, and execute permission,
+   forced JS/native error, force-kill/relaunch, reconnect, and 30-minute mic
+   acceptance tests.
+
+## Approved web-first route
+
+Sam approved a hardened browser canary as the first delivery route on
+2026-07-21. This does not replace the native Apple Silicon track; it moves the
+fastest low-risk compatibility evidence ahead of packaging and native work.
+
+The first implementation slice is intentionally server-served viewer only:
+
+- Disable the optional RNNoise sender-track replacement on desktop macOS and
+  keep the direct microphone publication path.
+- Keep Windows and other desktop platforms on their existing behavior.
+- Add deterministic platform and preference regression coverage.
+- Do not change the Windows native capture block, NSIS packaging, updater,
+  control plane, live deployment, or running clients.
+
+Follow-up slices remain separate review boundaries:
+
+1. Conservative browser screen publishing with capability-based direct-track
+   fallback and cleanup tests. Do not promise macOS system audio.
+2. Truthful output-selection and browser-update UI based on actual browser
+   capabilities, not broad platform assumptions.
+3. A private diagnostics control-plane foundation, followed by an explicitly
+   consented browser collector. Existing room/admin authentication is not a
+   sufficiently private owner boundary for diagnostic access and must not be
+   reused as though it were one.
+
+The web route remains a server-served viewer release. Existing Windows desktop
+clients also consume that viewer, so every change must be Mac- or
+capability-gated and must retain the complete Windows viewer regression suite.
+
+## External facts required before distribution
+
+For Spencer and Jeff: exact Mac model/chip, macOS version/build, Terminal
+comfort if Gatekeeper or launch fails, and which person is the primary first
+canary tester.


### PR DESCRIPTION
## What changed

- Keep desktop macOS on Echo's direct microphone publication path and disable the optional RNNoise sender-track replacement.
- Use a conservative direct display track for Mac browser screen sharing instead of the Chromium/NVENC-oriented 60 fps canvas pipeline.
- Request a single H264 layer capped at 30 fps / 5 Mbps for that conservative route.
- Disable browser output selection when `setSinkId` is unavailable and point users to system output.
- Show browser-appropriate permission guidance and hide the desktop updater action outside a native shell.
- Document the current-main audit, feature matrix, and web-first boundaries.

## Why

The historical Mac canary showed that RNNoise track replacement could make an initially working microphone go silent. Current browser screen publishing also assumes a Windows/Chromium hardware-encoding path and forces every share through a 60 fps canvas/Worker pipeline. Those assumptions are inappropriate for a deliberately lower-performance Mac web fallback.

## Safety / preservation

- Branched from current `origin/main` at `d6191a5f`.
- Server-served viewer changes only.
- No control-plane behavior, Windows NSIS packaging, updater endpoint, native Windows capture block, release workflow, or live service changed.
- Capable Windows browser sharing retains the existing canvas/simulcast profile.
- Native IPC keeps the existing Windows output controls enabled.
- No deployment is part of this PR.

## Release impact

`release-impact:server-only` — deploys as a server-served viewer snapshot. No desktop binary release is required.

## Verification

- `npm run verify:quick`: 188 tests passed; guardrails passed.
- Full syntax check: all 63 viewer JavaScript files passed.
- Playwright browser layout suite: 68 passed.
- `cargo check -p echo-core-control`: passed (two pre-existing warnings).
- Focused Mac tests cover classic platform detection, Chromium `userAgentData`, direct mic early exit, standards-only display constraints, direct-track publishing without canvas creation, single-layer 30 fps options, capture cleanup, output capability gating, and native updater gating.

## Deliberate limitations

- Mac web system-audio capture is not promised.
- Runtime validation still requires a real Mac using the deployed viewer.
- Private automatic diagnostics are a separate security-sensitive PR because the existing shared room/admin token is not an owner-private authorization boundary.
