### PR TITLE
Add private Mac web diagnostics collector

### DIFF
--- a/core/control/README.md
+++ b/core/control/README.md
@@ -26,6 +26,10 @@ The control plane is a Rust service responsible for:
 - DELETE /v1/rooms/{roomId}
 - GET /v1/metrics
 
+`GET /api/version` includes the control/viewer release version and the exact
+short Git SHA compiled into the control binary. Set `ECHO_GIT_SHA` explicitly
+for source-less packaging; normal repository builds discover it from Git.
+
 Notes:
 - LiveKit API key/secret are used to sign access tokens.
 - Admin auth is separate from room password.

--- a/core/control/build.rs
+++ b/core/control/build.rs
@@ -1,0 +1,66 @@
+use std::{env, path::PathBuf, process::Command};
+
+fn git_output(args: &[&str]) -> Option<String> {
+    let output = Command::new("git").args(args).output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let value = String::from_utf8(output.stdout).ok()?;
+    let value = value.trim();
+    (!value.is_empty()).then(|| value.to_owned())
+}
+
+fn valid_git_sha(value: &str) -> bool {
+    (7..=40).contains(&value.len())
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
+}
+
+fn short_sha(value: String) -> String {
+    value.chars().take(12).collect()
+}
+
+fn watch_git_path(path: Option<String>) {
+    let Some(path) = path else {
+        return;
+    };
+    let path = PathBuf::from(path);
+    if path.exists() {
+        println!("cargo:rerun-if-changed={}", path.display());
+    }
+}
+
+fn main() {
+    println!("cargo:rerun-if-env-changed=ECHO_GIT_SHA");
+
+    // Worktrees keep HEAD and branch refs under the repository's shared git
+    // directory. Watching both paths prevents an incremental control build from
+    // reporting the SHA from an earlier viewer-only commit.
+    watch_git_path(git_output(&["rev-parse", "--git-path", "HEAD"]));
+    if let Some(symbolic_ref) = git_output(&["symbolic-ref", "-q", "HEAD"]) {
+        watch_git_path(git_output(&["rev-parse", "--git-path", &symbolic_ref]));
+    }
+
+    let configured = match env::var("ECHO_GIT_SHA") {
+        Ok(value) => {
+            let value = value.trim().to_ascii_lowercase();
+            assert!(
+                valid_git_sha(&value),
+                "ECHO_GIT_SHA must contain 7 to 40 hexadecimal characters"
+            );
+            Some(short_sha(value))
+        }
+        Err(env::VarError::NotPresent) => None,
+        Err(env::VarError::NotUnicode(_)) => panic!("ECHO_GIT_SHA must be valid Unicode"),
+    };
+    let discovered = git_output(&["rev-parse", "--short=12", "HEAD"])
+        .map(|value| value.to_ascii_lowercase())
+        .filter(|value| valid_git_sha(value))
+        .map(short_sha);
+    let git_sha = configured
+        .or(discovered)
+        .expect("exact Git metadata is required; build from a Git checkout or set ECHO_GIT_SHA");
+
+    println!("cargo:rustc-env=ECHO_GIT_SHA={git_sha}");
+}

--- a/core/control/src/config.rs
+++ b/core/control/src/config.rs
@@ -165,7 +165,7 @@ pub fn stamp_viewer_index(viewer_dir: &PathBuf, v: &str) {
                 "style.css", "jam.css", "clubhouse-shell.css",
                 "layout-policy.js", "ui-shell.js",
                 "livekit-client.umd.js", "room-switch-state.js", "jam-session-state.js", "publish-state-reconcile.js",
-                "state.js", "debug.js", "urls.js", "settings.js", "display-status.js",
+                "state.js", "debug.js", "urls.js", "settings.js", "diagnostics-client.js", "display-status.js",
                 "native-presenter.js", "identity.js",
                 "rnnoise.js", "chimes.js", "room-status.js", "auth.js", "theme.js",
                 "chat.js", "soundboard.js", "admin-panel.js",
@@ -243,6 +243,7 @@ mod tests {
             <link rel="stylesheet" href="clubhouse-shell.css?v=old" />
             <script src="layout-policy.js?v=old"></script>
             <script src="ui-shell.js?v=old"></script>
+            <script src="diagnostics-client.js?v=old"></script>
             <script src="grid-layout.js?v=old"></script>
             <script src="camera-lobby-layout.js?v=old"></script>
             <script src="display-status.js?v=old"></script>
@@ -259,6 +260,7 @@ mod tests {
         assert!(stamped.contains("clubhouse-shell.css?v=0.6.12.test"));
         assert!(stamped.contains("layout-policy.js?v=0.6.12.test"));
         assert!(stamped.contains("ui-shell.js?v=0.6.12.test"));
+        assert!(stamped.contains("diagnostics-client.js?v=0.6.12.test"));
         assert!(stamped.contains("grid-layout.js?v=0.6.12.test"));
         assert!(stamped.contains("camera-lobby-layout.js?v=0.6.12.test"));
         assert!(stamped.contains("display-status.js?v=0.6.12.test"));

--- a/core/control/src/diagnostics.rs
+++ b/core/control/src/diagnostics.rs
@@ -2638,6 +2638,46 @@ mod tests {
     }
 
     #[test]
+    fn browser_diagnostics_fixture_matches_wire_contract() {
+        let raw = include_bytes!("../testdata/browser-diagnostics-envelope-v1.json");
+        let raw_text = std::str::from_utf8(raw).expect("fixture is UTF-8");
+        for forbidden_field in [
+            "\"message\"",
+            "\"fingerprint\"",
+            "\"identity\"",
+            "\"participant\"",
+            "\"room\"",
+            "\"token\"",
+            "\"email\"",
+            "\"device_label\"",
+        ] {
+            assert!(
+                !raw_text.contains(forbidden_field),
+                "browser fixture must not contain {forbidden_field}"
+            );
+        }
+
+        let parsed = parse_validate_and_sanitize(raw, NOW).expect("valid browser envelope");
+        assert_eq!(parsed.schema_version, INCIDENT_SCHEMA_VERSION);
+        assert_eq!(parsed.app.git_sha, "ceaaf6f1034a");
+        assert_eq!(parsed.app.channel, "web-canary");
+        assert_eq!(parsed.app.runtimes.browser_name.as_deref(), Some("Safari"));
+        assert_eq!(parsed.platform.client_kind, ClientKind::Browser);
+        assert_eq!(parsed.platform.operating_system, OperatingSystem::Macos);
+        assert_eq!(parsed.platform.architecture, CpuArchitecture::Unknown);
+        assert_eq!(parsed.platform.os_version, None);
+        assert_eq!(parsed.platform.os_build, None);
+        assert_eq!(parsed.events.len(), 3);
+        assert_eq!(parsed.events[0].code, "session.start");
+        assert_eq!(parsed.events[1].code, "media.devices_observed");
+        assert_eq!(parsed.events[2].code, "connection.connected");
+        assert!(parsed
+            .events
+            .iter()
+            .all(|event| event.message.is_none() && event.fingerprint.is_none()));
+    }
+
+    #[test]
     fn rejects_invalid_ids_timestamps_order_counts_and_strings() {
         let mut value = envelope(1);
         value.envelope_id = "not-an-id".to_owned();

--- a/core/control/src/file_serving.rs
+++ b/core/control/src/file_serving.rs
@@ -26,6 +26,7 @@ pub(crate) async fn health() -> Json<HealthResponse> {
 /// Returns server version and latest available client version from deploy/latest.json.
 pub(crate) async fn api_version() -> Json<serde_json::Value> {
     let server_version = env!("CARGO_PKG_VERSION");
+    let git_sha = env!("ECHO_GIT_SHA");
     let mut latest_client = String::new();
     if let Ok(data) = fs::read_to_string(resolve_deploy_dir().join("latest.json")) {
         if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&data) {
@@ -36,6 +37,7 @@ pub(crate) async fn api_version() -> Json<serde_json::Value> {
     }
     Json(serde_json::json!({
         "version": server_version,
+        "git_sha": git_sha,
         "latest_client": latest_client,
     }))
 }
@@ -56,6 +58,23 @@ pub(crate) async fn api_update_latest() -> axum::response::Response {
             "latest.json not found — no update available",
         )
             .into_response(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn version_response_exposes_the_compiled_git_revision() {
+        let Json(payload) = api_version().await;
+        let git_sha = payload["git_sha"].as_str().expect("git_sha string");
+        assert_eq!(git_sha, env!("ECHO_GIT_SHA"));
+        assert!((7..=12).contains(&git_sha.len()));
+        assert!(git_sha
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f')));
+        assert_eq!(payload["version"], env!("CARGO_PKG_VERSION"));
     }
 }
 

--- a/core/control/src/main.rs
+++ b/core/control/src/main.rs
@@ -608,6 +608,7 @@ async fn main() {
                 "clubhouse-shell.css",
                 "layout-policy.js",
                 "ui-shell.js",
+                "diagnostics-client.js",
                 "grid-layout.js",
                 "index.html",
                 "connect.js",

--- a/core/control/testdata/browser-diagnostics-envelope-v1.json
+++ b/core/control/testdata/browser-diagnostics-envelope-v1.json
@@ -1,0 +1,60 @@
+{
+  "schema_version": 1,
+  "envelope_id": "11111111-1111-4111-8111-111111111111",
+  "install_id": "22222222-2222-4222-8222-222222222222",
+  "session_id": "33333333-3333-4333-8333-333333333333",
+  "captured_at_ms": 1784999999000,
+  "sent_at_ms": 1785000000000,
+  "app": {
+    "version": "0.6.33",
+    "git_sha": "ceaaf6f1034a",
+    "channel": "web-canary",
+    "runtimes": {
+      "browser_name": "Safari",
+      "browser_version": "18.5",
+      "livekit_version": "2.15.4"
+    }
+  },
+  "platform": {
+    "client_kind": "browser",
+    "operating_system": "macos",
+    "architecture": "unknown"
+  },
+  "events": [
+    {
+      "sequence": 1,
+      "timestamp_ms": 1784999999100,
+      "event_type": "session_start",
+      "severity": "info",
+      "code": "session.start",
+      "details": {
+        "stage": "browser",
+        "started": true
+      }
+    },
+    {
+      "sequence": 2,
+      "timestamp_ms": 1784999999500,
+      "event_type": "media",
+      "severity": "info",
+      "code": "media.devices_observed",
+      "details": {
+        "camera": 1,
+        "granted": false,
+        "microphone": 2,
+        "output": 1
+      }
+    },
+    {
+      "sequence": 3,
+      "timestamp_ms": 1784999999900,
+      "event_type": "connection",
+      "severity": "info",
+      "code": "connection.connected",
+      "details": {
+        "connection_state": "connected",
+        "error_code": "unknown"
+      }
+    }
+  ]
+}

--- a/core/viewer-tests/tests/web-diagnostics-consent.spec.js
+++ b/core/viewer-tests/tests/web-diagnostics-consent.spec.js
@@ -1,0 +1,167 @@
+import { expect, test } from "@playwright/test";
+
+const MAC_SAFARI_USER_AGENT = [
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)",
+  "AppleWebKit/605.1.15 (KHTML, like Gecko)",
+  "Version/18.5 Safari/605.1.15",
+].join(" ");
+
+const DIAGNOSTICS_PREFIX = "echo-web-diagnostics-";
+const CONSENT_KEY = `${DIAGNOSTICS_PREFIX}consent-v1`;
+const INSTALL_KEY = `${DIAGNOSTICS_PREFIX}install-v1`;
+const QUEUE_KEY = `${DIAGNOSTICS_PREFIX}queue-v1`;
+const STATUS_KEY = `${DIAGNOSTICS_PREFIX}status-v1`;
+const ACTIVE_KEY = `${DIAGNOSTICS_PREFIX}active-v1`;
+
+test.use({ userAgent: MAC_SAFARI_USER_AGENT });
+
+async function readStorage(page) {
+  return page.evaluate(() => Object.fromEntries(
+    Array.from({ length: localStorage.length }, (_, index) => localStorage.key(index))
+      .filter(Boolean)
+      .map((key) => [key, localStorage.getItem(key)]),
+  ));
+}
+
+function diagnosticsState(storage) {
+  return Object.fromEntries(
+    Object.entries(storage).filter(([key]) => key.startsWith(DIAGNOSTICS_PREFIX)),
+  );
+}
+
+test("Mac web diagnostics remain data-free until consent and can be enabled from Settings", async ({ page }) => {
+  const versionRequests = [];
+  const diagnosticsUploads = [];
+
+  await page.addInitScript(() => {
+    Object.defineProperties(window.navigator, {
+      maxTouchPoints: { configurable: true, get: () => 0 },
+      platform: { configurable: true, get: () => "MacIntel" },
+    });
+  });
+
+  await page.route("**/api/**", async (route) => {
+    const request = route.request();
+    const url = new URL(request.url());
+    if (url.pathname === "/api/version") {
+      versionRequests.push(request.url());
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          version: "0.6.33",
+          git_sha: "abcdef123456",
+          latest_client: "",
+        }),
+      });
+      return;
+    }
+    if (url.pathname === "/api/online") {
+      await route.fulfill({ status: 200, contentType: "application/json", body: "[]" });
+      return;
+    }
+    if (url.pathname === "/api/diagnostics/v1/envelopes") {
+      diagnosticsUploads.push({ method: request.method(), postData: request.postData() });
+      await route.fulfill({ status: 202, contentType: "application/json", body: "{}" });
+      return;
+    }
+    await route.fulfill({
+      status: 501,
+      contentType: "application/json",
+      body: JSON.stringify({ error: "unmodeled viewer-test endpoint" }),
+    });
+  });
+
+  await page.goto("/", { waitUntil: "domcontentloaded" });
+
+  const consentModal = page.locator("#diagnostics-consent-modal");
+  await expect(consentModal).toBeVisible();
+  await expect(consentModal).toContainText("linked to your current Echo participant");
+  await expect(page.locator("#diagnostics-consent-decline")).toBeFocused();
+  await expect(page.locator("#diagnostics-settings-section")).not.toHaveClass(/\bhidden\b/);
+  expect(await page.evaluate(() => ({
+    consent: window.EchoWebDiagnosticsRuntime?.consentState(),
+    platform: navigator.platform,
+    touchPoints: navigator.maxTouchPoints,
+    userAgent: navigator.userAgent,
+  }))).toEqual({
+    consent: "unset",
+    platform: "MacIntel",
+    touchPoints: 0,
+    userAgent: MAC_SAFARI_USER_AGENT,
+  });
+  expect(diagnosticsState(await readStorage(page))).toEqual({});
+  expect(versionRequests).toHaveLength(0);
+  expect(diagnosticsUploads).toHaveLength(0);
+
+  await page.getByRole("button", { name: "Keep Off" }).click();
+  await expect(consentModal).toBeHidden();
+  await expect.poll(() => page.evaluate(() => (
+    window.EchoWebDiagnosticsRuntime?.consentState()
+  ))).toBe("disabled");
+  expect(diagnosticsState(await readStorage(page))).toEqual({
+    [CONSENT_KEY]: "disabled-v1",
+  });
+  expect(versionRequests).toHaveLength(0);
+  expect(diagnosticsUploads).toHaveLength(0);
+
+  await page.reload({ waitUntil: "domcontentloaded" });
+  await expect(consentModal).toBeHidden();
+  await expect(page.locator("#diagnostics-settings-section")).not.toHaveClass(/\bhidden\b/);
+  await expect(page.locator("#diagnostics-enabled-toggle")).not.toBeChecked();
+  expect(diagnosticsState(await readStorage(page))).toEqual({
+    [CONSENT_KEY]: "disabled-v1",
+  });
+  expect(versionRequests).toHaveLength(0);
+  expect(diagnosticsUploads).toHaveLength(0);
+
+  const storageBeforeEnable = await readStorage(page);
+  await page.evaluate(() => setSettingsPanelOpen(true));
+  await expect(page.locator("#settings-panel")).toBeVisible();
+
+  await page.locator("#diagnostics-enabled-toggle").check();
+  await expect(page.locator("#diagnostics-action-status")).toHaveText("Diagnostics are on.");
+  await expect(page.locator("#diagnostics-enabled-toggle")).toBeChecked();
+  await expect.poll(() => versionRequests.length).toBe(1);
+
+  const storageAfterEnable = await readStorage(page);
+  const changedKeys = Array.from(new Set([
+    ...Object.keys(storageBeforeEnable),
+    ...Object.keys(storageAfterEnable),
+  ])).filter((key) => storageBeforeEnable[key] !== storageAfterEnable[key]);
+  expect(changedKeys.every((key) => key.startsWith(DIAGNOSTICS_PREFIX))).toBe(true);
+
+  const enabledState = diagnosticsState(storageAfterEnable);
+  expect(Object.keys(enabledState).sort()).toEqual([
+    ACTIVE_KEY,
+    CONSENT_KEY,
+    INSTALL_KEY,
+    QUEUE_KEY,
+  ].sort());
+  expect(enabledState[CONSENT_KEY]).toBe("enabled-v1");
+  expect(enabledState[INSTALL_KEY]).toMatch(
+    /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+  );
+  expect(enabledState[STATUS_KEY]).toBeUndefined();
+
+  const queue = JSON.parse(enabledState[QUEUE_KEY]);
+  expect(queue.version).toBe(1);
+  expect(queue.envelopes).toEqual([]);
+  expect(queue.draft.events).toEqual([
+    expect.objectContaining({
+      event_type: "session_start",
+      severity: "info",
+      code: "session.start",
+    }),
+  ]);
+  expect(JSON.parse(enabledState[ACTIVE_KEY])).toMatchObject({
+    version: 1,
+    sessions: {
+      [queue.draft.session_id]: expect.objectContaining({
+        started_at_ms: expect.any(Number),
+        last_seen_ms: expect.any(Number),
+      }),
+    },
+  });
+  expect(diagnosticsUploads).toHaveLength(0);
+});

--- a/core/viewer-tests/tests/web-diagnostics-consent.spec.js
+++ b/core/viewer-tests/tests/web-diagnostics-consent.spec.js
@@ -29,6 +29,66 @@ function diagnosticsState(storage) {
   );
 }
 
+test("late diagnostics callbacks from a replaced room are ignored", async ({ page }) => {
+  await page.goto("/", { waitUntil: "domcontentloaded" });
+
+  const result = await page.evaluate(() => {
+    const replacedRoom = {
+      _echoDiagnosticsCommitted: true,
+      _echoExpectedDisconnect: false,
+    };
+    const activeRoom = {
+      _echoDiagnosticsCommitted: true,
+      _echoExpectedDisconnect: false,
+    };
+    const uncommittedRoom = {
+      _echoDiagnosticsCommitted: false,
+      _echoExpectedDisconnect: false,
+    };
+    const expectedDisconnectRoom = {
+      _echoDiagnosticsCommitted: true,
+      _echoExpectedDisconnect: true,
+    };
+    const recorded = [];
+
+    room = activeRoom;
+    const callbackKinds = ["state", "reconnecting", "error"];
+    const replacedResults = callbackKinds.map((kind) => (
+      recordActiveRoomDiagnostic(replacedRoom, () => recorded.push(`replaced:${kind}`))
+    ));
+    const activeResults = callbackKinds.map((kind) => (
+      recordActiveRoomDiagnostic(activeRoom, () => recorded.push(`active:${kind}`))
+    ));
+
+    room = uncommittedRoom;
+    const uncommittedResult = recordActiveRoomDiagnostic(
+      uncommittedRoom,
+      () => recorded.push("uncommitted"),
+    );
+    room = expectedDisconnectRoom;
+    const expectedDisconnectResult = recordActiveRoomDiagnostic(
+      expectedDisconnectRoom,
+      () => recorded.push("expected-disconnect"),
+    );
+
+    return {
+      activeResults,
+      expectedDisconnectResult,
+      recorded,
+      replacedResults,
+      uncommittedResult,
+    };
+  });
+
+  expect(result).toEqual({
+    activeResults: [true, true, true],
+    expectedDisconnectResult: false,
+    recorded: ["active:state", "active:reconnecting", "active:error"],
+    replacedResults: [false, false, false],
+    uncommittedResult: false,
+  });
+});
+
 test("Mac web diagnostics remain data-free until consent and can be enabled from Settings", async ({ page }) => {
   const versionRequests = [];
   const diagnosticsUploads = [];

--- a/core/viewer/connect.js
+++ b/core/viewer/connect.js
@@ -91,6 +91,18 @@ document.addEventListener(
 let switchingRoom = false;
 let connectSequence = 0;
 
+function recordActiveRoomDiagnostic(candidateRoom, recorder) {
+  if (!candidateRoom ||
+      candidateRoom !== room ||
+      candidateRoom._echoDiagnosticsCommitted !== true ||
+      candidateRoom._echoExpectedDisconnect ||
+      typeof recorder !== "function") {
+    return false;
+  }
+  recorder();
+  return true;
+}
+
 var _lastRoomSwitchTime = 0;
 async function switchRoom(roomId) {
   if (!room) return;
@@ -581,9 +593,10 @@ async function connectToRoom({ controlUrl, sfuUrl, roomId, identity, name, reuse
       } else {
         setStatus(`Connection: ${state}`);
       }
-      if (newRoom._echoDiagnosticsCommitted &&
-          !(state === "disconnected" && (_isRoomSwitch || newRoom._echoExpectedDisconnect))) {
-        window.EchoWebDiagnosticsRuntime?.recordConnectionState?.(state, null);
+      if (!(state === "disconnected" && _isRoomSwitch)) {
+        recordActiveRoomDiagnostic(newRoom, () => {
+          window.EchoWebDiagnosticsRuntime?.recordConnectionState?.(state, null);
+        });
       }
     });
   }
@@ -591,8 +604,10 @@ async function connectToRoom({ controlUrl, sfuUrl, roomId, identity, name, reuse
     newRoom.on(LK.RoomEvent.Disconnected, (reason) => {
       const detail = describeDisconnectReason(reason, LK);
       setStatus(`Disconnected: ${detail}`, true);
-      if (newRoom._echoDiagnosticsCommitted && !_isRoomSwitch && !newRoom._echoExpectedDisconnect) {
-        logEvent("room-disconnect", detail);
+      if (!_isRoomSwitch) {
+        recordActiveRoomDiagnostic(newRoom, () => {
+          logEvent("room-disconnect", detail);
+        });
       }
       // Stop the inbound stats poller so its 3s interval doesn't keep firing
       // against a stale token after disconnect. The participants-grid teardown
@@ -607,7 +622,7 @@ async function connectToRoom({ controlUrl, sfuUrl, roomId, identity, name, reuse
     newRoom.on(LK.RoomEvent.SignalReconnecting, () => {
       _isReconnecting = true;
       setStatus("Signal reconnecting...", true);
-      if (newRoom._echoDiagnosticsCommitted) logEvent("signal-reconnecting", "");
+      recordActiveRoomDiagnostic(newRoom, () => logEvent("signal-reconnecting", ""));
       debugLog("[reconnect] signal reconnecting — suppressing chimes and delaying cleanup");
       // Safety: auto-reset after 10s if reconnection stalls
       setTimeout(() => { if (_isReconnecting) { _isReconnecting = false; debugLog("[reconnect] safety timeout — resetting reconnecting flag"); } }, 10000);
@@ -617,7 +632,7 @@ async function connectToRoom({ controlUrl, sfuUrl, roomId, identity, name, reuse
     newRoom.on(LK.RoomEvent.SignalReconnected, () => {
       _isReconnecting = false;
       setStatus("Signal reconnected");
-      if (newRoom._echoDiagnosticsCommitted) logEvent("signal-reconnected", "");
+      recordActiveRoomDiagnostic(newRoom, () => logEvent("signal-reconnected", ""));
       debugLog("[reconnect] signal reconnected — cancelling pending disconnects");
       // Cancel any pending disconnect cleanups — the participant is back
       for (const [pendingKey, pendingTimer] of _pendingDisconnects) {
@@ -645,7 +660,7 @@ async function connectToRoom({ controlUrl, sfuUrl, roomId, identity, name, reuse
     newRoom.on(LK.RoomEvent.Reconnecting, () => {
       _isReconnecting = true;
       setStatus("Reconnecting...", true);
-      if (newRoom._echoDiagnosticsCommitted) logEvent("reconnecting", "");
+      recordActiveRoomDiagnostic(newRoom, () => logEvent("reconnecting", ""));
       debugLog("[reconnect] room reconnecting — suppressing chimes and delaying cleanup");
       setTimeout(() => { if (_isReconnecting) { _isReconnecting = false; debugLog("[reconnect] safety timeout — resetting reconnecting flag"); } }, 10000);
     });
@@ -654,7 +669,7 @@ async function connectToRoom({ controlUrl, sfuUrl, roomId, identity, name, reuse
     newRoom.on(LK.RoomEvent.Reconnected, () => {
       _isReconnecting = false;
       setStatus("Reconnected");
-      if (newRoom._echoDiagnosticsCommitted) logEvent("reconnected", "");
+      recordActiveRoomDiagnostic(newRoom, () => logEvent("reconnected", ""));
       debugLog("[reconnect] room reconnected — cancelling pending disconnects");
       for (const [pendingKey, pendingTimer] of _pendingDisconnects) {
         clearTimeout(pendingTimer);
@@ -679,9 +694,9 @@ async function connectToRoom({ controlUrl, sfuUrl, roomId, identity, name, reuse
   if (LK.RoomEvent?.ConnectionError) {
     newRoom.on(LK.RoomEvent.ConnectionError, (err) => {
       const detail = err?.message || String(err || "unknown");
-      if (newRoom._echoDiagnosticsCommitted) {
+      recordActiveRoomDiagnostic(newRoom, () => {
         window.EchoWebDiagnosticsRuntime?.recordConnectionState?.("error", err?.name);
-      }
+      });
       setStatus(`Connection error: ${detail}`, true);
     });
   }

--- a/core/viewer/connect.js
+++ b/core/viewer/connect.js
@@ -581,13 +581,19 @@ async function connectToRoom({ controlUrl, sfuUrl, roomId, identity, name, reuse
       } else {
         setStatus(`Connection: ${state}`);
       }
+      if (newRoom._echoDiagnosticsCommitted &&
+          !(state === "disconnected" && (_isRoomSwitch || newRoom._echoExpectedDisconnect))) {
+        window.EchoWebDiagnosticsRuntime?.recordConnectionState?.(state, null);
+      }
     });
   }
   if (LK.RoomEvent?.Disconnected) {
     newRoom.on(LK.RoomEvent.Disconnected, (reason) => {
       const detail = describeDisconnectReason(reason, LK);
       setStatus(`Disconnected: ${detail}`, true);
-      logEvent("room-disconnect", detail);
+      if (newRoom._echoDiagnosticsCommitted && !_isRoomSwitch && !newRoom._echoExpectedDisconnect) {
+        logEvent("room-disconnect", detail);
+      }
       // Stop the inbound stats poller so its 3s interval doesn't keep firing
       // against a stale token after disconnect. The participants-grid teardown
       // also calls this, but only when the user actually navigates away —
@@ -601,7 +607,7 @@ async function connectToRoom({ controlUrl, sfuUrl, roomId, identity, name, reuse
     newRoom.on(LK.RoomEvent.SignalReconnecting, () => {
       _isReconnecting = true;
       setStatus("Signal reconnecting...", true);
-      logEvent("signal-reconnecting", "");
+      if (newRoom._echoDiagnosticsCommitted) logEvent("signal-reconnecting", "");
       debugLog("[reconnect] signal reconnecting — suppressing chimes and delaying cleanup");
       // Safety: auto-reset after 10s if reconnection stalls
       setTimeout(() => { if (_isReconnecting) { _isReconnecting = false; debugLog("[reconnect] safety timeout — resetting reconnecting flag"); } }, 10000);
@@ -611,7 +617,7 @@ async function connectToRoom({ controlUrl, sfuUrl, roomId, identity, name, reuse
     newRoom.on(LK.RoomEvent.SignalReconnected, () => {
       _isReconnecting = false;
       setStatus("Signal reconnected");
-      logEvent("signal-reconnected", "");
+      if (newRoom._echoDiagnosticsCommitted) logEvent("signal-reconnected", "");
       debugLog("[reconnect] signal reconnected — cancelling pending disconnects");
       // Cancel any pending disconnect cleanups — the participant is back
       for (const [pendingKey, pendingTimer] of _pendingDisconnects) {
@@ -639,7 +645,7 @@ async function connectToRoom({ controlUrl, sfuUrl, roomId, identity, name, reuse
     newRoom.on(LK.RoomEvent.Reconnecting, () => {
       _isReconnecting = true;
       setStatus("Reconnecting...", true);
-      logEvent("reconnecting", "");
+      if (newRoom._echoDiagnosticsCommitted) logEvent("reconnecting", "");
       debugLog("[reconnect] room reconnecting — suppressing chimes and delaying cleanup");
       setTimeout(() => { if (_isReconnecting) { _isReconnecting = false; debugLog("[reconnect] safety timeout — resetting reconnecting flag"); } }, 10000);
     });
@@ -648,7 +654,7 @@ async function connectToRoom({ controlUrl, sfuUrl, roomId, identity, name, reuse
     newRoom.on(LK.RoomEvent.Reconnected, () => {
       _isReconnecting = false;
       setStatus("Reconnected");
-      logEvent("reconnected", "");
+      if (newRoom._echoDiagnosticsCommitted) logEvent("reconnected", "");
       debugLog("[reconnect] room reconnected — cancelling pending disconnects");
       for (const [pendingKey, pendingTimer] of _pendingDisconnects) {
         clearTimeout(pendingTimer);
@@ -673,6 +679,9 @@ async function connectToRoom({ controlUrl, sfuUrl, roomId, identity, name, reuse
   if (LK.RoomEvent?.ConnectionError) {
     newRoom.on(LK.RoomEvent.ConnectionError, (err) => {
       const detail = err?.message || String(err || "unknown");
+      if (newRoom._echoDiagnosticsCommitted) {
+        window.EchoWebDiagnosticsRuntime?.recordConnectionState?.("error", err?.name);
+      }
       setStatus(`Connection error: ${detail}`, true);
     });
   }
@@ -1331,10 +1340,15 @@ async function connectToRoom({ controlUrl, sfuUrl, roomId, identity, name, reuse
     autoSubscribe: true,
     rtcConfig: { iceServers: iceServers },
   });
-  if (seq !== connectSequence) { newRoom.disconnect(); return; }
+  if (seq !== connectSequence) {
+    newRoom._echoExpectedDisconnect = true;
+    newRoom.disconnect();
+    return;
+  }
 
   // New room is connected — NOW disconnect old room and swap
   if (hadOldRoom && oldRoom) {
+    oldRoom._echoExpectedDisconnect = true;
     oldRoom.disconnect();
     clearMedia();
     clearSoundboardState();
@@ -1345,6 +1359,9 @@ async function connectToRoom({ controlUrl, sfuUrl, roomId, identity, name, reuse
   // Commit credentials only after the SFU connection and room swap succeed. A
   // failed or superseded switch must keep the old room's participant token so
   // heartbeat, Jam, chat, and native-presenter requests remain authenticated.
+  window.EchoWebDiagnosticsRuntime?.credentialBoundary?.(hadOldRoom || !!currentAccessToken);
+  newRoom._echoDiagnosticsCommitted = true;
+  window.EchoWebDiagnosticsRuntime?.recordConnectionState?.("connected", null);
   currentAccessToken = window.EchoRoomSwitchState &&
     typeof window.EchoRoomSwitchState.commitConnectedAccessToken === "function"
     ? window.EchoRoomSwitchState.commitConnectedAccessToken(tokenCache, roomId, accessToken)
@@ -1721,6 +1738,7 @@ async function connect() {
   try {
     await connectToRoom({ controlUrl, sfuUrl, roomId: roomName, identity, name, reuseAdmin: false });
   } catch (err) {
+    window.EchoWebDiagnosticsRuntime?.recordConnectionState?.("failed", err?.name);
     setStatus(err.message || "Connect failed", true);
     // Show password field so user can re-enter credentials
     var pwField = document.getElementById("password-field");
@@ -1752,6 +1770,7 @@ async function disconnect() {
   _screenShareVideoTrack = null;
   _screenShareAudioTrack = null;
   disableNoiseCancellation();
+  room._echoExpectedDisconnect = true;
   room.disconnect();
   room = null;
   cleanupPrewarmedRooms(); // Clean up pre-warmed connections and token cache

--- a/core/viewer/debug.js
+++ b/core/viewer/debug.js
@@ -26,22 +26,14 @@ function debugLog(message) {
   }
 }
 
-// ── Persistent event logging (server-side JSONL) ──
-// Captures important events (freeze, screen share start/stop, layer changes)
-// to daily stats log files for offline diagnosis.
-function logEvent(eventName, detail) {
+// Legacy call sites feed the consented structured diagnostics collector. The
+// old endpoint never existed, and free-form `detail` is deliberately ignored.
+function logEvent(eventName, _detail) {
   try {
-    if (!room?.localParticipant?.identity) return;
-    fetch(apiUrl("/api/stats-log"), {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        identity: room.localParticipant.identity,
-        room: currentRoomName || "",
-        event: eventName,
-        event_detail: detail || null,
-      }),
-    }).catch(function() {});
+    var diagnostics = typeof window !== "undefined" ? window.EchoWebDiagnosticsRuntime : null;
+    if (diagnostics && typeof diagnostics.recordLegacyEvent === "function") {
+      diagnostics.recordLegacyEvent(eventName);
+    }
   } catch (e) {}
 }
 
@@ -169,5 +161,6 @@ if (typeof module === "object" && module.exports) {
   module.exports = {
     buildNativePresenterDebugFallback,
     getNativePresenterDebugReport,
+    logEvent,
   };
 }

--- a/core/viewer/debug.test.js
+++ b/core/viewer/debug.test.js
@@ -3,7 +3,25 @@ const assert = require("node:assert/strict");
 const {
   buildNativePresenterDebugFallback,
   getNativePresenterDebugReport,
+  logEvent,
 } = require("./debug.js");
+
+test("legacy event logging delegates only the event name to private diagnostics", () => {
+  const oldWindow = global.window;
+  const calls = [];
+  global.window = {
+    EchoWebDiagnosticsRuntime: {
+      recordLegacyEvent() {
+        calls.push(Array.from(arguments));
+      },
+    },
+  };
+
+  logEvent("room-join", "private-room as private-user");
+
+  assert.deepEqual(calls, [["room-join"]]);
+  global.window = oldWindow;
+});
 
 test("native presenter debug fallback uses client stats schema", () => {
   const report = buildNativePresenterDebugFallback("native presenter script unavailable");

--- a/core/viewer/diagnostics-client.js
+++ b/core/viewer/diagnostics-client.js
@@ -1,0 +1,1201 @@
+(function (root, factory) {
+  var api = factory();
+  if (typeof module === "object" && module.exports) module.exports = api;
+  if (root) root.EchoWebDiagnostics = api;
+  if (root && root.document) {
+    Promise.resolve().then(function () {
+      try { api.installBrowserRuntime(root); } catch (_) {}
+    });
+  }
+})(typeof globalThis !== "undefined" ? globalThis : this, function () {
+  "use strict";
+
+  var CONSENT_KEY = "echo-web-diagnostics-consent-v1";
+  var INSTALL_KEY = "echo-web-diagnostics-install-v1";
+  var QUEUE_KEY = "echo-web-diagnostics-queue-v1";
+  var STATUS_KEY = "echo-web-diagnostics-status-v1";
+  var ACTIVE_KEY = "echo-web-diagnostics-active-v1";
+  var CONSENT_ENABLED = "enabled-v1";
+  var CONSENT_DISABLED = "disabled-v1";
+  var QUEUE_VERSION = 1;
+  var MAX_ENVELOPES = 10;
+  var MAX_ENVELOPE_BYTES = 64 * 1024;
+  var MAX_QUEUE_BYTES = 512 * 1024;
+  var MAX_EVENTS_PER_ENVELOPE = 50;
+  var QUEUE_TTL_MS = 72 * 60 * 60 * 1000;
+  var SESSION_STALE_MS = 5 * 60 * 1000;
+  var SEAL_INTERVAL_MS = 15 * 1000;
+  var HEARTBEAT_AUTH_MAX_MS = 18 * 1000;
+
+  var EVENT_PREFIXES = {
+    session_start: ["session."],
+    session_end: ["session."],
+    unclean_shutdown: ["session."],
+    javascript_error: ["javascript.", "promise."],
+    unhandled_rejection: ["javascript.", "promise."],
+    permission: ["permission.", "microphone.", "camera.", "screen_share."],
+    media: ["media.", "microphone.", "camera.", "screen_share."],
+    connection: ["connection.", "ice.", "livekit.", "sfu.", "webrtc."],
+    reconnect: ["reconnect.", "connection."],
+  };
+  var SEVERITIES = new Set(["debug", "info", "warning", "error", "fatal"]);
+  var DETAIL_KEYS = new Set([
+    "action", "actual", "attempt", "audio", "browser", "camera", "clean", "column",
+    "connection_state", "count", "current", "denied", "device_count", "device_kind",
+    "direction", "duration_ms", "enabled", "ended", "error_code", "expected",
+    "failure_stage", "granted", "kind", "line", "media_kind", "microphone", "operation",
+    "output", "permission", "permission_state", "phase", "previous", "published",
+    "reconnect_count", "requested", "result", "room_state", "screen", "selected", "stage",
+    "started", "state", "status", "subscribed", "target", "track_state", "transport",
+    "unclean", "video", "visibility",
+  ]);
+  var CHANNELS = new Set(["web", "web-canary", "web-smoke", "test"]);
+  var OS_VALUES = new Set(["macos", "windows", "linux", "ios", "android", "unknown"]);
+  var ARCH_VALUES = new Set(["aarch64", "x86_64", "x86", "arm", "unknown"]);
+  var SAFE_STATES = new Set([
+    "connecting", "connected", "reconnecting", "disconnected", "failed", "error", "enabled",
+    "disabled", "started", "stopped", "granted", "denied", "available", "unavailable",
+    "browser", "microphone", "camera", "screen", "output", "unknown",
+  ]);
+  var SAFE_ACTIONS = new Set(["enable", "disable", "start", "stop", "observe", "connect"]);
+  var MEDIA_KINDS = new Set(["microphone", "camera", "screen"]);
+  var CONNECTION_STATES = new Set(["connecting", "connected", "reconnecting", "disconnected", "failed", "error"]);
+  var ERROR_NAMES = new Map([
+    ["NotAllowedError", "permission_denied"],
+    ["PermissionDeniedError", "permission_denied"],
+    ["NotFoundError", "device_not_found"],
+    ["DevicesNotFoundError", "device_not_found"],
+    ["NotReadableError", "device_unavailable"],
+    ["TrackStartError", "device_unavailable"],
+    ["AbortError", "aborted"],
+    ["TypeError", "type_error"],
+    ["RangeError", "range_error"],
+    ["ReferenceError", "reference_error"],
+    ["SyntaxError", "syntax_error"],
+    ["MicrophonePublishError", "publish_failed"],
+  ]);
+  var LEGACY_EVENTS = {
+    "room-join": ["connection", "connection.joined", "info"],
+    "room-disconnect": ["connection", "connection.disconnected", "warning"],
+    "signal-reconnecting": ["reconnect", "reconnect.started", "warning"],
+    "reconnecting": ["reconnect", "reconnect.started", "warning"],
+    "signal-reconnected": ["reconnect", "reconnect.completed", "info"],
+    "reconnected": ["reconnect", "reconnect.completed", "info"],
+    "loss-drop": ["media", "media.receiver_quality_degraded", "warning"],
+    "layer-downgrade": ["media", "media.receiver_quality_degraded", "warning"],
+    "loss-snapback": ["media", "media.receiver_quality_recovered", "info"],
+    "layer-upgrade": ["media", "media.receiver_quality_recovered", "info"],
+    "screen-share-start": ["media", "screen_share.started", "info"],
+    "screen-share-stop": ["media", "screen_share.stopped", "info"],
+    "camera-reduced": ["media", "camera.quality_reduced", "warning"],
+    "camera-restored": ["media", "camera.quality_restored", "info"],
+    "bitrate-cap-applied": ["media", "media.bandwidth_limited", "warning"],
+    "bwe-watchdog-kick": ["media", "media.bandwidth_recovery", "warning"],
+    "bwe-rescue": ["media", "media.bandwidth_recovery", "warning"],
+    "bwe-rescue-hard": ["media", "media.bandwidth_recovery", "warning"],
+  };
+
+  function byteLength(value) {
+    if (typeof TextEncoder === "function") return new TextEncoder().encode(value).length;
+    return unescape(encodeURIComponent(value)).length;
+  }
+
+  function canonicalUuid(value) {
+    return typeof value === "string" && /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/.test(value);
+  }
+
+  function secureUuid(cryptoObject) {
+    if (!cryptoObject) return null;
+    if (typeof cryptoObject.randomUUID === "function") {
+      var generated = String(cryptoObject.randomUUID()).toLowerCase();
+      return canonicalUuid(generated) ? generated : null;
+    }
+    if (typeof cryptoObject.getRandomValues !== "function") return null;
+    var bytes = new Uint8Array(16);
+    cryptoObject.getRandomValues(bytes);
+    bytes[6] = (bytes[6] & 15) | 64;
+    bytes[8] = (bytes[8] & 63) | 128;
+    var hex = Array.from(bytes, function (item) { return item.toString(16).padStart(2, "0"); }).join("");
+    return hex.slice(0, 8) + "-" + hex.slice(8, 12) + "-" + hex.slice(12, 16) + "-" +
+      hex.slice(16, 20) + "-" + hex.slice(20);
+  }
+
+  function safeInteger(value, maximum) {
+    var number = Number(value);
+    if (!Number.isFinite(number)) return 0;
+    return Math.max(0, Math.min(maximum || 0x7fffffff, Math.round(number)));
+  }
+
+  function safeErrorCode(errorName) {
+    return typeof errorName === "string" ? (ERROR_NAMES.get(errorName) || "unknown") : "unknown";
+  }
+
+  function safeToken(value, allowed) {
+    value = String(value || "").toLowerCase();
+    if (allowed && !allowed.has(value)) return "unknown";
+    return /^[a-z][a-z0-9_-]{0,47}$/.test(value) ? value : "unknown";
+  }
+
+  function sanitizeDetails(details) {
+    var output = {};
+    if (!details || typeof details !== "object" || Array.isArray(details)) return output;
+    Object.keys(details).slice(0, 32).forEach(function (key) {
+      if (!DETAIL_KEYS.has(key)) return;
+      var value = details[key];
+      if (typeof value === "boolean") output[key] = value;
+      else if (typeof value === "number" && Number.isFinite(value)) output[key] = Math.max(-1e9, Math.min(1e9, value));
+      else if (typeof value === "string" && /^[a-z][a-z0-9_.-]{0,63}$/.test(value)) output[key] = value;
+    });
+    return output;
+  }
+
+  function sanitizeEvent(event) {
+    if (!event || !EVENT_PREFIXES[event.event_type] || !SEVERITIES.has(event.severity)) return null;
+    var code = String(event.code || "");
+    if (code.length > 96 || !/^[A-Za-z][A-Za-z0-9_-]*(\.[A-Za-z][A-Za-z0-9_-]*)+$/.test(code)) return null;
+    if (!EVENT_PREFIXES[event.event_type].some(function (prefix) { return code.indexOf(prefix) === 0; })) return null;
+    return {
+      timestamp_ms: safeInteger(event.timestamp_ms, Number.MAX_SAFE_INTEGER),
+      event_type: event.event_type,
+      severity: event.severity,
+      code: code,
+      details: sanitizeDetails(event.details),
+    };
+  }
+
+  function safeMetadata(input) {
+    if (!input || !input.app || !input.platform) return null;
+    var version = String(input.app.version || "");
+    var sha = String(input.app.git_sha || "").toLowerCase();
+    var channel = String(input.app.channel || "");
+    if (!/^[0-9A-Za-z][0-9A-Za-z.+-]{0,31}$/.test(version)) return null;
+    if (!/^[0-9a-f]{7,12}$/.test(sha) || !CHANNELS.has(channel)) return null;
+    var runtimes = {};
+    var sourceRuntimes = input.app.runtimes || {};
+    if (["Browser", "Edge", "Chrome", "Firefox", "Safari"].indexOf(sourceRuntimes.browser_name) >= 0) {
+      runtimes.browser_name = sourceRuntimes.browser_name;
+    }
+    if (typeof sourceRuntimes.browser_version === "string" &&
+        (/^[0-9]+(?:\.[0-9]+){0,5}$/.test(sourceRuntimes.browser_version) || sourceRuntimes.browser_version === "unknown")) {
+      runtimes.browser_version = sourceRuntimes.browser_version;
+    }
+    if (typeof sourceRuntimes.livekit_version === "string" &&
+        /^[0-9A-Za-z][0-9A-Za-z.+-]{0,63}$/.test(sourceRuntimes.livekit_version)) {
+      runtimes.livekit_version = sourceRuntimes.livekit_version;
+    }
+    var operatingSystem = OS_VALUES.has(input.platform.operating_system) ? input.platform.operating_system : "unknown";
+    var architecture = ARCH_VALUES.has(input.platform.architecture) ? input.platform.architecture : "unknown";
+    return {
+      app: { version: version, git_sha: sha, channel: channel, runtimes: runtimes },
+      platform: { client_kind: "browser", operating_system: operatingSystem, architecture: architecture },
+    };
+  }
+
+  function hasExactKeys(value, expected) {
+    if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+    var actual = Object.keys(value).sort();
+    var wanted = expected.slice().sort();
+    return actual.length === wanted.length && actual.every(function (key, index) { return key === wanted[index]; });
+  }
+
+  function validateSealedBody(body, expectedInstallId) {
+    if (typeof body !== "string" || !body || byteLength(body) > MAX_ENVELOPE_BYTES) return false;
+    try {
+      var envelope = JSON.parse(body);
+      if (JSON.stringify(envelope) !== body) return false;
+      if (!hasExactKeys(envelope, [
+        "schema_version", "envelope_id", "install_id", "session_id", "captured_at_ms",
+        "sent_at_ms", "app", "platform", "events",
+      ])) return false;
+      if (envelope.schema_version !== 1 || !canonicalUuid(envelope.envelope_id) ||
+          !canonicalUuid(envelope.install_id) || !canonicalUuid(envelope.session_id)) return false;
+      if (expectedInstallId && envelope.install_id !== expectedInstallId) return false;
+      if (!Number.isSafeInteger(envelope.captured_at_ms) || envelope.captured_at_ms <= 0 ||
+          !Number.isSafeInteger(envelope.sent_at_ms) || envelope.sent_at_ms < envelope.captured_at_ms) return false;
+      if (!hasExactKeys(envelope.app, ["version", "git_sha", "channel", "runtimes"]) ||
+          !hasExactKeys(envelope.platform, ["client_kind", "operating_system", "architecture"]) ||
+          !hasExactKeys(envelope.app.runtimes, Object.keys(envelope.app.runtimes))) return false;
+      var runtimeKeys = Object.keys(envelope.app.runtimes);
+      if (runtimeKeys.some(function (key) {
+        return ["browser_name", "browser_version", "livekit_version"].indexOf(key) < 0;
+      })) return false;
+      var normalizedMetadata = safeMetadata({ app: envelope.app, platform: envelope.platform });
+      if (!normalizedMetadata || JSON.stringify(normalizedMetadata.app) !== JSON.stringify(envelope.app) ||
+          JSON.stringify(normalizedMetadata.platform) !== JSON.stringify(envelope.platform)) return false;
+      if (!Array.isArray(envelope.events) || envelope.events.length < 1 ||
+          envelope.events.length > MAX_EVENTS_PER_ENVELOPE) return false;
+      var priorTimestamp = envelope.captured_at_ms;
+      for (var index = 0; index < envelope.events.length; index += 1) {
+        var event = envelope.events[index];
+        if (!hasExactKeys(event, ["sequence", "timestamp_ms", "event_type", "severity", "code", "details"]) ||
+            event.sequence !== index + 1 || !Number.isSafeInteger(event.timestamp_ms) ||
+            event.timestamp_ms < priorTimestamp || event.timestamp_ms > envelope.sent_at_ms) return false;
+        var normalizedEvent = sanitizeEvent(event);
+        if (!normalizedEvent || normalizedEvent.timestamp_ms !== event.timestamp_ms ||
+            normalizedEvent.event_type !== event.event_type || normalizedEvent.severity !== event.severity ||
+            normalizedEvent.code !== event.code ||
+            JSON.stringify(normalizedEvent.details) !== JSON.stringify(event.details)) return false;
+        priorTimestamp = event.timestamp_ms;
+      }
+      return true;
+    } catch (_) {
+      return false;
+    }
+  }
+
+  function emptyQueue() {
+    return { version: QUEUE_VERSION, revision: 0, writer: "", draft: null, envelopes: [] };
+  }
+
+  function parseQueue(raw, now) {
+    if (!raw) return emptyQueue();
+    try {
+      var parsed = JSON.parse(raw);
+      if (!parsed || parsed.version !== QUEUE_VERSION || !Array.isArray(parsed.envelopes)) return emptyQueue();
+      var output = emptyQueue();
+      output.revision = safeInteger(parsed.revision, Number.MAX_SAFE_INTEGER);
+      if (parsed.draft && canonicalUuid(parsed.draft.session_id) && Array.isArray(parsed.draft.events)) {
+        var draftEvents = parsed.draft.events.map(sanitizeEvent).filter(Boolean).slice(-MAX_EVENTS_PER_ENVELOPE);
+        var draftCapturedAt = safeInteger(parsed.draft.captured_at_ms, Number.MAX_SAFE_INTEGER);
+        if (draftEvents.length && draftCapturedAt && draftCapturedAt + QUEUE_TTL_MS >= now &&
+            draftCapturedAt <= now + 5 * 60 * 1000) {
+          output.draft = {
+            session_id: parsed.draft.session_id,
+            captured_at_ms: draftCapturedAt,
+            scope: typeof parsed.draft.scope === "string" && /^[0-9a-f]{64}$/.test(parsed.draft.scope)
+              ? parsed.draft.scope : null,
+            events: draftEvents,
+          };
+        }
+      }
+      parsed.envelopes.forEach(function (item) {
+        if (!item || !validateSealedBody(item.body)) return;
+        var createdAt = safeInteger(item.created_at_ms, Number.MAX_SAFE_INTEGER);
+        if (!createdAt || createdAt + QUEUE_TTL_MS < now || createdAt > now + 5 * 60 * 1000) return;
+        output.envelopes.push({
+          body: item.body,
+          created_at_ms: createdAt,
+          scope: typeof item.scope === "string" && /^[0-9a-f]{64}$/.test(item.scope) ? item.scope : null,
+          attempts: safeInteger(item.attempts, 20),
+          next_attempt_ms: safeInteger(item.next_attempt_ms, Number.MAX_SAFE_INTEGER),
+        });
+      });
+      output.envelopes = output.envelopes.slice(-MAX_ENVELOPES);
+      return enforceQueueBounds(output);
+    } catch (_) {
+      return emptyQueue();
+    }
+  }
+
+  function queueBytes(queue) {
+    return byteLength(JSON.stringify(queue));
+  }
+
+  function enforceQueueBounds(queue) {
+    while (queue.envelopes.length > MAX_ENVELOPES || queueBytes(queue) > MAX_QUEUE_BYTES) queue.envelopes.shift();
+    while (queue.draft && queue.draft.events.length > 1 && queueBytes(queue) > MAX_QUEUE_BYTES) {
+      queue.draft.events.shift();
+      queue.draft.captured_at_ms = queue.draft.events[0].timestamp_ms;
+    }
+    if (queue.draft && queueBytes(queue) > MAX_QUEUE_BYTES) queue.draft = null;
+    return queue;
+  }
+
+  function decodeJwtSubject(token) {
+    try {
+      if (typeof token !== "string" || token.length < 3 || token.length > 16 * 1024) return null;
+      var parts = token.split(".");
+      if (parts.length !== 3) return null;
+      var encoded = parts[1].replace(/-/g, "+").replace(/_/g, "/");
+      while (encoded.length % 4) encoded += "=";
+      var json;
+      if (typeof atob === "function") json = decodeURIComponent(Array.from(atob(encoded), function (char) {
+        return "%" + char.charCodeAt(0).toString(16).padStart(2, "0");
+      }).join(""));
+      else if (typeof Buffer !== "undefined") json = Buffer.from(encoded, "base64").toString("utf8");
+      else return null;
+      var payload = JSON.parse(json);
+      return typeof payload.sub === "string" && payload.sub.length > 0 && payload.sub.length <= 256
+        ? payload.sub : null;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  async function defaultScopeDigest(token, installId, origin, cryptoObject) {
+    var subject = decodeJwtSubject(token);
+    if (!subject || !cryptoObject || !cryptoObject.subtle || typeof TextEncoder !== "function") return null;
+    var bytes = new TextEncoder().encode(installId + "\0" + origin + "\0" + subject);
+    var digest = await cryptoObject.subtle.digest("SHA-256", bytes);
+    return Array.from(new Uint8Array(digest), function (item) { return item.toString(16).padStart(2, "0"); }).join("");
+  }
+
+  function createCollector(options) {
+    options = options || {};
+    var storage = options.storage;
+    var cryptoObject = options.crypto;
+    var fetchImpl = options.fetch;
+    var now = options.now || Date.now;
+    var setTimer = options.setTimeout || setTimeout;
+    var clearTimer = options.clearTimeout || clearTimeout;
+    var setRepeating = options.setInterval || setInterval;
+    var clearRepeating = options.clearInterval || clearInterval;
+    var metadataProvider = options.metadataProvider;
+    var scopeDigest = options.scopeDigest || function (token, installId, origin) {
+      return defaultScopeDigest(token, installId, origin, cryptoObject);
+    };
+    var eventTarget = options.eventTarget || null;
+    var writerId = secureUuid(cryptoObject);
+    var sessionId = null;
+    var installId = null;
+    var enabled = false;
+    var started = false;
+    var metadata = null;
+    var metadataPromise = null;
+    var auth = null;
+    var uploadAbort = null;
+    var uploading = false;
+    var uploadSequence = 0;
+    var pageDisabled = false;
+    var sealTimer = null;
+    var sessionTimer = null;
+    var retryTimer = null;
+    var reconnecting = false;
+    var lastEventCode = "";
+    var lastEventAt = 0;
+    var handlers = null;
+    var lifecycleVersion = 0;
+    var enablePromise = null;
+    var heartbeatVersion = 0;
+    var credentialSeen = false;
+
+    function cancelUpload() {
+      uploadSequence += 1;
+      var controller = uploadAbort;
+      uploadAbort = null;
+      uploading = false;
+      if (controller) controller.abort();
+    }
+
+    function haltRuntime(statusCode) {
+      lifecycleVersion += 1;
+      heartbeatVersion += 1;
+      enabled = false;
+      started = false;
+      auth = null;
+      cancelUpload();
+      detachHandlers();
+      if (sealTimer) clearRepeating(sealTimer);
+      if (sessionTimer) clearRepeating(sessionTimer);
+      if (retryTimer) clearTimer(retryTimer);
+      sealTimer = sessionTimer = retryTimer = null;
+      if (statusCode) setStatus(statusCode);
+    }
+
+    function setStatus(code, at) {
+      var payload = JSON.stringify({ version: 1, code: safeToken(code), at_ms: safeInteger(at || now(), Number.MAX_SAFE_INTEGER) });
+      try { storage.setItem(STATUS_KEY, payload); } catch (_) {}
+    }
+
+    function consentState() {
+      try {
+        var value = storage.getItem(CONSENT_KEY);
+        if (value === CONSENT_ENABLED) return "enabled";
+        if (value === CONSENT_DISABLED) return "disabled";
+        return "unset";
+      } catch (_) {
+        return "disabled";
+      }
+    }
+
+    function loadQueue() {
+      try { return parseQueue(storage.getItem(QUEUE_KEY), now()); }
+      catch (_) { haltRuntime("storage_unavailable"); return emptyQueue(); }
+    }
+
+    function saveQueue(queue) {
+      if (!enabled) return false;
+      try {
+        queue.revision = safeInteger(queue.revision + 1, Number.MAX_SAFE_INTEGER);
+        queue.writer = writerId || "";
+        enforceQueueBounds(queue);
+        storage.setItem(QUEUE_KEY, JSON.stringify(queue));
+        return true;
+      } catch (_) {
+        haltRuntime("storage_unavailable");
+        return false;
+      }
+    }
+
+    function ensureInstallId() {
+      try {
+        var existing = storage.getItem(INSTALL_KEY);
+        if (canonicalUuid(existing)) return existing;
+        var generated = secureUuid(cryptoObject);
+        if (!generated) return null;
+        storage.setItem(INSTALL_KEY, generated);
+        return generated;
+      } catch (_) {
+        return null;
+      }
+    }
+
+    function recordInternal(eventType, code, severity, details, immediate) {
+      if (!enabled || !started || !sessionId) return false;
+      var timestamp = safeInteger(now(), Number.MAX_SAFE_INTEGER);
+      if (code === lastEventCode && timestamp - lastEventAt < 1500) return false;
+      var event = sanitizeEvent({
+        timestamp_ms: timestamp,
+        event_type: eventType,
+        severity: severity,
+        code: code,
+        details: details,
+      });
+      if (!event || !event.timestamp_ms) return false;
+      var queue = loadQueue();
+      if (!enabled) return false;
+      if (queue.draft && queue.draft.session_id !== sessionId && !sealQueueDraft(queue)) {
+        queue.draft = null;
+        setStatus("invalid_dropped");
+      }
+      if (!queue.draft) {
+        queue.draft = {
+          session_id: sessionId,
+          captured_at_ms: event.timestamp_ms,
+          scope: auth ? auth.scope : null,
+          events: [],
+        };
+      }
+      var prior = queue.draft.events[queue.draft.events.length - 1];
+      if (prior && event.timestamp_ms < prior.timestamp_ms) event.timestamp_ms = prior.timestamp_ms;
+      queue.draft.events.push(event);
+      if (queue.draft.events.length >= MAX_EVENTS_PER_ENVELOPE && metadata) sealQueueDraft(queue);
+      saveQueue(queue);
+      lastEventCode = code;
+      lastEventAt = timestamp;
+      if (immediate && metadata) {
+        var updated = loadQueue();
+        sealQueueDraft(updated);
+        saveQueue(updated);
+        void uploadAvailable();
+      }
+      return true;
+    }
+
+    function sealQueueDraft(queue) {
+      if (!metadata || !installId || !queue.draft || !queue.draft.events.length) return false;
+      var envelopeId = secureUuid(cryptoObject);
+      if (!envelopeId) return false;
+      var draftEvents = queue.draft.events.slice();
+      var body = "";
+      var sentAt = 0;
+      do {
+        var events = draftEvents.map(function (event, index) {
+          return {
+            sequence: index + 1,
+            timestamp_ms: event.timestamp_ms,
+            event_type: event.event_type,
+            severity: event.severity,
+            code: event.code,
+            details: event.details,
+          };
+        });
+        var capturedAt = draftEvents.length === queue.draft.events.length
+          ? Math.min(queue.draft.captured_at_ms, events[0].timestamp_ms)
+          : events[0].timestamp_ms;
+        sentAt = Math.max(safeInteger(now(), Number.MAX_SAFE_INTEGER), events[events.length - 1].timestamp_ms, capturedAt);
+        body = JSON.stringify({
+          schema_version: 1,
+          envelope_id: envelopeId,
+          install_id: installId,
+          session_id: queue.draft.session_id,
+          captured_at_ms: capturedAt,
+          sent_at_ms: sentAt,
+          app: metadata.app,
+          platform: metadata.platform,
+          events: events,
+        });
+        if (byteLength(body) > MAX_ENVELOPE_BYTES && draftEvents.length > 1) draftEvents.shift();
+        else break;
+      } while (draftEvents.length);
+      if (byteLength(body) > MAX_ENVELOPE_BYTES) return false;
+      queue.envelopes.push({
+        body: body,
+        created_at_ms: sentAt,
+        scope: queue.draft.scope || (queue.draft.session_id === sessionId && auth ? auth.scope : null),
+        attempts: 0,
+        next_attempt_ms: 0,
+      });
+      queue.draft = null;
+      enforceQueueBounds(queue);
+      return true;
+    }
+
+    function sealDraft() {
+      if (!enabled || !metadata) return false;
+      var queue = loadQueue();
+      var sealed = sealQueueDraft(queue);
+      if (sealed) saveQueue(queue);
+      return sealed;
+    }
+
+    function attachHandlers() {
+      if (!eventTarget || handlers) return;
+      handlers = {
+        error: function (event) {
+          var name = "unknown";
+          var line = 0;
+          var column = 0;
+          try { name = event && event.error ? event.error.name : "unknown"; } catch (_) {}
+          try { line = safeInteger(event && event.lineno, 1000000); } catch (_) {}
+          try { column = safeInteger(event && event.colno, 1000000); } catch (_) {}
+          recordInternal("javascript_error", "javascript.window_error", "error", {
+            error_code: safeErrorCode(name),
+            line: line,
+            column: column,
+          }, true);
+        },
+        rejection: function () {
+          recordInternal("unhandled_rejection", "promise.unhandled_rejection", "error", { error_code: "unknown" }, true);
+        },
+        pagehide: function (event) {
+          if (event && event.persisted) {
+            removeActiveSession();
+            return;
+          }
+          recordInternal("session_end", "session.end", "info", { clean: true }, false);
+          sealDraft();
+          removeActiveSession();
+        },
+        pageshow: function (event) {
+          if (event && event.persisted) refreshActiveSession(false);
+        },
+      };
+      eventTarget.addEventListener("error", handlers.error);
+      eventTarget.addEventListener("unhandledrejection", handlers.rejection);
+      eventTarget.addEventListener("pagehide", handlers.pagehide);
+      eventTarget.addEventListener("pageshow", handlers.pageshow);
+    }
+
+    function detachHandlers() {
+      if (!eventTarget || !handlers) return;
+      eventTarget.removeEventListener("error", handlers.error);
+      eventTarget.removeEventListener("unhandledrejection", handlers.rejection);
+      eventTarget.removeEventListener("pagehide", handlers.pagehide);
+      eventTarget.removeEventListener("pageshow", handlers.pageshow);
+      handlers = null;
+    }
+
+    function readActiveSessions() {
+      try {
+        var parsed = JSON.parse(storage.getItem(ACTIVE_KEY) || "{}");
+        if (!parsed || parsed.version !== 1 || !parsed.sessions || typeof parsed.sessions !== "object") {
+          return { version: 1, sessions: {} };
+        }
+        var sessions = {};
+        Object.keys(parsed.sessions).slice(-32).forEach(function (id) {
+          var item = parsed.sessions[id];
+          if (!canonicalUuid(id) || !item || !Number.isFinite(item.started_at_ms) ||
+              !Number.isFinite(item.last_seen_ms)) return;
+          sessions[id] = {
+            started_at_ms: safeInteger(item.started_at_ms, Number.MAX_SAFE_INTEGER),
+            last_seen_ms: safeInteger(item.last_seen_ms, Number.MAX_SAFE_INTEGER),
+            scope: typeof item.scope === "string" && /^[0-9a-f]{64}$/.test(item.scope) ? item.scope : null,
+          };
+        });
+        return { version: 1, sessions: sessions };
+      } catch (_) { return { version: 1, sessions: {} }; }
+    }
+
+    function writeActiveSessions(registry) {
+      try { storage.setItem(ACTIVE_KEY, JSON.stringify(registry)); } catch (_) {}
+    }
+
+    function refreshActiveSession(reportStale) {
+      if (!enabled || !sessionId) return;
+      var currentTime = safeInteger(now(), Number.MAX_SAFE_INTEGER);
+      var registry = readActiveSessions();
+      Object.keys(registry.sessions).forEach(function (id) {
+        var item = registry.sessions[id];
+        if (id !== sessionId && item.last_seen_ms + SESSION_STALE_MS < currentTime) {
+          if (item.last_seen_ms + QUEUE_TTL_MS < currentTime) {
+            delete registry.sessions[id];
+          } else if (reportStale && auth && item.scope === auth.scope) {
+            recordInternal("unclean_shutdown", "session.unclean_shutdown", "error", {
+              unclean: true,
+              duration_ms: safeInteger(item.last_seen_ms - item.started_at_ms, QUEUE_TTL_MS),
+            }, false);
+            delete registry.sessions[id];
+          } else if (reportStale && auth && item.scope === null) {
+            delete registry.sessions[id];
+          }
+        }
+      });
+      var existing = registry.sessions[sessionId];
+      registry.sessions[sessionId] = {
+        started_at_ms: existing ? existing.started_at_ms : currentTime,
+        last_seen_ms: currentTime,
+        scope: auth ? auth.scope : (existing ? existing.scope : null),
+      };
+      Object.keys(registry.sessions)
+        .filter(function (id) { return id !== sessionId; })
+        .sort(function (left, right) {
+          return registry.sessions[left].last_seen_ms - registry.sessions[right].last_seen_ms;
+        })
+        .slice(0, Math.max(0, Object.keys(registry.sessions).length - 32))
+        .forEach(function (id) { delete registry.sessions[id]; });
+      writeActiveSessions(registry);
+    }
+
+    function removeActiveSession() {
+      if (!sessionId) return;
+      var registry = readActiveSessions();
+      delete registry.sessions[sessionId];
+      if (Object.keys(registry.sessions).length) writeActiveSessions(registry);
+      else {
+        try { storage.removeItem(ACTIVE_KEY); } catch (_) {}
+      }
+    }
+
+    function scheduleRetry(delay) {
+      if (retryTimer) clearTimer(retryTimer);
+      retryTimer = setTimer(function () { retryTimer = null; void uploadAvailable(); }, Math.max(1000, delay));
+    }
+
+    function removeEnvelope(body) {
+      var queue = loadQueue();
+      queue.envelopes = queue.envelopes.filter(function (item) { return item.body !== body; });
+      saveQueue(queue);
+    }
+
+    function updateEnvelope(body, update) {
+      var queue = loadQueue();
+      var item = queue.envelopes.find(function (entry) { return entry.body === body; });
+      if (!item) return;
+      update(item);
+      saveQueue(queue);
+    }
+
+    async function uploadAvailable(force) {
+      if (!enabled || !auth || uploading || pageDisabled || !fetchImpl) return false;
+      if (auth.proved_at_ms + HEARTBEAT_AUTH_MAX_MS < now()) {
+        auth = null;
+        return false;
+      }
+      sealDraft();
+      var queue = loadQueue();
+      var candidate = queue.envelopes.find(function (item) {
+        return item.scope === auth.scope && (force || item.next_attempt_ms <= now());
+      });
+      if (!candidate) return false;
+      if (!validateSealedBody(candidate.body, installId)) {
+        removeEnvelope(candidate.body);
+        setStatus("invalid_dropped");
+        return false;
+      }
+      uploading = true;
+      var uploadOperation = uploadSequence + 1;
+      uploadSequence = uploadOperation;
+      var uploadHeartbeat = heartbeatVersion;
+      var uploadAuth = auth;
+      var controller = typeof AbortController === "function" ? new AbortController() : null;
+      uploadAbort = controller;
+      var timeout = controller ? setTimer(function () { controller.abort(); }, 10000) : null;
+      try {
+        var response = await fetchImpl(uploadAuth.origin + "/api/diagnostics/v1/envelopes", {
+          method: "POST",
+          headers: { "Content-Type": "application/json", Authorization: "Bearer " + uploadAuth.token },
+          body: candidate.body,
+          cache: "no-store",
+          signal: controller ? controller.signal : undefined,
+        });
+        if (uploadOperation !== uploadSequence || !enabled) return false;
+        if (response.status === 200 || response.status === 202) {
+          removeEnvelope(candidate.body);
+          setStatus(response.status === 200 ? "duplicate" : "accepted");
+        } else if (response.status === 401 || response.status === 403) {
+          if (uploadHeartbeat === heartbeatVersion) {
+            auth = null;
+            setStatus("auth_wait");
+          }
+        } else if (response.status === 404) {
+          pageDisabled = true;
+          setStatus("server_disabled");
+        } else if ([400, 409, 413, 422].indexOf(response.status) >= 0) {
+          removeEnvelope(candidate.body);
+          setStatus(response.status === 409 ? "conflict_dropped" : "invalid_dropped");
+        } else {
+          var retryAfter = response.status === 429 && response.headers && response.headers.get
+            ? parseRetryAfter(response.headers.get("Retry-After"), now()) : 0;
+          var delay = retryAfter || Math.min(300000, 5000 * Math.pow(2, Math.min(candidate.attempts, 6)));
+          updateEnvelope(candidate.body, function (item) {
+            item.attempts += 1;
+            item.next_attempt_ms = now() + delay;
+          });
+          setStatus(response.status === 429 ? "rate_limited" : "retry_wait");
+          scheduleRetry(delay);
+        }
+      } catch (_) {
+        if (uploadOperation === uploadSequence && enabled && auth) {
+          var networkDelay = Math.min(300000, 5000 * Math.pow(2, Math.min(candidate.attempts, 6)));
+          updateEnvelope(candidate.body, function (item) {
+            item.attempts += 1;
+            item.next_attempt_ms = now() + networkDelay;
+          });
+          setStatus("network_wait");
+          scheduleRetry(networkDelay);
+        }
+      } finally {
+        if (timeout) clearTimer(timeout);
+        if (uploadOperation === uploadSequence) {
+          uploadAbort = null;
+          uploading = false;
+        }
+      }
+      if (uploadOperation === uploadSequence && enabled && auth && !pageDisabled) {
+        var remaining = loadQueue().envelopes.some(function (item) {
+          return item.scope === auth.scope && item.next_attempt_ms <= now();
+        });
+        if (remaining) scheduleRetry(1000);
+      }
+      return true;
+    }
+
+    function parseRetryAfter(value, currentTime) {
+      var seconds = Number(value);
+      if (Number.isFinite(seconds) && seconds > 0) return Math.min(300000, Math.ceil(seconds * 1000));
+      var target = Date.parse(String(value || ""));
+      if (!Number.isFinite(target) || target <= currentTime) return 0;
+      return Math.min(300000, target - currentTime);
+    }
+
+    async function enableInternal(generation) {
+      if (!storage || !writerId || !metadataProvider) return false;
+      try { storage.setItem(CONSENT_KEY, CONSENT_ENABLED); }
+      catch (_) { return false; }
+      enabled = true;
+      installId = ensureInstallId();
+      sessionId = secureUuid(cryptoObject);
+      if (!installId || !sessionId) {
+        enabled = false;
+        try { storage.setItem(CONSENT_KEY, CONSENT_DISABLED); } catch (_) {}
+        return false;
+      }
+      pageDisabled = false;
+      var pendingMetadata = Promise.resolve().then(metadataProvider).then(safeMetadata).catch(function () { return null; });
+      metadataPromise = pendingMetadata;
+      var resolvedMetadata = await pendingMetadata;
+      if (generation !== lifecycleVersion || !enabled) return false;
+      if (!resolvedMetadata) {
+        metadata = null;
+        haltRuntime("metadata_unavailable");
+        return false;
+      }
+      metadata = resolvedMetadata;
+      var existingQueue = loadQueue();
+      if (!enabled || generation !== lifecycleVersion) return false;
+      if (existingQueue.draft) {
+        if (!sealQueueDraft(existingQueue)) {
+          existingQueue.draft = null;
+          setStatus("invalid_dropped");
+        }
+        saveQueue(existingQueue);
+      }
+      if (!enabled || generation !== lifecycleVersion) return false;
+      started = true;
+      attachHandlers();
+      sessionTimer = setRepeating(function () { refreshActiveSession(true); }, 10000);
+      sealTimer = setRepeating(function () { if (sealDraft()) void uploadAvailable(); }, SEAL_INTERVAL_MS);
+      recordInternal("session_start", "session.start", "info", { started: true, stage: "browser" }, false);
+      refreshActiveSession(true);
+      return true;
+    }
+
+    function enable() {
+      if (enabled && started) return Promise.resolve(true);
+      if (enablePromise) return enablePromise;
+      var generation = lifecycleVersion + 1;
+      lifecycleVersion = generation;
+      var pending = enableInternal(generation);
+      enablePromise = pending;
+      pending.then(function () {
+        if (enablePromise === pending) enablePromise = null;
+      }, function () {
+        if (enablePromise === pending) enablePromise = null;
+      });
+      return pending;
+    }
+
+    function disable(writeConsent) {
+      if (writeConsent !== false) {
+        try { storage.setItem(CONSENT_KEY, CONSENT_DISABLED); } catch (_) {}
+      }
+      haltRuntime();
+      enablePromise = null;
+      [INSTALL_KEY, QUEUE_KEY, STATUS_KEY, ACTIVE_KEY].forEach(function (key) {
+        try { storage.removeItem(key); } catch (_) {}
+      });
+      installId = sessionId = null;
+      metadata = null;
+      metadataPromise = null;
+      pageDisabled = false;
+      reconnecting = false;
+      credentialSeen = false;
+    }
+
+    function clearQueuedData() {
+      cancelUpload();
+      try { storage.removeItem(QUEUE_KEY); } catch (_) {}
+      setStatus("queue_cleared");
+    }
+
+    async function heartbeatSucceeded(context) {
+      if (!enabled || !started || !context || typeof context.token !== "string" || !context.token) return false;
+      var origin;
+      try {
+        var parsedUrl = new URL(context.controlUrl);
+        if (parsedUrl.protocol !== "http:" && parsedUrl.protocol !== "https:") return false;
+        origin = parsedUrl.origin;
+      }
+      catch (_) { return false; }
+      var heartbeatAttempt = heartbeatVersion + 1;
+      heartbeatVersion = heartbeatAttempt;
+      if (auth && (auth.token !== context.token || auth.origin !== origin)) {
+        sealDraft();
+        cancelUpload();
+        auth = null;
+      }
+      var digest;
+      try { digest = await scopeDigest(context.token, installId, origin); }
+      catch (_) { return false; }
+      if (!digest || !/^[0-9a-f]{64}$/.test(digest)) return false;
+      if (heartbeatAttempt !== heartbeatVersion || !enabled || !started) return false;
+      if (auth && (auth.token !== context.token || auth.origin !== origin) && uploadAbort) uploadAbort.abort();
+      auth = { token: context.token, origin: origin, scope: digest, proved_at_ms: now() };
+      credentialSeen = true;
+      var queue = loadQueue();
+      if (!enabled) return false;
+      if (queue.draft && queue.draft.session_id === sessionId && queue.draft.scope === null) {
+        queue.draft.scope = digest;
+      }
+      queue.envelopes.forEach(function (item) {
+        if (item.scope !== null) return;
+        try {
+          var envelope = JSON.parse(item.body);
+          if (envelope.session_id === sessionId) item.scope = digest;
+        } catch (_) {}
+      });
+      saveQueue(queue);
+      refreshActiveSession(true);
+      await metadataPromise;
+      if (heartbeatAttempt !== heartbeatVersion || !auth || auth.token !== context.token || auth.origin !== origin) return false;
+      return uploadAvailable(false);
+    }
+
+    function invalidateHeartbeat() {
+      heartbeatVersion += 1;
+      sealDraft();
+      auth = null;
+      cancelUpload();
+    }
+
+    function credentialBoundary(replacingCredential) {
+      if (!enabled || !started) return false;
+      if (!credentialSeen && !replacingCredential) {
+        credentialSeen = true;
+        return true;
+      }
+      credentialSeen = true;
+      recordInternal("session_end", "session.end", "info", { clean: true, stage: "browser" }, false);
+      sealDraft();
+      removeActiveSession();
+      cancelUpload();
+      auth = null;
+      heartbeatVersion += 1;
+      var nextSessionId = secureUuid(cryptoObject);
+      if (!nextSessionId) {
+        haltRuntime("identifier_unavailable");
+        return false;
+      }
+      sessionId = nextSessionId;
+      lastEventCode = "";
+      lastEventAt = 0;
+      recordInternal("session_start", "session.start", "info", { started: true, stage: "browser" }, false);
+      refreshActiveSession(false);
+      return true;
+    }
+
+    function recordLegacyEvent(name) {
+      var mapped = LEGACY_EVENTS[name];
+      if (!mapped) return false;
+      return recordInternal(mapped[0], mapped[1], mapped[2], {}, mapped[2] !== "info");
+    }
+
+    function recordPermission(kind, granted, errorName) {
+      if (!MEDIA_KINDS.has(kind)) return false;
+      var prefix = kind === "screen" ? "screen_share" : kind;
+      return recordInternal("permission", prefix + (granted ? ".granted" : ".denied"), granted ? "info" : "error", {
+        permission: kind,
+        granted: !!granted,
+        denied: !granted,
+        error_code: granted ? "unknown" : safeErrorCode(errorName),
+      }, !granted);
+    }
+
+    function recordDeviceCounts(counts) {
+      counts = counts || {};
+      return recordInternal("media", "media.devices_observed", "info", {
+        microphone: safeInteger(counts.microphone, 100),
+        camera: safeInteger(counts.camera, 100),
+        output: safeInteger(counts.output, 100),
+        granted: !!counts.labelsAvailable,
+      }, false);
+    }
+
+    function recordMedia(kind, action, state, errorName) {
+      if (!MEDIA_KINDS.has(kind) || !SAFE_ACTIONS.has(action) || !SAFE_STATES.has(state)) return false;
+      var prefix = kind === "screen" ? "screen_share" : kind;
+      var failed = state === "failed" || state === "error";
+      return recordInternal("media", prefix + "." + action, failed ? "warning" : "info", {
+        media_kind: kind,
+        action: action,
+        state: state,
+        error_code: failed ? safeErrorCode(errorName) : "unknown",
+      }, failed);
+    }
+
+    function recordConnectionState(state, errorName) {
+      if (!CONNECTION_STATES.has(state)) return false;
+      if (state === "reconnecting") {
+        if (reconnecting) return false;
+        reconnecting = true;
+        return recordInternal("reconnect", "reconnect.started", "warning", { connection_state: state }, true);
+      }
+      if (state === "connected" && reconnecting) {
+        reconnecting = false;
+        return recordInternal("reconnect", "reconnect.completed", "info", { connection_state: state }, false);
+      }
+      if (state === "disconnected") reconnecting = false;
+      var failed = state === "failed" || state === "error" || state === "disconnected";
+      return recordInternal("connection", "connection." + state, failed ? "warning" : "info", {
+        connection_state: state,
+        error_code: failed ? safeErrorCode(errorName) : "unknown",
+      }, failed);
+    }
+
+    function snapshot() {
+      var queue = loadQueue();
+      var status = null;
+      try { status = JSON.parse(storage.getItem(STATUS_KEY) || "null"); } catch (_) {}
+      return {
+        consent: consentState(),
+        enabled: enabled,
+        queued: queue.envelopes.length + (queue.draft && queue.draft.events.length ? 1 : 0),
+        sealed: queue.envelopes.length,
+        status: status && typeof status.code === "string" ? status : null,
+        authenticated: !!auth && auth.proved_at_ms + HEARTBEAT_AUTH_MAX_MS >= now(),
+      };
+    }
+
+    return {
+      enable: enable,
+      disable: disable,
+      consentState: consentState,
+      heartbeatSucceeded: heartbeatSucceeded,
+      invalidateHeartbeat: invalidateHeartbeat,
+      credentialBoundary: credentialBoundary,
+      recordLegacyEvent: recordLegacyEvent,
+      recordPermission: recordPermission,
+      recordDeviceCounts: recordDeviceCounts,
+      recordMedia: recordMedia,
+      recordConnectionState: recordConnectionState,
+      sendNow: async function () { await metadataPromise; sealDraft(); return uploadAvailable(true); },
+      clearQueuedData: clearQueuedData,
+      snapshot: snapshot,
+      _recordWindowError: function (event) { if (handlers) handlers.error(event); },
+      _recordUnhandledRejection: function (event) { if (handlers) handlers.rejection(event); },
+      _sealDraft: sealDraft,
+      _constants: { CONSENT_KEY: CONSENT_KEY, INSTALL_KEY: INSTALL_KEY, QUEUE_KEY: QUEUE_KEY, STATUS_KEY: STATUS_KEY, ACTIVE_KEY: ACTIVE_KEY },
+    };
+  }
+
+  function isDesktopMacBrowser(environment) {
+    if (!environment || environment.__ECHO_NATIVE__ || !environment.navigator) return false;
+    var navigatorObject = environment.navigator;
+    var platform = String(navigatorObject.platform || "");
+    var userAgent = String(navigatorObject.userAgent || "");
+    var isMac = /^Mac/.test(platform) || /Macintosh|Mac OS X/.test(userAgent);
+    var isIPadMasquerading = isMac && Number(navigatorObject.maxTouchPoints || 0) > 1;
+    return isMac && !isIPadMasquerading;
+  }
+
+  function detectBrowserRuntime(navigatorObject, livekit) {
+    var userAgent = String((navigatorObject && navigatorObject.userAgent) || "");
+    var browserName = "Browser";
+    var browserVersion = "unknown";
+    var match = userAgent.match(/Edg\/([0-9.]+)/);
+    if (match) { browserName = "Edge"; browserVersion = match[1]; }
+    else if ((match = userAgent.match(/Chrome\/([0-9.]+)/))) { browserName = "Chrome"; browserVersion = match[1]; }
+    else if ((match = userAgent.match(/Firefox\/([0-9.]+)/))) { browserName = "Firefox"; browserVersion = match[1]; }
+    else if ((match = userAgent.match(/Version\/([0-9.]+).*Safari/))) { browserName = "Safari"; browserVersion = match[1]; }
+    var runtimes = { browser_name: browserName, browser_version: browserVersion };
+    if (livekit && typeof livekit.version === "string") runtimes.livekit_version = livekit.version;
+    return runtimes;
+  }
+
+  function browserMetadataProvider(environment) {
+    return async function () {
+      var endpoint = typeof environment.apiUrl === "function" ? environment.apiUrl("/api/version") : "/api/version";
+      var response = await environment.fetch(endpoint, { cache: "no-store" });
+      if (!response.ok) throw new Error("version unavailable");
+      var payload = await response.json();
+      return {
+        app: {
+          version: payload.version,
+          git_sha: payload.git_sha,
+          channel: "web-canary",
+          runtimes: detectBrowserRuntime(environment.navigator, environment.LivekitClient),
+        },
+        platform: { client_kind: "browser", operating_system: "macos", architecture: "unknown" },
+      };
+    };
+  }
+
+  function installBrowserRuntime(environment) {
+    if (!isDesktopMacBrowser(environment) || environment.EchoWebDiagnosticsRuntime) return null;
+    var storage;
+    var boundFetch;
+    try {
+      storage = environment.localStorage;
+      boundFetch = environment.fetch.bind(environment);
+    } catch (_) {
+      return null;
+    }
+    var collector = createCollector({
+      storage: storage,
+      crypto: environment.crypto,
+      fetch: boundFetch,
+      metadataProvider: browserMetadataProvider(environment),
+      scopeDigest: function (token, installId, origin) {
+        return defaultScopeDigest(token, installId, origin, environment.crypto);
+      },
+      eventTarget: environment,
+    });
+    environment.EchoWebDiagnosticsRuntime = collector;
+
+    var documentObject = environment.document;
+    var section = documentObject.getElementById("diagnostics-settings-section");
+    var toggle = documentObject.getElementById("diagnostics-enabled-toggle");
+    var modal = documentObject.getElementById("diagnostics-consent-modal");
+    var accept = documentObject.getElementById("diagnostics-consent-accept");
+    var decline = documentObject.getElementById("diagnostics-consent-decline");
+    var send = documentObject.getElementById("diagnostics-send-now");
+    var clear = documentObject.getElementById("diagnostics-delete-queued");
+    var lastUpload = documentObject.getElementById("diagnostics-last-upload");
+    var queueCount = documentObject.getElementById("diagnostics-queue-count");
+    var actionStatus = documentObject.getElementById("diagnostics-action-status");
+    if (section) section.classList.remove("hidden");
+
+    function statusLabel(status) {
+      var labels = {
+        accepted: "Accepted", duplicate: "Already received", auth_wait: "Waiting for a fresh heartbeat",
+        server_disabled: "Unavailable on this server", conflict_dropped: "Corrupt report removed",
+        invalid_dropped: "Invalid report removed", rate_limited: "Rate limited; retry scheduled",
+        retry_wait: "Server unavailable; retry scheduled", network_wait: "Offline; retry scheduled",
+        metadata_unavailable: "Build metadata unavailable", queue_cleared: "Queued data deleted",
+        storage_unavailable: "Browser storage unavailable", identifier_unavailable: "Secure random source unavailable",
+      };
+      return labels[status] || "Never";
+    }
+
+    function render() {
+      var snapshot = collector.snapshot();
+      if (toggle) toggle.checked = snapshot.consent === "enabled";
+      if (queueCount) queueCount.textContent = snapshot.queued + (snapshot.queued === 1 ? " report" : " reports");
+      if (lastUpload) {
+        lastUpload.textContent = snapshot.status ? statusLabel(snapshot.status.code) +
+          (snapshot.status.at_ms ? " - " + new Date(snapshot.status.at_ms).toLocaleString() : "") : "Never";
+      }
+      if (send) send.disabled = snapshot.consent !== "enabled" || !snapshot.authenticated;
+      if (clear) clear.disabled = snapshot.queued === 0;
+    }
+
+    async function setEnabled(next) {
+      if (next) {
+        if (actionStatus) actionStatus.textContent = "Starting private diagnostics...";
+        var ready = await collector.enable();
+        if (actionStatus) actionStatus.textContent = ready ? "Diagnostics are on." : "Diagnostics could not start safely.";
+      } else {
+        collector.disable();
+        if (actionStatus) actionStatus.textContent = "Diagnostics are off. Queued browser data was deleted.";
+      }
+      render();
+    }
+
+    if (toggle) toggle.addEventListener("change", function () { void setEnabled(toggle.checked); });
+    if (accept) accept.addEventListener("click", function () {
+      modal.hidden = true;
+      void setEnabled(true);
+    });
+    if (decline) decline.addEventListener("click", function () {
+      modal.hidden = true;
+      void setEnabled(false);
+    });
+    if (send) send.addEventListener("click", async function () {
+      if (actionStatus) actionStatus.textContent = "Sending queued diagnostics...";
+      var sent = await collector.sendNow();
+      if (actionStatus) actionStatus.textContent = sent ? "Send attempted." : "Waiting for a connected heartbeat.";
+      render();
+    });
+    if (clear) clear.addEventListener("click", function () {
+      collector.clearQueuedData();
+      if (actionStatus) actionStatus.textContent = "Queued browser data deleted. Accepted server reports are unchanged.";
+      render();
+    });
+    environment.addEventListener("storage", function (event) {
+      if (event.key !== CONSENT_KEY) return;
+      if (event.newValue === CONSENT_DISABLED) collector.disable(false);
+      else if (event.newValue === CONSENT_ENABLED) void collector.enable();
+      render();
+    });
+
+    var start = function () {
+      var state = collector.consentState();
+      render();
+      if (state === "enabled") void collector.enable().then(render);
+      else if (state === "unset" && modal) {
+        modal.hidden = false;
+        if (decline) setTimeout(function () { decline.focus(); }, 0);
+      }
+    };
+    Promise.resolve(environment._settingsReadyPromise || null).then(start, start);
+    environment.setInterval(render, 1000);
+    return collector;
+  }
+
+  return {
+    createCollector: createCollector,
+    installBrowserRuntime: installBrowserRuntime,
+    isDesktopMacBrowser: isDesktopMacBrowser,
+    detectBrowserRuntime: detectBrowserRuntime,
+    safeMetadata: safeMetadata,
+    sanitizeEvent: sanitizeEvent,
+    validateSealedBody: validateSealedBody,
+    parseQueue: parseQueue,
+    secureUuid: secureUuid,
+    decodeJwtSubject: decodeJwtSubject,
+    constants: {
+      CONSENT_KEY: CONSENT_KEY,
+      INSTALL_KEY: INSTALL_KEY,
+      QUEUE_KEY: QUEUE_KEY,
+      STATUS_KEY: STATUS_KEY,
+      ACTIVE_KEY: ACTIVE_KEY,
+      CONSENT_ENABLED: CONSENT_ENABLED,
+      CONSENT_DISABLED: CONSENT_DISABLED,
+      MAX_ENVELOPES: MAX_ENVELOPES,
+      MAX_ENVELOPE_BYTES: MAX_ENVELOPE_BYTES,
+      MAX_QUEUE_BYTES: MAX_QUEUE_BYTES,
+      QUEUE_TTL_MS: QUEUE_TTL_MS,
+    },
+  };
+});

--- a/core/viewer/diagnostics-client.js
+++ b/core/viewer/diagnostics-client.js
@@ -394,7 +394,13 @@
 
     function setStatus(code, at) {
       var payload = JSON.stringify({ version: 1, code: safeToken(code), at_ms: safeInteger(at || now(), Number.MAX_SAFE_INTEGER) });
-      try { storage.setItem(STATUS_KEY, payload); } catch (_) {}
+      try {
+        if (storage.getItem(CONSENT_KEY) !== CONSENT_ENABLED) return false;
+        storage.setItem(STATUS_KEY, payload);
+        return true;
+      } catch (_) {
+        return false;
+      }
     }
 
     function consentState() {
@@ -408,6 +414,14 @@
       }
     }
 
+    function requirePersistedConsent() {
+      try {
+        if (storage.getItem(CONSENT_KEY) === CONSENT_ENABLED) return true;
+      } catch (_) {}
+      disable(false);
+      return false;
+    }
+
     function loadQueue() {
       try { return parseQueue(storage.getItem(QUEUE_KEY), now()); }
       catch (_) { haltRuntime("storage_unavailable"); return emptyQueue(); }
@@ -415,6 +429,7 @@
 
     function saveQueue(queue) {
       if (!enabled) return false;
+      if (!requirePersistedConsent()) return false;
       try {
         queue.revision = safeInteger(queue.revision + 1, Number.MAX_SAFE_INTEGER);
         queue.writer = writerId || "";
@@ -608,7 +623,13 @@
     }
 
     function writeActiveSessions(registry) {
-      try { storage.setItem(ACTIVE_KEY, JSON.stringify(registry)); } catch (_) {}
+      if (!enabled || !requirePersistedConsent()) return false;
+      try {
+        storage.setItem(ACTIVE_KEY, JSON.stringify(registry));
+        return true;
+      } catch (_) {
+        return false;
+      }
     }
 
     function refreshActiveSession(reportStale) {
@@ -658,26 +679,29 @@
     }
 
     function scheduleRetry(delay) {
+      if (!enabled || !requirePersistedConsent()) return false;
       if (retryTimer) clearTimer(retryTimer);
       retryTimer = setTimer(function () { retryTimer = null; void uploadAvailable(); }, Math.max(1000, delay));
+      return true;
     }
 
     function removeEnvelope(body) {
       var queue = loadQueue();
       queue.envelopes = queue.envelopes.filter(function (item) { return item.body !== body; });
-      saveQueue(queue);
+      return saveQueue(queue);
     }
 
     function updateEnvelope(body, update) {
       var queue = loadQueue();
       var item = queue.envelopes.find(function (entry) { return entry.body === body; });
-      if (!item) return;
+      if (!item) return false;
       update(item);
-      saveQueue(queue);
+      return saveQueue(queue);
     }
 
     async function uploadAvailable(force) {
       if (!enabled || !auth || uploading || pageDisabled || !fetchImpl) return false;
+      if (!requirePersistedConsent()) return false;
       if (auth.proved_at_ms + HEARTBEAT_AUTH_MAX_MS < now()) {
         auth = null;
         return false;
@@ -689,8 +713,11 @@
       });
       if (!candidate) return false;
       if (!validateSealedBody(candidate.body, installId)) {
-        removeEnvelope(candidate.body);
-        setStatus("invalid_dropped");
+        if (!removeEnvelope(candidate.body)) return false;
+        if (!setStatus("invalid_dropped")) {
+          disable(false);
+          return false;
+        }
         return false;
       }
       uploading = true;
@@ -702,6 +729,7 @@
       uploadAbort = controller;
       var timeout = controller ? setTimer(function () { controller.abort(); }, 10000) : null;
       try {
+        if (!requirePersistedConsent()) return false;
         var response = await fetchImpl(uploadAuth.origin + "/api/diagnostics/v1/envelopes", {
           method: "POST",
           headers: { "Content-Type": "application/json", Authorization: "Bearer " + uploadAuth.token },
@@ -709,42 +737,60 @@
           cache: "no-store",
           signal: controller ? controller.signal : undefined,
         });
-        if (uploadOperation !== uploadSequence || !enabled) return false;
+        if (uploadOperation !== uploadSequence || !enabled || !requirePersistedConsent()) return false;
         if (response.status === 200 || response.status === 202) {
-          removeEnvelope(candidate.body);
-          setStatus(response.status === 200 ? "duplicate" : "accepted");
+          if (!removeEnvelope(candidate.body)) return false;
+          if (!setStatus(response.status === 200 ? "duplicate" : "accepted")) {
+            disable(false);
+            return false;
+          }
         } else if (response.status === 401 || response.status === 403) {
           if (uploadHeartbeat === heartbeatVersion) {
             auth = null;
-            setStatus("auth_wait");
+            if (!setStatus("auth_wait")) {
+              disable(false);
+              return false;
+            }
           }
         } else if (response.status === 404) {
           pageDisabled = true;
-          setStatus("server_disabled");
+          if (!setStatus("server_disabled")) {
+            disable(false);
+            return false;
+          }
         } else if ([400, 409, 413, 422].indexOf(response.status) >= 0) {
-          removeEnvelope(candidate.body);
-          setStatus(response.status === 409 ? "conflict_dropped" : "invalid_dropped");
+          if (!removeEnvelope(candidate.body)) return false;
+          if (!setStatus(response.status === 409 ? "conflict_dropped" : "invalid_dropped")) {
+            disable(false);
+            return false;
+          }
         } else {
           var retryAfter = response.status === 429 && response.headers && response.headers.get
             ? parseRetryAfter(response.headers.get("Retry-After"), now()) : 0;
           var delay = retryAfter || Math.min(300000, 5000 * Math.pow(2, Math.min(candidate.attempts, 6)));
-          updateEnvelope(candidate.body, function (item) {
+          if (!updateEnvelope(candidate.body, function (item) {
             item.attempts += 1;
             item.next_attempt_ms = now() + delay;
-          });
-          setStatus(response.status === 429 ? "rate_limited" : "retry_wait");
-          scheduleRetry(delay);
+          })) return false;
+          if (!setStatus(response.status === 429 ? "rate_limited" : "retry_wait")) {
+            disable(false);
+            return false;
+          }
+          if (!scheduleRetry(delay)) return false;
         }
       } catch (_) {
-        if (uploadOperation === uploadSequence && enabled && auth) {
-          var networkDelay = Math.min(300000, 5000 * Math.pow(2, Math.min(candidate.attempts, 6)));
-          updateEnvelope(candidate.body, function (item) {
-            item.attempts += 1;
-            item.next_attempt_ms = now() + networkDelay;
-          });
-          setStatus("network_wait");
-          scheduleRetry(networkDelay);
+        if (uploadOperation !== uploadSequence || !enabled || !auth) return false;
+        if (!requirePersistedConsent()) return false;
+        var networkDelay = Math.min(300000, 5000 * Math.pow(2, Math.min(candidate.attempts, 6)));
+        if (!updateEnvelope(candidate.body, function (item) {
+          item.attempts += 1;
+          item.next_attempt_ms = now() + networkDelay;
+        })) return false;
+        if (!setStatus("network_wait")) {
+          disable(false);
+          return false;
         }
+        if (!scheduleRetry(networkDelay)) return false;
       } finally {
         if (timeout) clearTimer(timeout);
         if (uploadOperation === uploadSequence) {
@@ -785,7 +831,7 @@
       var pendingMetadata = Promise.resolve().then(metadataProvider).then(safeMetadata).catch(function () { return null; });
       metadataPromise = pendingMetadata;
       var resolvedMetadata = await pendingMetadata;
-      if (generation !== lifecycleVersion || !enabled) return false;
+      if (generation !== lifecycleVersion || !enabled || !requirePersistedConsent()) return false;
       if (!resolvedMetadata) {
         metadata = null;
         haltRuntime("metadata_unavailable");
@@ -844,9 +890,14 @@
     }
 
     function clearQueuedData() {
+      if (!enabled || !requirePersistedConsent()) return false;
       cancelUpload();
       try { storage.removeItem(QUEUE_KEY); } catch (_) {}
-      setStatus("queue_cleared");
+      if (!setStatus("queue_cleared")) {
+        disable(false);
+        return false;
+      }
+      return true;
     }
 
     async function heartbeatSucceeded(context) {

--- a/core/viewer/diagnostics-client.test.js
+++ b/core/viewer/diagnostics-client.test.js
@@ -1,0 +1,1060 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { webcrypto } = require("node:crypto");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const diagnostics = require("./diagnostics-client.js");
+
+const {
+  CONSENT_KEY,
+  INSTALL_KEY,
+  QUEUE_KEY,
+  STATUS_KEY,
+  ACTIVE_KEY,
+  CONSENT_ENABLED,
+  CONSENT_DISABLED,
+  MAX_ENVELOPES,
+  MAX_ENVELOPE_BYTES,
+  MAX_QUEUE_BYTES,
+  QUEUE_TTL_MS,
+} = diagnostics.constants;
+
+const BASE_TIME = 1_784_660_000_000;
+const SCOPE_A = "a".repeat(64);
+const SCOPE_B = "b".repeat(64);
+
+class MemoryStorage {
+  constructor(initial) {
+    this.values = new Map();
+    this.writes = [];
+    this.removes = [];
+    Object.entries(initial || {}).forEach(([key, value]) => {
+      this.values.set(String(key), String(value));
+    });
+  }
+
+  get length() {
+    return this.values.size;
+  }
+
+  key(index) {
+    return Array.from(this.values.keys())[index] ?? null;
+  }
+
+  getItem(key) {
+    key = String(key);
+    return this.values.has(key) ? this.values.get(key) : null;
+  }
+
+  setItem(key, value) {
+    key = String(key);
+    value = String(value);
+    this.values.set(key, value);
+    this.writes.push({ key, value });
+  }
+
+  removeItem(key) {
+    key = String(key);
+    this.values.delete(key);
+    this.removes.push(key);
+  }
+
+  dump() {
+    return JSON.stringify(Object.fromEntries(this.values));
+  }
+}
+
+class MemoryEventTarget {
+  constructor() {
+    this.listeners = new Map();
+  }
+
+  addEventListener(type, listener) {
+    if (!this.listeners.has(type)) this.listeners.set(type, new Set());
+    this.listeners.get(type).add(listener);
+  }
+
+  removeEventListener(type, listener) {
+    const listeners = this.listeners.get(type);
+    if (listeners) listeners.delete(listener);
+  }
+
+  dispatch(type, event) {
+    for (const listener of this.listeners.get(type) || []) listener(event);
+  }
+
+  count(type) {
+    return (this.listeners.get(type) || new Set()).size;
+  }
+}
+
+class MemoryTimers {
+  constructor() {
+    this.nextId = 1;
+    this.timeouts = new Map();
+    this.intervals = new Map();
+  }
+
+  setTimeout(callback, delay) {
+    const id = this.nextId++;
+    this.timeouts.set(id, { callback, delay });
+    return id;
+  }
+
+  clearTimeout(id) {
+    this.timeouts.delete(id);
+  }
+
+  setInterval(callback, delay) {
+    const id = this.nextId++;
+    this.intervals.set(id, { callback, delay });
+    return id;
+  }
+
+  clearInterval(id) {
+    this.intervals.delete(id);
+  }
+}
+
+function uuidFor(number, uppercase) {
+  const suffix = Number(number).toString(16).padStart(12, "0");
+  const value = `00000000-0000-4000-8000-${suffix}`;
+  return uppercase ? value.toUpperCase() : value;
+}
+
+function deterministicCrypto(options) {
+  const opts = options || {};
+  let next = opts.start || 1;
+  return {
+    randomUUID() {
+      if (opts.throwRandomUuid) throw new Error("secure random source failed");
+      if (opts.invalidRandomUuid) return "not-a-uuid";
+      return uuidFor(next++, opts.uppercase);
+    },
+  };
+}
+
+function getRandomValuesCrypto() {
+  let counter = 0;
+  return {
+    getRandomValues(bytes) {
+      for (let index = 0; index < bytes.length; index += 1) {
+        bytes[index] = (counter + index + 1) & 0xff;
+      }
+      counter += bytes.length;
+      return bytes;
+    },
+  };
+}
+
+class FetchHarness {
+  constructor(plan) {
+    this.plan = Array.from(plan || []);
+    this.calls = [];
+  }
+
+  async fetch(url, init) {
+    const captured = {
+      url: String(url),
+      method: init && init.method,
+      headers: init && { ...init.headers },
+      body: init && init.body,
+      cache: init && init.cache,
+    };
+    this.calls.push(captured);
+    const next = this.plan.length ? this.plan.shift() : { status: 503 };
+    if (next && next.error) throw next.error;
+    const headers = new Map(
+      Object.entries((next && next.headers) || {}).map(([key, value]) => [key.toLowerCase(), String(value)]),
+    );
+    return {
+      status: next.status,
+      ok: next.status >= 200 && next.status < 300,
+      headers: { get: (name) => headers.get(String(name).toLowerCase()) ?? null },
+    };
+  }
+}
+
+class DeferredFetchHarness extends FetchHarness {
+  constructor() {
+    super();
+    this.pending = [];
+  }
+
+  async fetch(url, init) {
+    this.calls.push({
+      url: String(url),
+      method: init && init.method,
+      headers: init && { ...init.headers },
+      body: init && init.body,
+      cache: init && init.cache,
+    });
+    return new Promise((resolve) => this.pending.push(resolve));
+  }
+
+  respond(status) {
+    const resolve = this.pending.shift();
+    assert.ok(resolve, "expected a pending fetch");
+    resolve({ status, ok: status >= 200 && status < 300, headers: { get: () => null } });
+  }
+}
+
+function validMetadata(overrides) {
+  const base = {
+    app: {
+      version: "0.6.33.1784660000",
+      git_sha: "ceaaf6f1",
+      channel: "web-canary",
+      runtimes: {
+        browser_name: "Safari",
+        browser_version: "18.5",
+        livekit_version: "2.15.3",
+      },
+    },
+    platform: {
+      client_kind: "browser",
+      operating_system: "macos",
+      architecture: "unknown",
+    },
+  };
+  if (!overrides) return base;
+  return {
+    app: { ...base.app, ...(overrides.app || {}) },
+    platform: { ...base.platform, ...(overrides.platform || {}) },
+  };
+}
+
+function createHarness(options) {
+  const opts = options || {};
+  const storage = opts.storage || new MemoryStorage(opts.initialStorage);
+  const eventTarget = opts.eventTarget || new MemoryEventTarget();
+  const timers = opts.timers || new MemoryTimers();
+  const fetchHarness = opts.fetchHarness || new FetchHarness(opts.responses);
+  const crypto = opts.crypto || deterministicCrypto({ uppercase: opts.uppercaseUuids });
+  let currentTime = opts.now || BASE_TIME;
+  const metadata = Object.prototype.hasOwnProperty.call(opts, "metadata")
+    ? opts.metadata
+    : validMetadata();
+  const metadataProvider = opts.metadataProvider || (async () => metadata);
+  const scopeDigest = opts.useDefaultScopeDigest ? undefined : (opts.scopeDigest || (async (token) => (
+    String(token).includes("scope-b") ? SCOPE_B : SCOPE_A
+  )));
+
+  const collector = diagnostics.createCollector({
+    storage,
+    crypto,
+    fetch: fetchHarness.fetch.bind(fetchHarness),
+    now: () => currentTime,
+    setTimeout: timers.setTimeout.bind(timers),
+    clearTimeout: timers.clearTimeout.bind(timers),
+    setInterval: timers.setInterval.bind(timers),
+    clearInterval: timers.clearInterval.bind(timers),
+    metadataProvider,
+    ...(scopeDigest ? { scopeDigest } : {}),
+    eventTarget,
+  });
+
+  return {
+    collector,
+    storage,
+    eventTarget,
+    timers,
+    fetchHarness,
+    crypto,
+    now: () => currentTime,
+    advance(milliseconds) {
+      currentTime += milliseconds;
+      return currentTime;
+    },
+  };
+}
+
+function readQueue(storage, now) {
+  return diagnostics.parseQueue(storage.getItem(QUEUE_KEY), now || BASE_TIME);
+}
+
+function readStatus(storage) {
+  return JSON.parse(storage.getItem(STATUS_KEY) || "null");
+}
+
+function utf8Bytes(value) {
+  return new TextEncoder().encode(value).length;
+}
+
+function jwtForSubject(subject) {
+  const encode = (value) => Buffer.from(JSON.stringify(value)).toString("base64url");
+  return `${encode({ alg: "none" })}.${encode({ sub: subject })}.signature`;
+}
+
+function makeEnvelope(options) {
+  const opts = options || {};
+  const eventCount = opts.eventCount || 1;
+  const capturedAt = opts.capturedAt || BASE_TIME;
+  const details = opts.details || { connection_state: "connected" };
+  const events = [];
+  for (let index = 0; index < eventCount; index += 1) {
+    events.push({
+      sequence: index + 1,
+      timestamp_ms: capturedAt + index,
+      event_type: "connection",
+      severity: "info",
+      code: "connection.connected",
+      details: { ...details },
+    });
+  }
+  return JSON.stringify({
+    schema_version: 1,
+    envelope_id: opts.envelopeId || uuidFor(opts.number || 100),
+    install_id: opts.installId || uuidFor(200),
+    session_id: opts.sessionId || uuidFor(300),
+    captured_at_ms: capturedAt,
+    sent_at_ms: capturedAt + eventCount,
+    app: validMetadata().app,
+    platform: validMetadata().platform,
+    events,
+  });
+}
+
+function queueDocument(envelopes, options) {
+  const opts = options || {};
+  return JSON.stringify({
+    version: 1,
+    revision: 1,
+    writer: "",
+    draft: opts.draft || null,
+    envelopes: envelopes.map((body, index) => ({
+      body,
+      created_at_ms: (opts.createdAt || BASE_TIME) + index,
+      scope: opts.scope === undefined ? SCOPE_A : opts.scope,
+      attempts: 0,
+      next_attempt_ms: 0,
+    })),
+  });
+}
+
+test("desktop Mac browser gating excludes native shell, iPad masquerade, and non-Mac browsers", () => {
+  assert.equal(diagnostics.isDesktopMacBrowser({
+    __ECHO_NATIVE__: false,
+    navigator: { platform: "MacIntel", userAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)", maxTouchPoints: 0 },
+  }), true);
+  assert.equal(diagnostics.isDesktopMacBrowser({
+    __ECHO_NATIVE__: true,
+    navigator: { platform: "MacIntel", userAgent: "Mozilla/5.0 (Macintosh)", maxTouchPoints: 0 },
+  }), false);
+  assert.equal(diagnostics.isDesktopMacBrowser({
+    __ECHO_NATIVE__: false,
+    navigator: { platform: "MacIntel", userAgent: "Mozilla/5.0 (Macintosh)", maxTouchPoints: 5 },
+  }), false);
+  assert.equal(diagnostics.isDesktopMacBrowser({
+    __ECHO_NATIVE__: false,
+    navigator: { platform: "iPad", userAgent: "Mozilla/5.0 (Macintosh; Mac OS X)", maxTouchPoints: 5 },
+  }), false);
+  assert.equal(diagnostics.isDesktopMacBrowser({
+    __ECHO_NATIVE__: false,
+    navigator: { platform: "Win32", userAgent: "Mozilla/5.0 (Windows NT 10.0)", maxTouchPoints: 0 },
+  }), false);
+
+  const nativeStorage = new MemoryStorage();
+  const nativeEnvironment = {
+    __ECHO_NATIVE__: true,
+    navigator: { platform: "MacIntel", userAgent: "Mozilla/5.0 (Macintosh)", maxTouchPoints: 0 },
+    localStorage: nativeStorage,
+  };
+  assert.equal(diagnostics.installBrowserRuntime(nativeEnvironment), null);
+  assert.equal(nativeStorage.writes.length, 0);
+});
+
+test("secure UUID generation is canonical lowercase and fails closed without secure randomness", async (t) => {
+  assert.match(diagnostics.secureUuid(deterministicCrypto({ uppercase: true })), /^[0-9a-f-]{36}$/);
+  assert.match(diagnostics.secureUuid(getRandomValuesCrypto()), /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+  assert.equal(diagnostics.secureUuid({}), null);
+  assert.equal(diagnostics.secureUuid(deterministicCrypto({ invalidRandomUuid: true })), null);
+
+  await t.test("collector stays off when no secure UUID source exists", async () => {
+    const storage = new MemoryStorage();
+    const harness = createHarness({ storage, crypto: {} });
+    assert.equal(await harness.collector.enable(), false);
+    assert.equal(harness.collector.snapshot().enabled, false);
+    assert.equal(storage.getItem(INSTALL_KEY), null);
+    assert.equal(storage.getItem(QUEUE_KEY), null);
+    assert.equal(harness.fetchHarness.calls.length, 0);
+  });
+});
+
+test("absent or corrupt consent is OFF and nothing writes or uses the network before explicit enable", async () => {
+  const storage = new MemoryStorage({ [CONSENT_KEY]: "corrupt-v99" });
+  const harness = createHarness({ storage });
+  assert.equal(harness.collector.consentState(), "unset");
+  assert.equal(harness.collector.recordLegacyEvent("room-disconnect"), false);
+  assert.equal(harness.collector.recordPermission("microphone", false, "NotAllowedError"), false);
+  assert.equal(harness.collector.recordMedia("camera", "start", "failed", "NotReadableError"), false);
+  assert.equal(harness.collector.recordConnectionState("failed", "AbortError"), false);
+  assert.equal(await harness.collector.heartbeatSucceeded({
+    controlUrl: "https://control-before-enable.invalid/private",
+    token: "before-enable-token",
+  }), false);
+  assert.equal(storage.writes.length, 0);
+  assert.equal(harness.fetchHarness.calls.length, 0);
+  assert.equal(storage.getItem(QUEUE_KEY), null);
+});
+
+test("invalid build metadata fails closed before handlers, queueing, or upload", async () => {
+  const harness = createHarness({ metadata: validMetadata({ app: { git_sha: "not-a-sha" } }) });
+  assert.equal(await harness.collector.enable(), false);
+  const snapshot = harness.collector.snapshot();
+  assert.equal(snapshot.enabled, false);
+  assert.equal(snapshot.authenticated, false);
+  assert.equal(harness.eventTarget.count("error"), 0);
+  assert.equal(harness.storage.getItem(QUEUE_KEY), null);
+  assert.equal(readStatus(harness.storage).code, "metadata_unavailable");
+  assert.equal(await harness.collector.heartbeatSucceeded({
+    controlUrl: "https://control.invalid",
+    token: "metadata-failure-token",
+  }), false);
+  assert.equal(harness.fetchHarness.calls.length, 0);
+});
+
+test("global adapters never read raw error text, stack, source, or rejection reason", async () => {
+  const forbidden = [
+    "FORBIDDEN-MESSAGE-9fd3",
+    "Bearer secret.jwt.value",
+    "person@example.invalid",
+    "192.0.2.77",
+    "F:\\private\\trace.log",
+    "https://example.invalid/api?token=secret",
+    "a=candidate:1 1 udp 1 192.0.2.88 50000 typ host",
+    "private-identity-7475",
+  ];
+  const reads = { message: 0, stack: 0, filename: 0, source: 0, reason: 0 };
+  const errorObject = { name: "TypeError" };
+  Object.defineProperty(errorObject, "message", {
+    get() { reads.message += 1; throw new Error(forbidden[0]); },
+  });
+  Object.defineProperty(errorObject, "stack", {
+    get() { reads.stack += 1; throw new Error(forbidden[1]); },
+  });
+  const errorEvent = { error: errorObject, lineno: 17, colno: 23 };
+  Object.defineProperty(errorEvent, "filename", {
+    get() { reads.filename += 1; throw new Error(forbidden[5]); },
+  });
+  Object.defineProperty(errorEvent, "source", {
+    get() { reads.source += 1; throw new Error(forbidden[6]); },
+  });
+  const rejectionEvent = {};
+  Object.defineProperty(rejectionEvent, "reason", {
+    get() { reads.reason += 1; throw new Error(forbidden.join(" ")); },
+  });
+
+  const harness = createHarness({ responses: [{ status: 503 }] });
+  assert.equal(await harness.collector.enable(), true);
+  harness.eventTarget.dispatch("error", errorEvent);
+  harness.eventTarget.dispatch("unhandledrejection", rejectionEvent);
+  assert.deepEqual(reads, { message: 0, stack: 0, filename: 0, source: 0, reason: 0 });
+
+  await harness.collector.heartbeatSucceeded({
+    controlUrl: "https://control.example.test",
+    token: "memory-only-adapter-token",
+  });
+  assert.equal(harness.fetchHarness.calls.length, 1);
+  const persisted = harness.storage.dump();
+  const body = harness.fetchHarness.calls[0].body;
+  for (const value of forbidden) {
+    assert.equal(persisted.includes(value), false, `storage leaked ${value}`);
+    assert.equal(body.includes(value), false, `wire body leaked ${value}`);
+  }
+  assert.equal(body.includes("message"), false);
+  assert.equal(body.includes("fingerprint"), false);
+  const sent = JSON.parse(body);
+  const error = sent.events.find((event) => event.event_type === "javascript_error");
+  assert.equal(error.details.error_code, "type_error");
+  assert.equal(error.details.line, 17);
+  assert.equal(error.details.column, 23);
+});
+
+test("heartbeat is the only upload release and token/control URL remain memory-only", async () => {
+  const token = "TOKEN-MUST-NEVER-PERSIST-6d30";
+  const controlUrl = "https://private-control.example.test/some/path";
+  const harness = createHarness({ responses: [{ status: 503 }] });
+  assert.equal(await harness.collector.enable(), true);
+  harness.collector.recordPermission("microphone", false, "NotAllowedError");
+  assert.equal(harness.fetchHarness.calls.length, 0);
+
+  await harness.collector.heartbeatSucceeded({ controlUrl, token });
+  assert.equal(harness.fetchHarness.calls.length, 1);
+  assert.equal(harness.fetchHarness.calls[0].url, "https://private-control.example.test/api/diagnostics/v1/envelopes");
+  assert.equal(harness.fetchHarness.calls[0].headers.Authorization, `Bearer ${token}`);
+  const persisted = harness.storage.dump();
+  assert.equal(persisted.includes(token), false);
+  assert.equal(persisted.includes("private-control.example.test"), false);
+  assert.equal(persisted.includes("some/path"), false);
+
+  harness.collector.invalidateHeartbeat();
+  assert.equal(harness.collector.snapshot().authenticated, false);
+  assert.equal(await harness.collector.sendNow(), false);
+  assert.equal(harness.fetchHarness.calls.length, 1);
+});
+
+for (const successStatus of [202, 200]) {
+  test(`${successStatus} acknowledgement deletes the sealed envelope`, async () => {
+    const harness = createHarness({ responses: [{ status: successStatus }] });
+    assert.equal(await harness.collector.enable(), true);
+    assert.equal(await harness.collector.heartbeatSucceeded({
+      controlUrl: "https://control.example.test",
+      token: `ack-${successStatus}`,
+    }), true);
+    assert.equal(harness.fetchHarness.calls.length, 1);
+    assert.equal(harness.collector.snapshot().sealed, 0);
+    assert.equal(harness.collector.snapshot().queued, 0);
+    assert.equal(readStatus(harness.storage).code, successStatus === 202 ? "accepted" : "duplicate");
+  });
+}
+
+test("sealed request bytes remain identical across a 5xx retry", async () => {
+  const harness = createHarness({ responses: [{ status: 503 }, { status: 202 }] });
+  assert.equal(await harness.collector.enable(), true);
+  await harness.collector.heartbeatSucceeded({
+    controlUrl: "https://control.example.test",
+    token: "retry-scope-a",
+  });
+  assert.equal(harness.fetchHarness.calls.length, 1);
+  const firstBody = harness.fetchHarness.calls[0].body;
+  const queuedAfterFailure = readQueue(harness.storage, harness.now());
+  assert.equal(queuedAfterFailure.envelopes.length, 1);
+  assert.equal(queuedAfterFailure.envelopes[0].body, firstBody);
+  assert.equal(queuedAfterFailure.envelopes[0].attempts, 1);
+  assert.equal(readStatus(harness.storage).code, "retry_wait");
+
+  harness.advance(5_000);
+  await harness.collector.heartbeatSucceeded({
+    controlUrl: "https://control.example.test",
+    token: "retry-scope-a",
+  });
+  assert.equal(harness.fetchHarness.calls.length, 2);
+  assert.equal(harness.fetchHarness.calls[1].body, firstBody);
+  assert.equal(harness.collector.snapshot().sealed, 0);
+});
+
+test("401 waits for a new heartbeat without deleting or looping", async () => {
+  const harness = createHarness({ responses: [{ status: 401 }, { status: 202 }] });
+  await harness.collector.enable();
+  await harness.collector.heartbeatSucceeded({
+    controlUrl: "https://control.example.test",
+    token: "expired-participant-token",
+  });
+  assert.equal(harness.fetchHarness.calls.length, 1);
+  assert.equal(harness.collector.snapshot().sealed, 1);
+  assert.equal(harness.collector.snapshot().authenticated, false);
+  assert.equal(readStatus(harness.storage).code, "auth_wait");
+  assert.equal(await harness.collector.sendNow(), false);
+  assert.equal(harness.fetchHarness.calls.length, 1);
+});
+
+test("404 disables uploads for the rest of the page without deleting the queue", async () => {
+  const harness = createHarness({ responses: [{ status: 404 }, { status: 202 }] });
+  await harness.collector.enable();
+  await harness.collector.heartbeatSucceeded({
+    controlUrl: "https://control.example.test",
+    token: "disabled-server-token",
+  });
+  assert.equal(harness.fetchHarness.calls.length, 1);
+  assert.equal(harness.collector.snapshot().sealed, 1);
+  assert.equal(readStatus(harness.storage).code, "server_disabled");
+  harness.advance(1_000);
+  assert.equal(await harness.collector.heartbeatSucceeded({
+    controlUrl: "https://control.example.test",
+    token: "new-disabled-server-token",
+  }), false);
+  assert.equal(harness.fetchHarness.calls.length, 1);
+  assert.equal(harness.collector.snapshot().sealed, 1);
+});
+
+for (const terminalStatus of [400, 409, 413, 422]) {
+  test(`${terminalStatus} drops the terminal envelope and does not hot-loop`, async () => {
+    const harness = createHarness({ responses: [{ status: terminalStatus }, { status: 202 }] });
+    await harness.collector.enable();
+    await harness.collector.heartbeatSucceeded({
+      controlUrl: "https://control.example.test",
+      token: `terminal-${terminalStatus}`,
+    });
+    assert.equal(harness.fetchHarness.calls.length, 1);
+    assert.equal(harness.collector.snapshot().sealed, 0);
+    assert.equal(readStatus(harness.storage).code, terminalStatus === 409 ? "conflict_dropped" : "invalid_dropped");
+    await harness.collector.heartbeatSucceeded({
+      controlUrl: "https://control.example.test",
+      token: `terminal-${terminalStatus}`,
+    });
+    assert.equal(harness.fetchHarness.calls.length, 1);
+  });
+}
+
+test("429 honors Retry-After and retries the exact sealed bytes only after the window", async () => {
+  const harness = createHarness({
+    responses: [
+      { status: 429, headers: { "Retry-After": "9" } },
+      { status: 202 },
+    ],
+  });
+  await harness.collector.enable();
+  await harness.collector.heartbeatSucceeded({
+    controlUrl: "https://control.example.test",
+    token: "rate-limit-token",
+  });
+  const firstBody = harness.fetchHarness.calls[0].body;
+  const queued = readQueue(harness.storage, harness.now());
+  assert.equal(queued.envelopes[0].next_attempt_ms, harness.now() + 9_000);
+  assert.equal(readStatus(harness.storage).code, "rate_limited");
+
+  harness.advance(8_999);
+  await harness.collector.heartbeatSucceeded({
+    controlUrl: "https://control.example.test",
+    token: "rate-limit-token",
+  });
+  assert.equal(harness.fetchHarness.calls.length, 1);
+  harness.advance(1);
+  await harness.collector.heartbeatSucceeded({
+    controlUrl: "https://control.example.test",
+    token: "rate-limit-token",
+  });
+  assert.equal(harness.fetchHarness.calls.length, 2);
+  assert.equal(harness.fetchHarness.calls[1].body, firstBody);
+});
+
+test("a sealed envelope never crosses participant scope", async () => {
+  const harness = createHarness({ responses: [{ status: 503 }, { status: 202 }] });
+  await harness.collector.enable();
+  await harness.collector.heartbeatSucceeded({
+    controlUrl: "https://control.example.test",
+    token: "participant-scope-a",
+  });
+  assert.equal(harness.fetchHarness.calls.length, 1);
+  const body = harness.fetchHarness.calls[0].body;
+  const queueA = readQueue(harness.storage, harness.now());
+  assert.equal(queueA.envelopes[0].scope, SCOPE_A);
+  assert.equal(queueA.envelopes[0].body, body);
+
+  harness.advance(5_000);
+  assert.equal(await harness.collector.heartbeatSucceeded({
+    controlUrl: "https://control.example.test",
+    token: "participant-scope-b",
+  }), false);
+  assert.equal(harness.fetchHarness.calls.length, 1);
+  assert.equal(harness.collector.snapshot().sealed, 1);
+
+  await harness.collector.heartbeatSucceeded({
+    controlUrl: "https://control.example.test",
+    token: "participant-scope-a-refreshed",
+  });
+  assert.equal(harness.fetchHarness.calls.length, 2);
+  assert.equal(harness.fetchHarness.calls[1].body, body);
+});
+
+test("a sealed envelope never crosses control origins even when the JWT subject matches", async () => {
+  const harness = createHarness({
+    responses: [{ status: 503 }, { status: 202 }],
+    scopeDigest: async (_token, _installId, origin) => (
+      origin === "https://control-a.example.test" ? SCOPE_A : SCOPE_B
+    ),
+  });
+  await harness.collector.enable();
+  await harness.collector.heartbeatSucceeded({
+    controlUrl: "https://control-a.example.test/room",
+    token: "same-subject-token",
+  });
+  assert.equal(harness.fetchHarness.calls.length, 1);
+  const body = harness.fetchHarness.calls[0].body;
+  assert.equal(readQueue(harness.storage, harness.now()).envelopes[0].scope, SCOPE_A);
+
+  harness.advance(5_000);
+  assert.equal(await harness.collector.heartbeatSucceeded({
+    controlUrl: "https://control-b.example.test/room",
+    token: "same-subject-token",
+  }), false);
+  assert.equal(harness.fetchHarness.calls.length, 1);
+
+  await harness.collector.heartbeatSucceeded({
+    controlUrl: "https://control-a.example.test/room",
+    token: "same-subject-token",
+  });
+  assert.equal(harness.fetchHarness.calls.length, 2);
+  assert.equal(harness.fetchHarness.calls[1].body, body);
+});
+
+test("the default scope digest is stable per install, subject, and normalized control origin", async () => {
+  async function scopeFor(controlUrl) {
+    const crypto = deterministicCrypto({ start: 1200 });
+    crypto.subtle = webcrypto.subtle;
+    const harness = createHarness({
+      crypto,
+      useDefaultScopeDigest: true,
+      responses: [{ status: 503 }],
+    });
+    await harness.collector.enable();
+    await harness.collector.heartbeatSucceeded({
+      controlUrl,
+      token: jwtForSubject("same-participant"),
+    });
+    return readQueue(harness.storage, harness.now()).envelopes[0].scope;
+  }
+
+  const first = await scopeFor("https://control-a.example.test/one");
+  const sameOrigin = await scopeFor("https://control-a.example.test/two");
+  const otherOrigin = await scopeFor("https://control-b.example.test/one");
+  assert.match(first, /^[0-9a-f]{64}$/);
+  assert.equal(first, sameOrigin);
+  assert.notEqual(first, otherOrigin);
+});
+
+test("credential changes seal the old scope and rotate the diagnostics session", async () => {
+  const harness = createHarness({ responses: [{ status: 503 }, { status: 202 }] });
+  await harness.collector.enable();
+  const initialSession = readQueue(harness.storage, harness.now()).draft.session_id;
+  assert.equal(harness.collector.credentialBoundary(), true, "first credential adopts the page session");
+  assert.equal(readQueue(harness.storage, harness.now()).draft.session_id, initialSession);
+
+  await harness.collector.heartbeatSucceeded({
+    controlUrl: "https://control.example.test",
+    token: "participant-scope-a",
+  });
+  harness.collector.recordMedia("camera", "enable", "enabled", null);
+  assert.equal(harness.collector.credentialBoundary(), true);
+  const rotatedSession = readQueue(harness.storage, harness.now()).draft.session_id;
+  assert.notEqual(rotatedSession, initialSession);
+
+  harness.collector.recordConnectionState("connecting", null);
+  await harness.collector.heartbeatSucceeded({
+    controlUrl: "https://control.example.test",
+    token: "participant-scope-b",
+  });
+  assert.equal(harness.fetchHarness.calls.length, 2);
+  const secondEnvelope = JSON.parse(harness.fetchHarness.calls[1].body);
+  assert.equal(secondEnvelope.session_id, rotatedSession);
+  assert.notEqual(secondEnvelope.session_id, initialSession);
+
+  const remaining = readQueue(harness.storage, harness.now()).envelopes;
+  assert.ok(remaining.length >= 1);
+  assert.ok(remaining.every((item) => item.scope === SCOPE_A));
+  assert.ok(remaining.every((item) => JSON.parse(item.body).session_id === initialSession));
+});
+
+test("an already-connected replacement rotates even before diagnostics sees its first heartbeat", async () => {
+  const harness = createHarness({ responses: [{ status: 202 }] });
+  await harness.collector.enable();
+  const initialSession = readQueue(harness.storage, harness.now()).draft.session_id;
+
+  assert.equal(harness.collector.credentialBoundary(true), true);
+  const afterBoundary = readQueue(harness.storage, harness.now());
+  assert.notEqual(afterBoundary.draft.session_id, initialSession);
+  assert.ok(afterBoundary.envelopes.some((item) => (
+    item.scope === null && JSON.parse(item.body).session_id === initialSession
+  )));
+
+  await harness.collector.heartbeatSucceeded({
+    controlUrl: "https://replacement.example.test",
+    token: "participant-scope-b",
+  });
+  assert.equal(harness.fetchHarness.calls.length, 1);
+  const sent = JSON.parse(harness.fetchHarness.calls[0].body);
+  assert.equal(sent.session_id, afterBoundary.draft.session_id);
+  const remaining = readQueue(harness.storage, harness.now()).envelopes;
+  assert.ok(remaining.some((item) => item.scope === null));
+});
+
+test("queue parsing enforces TTL, count, total byte bounds, and corrupt-body rejection", () => {
+  const freshBody = makeEnvelope({ number: 401 });
+  const oldBody = makeEnvelope({ number: 402, capturedAt: BASE_TIME - QUEUE_TTL_MS - 10_000 });
+  const ttlRaw = JSON.stringify({
+    version: 1,
+    revision: 1,
+    writer: "",
+    draft: null,
+    envelopes: [
+      { body: oldBody, created_at_ms: BASE_TIME - QUEUE_TTL_MS - 1, scope: SCOPE_A, attempts: 0, next_attempt_ms: 0 },
+      { body: freshBody, created_at_ms: BASE_TIME, scope: SCOPE_A, attempts: 0, next_attempt_ms: 0 },
+    ],
+  });
+  assert.deepEqual(diagnostics.parseQueue("not-json", BASE_TIME).envelopes, []);
+  const ttlQueue = diagnostics.parseQueue(ttlRaw, BASE_TIME);
+  assert.equal(ttlQueue.envelopes.length, 1);
+  assert.equal(ttlQueue.envelopes[0].body, freshBody);
+
+  const manyBodies = Array.from({ length: MAX_ENVELOPES + 4 }, (_, index) => (
+    makeEnvelope({ number: 500 + index })
+  ));
+  const countQueue = diagnostics.parseQueue(queueDocument(manyBodies), BASE_TIME + 100);
+  assert.equal(countQueue.envelopes.length, MAX_ENVELOPES);
+  assert.equal(JSON.parse(countQueue.envelopes[0].body).envelope_id, uuidFor(504));
+
+  const detailKeys = [
+    "action", "actual", "attempt", "audio", "browser", "camera", "clean", "column",
+    "connection_state", "count", "current", "denied", "device_count", "device_kind",
+    "direction", "duration_ms", "enabled", "ended", "error_code", "expected", "failure_stage",
+    "granted", "kind", "line", "media_kind", "microphone", "operation", "output",
+    "permission", "permission_state", "phase", "previous",
+  ];
+  const denseDetails = Object.fromEntries(detailKeys.map((key) => [key, `a${"x".repeat(62)}`]));
+  let denseBody = null;
+  for (let eventCount = 50; eventCount >= 1; eventCount -= 1) {
+    const candidate = makeEnvelope({ number: 700, eventCount, details: denseDetails });
+    if (utf8Bytes(candidate) <= MAX_ENVELOPE_BYTES && utf8Bytes(candidate) > MAX_QUEUE_BYTES / MAX_ENVELOPES) {
+      denseBody = candidate;
+      break;
+    }
+  }
+  assert.ok(denseBody, "fixture should exercise aggregate queue byte eviction");
+  const denseBodies = Array.from({ length: MAX_ENVELOPES }, (_, index) => {
+    const parsed = JSON.parse(denseBody);
+    parsed.envelope_id = uuidFor(800 + index);
+    return JSON.stringify(parsed);
+  });
+  const byteQueue = diagnostics.parseQueue(queueDocument(denseBodies), BASE_TIME + 100);
+  assert.ok(byteQueue.envelopes.reduce((sum, item) => sum + utf8Bytes(item.body), 0) <= MAX_QUEUE_BYTES);
+  assert.ok(byteQueue.envelopes.length < MAX_ENVELOPES);
+  const persistedQueueBytes = utf8Bytes(JSON.stringify(byteQueue));
+  assert.ok(
+    persistedQueueBytes <= MAX_QUEUE_BYTES,
+    `persisted queue document must stay within the hard byte cap (${persistedQueueBytes} > ${MAX_QUEUE_BYTES})`,
+  );
+
+  const mixedRaw = JSON.stringify({
+    version: 1,
+    revision: 1,
+    writer: "",
+    draft: null,
+    envelopes: [
+      { body: "{", created_at_ms: BASE_TIME, scope: SCOPE_A, attempts: 0, next_attempt_ms: 0 },
+      { body: freshBody, created_at_ms: BASE_TIME, scope: SCOPE_A, attempts: 0, next_attempt_ms: 0 },
+      { body: JSON.stringify({ secret: "FORBIDDEN-CORRUPT-BODY" }), created_at_ms: BASE_TIME, scope: SCOPE_A, attempts: 0, next_attempt_ms: 0 },
+    ],
+  });
+  const mixed = diagnostics.parseQueue(mixedRaw, BASE_TIME);
+  assert.equal(mixed.envelopes.length, 1);
+  assert.equal(mixed.envelopes[0].body, freshBody);
+});
+
+test("a malformed persisted body is discarded before fetch", async () => {
+  const harness = createHarness({ responses: [{ status: 202 }] });
+  await harness.collector.enable();
+  harness.storage.setItem(QUEUE_KEY, JSON.stringify({
+    version: 1,
+    revision: 9,
+    writer: "",
+    draft: null,
+    envelopes: [{
+      body: "{\"token\":\"FORBIDDEN-MALFORMED\"}",
+      created_at_ms: harness.now(),
+      scope: SCOPE_A,
+      attempts: 0,
+      next_attempt_ms: 0,
+    }],
+  }));
+  assert.equal(await harness.collector.heartbeatSucceeded({
+    controlUrl: "https://control.example.test",
+    token: "malformed-body-token",
+  }), false);
+  assert.equal(harness.fetchHarness.calls.length, 0);
+  assert.equal(harness.collector.snapshot().sealed, 0);
+});
+
+test("opt-out persists OFF, detaches handlers, and deletes only diagnostics-owned data", async () => {
+  const storage = new MemoryStorage({ unrelated_application_key: "keep-me" });
+  const harness = createHarness({ storage, responses: [{ status: 401 }] });
+  await harness.collector.enable();
+  assert.equal(harness.eventTarget.count("error"), 1);
+  harness.collector.recordPermission("camera", false, "NotAllowedError");
+  await harness.collector.heartbeatSucceeded({
+    controlUrl: "https://control.example.test",
+    token: "opt-out-token",
+  });
+  assert.ok(storage.getItem(INSTALL_KEY));
+  assert.ok(storage.getItem(QUEUE_KEY));
+  assert.ok(storage.getItem(STATUS_KEY));
+  assert.ok(storage.getItem(ACTIVE_KEY));
+
+  storage.removes.length = 0;
+  harness.collector.disable();
+  assert.equal(storage.getItem(CONSENT_KEY), CONSENT_DISABLED);
+  assert.equal(storage.getItem(INSTALL_KEY), null);
+  assert.equal(storage.getItem(QUEUE_KEY), null);
+  assert.equal(storage.getItem(STATUS_KEY), null);
+  assert.equal(storage.getItem(ACTIVE_KEY), null);
+  assert.equal(storage.getItem("unrelated_application_key"), "keep-me");
+  assert.deepEqual(new Set(storage.removes), new Set([INSTALL_KEY, QUEUE_KEY, STATUS_KEY, ACTIVE_KEY]));
+  assert.equal(harness.eventTarget.count("error"), 0);
+  assert.equal(harness.eventTarget.count("unhandledrejection"), 0);
+  assert.equal(harness.eventTarget.count("pagehide"), 0);
+  assert.equal(harness.eventTarget.count("pageshow"), 0);
+  assert.equal(harness.collector.snapshot().enabled, false);
+});
+
+test("a late upload response cannot recreate diagnostics state after opt-out", async () => {
+  const fetchHarness = new DeferredFetchHarness();
+  const storage = new MemoryStorage({ unrelated_application_key: "keep-me" });
+  const harness = createHarness({ storage, fetchHarness });
+  await harness.collector.enable();
+  const pendingUpload = harness.collector.heartbeatSucceeded({
+    controlUrl: "https://control.example.test",
+    token: "late-response-token",
+  });
+  while (fetchHarness.calls.length === 0) await Promise.resolve();
+
+  harness.collector.disable();
+  fetchHarness.respond(404);
+  assert.equal(await pendingUpload, false);
+  assert.equal(storage.getItem(CONSENT_KEY), CONSENT_DISABLED);
+  assert.equal(storage.getItem(INSTALL_KEY), null);
+  assert.equal(storage.getItem(QUEUE_KEY), null);
+  assert.equal(storage.getItem(STATUS_KEY), null);
+  assert.equal(storage.getItem(ACTIVE_KEY), null);
+  assert.equal(storage.getItem("unrelated_application_key"), "keep-me");
+});
+
+test("a late old-credential response cannot poison a fresh credential upload", async () => {
+  const fetchHarness = new DeferredFetchHarness();
+  const harness = createHarness({ fetchHarness });
+  await harness.collector.enable();
+  const uploadA = harness.collector.heartbeatSucceeded({
+    controlUrl: "https://control-a.example.test",
+    token: "participant-scope-a",
+  });
+  while (fetchHarness.calls.length < 1) await Promise.resolve();
+
+  assert.equal(harness.collector.credentialBoundary(), true);
+  const uploadB = harness.collector.heartbeatSucceeded({
+    controlUrl: "https://control-b.example.test",
+    token: "participant-scope-b",
+  });
+  while (fetchHarness.calls.length < 2) await Promise.resolve();
+
+  fetchHarness.respond(404);
+  assert.equal(await uploadA, false);
+  assert.equal(harness.collector.snapshot().authenticated, true);
+  fetchHarness.respond(202);
+  assert.equal(await uploadB, true);
+  assert.equal(readStatus(harness.storage).code, "accepted");
+  assert.equal(harness.collector.snapshot().authenticated, true);
+});
+
+test("invalid public event arguments are ignored without mutating the queue", async () => {
+  const harness = createHarness();
+  await harness.collector.enable();
+  const before = harness.storage.getItem(QUEUE_KEY);
+  assert.equal(harness.collector.recordLegacyEvent("not-a-real-event", "FORBIDDEN-DETAIL"), false);
+  assert.equal(harness.collector.recordPermission("chat", false, "NotAllowedError"), false);
+  assert.equal(harness.collector.recordMedia("camera", "exfiltrate", "failed", "TypeError"), false);
+  assert.equal(harness.collector.recordMedia("camera", "start", "secret-state", "TypeError"), false);
+  assert.equal(harness.collector.recordConnectionState("secret-state", "TypeError"), false);
+  assert.equal(harness.storage.getItem(QUEUE_KEY), before);
+  assert.equal(harness.storage.dump().includes("FORBIDDEN-DETAIL"), false);
+});
+
+test("a stale session emits an unclean marker only under its proven participant scope", async () => {
+  const staleSession = uuidFor(900);
+  const freshSession = uuidFor(901);
+  const storage = new MemoryStorage({
+    [ACTIVE_KEY]: JSON.stringify({
+      version: 1,
+      sessions: {
+        [staleSession]: {
+          started_at_ms: BASE_TIME - 660_000,
+          last_seen_ms: BASE_TIME - 600_000,
+          scope: SCOPE_A,
+        },
+        [freshSession]: {
+          started_at_ms: BASE_TIME - 20_000,
+          last_seen_ms: BASE_TIME - 1_000,
+          scope: SCOPE_B,
+        },
+      },
+    }),
+  });
+  const bob = createHarness({
+    storage,
+    crypto: deterministicCrypto({ start: 1000 }),
+    responses: [{ status: 202 }],
+  });
+  assert.equal(await bob.collector.enable(), true);
+  await bob.collector.heartbeatSucceeded({
+    controlUrl: "https://control.example.test",
+    token: "participant-scope-b",
+  });
+  assert.equal(bob.fetchHarness.calls.length, 1);
+  assert.equal(bob.fetchHarness.calls[0].body.includes("session.unclean_shutdown"), false);
+  let active = JSON.parse(storage.getItem(ACTIVE_KEY));
+  assert.ok(active.sessions[staleSession], "Alice's stale sentinel must not be attributed to Bob");
+  assert.ok(active.sessions[freshSession], "fresh tab sentinel must survive another tab startup");
+
+  const alice = createHarness({
+    storage,
+    crypto: deterministicCrypto({ start: 1100 }),
+    responses: [{ status: 503 }],
+  });
+  assert.equal(await alice.collector.enable(), true);
+  await alice.collector.heartbeatSucceeded({
+    controlUrl: "https://control.example.test",
+    token: "participant-scope-a",
+  });
+  assert.equal(alice.fetchHarness.calls.length, 1);
+  const events = JSON.parse(alice.fetchHarness.calls[0].body).events;
+  const unclean = events.filter((event) => event.event_type === "unclean_shutdown");
+  assert.equal(unclean.length, 1);
+  assert.equal(unclean[0].code, "session.unclean_shutdown");
+  assert.deepEqual(unclean[0].details, { unclean: true, duration_ms: 60000 });
+
+  active = JSON.parse(storage.getItem(ACTIVE_KEY));
+  assert.equal(active.sessions[staleSession], undefined);
+  assert.ok(active.sessions[freshSession], "fresh tab sentinel must survive another tab startup");
+  assert.ok(Object.values(active.sessions).some((item) => item.scope === SCOPE_A));
+  assert.ok(Object.values(active.sessions).some((item) => item.scope === SCOPE_B));
+});
+
+test("back-forward cache suspension removes and restores the active sentinel without a false shutdown", async () => {
+  const harness = createHarness();
+  await harness.collector.enable();
+  const beforeQueue = harness.storage.getItem(QUEUE_KEY);
+  const sessionId = readQueue(harness.storage, harness.now()).draft.session_id;
+  assert.ok(JSON.parse(harness.storage.getItem(ACTIVE_KEY)).sessions[sessionId]);
+
+  harness.eventTarget.dispatch("pagehide", { persisted: true });
+  assert.equal(harness.storage.getItem(ACTIVE_KEY), null);
+  assert.equal(harness.storage.getItem(QUEUE_KEY), beforeQueue);
+
+  harness.eventTarget.dispatch("pageshow", { persisted: true });
+  assert.ok(JSON.parse(harness.storage.getItem(ACTIVE_KEY)).sessions[sessionId]);
+  assert.equal(harness.storage.getItem(QUEUE_KEY), beforeQueue);
+});
+
+test("sealed envelope identifiers are lowercase even if randomUUID returns uppercase", async () => {
+  const harness = createHarness({
+    uppercaseUuids: true,
+    responses: [{ status: 503 }],
+  });
+  assert.equal(await harness.collector.enable(), true);
+  await harness.collector.heartbeatSucceeded({
+    controlUrl: "https://control.example.test",
+    token: "uppercase-uuid-token",
+  });
+  const envelope = JSON.parse(harness.fetchHarness.calls[0].body);
+  for (const id of [envelope.envelope_id, envelope.install_id, envelope.session_id]) {
+    assert.match(id, /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+    assert.equal(id, id.toLowerCase());
+  }
+  assert.equal(harness.storage.getItem(INSTALL_KEY), envelope.install_id);
+  assert.equal(harness.storage.dump().includes("uppercase-uuid-token"), false);
+});
+
+test("exported sealed-body validator accepts the deterministic JS fixture", () => {
+  const body = makeEnvelope({ number: 999 });
+  assert.equal(diagnostics.validateSealedBody(body, uuidFor(200)), true);
+  const parsed = JSON.parse(body);
+  parsed.events[0].message = "FORBIDDEN";
+  assert.equal(diagnostics.validateSealedBody(JSON.stringify(parsed), uuidFor(200)), false);
+});
+
+test("the shared browser envelope fixture matches the JS wire contract", () => {
+  const fixturePath = path.join(__dirname, "..", "control", "testdata", "browser-diagnostics-envelope-v1.json");
+  const fixture = JSON.parse(fs.readFileSync(fixturePath, "utf8"));
+  assert.equal(diagnostics.validateSealedBody(JSON.stringify(fixture), fixture.install_id), true);
+});

--- a/core/viewer/diagnostics-client.test.js
+++ b/core/viewer/diagnostics-client.test.js
@@ -192,13 +192,19 @@ class DeferredFetchHarness extends FetchHarness {
       body: init && init.body,
       cache: init && init.cache,
     });
-    return new Promise((resolve) => this.pending.push(resolve));
+    return new Promise((resolve, reject) => this.pending.push({ resolve, reject }));
   }
 
   respond(status) {
-    const resolve = this.pending.shift();
-    assert.ok(resolve, "expected a pending fetch");
-    resolve({ status, ok: status >= 200 && status < 300, headers: { get: () => null } });
+    const pending = this.pending.shift();
+    assert.ok(pending, "expected a pending fetch");
+    pending.resolve({ status, ok: status >= 200 && status < 300, headers: { get: () => null } });
+  }
+
+  reject(error) {
+    const pending = this.pending.shift();
+    assert.ok(pending, "expected a pending fetch");
+    pending.reject(error || new Error("network unavailable"));
   }
 }
 
@@ -278,6 +284,24 @@ function readQueue(storage, now) {
 
 function readStatus(storage) {
   return JSON.parse(storage.getItem(STATUS_KEY) || "null");
+}
+
+function interceptNextStorageMutation(storage, method, key, afterMutation) {
+  const original = storage[method].bind(storage);
+  let armed = false;
+  let fired = false;
+  storage[method] = function (...args) {
+    const result = original(...args);
+    if (armed && !fired && String(args[0]) === key) {
+      fired = true;
+      afterMutation();
+    }
+    return result;
+  };
+  return {
+    arm() { armed = true; },
+    fired() { return fired; },
+  };
 }
 
 function utf8Bytes(value) {
@@ -887,6 +911,213 @@ test("opt-out persists OFF, detaches handlers, and deletes only diagnostics-owne
   assert.equal(harness.eventTarget.count("pagehide"), 0);
   assert.equal(harness.eventTarget.count("pageshow"), 0);
   assert.equal(harness.collector.snapshot().enabled, false);
+});
+
+test("a delayed tab cannot recreate its queue after another tab opts out", async () => {
+  const storage = new MemoryStorage({ unrelated_application_key: "keep-me" });
+  const staleTab = createHarness({ storage });
+  const optingOutTab = createHarness({ storage });
+  await staleTab.collector.enable();
+  assert.ok(storage.getItem(QUEUE_KEY));
+
+  optingOutTab.collector.disable();
+  assert.equal(storage.getItem(CONSENT_KEY), CONSENT_DISABLED);
+  assert.equal(storage.getItem(QUEUE_KEY), null);
+
+  // Deliberately do not deliver a storage event to the stale tab.
+  staleTab.collector.recordDeviceCounts({ microphone: 1, camera: 1, output: 1 });
+  assert.equal(staleTab.collector.snapshot().enabled, false);
+  assert.equal(storage.getItem(CONSENT_KEY), CONSENT_DISABLED);
+  assert.equal(storage.getItem(INSTALL_KEY), null);
+  assert.equal(storage.getItem(QUEUE_KEY), null);
+  assert.equal(storage.getItem(STATUS_KEY), null);
+  assert.equal(storage.getItem(ACTIVE_KEY), null);
+  assert.equal(storage.getItem("unrelated_application_key"), "keep-me");
+  assert.equal(staleTab.fetchHarness.calls.length, 0);
+});
+
+test("a delayed tab cannot recreate its active sentinel after another tab opts out", async () => {
+  const storage = new MemoryStorage();
+  const staleTab = createHarness({ storage });
+  const optingOutTab = createHarness({ storage });
+  await staleTab.collector.enable();
+  const sessionRefresh = Array.from(staleTab.timers.intervals.values())
+    .find((timer) => timer.delay === 10000);
+  assert.ok(sessionRefresh);
+
+  optingOutTab.collector.disable();
+  sessionRefresh.callback();
+
+  assert.equal(staleTab.collector.snapshot().enabled, false);
+  assert.equal(storage.getItem(CONSENT_KEY), CONSENT_DISABLED);
+  assert.equal(storage.getItem(INSTALL_KEY), null);
+  assert.equal(storage.getItem(QUEUE_KEY), null);
+  assert.equal(storage.getItem(STATUS_KEY), null);
+  assert.equal(storage.getItem(ACTIVE_KEY), null);
+});
+
+test("a delayed tab rechecks shared consent immediately before starting fetch", async () => {
+  const storage = new MemoryStorage();
+  const staleTab = createHarness({ storage, responses: [{ status: 202 }] });
+  const optingOutTab = createHarness({ storage });
+  await staleTab.collector.enable();
+  assert.equal(await staleTab.collector.heartbeatSucceeded({
+    controlUrl: "https://control.example.test",
+    token: "shared-consent-token",
+  }), true);
+  assert.equal(staleTab.fetchHarness.calls.length, 1);
+
+  staleTab.collector.recordDeviceCounts({ microphone: 1, camera: 1, output: 1 });
+  assert.equal(staleTab.collector._sealDraft(), true);
+  assert.equal(staleTab.collector.snapshot().sealed, 1);
+
+  const originalGetItem = storage.getItem.bind(storage);
+  let revokedAtNetworkBoundary = false;
+  storage.getItem = function (key) {
+    if (!revokedAtNetworkBoundary && String(key) === CONSENT_KEY) {
+      revokedAtNetworkBoundary = true;
+      optingOutTab.collector.disable();
+    }
+    return originalGetItem(key);
+  };
+
+  assert.equal(await staleTab.collector.sendNow(), false);
+  assert.equal(revokedAtNetworkBoundary, true);
+  assert.equal(staleTab.fetchHarness.calls.length, 1);
+  assert.equal(staleTab.collector.snapshot().enabled, false);
+  assert.equal(storage.getItem(CONSENT_KEY), CONSENT_DISABLED);
+  assert.equal(storage.getItem(INSTALL_KEY), null);
+  assert.equal(storage.getItem(QUEUE_KEY), null);
+  assert.equal(storage.getItem(STATUS_KEY), null);
+  assert.equal(storage.getItem(ACTIVE_KEY), null);
+});
+
+test("a delayed upload response cannot recreate state after another tab opts out", async () => {
+  const storage = new MemoryStorage();
+  const fetchHarness = new DeferredFetchHarness();
+  const staleTab = createHarness({ storage, fetchHarness });
+  const optingOutTab = createHarness({ storage });
+  await staleTab.collector.enable();
+  const pendingUpload = staleTab.collector.heartbeatSucceeded({
+    controlUrl: "https://control.example.test",
+    token: "cross-tab-late-response-token",
+  });
+  while (fetchHarness.calls.length === 0) await Promise.resolve();
+
+  optingOutTab.collector.disable();
+  fetchHarness.respond(202);
+
+  assert.equal(await pendingUpload, false);
+  assert.equal(staleTab.collector.snapshot().enabled, false);
+  assert.equal(storage.getItem(CONSENT_KEY), CONSENT_DISABLED);
+  assert.equal(storage.getItem(INSTALL_KEY), null);
+  assert.equal(storage.getItem(QUEUE_KEY), null);
+  assert.equal(storage.getItem(STATUS_KEY), null);
+  assert.equal(storage.getItem(ACTIVE_KEY), null);
+});
+
+test("an in-flight enable cannot restart after another tab opts out", async () => {
+  const storage = new MemoryStorage();
+  let resolveMetadata;
+  const staleTab = createHarness({
+    storage,
+    metadataProvider: () => new Promise((resolve) => { resolveMetadata = resolve; }),
+  });
+  const optingOutTab = createHarness({ storage });
+  const pendingEnable = staleTab.collector.enable();
+  while (!resolveMetadata) await Promise.resolve();
+
+  optingOutTab.collector.disable();
+  resolveMetadata(validMetadata());
+
+  assert.equal(await pendingEnable, false);
+  assert.equal(staleTab.collector.snapshot().enabled, false);
+  assert.equal(storage.getItem(CONSENT_KEY), CONSENT_DISABLED);
+  assert.equal(storage.getItem(INSTALL_KEY), null);
+  assert.equal(storage.getItem(QUEUE_KEY), null);
+  assert.equal(storage.getItem(STATUS_KEY), null);
+  assert.equal(storage.getItem(ACTIVE_KEY), null);
+});
+
+test("queue clearing cannot recreate status when another tab opts out at the delete boundary", async () => {
+  const storage = new MemoryStorage();
+  const staleTab = createHarness({ storage });
+  const optingOutTab = createHarness({ storage });
+  await staleTab.collector.enable();
+  const boundary = interceptNextStorageMutation(storage, "removeItem", QUEUE_KEY, () => {
+    optingOutTab.collector.disable();
+  });
+  boundary.arm();
+
+  assert.equal(staleTab.collector.clearQueuedData(), false);
+  assert.equal(boundary.fired(), true);
+  assert.equal(staleTab.collector.snapshot().enabled, false);
+  assert.equal(storage.getItem(CONSENT_KEY), CONSENT_DISABLED);
+  assert.equal(storage.getItem(INSTALL_KEY), null);
+  assert.equal(storage.getItem(QUEUE_KEY), null);
+  assert.equal(storage.getItem(STATUS_KEY), null);
+  assert.equal(storage.getItem(ACTIVE_KEY), null);
+  assert.equal(staleTab.timers.timeouts.size, 0);
+});
+
+for (const responseStatus of [202, 503]) {
+  test(`a ${responseStatus} response cannot recreate state or retry after boundary opt-out`, async () => {
+    const storage = new MemoryStorage();
+    const fetchHarness = new DeferredFetchHarness();
+    const staleTab = createHarness({ storage, fetchHarness });
+    const optingOutTab = createHarness({ storage });
+    await staleTab.collector.enable();
+    const pendingUpload = staleTab.collector.heartbeatSucceeded({
+      controlUrl: "https://control.example.test",
+      token: `boundary-response-${responseStatus}`,
+    });
+    while (fetchHarness.calls.length === 0) await Promise.resolve();
+    const boundary = interceptNextStorageMutation(storage, "setItem", QUEUE_KEY, () => {
+      optingOutTab.collector.disable();
+    });
+    boundary.arm();
+
+    fetchHarness.respond(responseStatus);
+
+    assert.equal(await pendingUpload, false);
+    assert.equal(boundary.fired(), true);
+    assert.equal(staleTab.collector.snapshot().enabled, false);
+    assert.equal(storage.getItem(CONSENT_KEY), CONSENT_DISABLED);
+    assert.equal(storage.getItem(INSTALL_KEY), null);
+    assert.equal(storage.getItem(QUEUE_KEY), null);
+    assert.equal(storage.getItem(STATUS_KEY), null);
+    assert.equal(storage.getItem(ACTIVE_KEY), null);
+    assert.equal(staleTab.timers.timeouts.size, 0);
+  });
+}
+
+test("a network failure cannot recreate status or retry after boundary opt-out", async () => {
+  const storage = new MemoryStorage();
+  const fetchHarness = new DeferredFetchHarness();
+  const staleTab = createHarness({ storage, fetchHarness });
+  const optingOutTab = createHarness({ storage });
+  await staleTab.collector.enable();
+  const pendingUpload = staleTab.collector.heartbeatSucceeded({
+    controlUrl: "https://control.example.test",
+    token: "boundary-network-failure",
+  });
+  while (fetchHarness.calls.length === 0) await Promise.resolve();
+  const boundary = interceptNextStorageMutation(storage, "setItem", QUEUE_KEY, () => {
+    optingOutTab.collector.disable();
+  });
+  boundary.arm();
+
+  fetchHarness.reject(new Error("network unavailable"));
+
+  assert.equal(await pendingUpload, false);
+  assert.equal(boundary.fired(), true);
+  assert.equal(staleTab.collector.snapshot().enabled, false);
+  assert.equal(storage.getItem(CONSENT_KEY), CONSENT_DISABLED);
+  assert.equal(storage.getItem(INSTALL_KEY), null);
+  assert.equal(storage.getItem(QUEUE_KEY), null);
+  assert.equal(storage.getItem(STATUS_KEY), null);
+  assert.equal(storage.getItem(ACTIVE_KEY), null);
+  assert.equal(staleTab.timers.timeouts.size, 0);
 });
 
 test("a late upload response cannot recreate diagnostics state after opt-out", async () => {

--- a/core/viewer/index.html
+++ b/core/viewer/index.html
@@ -228,7 +228,25 @@
           <h3>Settings</h3>
           <button id="close-settings" type="button">Close</button>
         </div>
-        <div id="settings-device-panel" class="settings-body"></div>
+        <div id="settings-device-panel" class="settings-body">
+          <section id="diagnostics-settings-section" class="chime-settings-section hidden" aria-labelledby="diagnostics-settings-title">
+            <div id="diagnostics-settings-title" class="chime-settings-title">Private Web Diagnostics</div>
+            <label class="settings-toggle-row diagnostics-toggle-row" for="diagnostics-enabled-toggle">
+              <span>Send technical diagnostics to Sam's Echo server</span>
+              <input id="diagnostics-enabled-toggle" type="checkbox" />
+            </label>
+            <p class="settings-hint diagnostics-privacy-hint">Never includes chat, credentials, audio, video, screen content, screenshots, clipboard, device names, or files. Accepted reports are linked privately to your current Echo participant. Turning this off deletes queued data from this browser.</p>
+            <div class="diagnostics-status-grid" aria-live="polite">
+              <span>Delivery status</span><span id="diagnostics-last-upload">Never</span>
+              <span>Queued</span><span id="diagnostics-queue-count">0 reports</span>
+            </div>
+            <div class="diagnostics-actions">
+              <button id="diagnostics-send-now" type="button">Send Now</button>
+              <button id="diagnostics-delete-queued" type="button">Delete Queued Data</button>
+            </div>
+            <div id="diagnostics-action-status" class="settings-hint" aria-live="polite"></div>
+          </section>
+        </div>
         <div class="settings-body settings-perf-section">
           <label class="settings-toggle-row">
             <input type="checkbox" id="performance-mode-toggle">
@@ -514,6 +532,19 @@
       <pre id="debug-log"></pre>
     </div>
 
+    <div id="diagnostics-consent-modal" class="modal-overlay" role="dialog" aria-modal="true" aria-labelledby="diagnostics-consent-title" hidden>
+      <div class="modal diagnostics-consent-card">
+        <h2 id="diagnostics-consent-title">Mac Web Canary Diagnostics</h2>
+        <p>Echo can automatically send Sam a small, private timeline of technical failures and connection health. This helps diagnose browser problems without asking you to find or send log files.</p>
+        <p><strong>It never captures chat, passwords, tokens, audio, video, screen content, screenshots, clipboard, device names, or files.</strong> Accepted reports are linked to your current Echo participant so Sam can identify the affected session. They remain private on Echo and are normally deleted after about 14 days.</p>
+        <p>Browser privacy protections may prevent Echo from identifying the exact macOS build or Apple Silicon model. Missing values are reported as unknown, never guessed.</p>
+        <div class="modal-actions">
+          <button type="button" id="diagnostics-consent-decline">Keep Off</button>
+          <button type="button" id="diagnostics-consent-accept" class="primary">Allow Diagnostics</button>
+        </div>
+      </div>
+    </div>
+
     <script src="livekit-client.umd.js?v=0.6.11.1777930912"></script>
     <script src="room-switch-state.js?v=0.6.11.1777930912"></script>
     <script src="jam-session-state.js?v=0.6.11.1777930912"></script>
@@ -522,6 +553,7 @@
     <script src="debug.js?v=0.6.11.1777930912"></script>
     <script src="urls.js?v=0.6.11.1777930912"></script>
     <script src="settings.js?v=0.6.11.1777930912"></script>
+    <script src="diagnostics-client.js?v=0.6.11.1777930912"></script>
     <script src="display-status.js?v=0.6.10-local.1.1776128211"></script>
     <script src="native-presenter.js?v=0.6.11.1777921630"></script>
     <script src="identity.js?v=0.6.11.1777930912"></script>

--- a/core/viewer/media-controls.js
+++ b/core/viewer/media-controls.js
@@ -64,7 +64,9 @@ async function ensureDevicePermissions() {
     const audioStream = await navigator.mediaDevices.getUserMedia({ audio: true });
     audioStream.getTracks().forEach((t) => t.stop());
     gotAudio = true;
+    window.EchoWebDiagnosticsRuntime?.recordPermission?.("microphone", true, null);
   } catch (err) {
+    window.EchoWebDiagnosticsRuntime?.recordPermission?.("microphone", false, err?.name);
     debugLog("[devices] audio permission denied or unavailable: " + err.message);
   }
 
@@ -72,7 +74,9 @@ async function ensureDevicePermissions() {
     const videoStream = await navigator.mediaDevices.getUserMedia({ video: true });
     videoStream.getTracks().forEach((t) => t.stop());
     gotVideo = true;
+    window.EchoWebDiagnosticsRuntime?.recordPermission?.("camera", true, null);
   } catch (err) {
+    window.EchoWebDiagnosticsRuntime?.recordPermission?.("camera", false, err?.name);
     debugLog("[devices] video permission denied or unavailable: " + err.message);
   }
 
@@ -110,6 +114,12 @@ async function refreshDevices() {
 
   // Detect macOS permission-denied scenario: devices exist but all have empty labels
   const allLabelsEmpty = devices.length > 0 && devices.every((d) => !d.label);
+  window.EchoWebDiagnosticsRuntime?.recordDeviceCounts?.({
+    microphone: mics.length,
+    camera: cams.length,
+    output: speakers.length,
+    labelsAvailable: !allLabelsEmpty,
+  });
   if (allLabelsEmpty) {
     debugLog("[devices] enumerateDevices returned " + devices.length + " devices but all labels are empty (permissions not granted)");
   }
@@ -485,6 +495,12 @@ async function toggleMic(allowDuringRoomSwitch = false) {
     }
     const actualState = _isMicrophoneActuallyEnabled();
     micEnabled = actualState;
+    window.EchoWebDiagnosticsRuntime?.recordMedia?.(
+      "microphone",
+      desired ? "enable" : "disable",
+      actualState ? "enabled" : "disabled",
+      null
+    );
 
     if (actualState !== desired) {
       debugLog(`[mic] SDK state drift after toggle desired=${desired} actual=${actualState}`);
@@ -506,6 +522,11 @@ async function toggleMic(allowDuringRoomSwitch = false) {
 
     _syncLocalMicUi();
   } catch (err) {
+    if (err?.name === "NotAllowedError" || err?.name === "PermissionDeniedError") {
+      window.EchoWebDiagnosticsRuntime?.recordPermission?.("microphone", false, err.name);
+    } else {
+      window.EchoWebDiagnosticsRuntime?.recordMedia?.("microphone", desired ? "enable" : "disable", "failed", err?.name);
+    }
     debugLog("[mic] toggle error: " + (err.message || err) + " (name=" + err.name + ")");
     micEnabled = _isMicrophoneActuallyEnabled();
     // A failed enable should stay visibly and intentionally off. A failed
@@ -562,6 +583,12 @@ async function toggleCam() {
       debugLog("[cam] post-toggle drift: desired=" + desired + " actual=" + actualState);
     }
     camEnabled = actualState;
+    window.EchoWebDiagnosticsRuntime?.recordMedia?.(
+      "camera",
+      desired ? "enable" : "disable",
+      actualState ? "enabled" : "disabled",
+      null
+    );
     renderPublishButtons();
     if (room?.localParticipant) {
       const cardRef = ensureParticipantCard(room.localParticipant, true);
@@ -581,6 +608,11 @@ async function toggleCam() {
       }
     }
   } catch (err) {
+    if (err?.name === "NotAllowedError" || err?.name === "PermissionDeniedError") {
+      window.EchoWebDiagnosticsRuntime?.recordPermission?.("camera", false, err.name);
+    } else {
+      window.EchoWebDiagnosticsRuntime?.recordMedia?.("camera", desired ? "enable" : "disable", "failed", err?.name);
+    }
     debugLog("[cam] toggle error: " + (err.message || err) + " (name=" + err.name + ")");
     if (err.name === "NotAllowedError" || err.name === "PermissionDeniedError") {
       setStatus("Camera permission denied — grant access in System Settings > Privacy > Camera", true);
@@ -617,6 +649,11 @@ async function toggleScreen() {
       }
     }
   } catch (err) {
+    if (err?.name === "NotAllowedError" || err?.name === "PermissionDeniedError") {
+      window.EchoWebDiagnosticsRuntime?.recordPermission?.("screen", false, err.name);
+    } else {
+      window.EchoWebDiagnosticsRuntime?.recordMedia?.("screen", desired ? "start" : "stop", "failed", err?.name);
+    }
     setStatus(err.message || "Screen share failed", true);
   } finally {
     screenBtn.disabled = switchingRoom;

--- a/core/viewer/room-status.js
+++ b/core/viewer/room-status.js
@@ -405,6 +405,7 @@ function startHeartbeat() {
   _heartbeatAbort = new AbortController();
   const sendBeat = async () => {
     if (!_heartbeatAbort || _heartbeatAbort.signal.aborted) return;
+    const beatToken = currentAccessToken;
     const identity = identityInput ? identityInput.value : "";
     const name = nameInput.value.trim() || "Viewer";
     const beatRoom = roomSwitchState && roomSwitchState.heartbeatRoomName
@@ -413,11 +414,12 @@ function startHeartbeat() {
     try {
       const resp = await fetch(`${controlUrl}/v1/participants/heartbeat`, {
         method: "POST",
-        headers: { "Content-Type": "application/json", Authorization: `Bearer ${currentAccessToken}` },
+        headers: { "Content-Type": "application/json", Authorization: `Bearer ${beatToken}` },
         body: JSON.stringify({ room: beatRoom, identity, name, viewer_version: _viewerVersion }),
         signal: _heartbeatAbort.signal,
       });
       if (resp.status === 401 || resp.status === 403) {
+        window.EchoWebDiagnosticsRuntime?.invalidateHeartbeat?.();
         // A control restart clears the in-memory participant binding even when
         // the old LiveKit JWT still verifies cryptographically. Treat that as
         // the same forced-stale condition as an explicit stale heartbeat so the
@@ -425,10 +427,19 @@ function startHeartbeat() {
         showStaleBanner();
       } else if (resp.ok) {
         const data = await resp.json().catch(() => null);
-        if (data && data.stale) {
+        if (data && data.stale === true) {
+          window.EchoWebDiagnosticsRuntime?.invalidateHeartbeat?.();
           showStaleBanner();
-        } else {
+        } else if (data && data.stale === false) {
           hideStaleBanner();
+          if (beatToken === currentAccessToken) {
+            window.EchoWebDiagnosticsRuntime?.heartbeatSucceeded?.({
+              controlUrl,
+              token: beatToken,
+            });
+          }
+        } else {
+          window.EchoWebDiagnosticsRuntime?.invalidateHeartbeat?.();
         }
       }
     } catch {}
@@ -438,6 +449,7 @@ function startHeartbeat() {
 }
 
 function stopHeartbeat() {
+  window.EchoWebDiagnosticsRuntime?.invalidateHeartbeat?.();
   if (heartbeatTimer) {
     clearInterval(heartbeatTimer);
     heartbeatTimer = null;

--- a/core/viewer/screen-share-native.js
+++ b/core/viewer/screen-share-native.js
@@ -1015,50 +1015,6 @@ async function startScreenShareManual() {
             }).catch(() => {});
           }
 
-          // ── Persistent stats log (daily JSONL on server) ──
-          // Captures both outbound encoder stats and inbound viewer stats
-          // for offline analysis across sessions.
-          try {
-            var inboundArr = [];
-            _inboundDropTracker.forEach(function(dt, key) {
-              var lastBytes = _inboundScreenLastBytes.get(key);
-              if (!lastBytes) return;
-              var parts = key.split("-");
-              var source = parts[parts.length - 1]; // "screen" or "camera"
-              var fromId = parts.slice(0, parts.length - 1).join("-");
-              var avgF = dt.fpsHistory.length > 0
-                ? dt.fpsHistory.reduce(function(a, b) { return a + b; }, 0) / dt.fpsHistory.length : 0;
-              // Pull latest stats from the last debugLog data (stored in tracker)
-              if (dt._lastReport) {
-                inboundArr.push({
-                  from: fromId, source: source,
-                  fps: dt._lastReport.fps, width: dt._lastReport.w, height: dt._lastReport.h,
-                  bitrate_kbps: dt._lastReport.kbps, jitter_ms: dt._lastReport.jitter,
-                  lost: dt._lastReport.lost, dropped: dt._lastReport.dropped,
-                  decoded: dt._lastReport.decoded, nack: dt._lastReport.nack,
-                  pli: dt._lastReport.pli, avg_fps: Math.round(avgF),
-                  layer: dt.currentQuality, codec: dt._lastReport.codec || null,
-                });
-              }
-            });
-            fetch(apiUrl("/api/stats-log"), {
-              method: "POST",
-              headers: { "Content-Type": "application/json" },
-              body: JSON.stringify({
-                identity: room?.localParticipant?.identity || "",
-                room: currentRoomName || "",
-                out_fps: highLayer.fps, out_width: highLayer.w, out_height: highLayer.h,
-                out_bitrate_kbps: totalKbps,
-                out_bwe_kbps: typeof bwe === "number" ? bwe : null,
-                out_limit: highLayer.limit || null,
-                out_encoder: highLayer.codec || null,
-                out_layers: layers.length,
-                out_ice: iceInfo || null,
-                inbound: inboundArr.length > 0 ? inboundArr : null,
-              }),
-            }).catch(function() {});
-          } catch (e) {}
-
           // Adaptive camera quality: reduce camera when HIGH layer is bandwidth-constrained
           if (highLayerLimit === "bandwidth" || highLayerFps === 0) {
             _bwLimitedCount++;

--- a/core/viewer/style.css
+++ b/core/viewer/style.css
@@ -5598,6 +5598,51 @@ body.admin-mode .room-top {
   cursor: not-allowed;
 }
 
+.diagnostics-consent-card strong {
+  color: #f5f5f5;
+}
+
+.diagnostics-toggle-row {
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.diagnostics-toggle-row input {
+  flex: 0 0 auto;
+}
+
+.diagnostics-privacy-hint {
+  margin-top: 8px;
+}
+
+.diagnostics-status-grid {
+  display: grid;
+  grid-template-columns: minmax(90px, auto) 1fr;
+  gap: 4px 12px;
+  margin-top: 10px;
+  font-size: 12px;
+}
+
+.diagnostics-status-grid span:nth-child(odd) {
+  opacity: 0.65;
+}
+
+.diagnostics-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+@media (max-width: 560px) {
+  .diagnostics-consent-card {
+    min-width: 0;
+    width: calc(100vw - 32px);
+    box-sizing: border-box;
+  }
+}
+
 .admin-badge {
   display: inline-flex;
   align-items: center;

--- a/docs/WEB-DIAGNOSTICS-COLLECTOR.md
+++ b/docs/WEB-DIAGNOSTICS-COLLECTOR.md
@@ -48,6 +48,10 @@ report is private, not anonymous.
 - The complete persisted queue document (including JSON wrapper overhead) is
   limited to ten envelopes and 512 KiB, with a 72-hour retention window shorter
   than the server's seven-day ingestion maximum.
+- Concurrent tabs share browser storage on a best-effort basis. Simultaneous
+  writes can lose a diagnostic event or unclean-tab sentinel, but every sealed
+  report retains its participant-and-origin scope and cannot be uploaded under
+  a different scope.
 - Upload is released only by an HTTP-successful, non-stale participant heartbeat
   using the exact LiveKit JWT and control origin that heartbeat just proved.
 - `202 accepted` and `200 duplicate` remove the local envelope. Authentication,

--- a/docs/WEB-DIAGNOSTICS-COLLECTOR.md
+++ b/docs/WEB-DIAGNOSTICS-COLLECTOR.md
@@ -1,0 +1,84 @@
+# Mac Web Canary Diagnostics Collector
+
+Date: 2026-07-21
+Release impact: coordinated control-plane and server-served viewer update; no desktop binary
+
+## Scope
+
+This collector is limited to the desktop macOS browser fallback. It does not run
+inside the native Echo shell, on Windows/Linux browsers, or on iPadOS devices
+that identify themselves as `MacIntel`. Existing users therefore receive no
+prompt or collection behavior unless they are using the Mac web canary.
+
+Diagnostics remain off until the browser user explicitly accepts the first-run
+consent. The same Settings panel then provides an On/Off switch, last-upload
+status, Send Now, and Delete Queued Data. Turning diagnostics off first records
+the disabled preference, aborts pending work, and removes the browser-local
+diagnostics identifiers and queue. It cannot recall an incident that the Echo
+server already accepted; server incidents remain under the owner's normal
+retention/delete controls.
+
+## Privacy boundary
+
+The browser records only fixed event codes and allowlisted booleans, counts,
+numbers, and short enum-like values. The event adapters never read free-form
+error messages, stacks, source filenames, URLs, console arguments, device
+identifiers/labels, chat, screenshots, media content, clipboard data, window
+titles, processes, or files. Raw identities, room names, tokens, and headers are
+never placed in event details, browser storage, or the queued wire envelope.
+
+Collection sanitizes before browser storage. The control plane validates the
+closed schema and sanitizes again before private persistence. The participant
+JWT and successful-heartbeat control origin exist only in memory and are never
+included in a queued envelope. A local-only SHA-256 scope digest binds each
+queued wrapper to the diagnostics installation, normalized control origin, and
+JWT subject. The raw subject is used only in memory for that derivation. The
+wrapper is stripped before upload, and reports from another origin or
+participant cannot cross that boundary. After authentication, the server links
+an accepted report to the current Echo participant for private owner review; the
+report is private, not anonymous.
+
+## Delivery and retry model
+
+- Each diagnostics installation and page session uses a separate canonical
+  lowercase UUID generated with the browser's secure random source.
+- Draft events may be accumulated locally, but an envelope becomes immutable
+  before its first request. Every retry sends byte-identical JSON so a lost
+  acknowledgement cannot become an idempotency conflict.
+- The complete persisted queue document (including JSON wrapper overhead) is
+  limited to ten envelopes and 512 KiB, with a 72-hour retention window shorter
+  than the server's seven-day ingestion maximum.
+- Upload is released only by an HTTP-successful, non-stale participant heartbeat
+  using the exact LiveKit JWT and control origin that heartbeat just proved.
+- `202 accepted` and `200 duplicate` remove the local envelope. Authentication,
+  disabled-service, rate-limit, permanent-schema, and transient-server failures
+  follow bounded non-looping policies.
+- Credential replacement seals the prior draft and rotates the diagnostics
+  session. Late responses from an aborted upload cannot mutate a newer session
+  or recreate data after opt-out.
+- Unclean-tab sentinels use a conservative five-minute stale window and carry
+  only the same opaque local scope digest. A stale tab is reported only after a
+  matching participant heartbeat; unknown or different-user sentinels are
+  never attributed to the current user.
+- The server retains accepted detail for approximately 14 days under its global
+  disk cap.
+
+## Build metadata and browser limitations
+
+`GET /api/version` now returns the exact short Git SHA compiled into the control
+binary along with the release version. Repository builds discover the SHA from
+Git; source-less packaging must set `ECHO_GIT_SHA`, and the build fails rather
+than emitting a fake value when neither source is available.
+
+The browser reports its safe browser/LiveKit versions and that the operating
+system is macOS. Safari does not reliably reveal the Apple Silicon architecture
+or exact macOS build without fingerprint-heavy APIs, so those fields remain
+unknown or absent. The collector never guesses them.
+
+## Deliberate exclusions
+
+- No console interception or arbitrary-log upload.
+- No native/Tauri panic or Application Support spool; those require a native
+  Mac client and are outside the web fallback.
+- No third-party telemetry.
+- No live deployment, service restart, or tester rollout is part of this PR.


### PR DESCRIPTION
## Summary
- Add an explicit-consent private diagnostics collector for desktop Mac browsers only.
- Scope queued reports to the current participant and control origin, with immutable bounded retries and strict allowlisted payloads.
- Remove the dead free-form `/api/stats-log` browser calls and expose the real build SHA used by diagnostics.
- Add shared Rust/JavaScript wire-contract coverage, browser consent coverage, and operator documentation.

## User-facing impact
- [x] User-visible behavior changed
- [ ] No user-visible behavior change

Mac desktop-browser users can choose whether to send private diagnostics and manage/delete their local queue. Native Echo clients, iPad masquerading as Mac, and other platforms are excluded.

## Repro + validation evidence
### Before
1. The hardened Mac browser fallback had no private automatic diagnostic path.
2. Screen sharing still issued swallowed requests to a nonexistent free-form stats endpoint.

### After
1. Nothing is stored, identified, or uploaded before explicit opt-in; `Keep Off` receives initial focus.
2. Upload is released only by a successful, non-stale authenticated heartbeat for the same credential.
3. Reports contain fixed codes and allowlisted fields only, are bounded locally, and cannot cross participant or control-origin scope.
4. Opt-out detaches handlers and deletes diagnostics-owned local state.
5. Persisted consent and active-room identity are rechecked at cross-tab and room-replacement race boundaries.

### Evidence
- [x] Automated unit/regression coverage
- [x] Playwright consent flow
- [x] Isolated diagnostics API smoke test
- [x] Independent security and final-diff review

## Regression checklist (media/session)
- [x] Room switch/credential replacement paths covered by diagnostics and existing transition tests
- [x] Screen-share regression suite passed
- [x] Jam state regression suite passed
- [x] Mic/camera/share state regression suite passed
- [x] Disconnect/reconnect diagnostics paths covered

## Verification commands run
- [x] `npm run verify:quick` (guardrails + 231 viewer tests)
- [x] `cargo test -p echo-core-control --locked` (116 tests)
- [x] Full viewer Playwright suite (70/70)
- [x] `powershell -File core/control/test-diagnostics-api.ps1`
- [x] Focused Mac diagnostics Playwright test
- [x] `git diff --check` and JavaScript syntax checks

## Release impact
Server/viewer only. No desktop binary change and no macOS build/release action.

## Risk
- [ ] Low
- [x] Medium
- [ ] High

The collector touches authentication transitions and browser lifecycle events. It is opt-in, platform-gated, fail-closed, separately queued, and covered by race/scoping tests.

## Rollback plan
Revert this single commit/PR. Existing native clients and non-Mac browser behavior remain outside the collector gate.