### PR TITLE
Add private diagnostics owner UI

### DIFF
--- a/.github/workflows/pr-viewer-layout.yml
+++ b/.github/workflows/pr-viewer-layout.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches: [main, dev]
     paths:
+      - "core/admin/**"
       - "core/viewer/**"
       - "core/viewer-tests/**"
       - ".github/workflows/pr-viewer-layout.yml"

--- a/core/admin/diagnostics/diagnostics.css
+++ b/core/admin/diagnostics/diagnostics.css
@@ -1,0 +1,701 @@
+:root {
+  color-scheme: dark;
+  --background: #090b10;
+  --surface: #11151d;
+  --surface-raised: #171c26;
+  --surface-soft: #0d1118;
+  --border: #293140;
+  --border-strong: #3b465a;
+  --text: #f4f7fb;
+  --muted: #9ca8b9;
+  --subtle: #778397;
+  --accent: #70e2bf;
+  --accent-strong: #42cfa3;
+  --accent-ink: #06150f;
+  --danger: #ff7f8d;
+  --danger-soft: #32171d;
+  --warning: #ffc86a;
+  --info: #78bfff;
+  --focus: #a9f4de;
+  --shadow: 0 22px 60px rgb(0 0 0 / 35%);
+  --radius: 12px;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-synthesis: none;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  min-width: 320px;
+  background: var(--background);
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  color: var(--text);
+  background:
+    radial-gradient(circle at 20% -20%, rgb(55 148 121 / 17%), transparent 35rem),
+    linear-gradient(180deg, #0b0e14 0, var(--background) 22rem);
+}
+
+button,
+input,
+select {
+  font: inherit;
+}
+
+button,
+select {
+  cursor: pointer;
+}
+
+button:disabled,
+select:disabled,
+input:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+a {
+  color: var(--accent);
+}
+
+[hidden] {
+  display: none !important;
+}
+
+.skip-link {
+  position: fixed;
+  z-index: 100;
+  top: 0.75rem;
+  left: 0.75rem;
+  padding: 0.65rem 0.85rem;
+  border-radius: 8px;
+  color: var(--accent-ink);
+  background: var(--focus);
+  transform: translateY(-180%);
+}
+
+.skip-link:focus {
+  transform: translateY(0);
+}
+
+.site-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  min-height: 78px;
+  padding: 1rem clamp(1rem, 4vw, 3.5rem);
+  border-bottom: 1px solid var(--border);
+  background: rgb(9 11 16 / 82%);
+  backdrop-filter: blur(18px);
+}
+
+.site-header h1,
+.dashboard-heading h2,
+.login-card h2,
+.detail-heading h3 {
+  margin: 0;
+  line-height: 1.12;
+  letter-spacing: -0.025em;
+}
+
+.site-header h1 {
+  font-size: clamp(1.15rem, 2vw, 1.45rem);
+}
+
+.eyebrow {
+  margin: 0 0 0.3rem;
+  color: var(--accent);
+  font-size: 0.7rem;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.quiet-link {
+  color: var(--muted);
+  font-size: 0.84rem;
+  font-weight: 650;
+  text-underline-offset: 0.22rem;
+}
+
+.quiet-link:hover {
+  color: var(--text);
+}
+
+main {
+  width: min(1540px, 100%);
+  margin: 0 auto;
+  padding: clamp(1rem, 3vw, 2.5rem);
+}
+
+.login-view {
+  display: grid;
+  min-height: calc(100vh - 160px);
+  place-items: center;
+}
+
+.login-card {
+  width: min(100%, 500px);
+  padding: clamp(1.4rem, 5vw, 2.5rem);
+  border: 1px solid var(--border);
+  border-radius: 18px;
+  background: linear-gradient(145deg, rgb(23 28 38 / 96%), rgb(13 17 24 / 96%));
+  box-shadow: var(--shadow);
+}
+
+.login-card h2 {
+  max-width: 16ch;
+  font-size: clamp(1.75rem, 5vw, 2.5rem);
+}
+
+.lede {
+  margin: 0.9rem 0 1.6rem;
+  color: var(--muted);
+  line-height: 1.55;
+}
+
+.lede.compact {
+  margin: 0.55rem 0 0;
+  font-size: 0.9rem;
+}
+
+label {
+  display: block;
+  margin-bottom: 0.4rem;
+  color: #d7dee8;
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+
+input,
+select {
+  width: 100%;
+  min-height: 40px;
+  border: 1px solid var(--border-strong);
+  border-radius: 8px;
+  color: var(--text);
+  background: var(--surface-soft);
+  outline: none;
+}
+
+input {
+  padding: 0.65rem 0.75rem;
+}
+
+select {
+  padding: 0.55rem 2rem 0.55rem 0.65rem;
+}
+
+input:hover,
+select:hover {
+  border-color: #56647b;
+}
+
+input:focus-visible,
+select:focus-visible,
+button:focus-visible,
+a:focus-visible {
+  outline: 3px solid rgb(169 244 222 / 38%);
+  outline-offset: 2px;
+}
+
+.login-card input {
+  min-height: 48px;
+  margin-bottom: 0.9rem;
+}
+
+.button {
+  min-height: 38px;
+  padding: 0.55rem 0.85rem;
+  border: 1px solid var(--border-strong);
+  border-radius: 8px;
+  color: var(--text);
+  background: var(--surface-raised);
+  font-size: 0.8rem;
+  font-weight: 750;
+  line-height: 1.15;
+}
+
+.button:hover:not(:disabled) {
+  border-color: #607087;
+  background: #202735;
+}
+
+.button-primary {
+  width: 100%;
+  min-height: 46px;
+  border-color: var(--accent-strong);
+  color: var(--accent-ink);
+  background: var(--accent);
+}
+
+.button-primary:hover:not(:disabled) {
+  border-color: var(--focus);
+  background: var(--focus);
+}
+
+.button-quiet {
+  background: transparent;
+}
+
+.button-danger {
+  border-color: #7d3440;
+  color: #fff2f4;
+  background: #8d3341;
+}
+
+.button-danger:hover:not(:disabled) {
+  border-color: var(--danger);
+  background: #aa3d4d;
+}
+
+.button-danger-quiet {
+  border-color: #63303a;
+  color: var(--danger);
+  background: transparent;
+}
+
+.status-message {
+  min-height: 1.3em;
+  margin: 0.7rem 0 0;
+  color: var(--muted);
+  font-size: 0.8rem;
+  line-height: 1.4;
+}
+
+.status-message[data-tone="error"] {
+  color: var(--danger);
+}
+
+.status-message[data-tone="success"] {
+  color: var(--accent);
+}
+
+.status-message[data-tone="warning"] {
+  color: var(--warning);
+}
+
+.dashboard {
+  display: grid;
+  gap: 1rem;
+}
+
+.dashboard-heading,
+.detail-heading,
+.results-header,
+.pagination {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.dashboard-heading {
+  align-items: flex-end;
+  margin-bottom: 0.5rem;
+}
+
+.dashboard-heading h2 {
+  font-size: clamp(1.65rem, 4vw, 2.35rem);
+}
+
+.header-actions,
+.detail-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+}
+
+.toolbar {
+  display: grid;
+  grid-template-columns: minmax(210px, 1.45fr) repeat(3, minmax(145px, 0.8fr)) auto;
+  gap: 0.7rem;
+  padding: 0.85rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface);
+}
+
+.field-action {
+  align-self: end;
+}
+
+.field-spacer {
+  display: block;
+  height: 0;
+  overflow: hidden;
+}
+
+.results-header {
+  min-height: 28px;
+}
+
+.results-summary,
+.results-header .status-message {
+  margin: 0;
+  font-size: 0.8rem;
+}
+
+.results-summary {
+  color: var(--muted);
+}
+
+.table-shell {
+  position: relative;
+  min-height: 210px;
+  overflow-x: auto;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface);
+  box-shadow: 0 12px 35px rgb(0 0 0 / 18%);
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.78rem;
+}
+
+thead {
+  color: var(--muted);
+  background: #0f131a;
+}
+
+th,
+td {
+  padding: 0.72rem 0.75rem;
+  border-bottom: 1px solid var(--border);
+  text-align: left;
+  vertical-align: middle;
+}
+
+th {
+  font-size: 0.68rem;
+  font-weight: 800;
+  letter-spacing: 0.075em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+tbody tr:last-child td {
+  border-bottom: 0;
+}
+
+tbody tr:hover {
+  background: #151b24;
+}
+
+.primary-cell {
+  color: var(--text);
+  font-weight: 700;
+}
+
+.secondary-cell,
+.cell-meta {
+  color: var(--muted);
+}
+
+.cell-meta {
+  display: block;
+  margin-top: 0.18rem;
+  font-size: 0.69rem;
+}
+
+.monospace {
+  font-family: ui-monospace, SFMono-Regular, Consolas, "Liberation Mono", monospace;
+  font-size: 0.72rem;
+}
+
+.severity {
+  display: inline-flex;
+  align-items: center;
+  min-height: 22px;
+  padding: 0.2rem 0.46rem;
+  border: 1px solid var(--border-strong);
+  border-radius: 999px;
+  font-size: 0.66rem;
+  font-weight: 850;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.severity-debug,
+.severity-info {
+  color: var(--info);
+  background: #102032;
+}
+
+.severity-warning {
+  color: var(--warning);
+  background: #2c2414;
+}
+
+.severity-error,
+.severity-fatal {
+  color: var(--danger);
+  background: var(--danger-soft);
+}
+
+.event-tags {
+  display: flex;
+  max-width: 28rem;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+}
+
+.event-tag {
+  padding: 0.16rem 0.38rem;
+  border-radius: 5px;
+  color: #c4cedb;
+  background: #202633;
+  font-size: 0.65rem;
+  white-space: nowrap;
+}
+
+.row-action {
+  white-space: nowrap;
+  text-align: right;
+}
+
+.empty-state {
+  position: absolute;
+  inset: 44px 0 0;
+  display: grid;
+  align-content: center;
+  justify-items: center;
+  padding: 2rem;
+  color: var(--muted);
+  text-align: center;
+  background: var(--surface);
+}
+
+.empty-state p {
+  margin: 0.2rem;
+}
+
+.empty-title {
+  color: var(--text);
+  font-weight: 800;
+}
+
+.pagination {
+  justify-content: flex-end;
+}
+
+#page-label {
+  min-width: 4.5rem;
+  color: var(--muted);
+  font-size: 0.78rem;
+  text-align: center;
+}
+
+.detail-panel {
+  scroll-margin-top: 1rem;
+  padding: clamp(1rem, 2vw, 1.35rem);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius);
+  background: linear-gradient(145deg, var(--surface-raised), var(--surface));
+  box-shadow: var(--shadow);
+}
+
+.detail-heading {
+  padding-bottom: 0.9rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.detail-heading h3 {
+  font-size: 1.25rem;
+}
+
+.detail-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.65rem;
+  margin: 1rem 0 1.4rem;
+}
+
+.detail-card {
+  min-width: 0;
+  padding: 0.7rem;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface-soft);
+}
+
+.detail-label {
+  display: block;
+  margin-bottom: 0.28rem;
+  color: var(--subtle);
+  font-size: 0.64rem;
+  font-weight: 800;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.detail-value {
+  overflow-wrap: anywhere;
+  color: #e5eaf1;
+  font-size: 0.78rem;
+}
+
+.timeline-heading {
+  margin: 0 0 0.65rem;
+  font-size: 0.9rem;
+}
+
+.timeline {
+  display: grid;
+  gap: 0.5rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.timeline-event {
+  padding: 0.7rem 0.8rem;
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--border-strong);
+  border-radius: 8px;
+  background: var(--surface-soft);
+}
+
+.timeline-event[data-severity="warning"] {
+  border-left-color: var(--warning);
+}
+
+.timeline-event[data-severity="error"],
+.timeline-event[data-severity="fatal"] {
+  border-left-color: var(--danger);
+}
+
+.event-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.event-title {
+  min-width: 0;
+  font-size: 0.78rem;
+  font-weight: 800;
+  overflow-wrap: anywhere;
+}
+
+.event-time {
+  flex: 0 0 auto;
+  color: var(--subtle);
+  font-size: 0.67rem;
+}
+
+.event-details {
+  max-height: 240px;
+  margin: 0.55rem 0 0;
+  overflow: auto;
+  color: #b9c5d3;
+  font-family: ui-monospace, SFMono-Regular, Consolas, "Liberation Mono", monospace;
+  font-size: 0.68rem;
+  line-height: 1.55;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.detail-actions {
+  margin-top: 1rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--border);
+}
+
+.visually-hidden {
+  position: absolute !important;
+  width: 1px !important;
+  height: 1px !important;
+  padding: 0 !important;
+  margin: -1px !important;
+  overflow: hidden !important;
+  clip: rect(0, 0, 0, 0) !important;
+  white-space: nowrap !important;
+  border: 0 !important;
+}
+
+@media (max-width: 1080px) {
+  .toolbar {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .field-wide {
+    grid-column: 1 / -1;
+  }
+
+  .detail-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 720px) {
+  .site-header {
+    min-height: 68px;
+  }
+
+  .dashboard-heading,
+  .results-header {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .header-actions .button {
+    flex: 1;
+  }
+
+  .toolbar {
+    grid-template-columns: 1fr;
+  }
+
+  .field-wide {
+    grid-column: auto;
+  }
+
+  .field-action .button {
+    width: 100%;
+  }
+
+  th,
+  td {
+    padding: 0.65rem;
+  }
+
+  th:nth-child(3),
+  td:nth-child(3),
+  th:nth-child(5),
+  td:nth-child(5) {
+    display: none;
+  }
+
+  .pagination {
+    justify-content: space-between;
+  }
+
+  .detail-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .event-heading {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 0.3rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    transition: none !important;
+  }
+}

--- a/core/admin/diagnostics/diagnostics.js
+++ b/core/admin/diagnostics/diagnostics.js
@@ -1,0 +1,967 @@
+(function () {
+  "use strict";
+
+  var PAGE_SIZE = 50;
+  var PAGE_FETCH_SIZE = PAGE_SIZE + 1;
+  var TOKEN_MAX_LENGTH = 8192;
+  var DOWNLOAD_MAX_BYTES = 384 * 1024;
+  var INCIDENT_ID_PATTERN = /^inc_[0-9a-f]{32}$/;
+  var SAFE_TOKEN_PATTERN = /^[a-z0-9][a-z0-9._-]{0,127}$/;
+  var SEVERITIES = ["debug", "info", "warning", "error", "fatal"];
+  var EVENT_TYPES = new Set([
+    "session_start", "session_end", "unclean_shutdown", "javascript_error",
+    "unhandled_rejection", "console_warning", "console_error", "permission",
+    "media", "connection", "reconnect", "tauri_ipc_error", "native_error",
+  ]);
+  var OPERATING_SYSTEMS = new Set([
+    "macos", "windows", "linux", "ios", "android", "unknown",
+  ]);
+  var ARCHITECTURES = new Set(["aarch64", "x86_64", "x86", "arm", "unknown"]);
+  var CLIENT_KINDS = new Set(["browser", "desktop"]);
+
+  var elements = {
+    loginView: document.getElementById("login-view"),
+    dashboardView: document.getElementById("dashboard-view"),
+    loginForm: document.getElementById("login-form"),
+    ownerSecret: document.getElementById("owner-secret"),
+    loginButton: document.getElementById("login-button"),
+    loginStatus: document.getElementById("login-status"),
+    refreshButton: document.getElementById("refresh-button"),
+    logoutButton: document.getElementById("logout-button"),
+    searchFilter: document.getElementById("search-filter"),
+    osFilter: document.getElementById("os-filter"),
+    severityFilter: document.getElementById("severity-filter"),
+    eventFilter: document.getElementById("event-filter"),
+    clearFiltersButton: document.getElementById("clear-filters-button"),
+    resultsSummary: document.getElementById("results-summary"),
+    dashboardStatus: document.getElementById("dashboard-status"),
+    incidentRows: document.getElementById("incident-rows"),
+    emptyState: document.getElementById("empty-state"),
+    emptyStateTitle: document.getElementById("empty-state-title"),
+    emptyStateCopy: document.getElementById("empty-state-copy"),
+    previousButton: document.getElementById("previous-button"),
+    nextButton: document.getElementById("next-button"),
+    pageLabel: document.getElementById("page-label"),
+    detailPanel: document.getElementById("detail-panel"),
+    detailTitle: document.getElementById("detail-title"),
+    detailContent: document.getElementById("detail-content"),
+    detailStatus: document.getElementById("detail-status"),
+    closeDetailButton: document.getElementById("close-detail-button"),
+    downloadButton: document.getElementById("download-button"),
+    deleteButton: document.getElementById("delete-button"),
+  };
+
+  var state = {
+    token: null,
+    generation: 0,
+    expiryTimer: null,
+    controllers: new Set(),
+    objectUrls: new Set(),
+    currentPage: null,
+    previousPages: [],
+    selectedIncidentId: null,
+    detailReturnFocus: null,
+    rowActions: new Map(),
+    pageSequence: 0,
+    detailSequence: 0,
+  };
+
+  function text(value, maximum) {
+    if (typeof value !== "string") return "";
+    var limit = maximum || 256;
+    return value.length <= limit ? value : value.slice(0, limit);
+  }
+
+  function integer(value, maximum) {
+    if (!Number.isSafeInteger(value) || value < 0) return 0;
+    return Math.min(value, maximum || Number.MAX_SAFE_INTEGER);
+  }
+
+  function safeIncidentId(value) {
+    return typeof value === "string" && INCIDENT_ID_PATTERN.test(value) ? value : null;
+  }
+
+  function safeToken(value, fallback) {
+    return typeof value === "string" && SAFE_TOKEN_PATTERN.test(value) ? value : fallback;
+  }
+
+  function safeEnum(value, allowed, fallback) {
+    return typeof value === "string" && allowed.has(value) ? value : fallback;
+  }
+
+  function makeElement(tag, className, value) {
+    var node = document.createElement(tag);
+    if (className) node.className = className;
+    if (value !== undefined && value !== null) node.textContent = String(value);
+    return node;
+  }
+
+  function setStatus(node, message, tone) {
+    node.textContent = message || "";
+    if (tone) node.dataset.tone = tone;
+    else node.removeAttribute("data-tone");
+  }
+
+  function setButtonBusy(button, busy) {
+    button.disabled = Boolean(busy);
+    button.setAttribute("aria-busy", busy ? "true" : "false");
+  }
+
+  function setDetailActionsEnabled(enabled) {
+    setButtonBusy(elements.downloadButton, false);
+    setButtonBusy(elements.deleteButton, false);
+    elements.downloadButton.disabled = !enabled;
+    elements.deleteButton.disabled = !enabled;
+  }
+
+  function resetPageControlBusy() {
+    setButtonBusy(elements.refreshButton, false);
+    setButtonBusy(elements.previousButton, false);
+    setButtonBusy(elements.nextButton, false);
+  }
+
+  function formatTimestamp(milliseconds) {
+    if (!Number.isSafeInteger(milliseconds) || milliseconds <= 0) return "Unknown";
+    try {
+      return new Date(milliseconds).toLocaleString([], {
+        year: "numeric", month: "short", day: "2-digit",
+        hour: "2-digit", minute: "2-digit", second: "2-digit",
+      });
+    } catch (_) {
+      return "Unknown";
+    }
+  }
+
+  function prettyToken(value) {
+    return text(value, 128).replace(/_/g, " ");
+  }
+
+  function retryMessage(response) {
+    var raw = response && response.headers ? response.headers.get("Retry-After") : null;
+    var seconds = Number(raw);
+    if (!Number.isFinite(seconds) || seconds <= 0) {
+      return "Too many attempts. Try again later.";
+    }
+    seconds = Math.min(900, Math.max(1, Math.ceil(seconds)));
+    if (seconds >= 60) {
+      return "Too many attempts. Try again in " + Math.ceil(seconds / 60) + " minutes.";
+    }
+    return "Too many attempts. Try again in " + seconds + " seconds.";
+  }
+
+  function failureMessage(response, context) {
+    var status = response ? response.status : 0;
+    if (status === 429) return retryMessage(response);
+    if (status === 404) {
+      if (context === "login" || context === "list") {
+        return "Private diagnostics are not enabled on this server.";
+      }
+      return "The incident no longer exists or private diagnostics are unavailable.";
+    }
+    if (status === 400 || status === 422) return "The diagnostics request was rejected.";
+    if (status === 413) return "The sign-in request is too large.";
+    if (status >= 500 || status === 0) return "Diagnostics are temporarily unavailable. Try again.";
+    if (status === 401 || status === 403) return "Session expired. Sign in again.";
+    return "Diagnostics are temporarily unavailable. Try again.";
+  }
+
+  function abortRequests() {
+    state.controllers.forEach(function (controller) { controller.abort(); });
+    state.controllers.clear();
+  }
+
+  function revokeObjectUrls() {
+    state.objectUrls.forEach(function (url) { URL.revokeObjectURL(url); });
+    state.objectUrls.clear();
+  }
+
+  function clearExpiryTimer() {
+    if (state.expiryTimer !== null) window.clearTimeout(state.expiryTimer);
+    state.expiryTimer = null;
+  }
+
+  function clearPrivateView() {
+    state.currentPage = null;
+    state.previousPages = [];
+    state.selectedIncidentId = null;
+    state.detailReturnFocus = null;
+    state.rowActions.clear();
+    state.pageSequence += 1;
+    state.detailSequence += 1;
+    elements.incidentRows.replaceChildren();
+    elements.detailContent.replaceChildren();
+    elements.detailPanel.hidden = true;
+    elements.detailTitle.textContent = "Selected incident";
+    elements.searchFilter.value = "";
+    elements.osFilter.value = "";
+    elements.severityFilter.value = "";
+    elements.eventFilter.value = "";
+    elements.resultsSummary.textContent = "No page loaded.";
+    elements.pageLabel.textContent = "Page 1";
+    resetPageControlBusy();
+    elements.previousButton.disabled = true;
+    elements.nextButton.disabled = true;
+    setDetailActionsEnabled(false);
+    setStatus(elements.dashboardStatus, "");
+    setStatus(elements.detailStatus, "");
+  }
+
+  function endSession(message, shouldFocus) {
+    state.generation += 1;
+    state.token = null;
+    abortRequests();
+    clearExpiryTimer();
+    revokeObjectUrls();
+    clearPrivateView();
+    elements.dashboardView.hidden = true;
+    elements.loginView.hidden = false;
+    elements.ownerSecret.value = "";
+    setButtonBusy(elements.loginButton, false);
+    setStatus(elements.loginStatus, message || "", message ? "warning" : "");
+    if (shouldFocus !== false) elements.ownerSecret.focus();
+  }
+
+  function beginRequest() {
+    var controller = new AbortController();
+    state.controllers.add(controller);
+    return controller;
+  }
+
+  function finishRequest(controller) {
+    state.controllers.delete(controller);
+  }
+
+  function protectedOptions(method, controller, body) {
+    var headers = { Authorization: "Bearer " + state.token };
+    if (body !== undefined) headers["Content-Type"] = "application/json";
+    var options = {
+      method: method || "GET",
+      headers: headers,
+      cache: "no-store",
+      credentials: "omit",
+      redirect: "error",
+      referrerPolicy: "no-referrer",
+      signal: controller.signal,
+    };
+    if (body !== undefined) options.body = JSON.stringify(body);
+    return options;
+  }
+
+  function validOwnerToken(value) {
+    return typeof value === "string" && value.length > 0 && value.length <= TOKEN_MAX_LENGTH &&
+      /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/.test(value);
+  }
+
+  function severityRank(value) {
+    var rank = SEVERITIES.indexOf(value);
+    return rank < 0 ? 0 : rank;
+  }
+
+  function sanitizeSummary(raw) {
+    if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
+    var incidentId = safeIncidentId(raw.incident_id);
+    if (!incidentId) return null;
+    var eventTypes = Array.isArray(raw.event_types)
+      ? raw.event_types.filter(function (value) { return EVENT_TYPES.has(value); }).slice(0, 16)
+      : [];
+    return {
+      incidentId: incidentId,
+      envelopeId: text(raw.envelope_id, 64),
+      identity: text(raw.authenticated_identity, 256),
+      receivedAt: integer(raw.received_at_ms),
+      capturedAt: integer(raw.captured_at_ms),
+      sessionId: text(raw.session_id, 64),
+      appVersion: text(raw.app_version, 64),
+      channel: text(raw.channel, 64),
+      clientKind: safeEnum(raw.client_kind, CLIENT_KINDS, "browser"),
+      operatingSystem: safeEnum(raw.operating_system, OPERATING_SYSTEMS, "unknown"),
+      architecture: safeEnum(raw.architecture, ARCHITECTURES, "unknown"),
+      eventCount: integer(raw.event_count, 1000),
+      highestSeverity: SEVERITIES.includes(raw.highest_severity) ? raw.highest_severity : "debug",
+      eventTypes: eventTypes,
+    };
+  }
+
+  function sanitizeDetailValue(value, depth) {
+    if (depth > 3) return "[truncated]";
+    if (value === null || typeof value === "boolean") return value;
+    if (typeof value === "number") return Number.isFinite(value) ? value : "[invalid number]";
+    if (typeof value === "string") return text(value, 512);
+    if (Array.isArray(value)) {
+      return value.slice(0, 20).map(function (item) { return sanitizeDetailValue(item, depth + 1); });
+    }
+    if (value && typeof value === "object") {
+      var result = Object.create(null);
+      Object.keys(value).slice(0, 50).forEach(function (key) {
+        var safeKey = text(key, 64);
+        var normalizedKey = safeKey.toLowerCase();
+        if (!safeKey || normalizedKey.includes("message") || normalizedKey.includes("fingerprint") ||
+            normalizedKey.includes("digest")) return;
+        result[safeKey] = sanitizeDetailValue(value[key], depth + 1);
+      });
+      return result;
+    }
+    return "[unsupported]";
+  }
+
+  function sanitizeDetail(raw, requestedIncidentId) {
+    if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
+    var incidentId = safeIncidentId(raw.incident_id);
+    if (!incidentId || incidentId !== requestedIncidentId) return null;
+    var envelope = raw.envelope;
+    if (!envelope || typeof envelope !== "object" || Array.isArray(envelope)) return null;
+    var app = envelope.app && typeof envelope.app === "object" ? envelope.app : {};
+    var platform = envelope.platform && typeof envelope.platform === "object" ? envelope.platform : {};
+    var runtimes = app.runtimes && typeof app.runtimes === "object" ? app.runtimes : {};
+    var events = Array.isArray(envelope.events) ? envelope.events.slice(0, 50) : [];
+    var sanitizedEvents = events.map(function (event) {
+      if (!event || typeof event !== "object" || Array.isArray(event)) return null;
+      var eventType = safeEnum(event.event_type, EVENT_TYPES, null);
+      var severity = SEVERITIES.includes(event.severity) ? event.severity : "debug";
+      if (!eventType) return null;
+      return {
+        sequence: integer(event.sequence, 1000000),
+        timestamp: integer(event.timestamp_ms),
+        eventType: eventType,
+        severity: severity,
+        code: safeToken(event.code, "unknown"),
+        details: sanitizeDetailValue(
+          event.details && typeof event.details === "object" ? event.details : {},
+          0,
+        ),
+      };
+    }).filter(Boolean);
+    return {
+      incidentId: incidentId,
+      receivedAt: integer(raw.received_at_ms),
+      identity: text(raw.authenticated_identity, 256),
+      envelopeId: text(envelope.envelope_id, 64),
+      installId: text(envelope.install_id, 64),
+      sessionId: text(envelope.session_id, 64),
+      capturedAt: integer(envelope.captured_at_ms),
+      sentAt: integer(envelope.sent_at_ms),
+      app: {
+        version: text(app.version, 64),
+        gitSha: text(app.git_sha, 16),
+        channel: text(app.channel, 64),
+        browserName: text(runtimes.browser_name, 64),
+        browserVersion: text(runtimes.browser_version, 64),
+        webviewVersion: text(runtimes.webview_version, 64),
+        livekitVersion: text(runtimes.livekit_version, 64),
+        tauriVersion: text(runtimes.tauri_version, 64),
+      },
+      platform: {
+        clientKind: safeEnum(platform.client_kind, CLIENT_KINDS, "browser"),
+        operatingSystem: safeEnum(platform.operating_system, OPERATING_SYSTEMS, "unknown"),
+        architecture: safeEnum(platform.architecture, ARCHITECTURES, "unknown"),
+        osVersion: text(platform.os_version, 64),
+        osBuild: text(platform.os_build, 64),
+      },
+      events: sanitizedEvents,
+    };
+  }
+
+  function appendTextLine(parent, primary, secondary, primaryClass) {
+    var primaryNode = makeElement("span", primaryClass || "primary-cell", primary);
+    parent.appendChild(primaryNode);
+    if (secondary) parent.appendChild(makeElement("span", "cell-meta", secondary));
+  }
+
+  function filterMatches(item) {
+    var query = elements.searchFilter.value.toLowerCase();
+    if (query) {
+      var haystack = [item.identity, item.incidentId].join(" ").toLowerCase();
+      if (!haystack.includes(query)) return false;
+    }
+    if (elements.osFilter.value && item.operatingSystem !== elements.osFilter.value) return false;
+    if (elements.severityFilter.value &&
+        severityRank(item.highestSeverity) < severityRank(elements.severityFilter.value)) return false;
+    if (elements.eventFilter.value && !item.eventTypes.includes(elements.eventFilter.value)) return false;
+    return true;
+  }
+
+  function renderIncidentRow(item) {
+    var row = document.createElement("tr");
+
+    var receivedCell = document.createElement("td");
+    appendTextLine(receivedCell, formatTimestamp(item.receivedAt), "Captured " + formatTimestamp(item.capturedAt));
+    row.appendChild(receivedCell);
+
+    var identityCell = document.createElement("td");
+    appendTextLine(identityCell, item.identity || "Unknown participant", item.incidentId);
+    identityCell.lastChild.classList.add("monospace");
+    row.appendChild(identityCell);
+
+    var platformCell = document.createElement("td");
+    appendTextLine(
+      platformCell,
+      prettyToken(item.operatingSystem) + " · " + prettyToken(item.architecture),
+      (item.appVersion || "Unknown build") + " · " + (item.channel || "unknown channel"),
+    );
+    row.appendChild(platformCell);
+
+    var severityCell = document.createElement("td");
+    severityCell.appendChild(makeElement(
+      "span",
+      "severity severity-" + item.highestSeverity,
+      item.highestSeverity,
+    ));
+    row.appendChild(severityCell);
+
+    var eventsCell = document.createElement("td");
+    var tags = makeElement("div", "event-tags");
+    item.eventTypes.forEach(function (eventType) {
+      tags.appendChild(makeElement("span", "event-tag", prettyToken(eventType)));
+    });
+    if (!item.eventTypes.length) tags.appendChild(makeElement("span", "event-tag", "No event type"));
+    eventsCell.appendChild(tags);
+    eventsCell.appendChild(makeElement(
+      "span",
+      "cell-meta",
+      item.eventCount + (item.eventCount === 1 ? " event" : " events"),
+    ));
+    row.appendChild(eventsCell);
+
+    var actionCell = makeElement("td", "row-action");
+    var viewButton = makeElement("button", "button button-quiet", "View details");
+    viewButton.type = "button";
+    viewButton.setAttribute("aria-label", "View details for incident " + item.incidentId.slice(-8));
+    viewButton.addEventListener("click", function () { void loadDetail(item.incidentId, viewButton); });
+    state.rowActions.set(item.incidentId, viewButton);
+    actionCell.appendChild(viewButton);
+    row.appendChild(actionCell);
+    return row;
+  }
+
+  function renderCurrentPage() {
+    var page = state.currentPage;
+    state.rowActions.clear();
+    if (!page) {
+      elements.incidentRows.replaceChildren();
+      elements.emptyState.hidden = false;
+      elements.nextButton.disabled = true;
+      elements.previousButton.disabled = true;
+      return;
+    }
+    var filtered = page.items.filter(filterMatches);
+    elements.incidentRows.replaceChildren.apply(
+      elements.incidentRows,
+      filtered.map(renderIncidentRow),
+    );
+    elements.emptyState.hidden = filtered.length !== 0;
+    elements.emptyStateTitle.textContent = page.items.length ? "No matching incidents" : "No incidents found";
+    elements.emptyStateCopy.textContent = page.items.length
+      ? "Nothing on this loaded page matches the current filters."
+      : "The server returned no incidents for this page.";
+    elements.resultsSummary.textContent = "Showing " + filtered.length + " of " + page.items.length +
+      " incidents on this loaded page. Filters do not query other pages.";
+    elements.pageLabel.textContent = "Page " + page.number;
+    elements.previousButton.disabled = state.previousPages.length === 0;
+    elements.nextButton.disabled = !page.hasNext;
+  }
+
+  function addDetailCard(grid, label, value, monospace) {
+    var card = makeElement("div", "detail-card");
+    card.appendChild(makeElement("span", "detail-label", label));
+    card.appendChild(makeElement(
+      "span",
+      "detail-value" + (monospace ? " monospace" : ""),
+      value || "Unknown",
+    ));
+    grid.appendChild(card);
+  }
+
+  function runtimeSummary(app) {
+    var values = [];
+    if (app.browserName) values.push(app.browserName + (app.browserVersion ? " " + app.browserVersion : ""));
+    if (app.webviewVersion) values.push("WebView " + app.webviewVersion);
+    if (app.livekitVersion) values.push("LiveKit " + app.livekitVersion);
+    if (app.tauriVersion) values.push("Tauri " + app.tauriVersion);
+    return values.join(" · ") || "Unknown";
+  }
+
+  function renderDetail(detail) {
+    var fragment = document.createDocumentFragment();
+    var grid = makeElement("div", "detail-grid");
+    addDetailCard(grid, "Participant", detail.identity);
+    addDetailCard(grid, "Received", formatTimestamp(detail.receivedAt));
+    addDetailCard(grid, "Captured", formatTimestamp(detail.capturedAt));
+    addDetailCard(grid, "Sent", formatTimestamp(detail.sentAt));
+    addDetailCard(
+      grid,
+      "Build",
+      [detail.app.version, detail.app.gitSha, detail.app.channel].filter(Boolean).join(" · "),
+      true,
+    );
+    addDetailCard(
+      grid,
+      "Platform",
+      [detail.platform.clientKind, detail.platform.operatingSystem, detail.platform.architecture]
+        .map(prettyToken).join(" · "),
+    );
+    addDetailCard(
+      grid,
+      "OS version",
+      [detail.platform.osVersion, detail.platform.osBuild].filter(Boolean).join(" · "),
+    );
+    addDetailCard(grid, "Runtime", runtimeSummary(detail.app));
+    addDetailCard(grid, "Incident ID", detail.incidentId, true);
+    addDetailCard(grid, "Envelope ID", detail.envelopeId, true);
+    addDetailCard(grid, "Install ID", detail.installId, true);
+    addDetailCard(grid, "Session ID", detail.sessionId, true);
+    fragment.appendChild(grid);
+
+    fragment.appendChild(makeElement("h4", "timeline-heading", "Event timeline"));
+    var timeline = makeElement("ol", "timeline");
+    detail.events.forEach(function (event) {
+      var eventNode = makeElement("li", "timeline-event");
+      eventNode.dataset.severity = event.severity;
+      var heading = makeElement("div", "event-heading");
+      heading.appendChild(makeElement(
+        "span",
+        "event-title",
+        "#" + event.sequence + " · " + prettyToken(event.eventType) + " · " + event.code,
+      ));
+      heading.appendChild(makeElement("time", "event-time", formatTimestamp(event.timestamp)));
+      eventNode.appendChild(heading);
+      eventNode.appendChild(makeElement(
+        "pre",
+        "event-details",
+        JSON.stringify(event.details, null, 2),
+      ));
+      timeline.appendChild(eventNode);
+    });
+    if (!detail.events.length) {
+      timeline.appendChild(makeElement("li", "timeline-event", "No valid events were returned."));
+    }
+    fragment.appendChild(timeline);
+    elements.detailContent.replaceChildren(fragment);
+    elements.detailTitle.textContent = "Incident " + detail.incidentId.slice(-8);
+    elements.detailPanel.hidden = false;
+    setStatus(elements.detailStatus, "");
+    elements.detailPanel.scrollIntoView({ behavior: "auto", block: "start" });
+  }
+
+  function handleProtectedFailure(response, context, statusNode) {
+    var message = failureMessage(response, context);
+    if (response.status === 401 || response.status === 403 ||
+        (response.status === 404 && context === "list")) {
+      endSession(message);
+      return;
+    }
+    setStatus(statusNode, message, response.status === 429 ? "warning" : "error");
+  }
+
+  async function fetchPage(cursor, pageNumber, pageSequence) {
+    if (!state.token) return null;
+    var requestGeneration = state.generation;
+    var controller = beginRequest();
+    var parameters = new URLSearchParams({ limit: String(PAGE_FETCH_SIZE) });
+    if (cursor) {
+      parameters.set("before_received_at_ms", String(cursor.receivedAt));
+      parameters.set("before_incident_id", cursor.incidentId);
+    }
+    try {
+      var response = await fetch(
+        "/admin/api/diagnostics?" + parameters.toString(),
+        protectedOptions("GET", controller),
+      );
+      if (requestGeneration !== state.generation || pageSequence !== state.pageSequence) return null;
+      if (!response.ok) {
+        handleProtectedFailure(response, "list", elements.dashboardStatus);
+        return null;
+      }
+      var payload = await response.json();
+      if (requestGeneration !== state.generation || pageSequence !== state.pageSequence) return null;
+      if (!payload || !Array.isArray(payload.incidents)) {
+        setStatus(elements.dashboardStatus, "The diagnostics response could not be verified.", "error");
+        return null;
+      }
+      var allItems = payload.incidents.slice(0, PAGE_FETCH_SIZE)
+        .map(sanitizeSummary).filter(Boolean);
+      var items = allItems.slice(0, PAGE_SIZE);
+      var lastDisplayed = items[items.length - 1];
+      return {
+        cursor: cursor,
+        number: pageNumber,
+        items: items,
+        hasNext: allItems.length > PAGE_SIZE && Boolean(lastDisplayed),
+        nextCursor: allItems.length > PAGE_SIZE && lastDisplayed ? {
+          receivedAt: lastDisplayed.receivedAt,
+          incidentId: lastDisplayed.incidentId,
+        } : null,
+      };
+    } catch (error) {
+      if (requestGeneration === state.generation && pageSequence === state.pageSequence &&
+          error && error.name !== "AbortError") {
+        setStatus(elements.dashboardStatus, failureMessage(null, "list"), "error");
+      }
+      return null;
+    } finally {
+      finishRequest(controller);
+    }
+  }
+
+  function closeDetail(restoreFocus) {
+    var incidentId = state.selectedIncidentId;
+    var returnFocus = state.detailReturnFocus;
+    state.detailSequence += 1;
+    state.selectedIncidentId = null;
+    state.detailReturnFocus = null;
+    elements.detailContent.replaceChildren();
+    elements.detailTitle.textContent = "Selected incident";
+    elements.detailPanel.hidden = true;
+    setDetailActionsEnabled(false);
+    setStatus(elements.detailStatus, "");
+    if (restoreFocus) {
+      var focusTarget = returnFocus && returnFocus.isConnected
+        ? returnFocus
+        : state.rowActions.get(incidentId);
+      if (focusTarget && focusTarget.isConnected && !focusTarget.disabled) focusTarget.focus();
+      else elements.searchFilter.focus();
+    }
+  }
+
+  async function replaceCurrentPage(cursor, pageNumber) {
+    var pageSequence = state.pageSequence + 1;
+    state.pageSequence = pageSequence;
+    setButtonBusy(elements.refreshButton, true);
+    setStatus(elements.dashboardStatus, "Loading incidents...");
+    var page = await fetchPage(cursor, pageNumber, pageSequence);
+    if (pageSequence !== state.pageSequence) return false;
+    resetPageControlBusy();
+    if (!page) {
+      renderCurrentPage();
+      return false;
+    }
+    state.currentPage = page;
+    closeDetail();
+    setStatus(elements.dashboardStatus, "Page refreshed.", "success");
+    renderCurrentPage();
+    return true;
+  }
+
+  async function loadNextPage() {
+    if (!state.currentPage || !state.currentPage.nextCursor) return;
+    var pageSequence = state.pageSequence + 1;
+    state.pageSequence = pageSequence;
+    var prior = state.currentPage;
+    setButtonBusy(elements.nextButton, true);
+    setStatus(elements.dashboardStatus, "Loading older incidents...");
+    var nextPage = await fetchPage(prior.nextCursor, prior.number + 1, pageSequence);
+    if (pageSequence !== state.pageSequence) return;
+    resetPageControlBusy();
+    if (!nextPage) {
+      renderCurrentPage();
+      return;
+    }
+    state.previousPages.push(prior);
+    state.currentPage = nextPage;
+    closeDetail();
+    setStatus(elements.dashboardStatus, "");
+    renderCurrentPage();
+  }
+
+  function showPreviousPage() {
+    state.pageSequence += 1;
+    resetPageControlBusy();
+    var prior = state.previousPages.pop();
+    if (!prior) {
+      renderCurrentPage();
+      return;
+    }
+    state.currentPage = prior;
+    closeDetail();
+    setStatus(elements.dashboardStatus, "");
+    renderCurrentPage();
+  }
+
+  async function refreshCurrentPage() {
+    var cursor = state.currentPage ? state.currentPage.cursor : null;
+    var number = state.currentPage ? state.currentPage.number : 1;
+    return replaceCurrentPage(cursor, number);
+  }
+
+  async function loadDetail(incidentId, returnFocus) {
+    if (!state.token || !safeIncidentId(incidentId)) return;
+    var detailSequence = state.detailSequence + 1;
+    state.detailSequence = detailSequence;
+    state.selectedIncidentId = incidentId;
+    state.detailReturnFocus = returnFocus && typeof returnFocus.focus === "function"
+      ? returnFocus
+      : null;
+    var requestGeneration = state.generation;
+    var controller = beginRequest();
+    elements.detailPanel.hidden = false;
+    elements.detailContent.replaceChildren();
+    elements.detailTitle.textContent = "Loading incident";
+    setDetailActionsEnabled(false);
+    setStatus(elements.detailStatus, "Loading redacted detail...");
+    try {
+      var response = await fetch(
+        "/admin/api/diagnostics/" + encodeURIComponent(incidentId),
+        protectedOptions("GET", controller),
+      );
+      if (requestGeneration !== state.generation || detailSequence !== state.detailSequence) return;
+      if (!response.ok) {
+        handleProtectedFailure(response, "detail", elements.detailStatus);
+        return;
+      }
+      var payload = await response.json();
+      if (requestGeneration !== state.generation || detailSequence !== state.detailSequence) return;
+      var detail = sanitizeDetail(payload, incidentId);
+      if (!detail) {
+        setStatus(elements.detailStatus, "The incident response could not be verified.", "error");
+        return;
+      }
+      renderDetail(detail);
+      setDetailActionsEnabled(true);
+      elements.detailTitle.focus({ preventScroll: true });
+    } catch (error) {
+      if (requestGeneration === state.generation && detailSequence === state.detailSequence &&
+          error && error.name !== "AbortError") {
+        setStatus(elements.detailStatus, failureMessage(null, "detail"), "error");
+      }
+    } finally {
+      finishRequest(controller);
+    }
+  }
+
+  async function signIn(secret) {
+    state.generation += 1;
+    abortRequests();
+    clearExpiryTimer();
+    revokeObjectUrls();
+    clearPrivateView();
+    state.token = null;
+    var requestGeneration = state.generation;
+    var controller = beginRequest();
+    var requestBody = JSON.stringify({ secret: secret });
+    secret = "";
+    setButtonBusy(elements.loginButton, true);
+    setStatus(elements.loginStatus, "Signing in...");
+    elements.ownerSecret.value = "";
+    try {
+      var response = await fetch("/v1/auth/diagnostics/login", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: requestBody,
+        cache: "no-store",
+        credentials: "omit",
+        redirect: "error",
+        referrerPolicy: "no-referrer",
+        signal: controller.signal,
+      });
+      requestBody = "";
+      if (requestGeneration !== state.generation) return;
+      if (!response.ok) {
+        setStatus(
+          elements.loginStatus,
+          response.status === 401 ? "Sign-in failed." : failureMessage(response, "login"),
+          response.status === 429 ? "warning" : "error",
+        );
+        return;
+      }
+      var payload = await response.json();
+      if (requestGeneration !== state.generation) return;
+      var expiresIn = payload && payload.expires_in_seconds;
+      if (!payload || payload.ok !== true || !validOwnerToken(payload.token) ||
+          !Number.isSafeInteger(expiresIn) || expiresIn < 1 || expiresIn > 3600) {
+        setStatus(elements.loginStatus, "The sign-in response could not be verified.", "error");
+        return;
+      }
+      state.token = payload.token;
+      state.expiryTimer = window.setTimeout(function () {
+        if (requestGeneration === state.generation) endSession("Session expired. Sign in again.");
+      }, expiresIn * 1000);
+      elements.loginView.hidden = true;
+      elements.dashboardView.hidden = false;
+      setStatus(elements.loginStatus, "");
+      var loaded = await replaceCurrentPage(null, 1);
+      if (!loaded && state.token) renderCurrentPage();
+    } catch (error) {
+      if (requestGeneration === state.generation && error && error.name !== "AbortError") {
+        setStatus(elements.loginStatus, failureMessage(null, "login"), "error");
+      }
+    } finally {
+      requestBody = "";
+      finishRequest(controller);
+      if (requestGeneration === state.generation) setButtonBusy(elements.loginButton, false);
+    }
+  }
+
+  async function readBoundedResponseText(response) {
+    var declaredLength = response.headers.get("Content-Length");
+    if (declaredLength && /^\d+$/.test(declaredLength) && Number(declaredLength) > DOWNLOAD_MAX_BYTES) {
+      if (response.body && typeof response.body.cancel === "function") {
+        try { await response.body.cancel(); } catch (_) {}
+      }
+      throw new Error("Download exceeds the browser safety limit");
+    }
+    if (!response.body || typeof response.body.getReader !== "function") {
+      throw new Error("A bounded download stream is unavailable");
+    }
+
+    var reader = response.body.getReader();
+    var decoder = new TextDecoder("utf-8", { fatal: true });
+    var totalBytes = 0;
+    var textBody = "";
+    var streamClosed = false;
+    try {
+      while (true) {
+        var chunk = await reader.read();
+        if (chunk.done) {
+          streamClosed = true;
+          break;
+        }
+        totalBytes += chunk.value.byteLength;
+        if (totalBytes > DOWNLOAD_MAX_BYTES) {
+          try { await reader.cancel(); } catch (_) {}
+          streamClosed = true;
+          throw new Error("Download exceeds the browser safety limit");
+        }
+        textBody += decoder.decode(chunk.value, { stream: true });
+      }
+      textBody += decoder.decode();
+      return textBody;
+    } finally {
+      if (!streamClosed) {
+        try { await reader.cancel(); } catch (_) {}
+      }
+      reader.releaseLock();
+    }
+  }
+
+  async function downloadSelected() {
+    var incidentId = safeIncidentId(state.selectedIncidentId);
+    if (!state.token || !incidentId) return;
+    var requestGeneration = state.generation;
+    var controller = beginRequest();
+    setButtonBusy(elements.downloadButton, true);
+    setStatus(elements.detailStatus, "Preparing redacted download...");
+    try {
+      var response = await fetch(
+        "/admin/api/diagnostics/" + encodeURIComponent(incidentId) + "/download",
+        protectedOptions("GET", controller),
+      );
+      if (requestGeneration !== state.generation || state.selectedIncidentId !== incidentId) {
+        if (response.body && typeof response.body.cancel === "function") {
+          try { await response.body.cancel(); } catch (_) {}
+        }
+        return;
+      }
+      if (!response.ok) {
+        handleProtectedFailure(response, "download", elements.detailStatus);
+        return;
+      }
+      var body = await readBoundedResponseText(response);
+      if (requestGeneration !== state.generation || state.selectedIncidentId !== incidentId) return;
+      var blob = new Blob([body], { type: "application/json;charset=utf-8" });
+      if (blob.size > DOWNLOAD_MAX_BYTES) {
+        setStatus(elements.detailStatus, "The redacted download is larger than the safe browser limit.", "error");
+        return;
+      }
+      var parsed;
+      try { parsed = JSON.parse(body); }
+      catch (_) { parsed = null; }
+      if (!parsed || parsed.incident_id !== incidentId) {
+        setStatus(elements.detailStatus, "The redacted download could not be verified.", "error");
+        return;
+      }
+      var objectUrl = URL.createObjectURL(blob);
+      state.objectUrls.add(objectUrl);
+      var anchor = document.createElement("a");
+      anchor.href = objectUrl;
+      anchor.download = "echo-diagnostic-" + incidentId + ".json";
+      anchor.rel = "noopener";
+      anchor.className = "visually-hidden";
+      anchor.textContent = "Download redacted incident";
+      document.body.appendChild(anchor);
+      anchor.click();
+      anchor.remove();
+      window.setTimeout(function () {
+        if (state.objectUrls.delete(objectUrl)) URL.revokeObjectURL(objectUrl);
+      }, 0);
+      setStatus(elements.detailStatus, "Redacted download prepared.", "success");
+    } catch (error) {
+      if (requestGeneration === state.generation && state.selectedIncidentId === incidentId &&
+          error && error.name !== "AbortError") {
+        setStatus(elements.detailStatus, failureMessage(null, "download"), "error");
+      }
+    } finally {
+      finishRequest(controller);
+      if (requestGeneration === state.generation && state.selectedIncidentId === incidentId) {
+        setButtonBusy(elements.downloadButton, false);
+      }
+    }
+  }
+
+  async function deleteSelected() {
+    var incidentId = safeIncidentId(state.selectedIncidentId);
+    if (!state.token || !incidentId) return;
+    if (!window.confirm("Delete this diagnostic incident permanently? This cannot be undone.")) return;
+    var requestGeneration = state.generation;
+    var controller = beginRequest();
+    setButtonBusy(elements.deleteButton, true);
+    setStatus(elements.detailStatus, "Deleting incident...");
+    try {
+      var response = await fetch(
+        "/admin/api/diagnostics/" + encodeURIComponent(incidentId),
+        protectedOptions("DELETE", controller),
+      );
+      if (requestGeneration !== state.generation || state.selectedIncidentId !== incidentId) return;
+      if (response.status !== 204) {
+        handleProtectedFailure(response, "delete", elements.detailStatus);
+        return;
+      }
+      if (state.currentPage) {
+        state.currentPage.items = state.currentPage.items.filter(function (item) {
+          return item.incidentId !== incidentId;
+        });
+      }
+      closeDetail();
+      renderCurrentPage();
+      elements.resultsSummary.focus({ preventScroll: true });
+      setStatus(elements.dashboardStatus, "Incident deleted.", "success");
+      var refreshed = await refreshCurrentPage();
+      if (refreshed) setStatus(elements.dashboardStatus, "Incident deleted.", "success");
+    } catch (error) {
+      if (requestGeneration === state.generation && state.selectedIncidentId === incidentId &&
+          error && error.name !== "AbortError") {
+        setStatus(elements.detailStatus, failureMessage(null, "delete"), "error");
+      }
+    } finally {
+      finishRequest(controller);
+      if (requestGeneration === state.generation && state.selectedIncidentId === incidentId) {
+        setButtonBusy(elements.deleteButton, false);
+      }
+    }
+  }
+
+  elements.loginForm.addEventListener("submit", function (event) {
+    event.preventDefault();
+    var secret = elements.ownerSecret.value;
+    if (secret.length) void signIn(secret);
+  });
+  elements.logoutButton.addEventListener("click", function () { endSession("Signed out."); });
+  elements.refreshButton.addEventListener("click", function () { void refreshCurrentPage(); });
+  elements.nextButton.addEventListener("click", function () { void loadNextPage(); });
+  elements.previousButton.addEventListener("click", showPreviousPage);
+  elements.closeDetailButton.addEventListener("click", function () { closeDetail(true); });
+  elements.downloadButton.addEventListener("click", function () { void downloadSelected(); });
+  elements.deleteButton.addEventListener("click", function () { void deleteSelected(); });
+  elements.clearFiltersButton.addEventListener("click", function () {
+    elements.searchFilter.value = "";
+    elements.osFilter.value = "";
+    elements.severityFilter.value = "";
+    elements.eventFilter.value = "";
+    renderCurrentPage();
+  });
+  elements.searchFilter.addEventListener("input", renderCurrentPage);
+  elements.osFilter.addEventListener("change", renderCurrentPage);
+  elements.severityFilter.addEventListener("change", renderCurrentPage);
+  elements.eventFilter.addEventListener("change", renderCurrentPage);
+  window.addEventListener("pagehide", function () { endSession("", false); });
+
+  endSession("");
+})();

--- a/core/admin/diagnostics/index.html
+++ b/core/admin/diagnostics/index.html
@@ -1,0 +1,166 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="referrer" content="no-referrer">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; base-uri 'none'; connect-src 'self'; font-src 'self'; form-action 'self'; img-src 'self'; object-src 'none'; script-src 'self'; style-src 'self'">
+  <title>Private Diagnostics | Echo Chamber</title>
+  <link rel="stylesheet" href="./diagnostics.css">
+</head>
+<body>
+  <a class="skip-link" href="#main-content">Skip to diagnostics</a>
+
+  <header class="site-header">
+    <div>
+      <p class="eyebrow">Echo Chamber</p>
+      <h1>Private Diagnostics</h1>
+    </div>
+    <a class="quiet-link" href="/admin/">Main admin</a>
+  </header>
+
+  <main id="main-content">
+    <section id="login-view" class="login-view" aria-labelledby="login-title">
+      <form id="login-form" class="login-card" action="/admin/diagnostics/" method="get" autocomplete="off">
+        <p class="eyebrow">Owner access</p>
+        <h2 id="login-title">Open diagnostic incidents</h2>
+        <p class="lede">
+          Use the separately configured diagnostics owner secret. Ordinary room
+          and admin credentials cannot open this private surface.
+        </p>
+        <label for="owner-secret">Diagnostics owner secret</label>
+        <input
+          id="owner-secret"
+          type="password"
+          autocomplete="off"
+          autocapitalize="none"
+          spellcheck="false"
+          required
+        >
+        <button id="login-button" class="button button-primary" type="submit">Sign in</button>
+        <p id="login-status" class="status-message" role="status" aria-live="polite"></p>
+      </form>
+    </section>
+
+    <section id="dashboard-view" class="dashboard" aria-labelledby="dashboard-title" hidden>
+      <div class="dashboard-heading">
+        <div>
+          <p class="eyebrow">Owner-only records</p>
+          <h2 id="dashboard-title">Diagnostic incidents</h2>
+          <p class="lede compact">
+            Records stay in memory on this page. Refresh is manual and filters
+            apply only to the loaded page.
+          </p>
+        </div>
+        <div class="header-actions">
+          <button id="refresh-button" class="button" type="button">Refresh page</button>
+          <button id="logout-button" class="button button-danger-quiet" type="button">Sign out</button>
+        </div>
+      </div>
+
+      <div class="toolbar" aria-label="Current-page filters">
+        <div class="field field-wide">
+          <label for="search-filter">Identity or incident</label>
+          <input id="search-filter" type="search" autocomplete="off" placeholder="Search this page">
+        </div>
+        <div class="field">
+          <label for="os-filter">Operating system</label>
+          <select id="os-filter">
+            <option value="">All systems</option>
+            <option value="macos">macOS</option>
+            <option value="windows">Windows</option>
+            <option value="linux">Linux</option>
+            <option value="ios">iOS</option>
+            <option value="android">Android</option>
+            <option value="unknown">Unknown</option>
+          </select>
+        </div>
+        <div class="field">
+          <label for="severity-filter">Minimum severity</label>
+          <select id="severity-filter">
+            <option value="">Any severity</option>
+            <option value="debug">Debug</option>
+            <option value="info">Info</option>
+            <option value="warning">Warning</option>
+            <option value="error">Error</option>
+            <option value="fatal">Fatal</option>
+          </select>
+        </div>
+        <div class="field">
+          <label for="event-filter">Event type</label>
+          <select id="event-filter">
+            <option value="">All event types</option>
+            <option value="session_start">Session start</option>
+            <option value="session_end">Session end</option>
+            <option value="unclean_shutdown">Unclean shutdown</option>
+            <option value="javascript_error">JavaScript error</option>
+            <option value="unhandled_rejection">Unhandled rejection</option>
+            <option value="console_warning">Console warning</option>
+            <option value="console_error">Console error</option>
+            <option value="permission">Permission</option>
+            <option value="media">Media</option>
+            <option value="connection">Connection</option>
+            <option value="reconnect">Reconnect</option>
+            <option value="tauri_ipc_error">Tauri IPC error</option>
+            <option value="native_error">Native error</option>
+          </select>
+        </div>
+        <div class="field field-action">
+          <span class="field-spacer" aria-hidden="true">Filters</span>
+          <button id="clear-filters-button" class="button button-quiet" type="button">Clear filters</button>
+        </div>
+      </div>
+
+      <div class="results-header">
+        <p id="results-summary" class="results-summary" tabindex="-1">No page loaded.</p>
+        <p id="dashboard-status" class="status-message" role="status" aria-live="polite"></p>
+      </div>
+
+      <div class="table-shell">
+        <table>
+          <caption class="visually-hidden">Diagnostic incidents on the current server page</caption>
+          <thead>
+            <tr>
+              <th scope="col">Received</th>
+              <th scope="col">Identity</th>
+              <th scope="col">Platform</th>
+              <th scope="col">Severity</th>
+              <th scope="col">Events</th>
+              <th scope="col"><span class="visually-hidden">Actions</span></th>
+            </tr>
+          </thead>
+          <tbody id="incident-rows"></tbody>
+        </table>
+        <div id="empty-state" class="empty-state" hidden>
+          <p id="empty-state-title" class="empty-title">No incidents found</p>
+          <p id="empty-state-copy">This page has no incidents matching the current filters.</p>
+        </div>
+      </div>
+
+      <nav class="pagination" aria-label="Incident pages">
+        <button id="previous-button" class="button button-quiet" type="button" disabled>Previous</button>
+        <span id="page-label">Page 1</span>
+        <button id="next-button" class="button button-quiet" type="button" disabled>Next</button>
+      </nav>
+
+      <section id="detail-panel" class="detail-panel" aria-labelledby="detail-title" hidden>
+        <div class="detail-heading">
+          <div>
+            <p class="eyebrow">Incident detail</p>
+            <h3 id="detail-title" tabindex="-1">Selected incident</h3>
+          </div>
+          <button id="close-detail-button" class="button button-quiet" type="button">Close</button>
+        </div>
+        <div id="detail-content"></div>
+        <div class="detail-actions">
+          <button id="download-button" class="button" type="button" disabled>Download redacted JSON</button>
+          <button id="delete-button" class="button button-danger" type="button" disabled>Delete incident</button>
+        </div>
+        <p id="detail-status" class="status-message" role="status" aria-live="polite"></p>
+      </section>
+    </section>
+  </main>
+
+  <script src="./diagnostics.js" defer></script>
+</body>
+</html>

--- a/core/control/README.md
+++ b/core/control/README.md
@@ -41,6 +41,11 @@ Notes:
 
 ## Private diagnostics endpoints
 
+- `GET /admin/diagnostics/` - open the dedicated private owner UI. It uses only
+  the separately configured diagnostics owner secret; ordinary admin and room
+  credentials are not accepted. Its bearer token and incident data remain in
+  page memory and are cleared on sign-out, reload, expiry, or authentication
+  failure.
 - `POST /v1/auth/diagnostics/login` - exchange the configured owner secret for
   a one-hour diagnostics-only bearer token.
 - `POST /api/diagnostics/v1/envelopes` - submit a strict, redacted incident

--- a/core/control/src/main.rs
+++ b/core/control/src/main.rs
@@ -26,7 +26,7 @@ use rooms::*;
 use sfu_proxy::*;
 use soundboard::*;
 
-use axum::http::HeaderValue;
+use axum::http::{HeaderName, HeaderValue};
 use axum::{
     extract::DefaultBodyLimit,
     routing::{get, post},
@@ -42,7 +42,7 @@ use std::{
     sync::{Arc, Mutex, RwLock},
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
-use tower::Layer;
+use tower::{Layer, ServiceBuilder};
 use tower_http::cors::{Any, CorsLayer};
 use tower_http::services::ServeDir;
 use tower_http::set_header::SetResponseHeaderLayer;
@@ -694,6 +694,27 @@ async fn main() {
         .route("/admin/api/deploys", get(admin_deploys))
         .route("/admin/api/force-reload", post(admin_force_reload))
         .nest("/admin/api/diagnostics", diagnostics_owner_routes)
+        .nest_service(
+            "/admin/diagnostics",
+            ServiceBuilder::new()
+                .layer(SetResponseHeaderLayer::overriding(
+                    axum::http::header::CACHE_CONTROL,
+                    HeaderValue::from_static("no-store"),
+                ))
+                .layer(SetResponseHeaderLayer::overriding(
+                    HeaderName::from_static("x-content-type-options"),
+                    HeaderValue::from_static("nosniff"),
+                ))
+                .layer(SetResponseHeaderLayer::overriding(
+                    HeaderName::from_static("referrer-policy"),
+                    HeaderValue::from_static("no-referrer"),
+                ))
+                .layer(SetResponseHeaderLayer::overriding(
+                    HeaderName::from_static("x-frame-options"),
+                    HeaderValue::from_static("DENY"),
+                ))
+                .service(ServeDir::new(admin_dir.join("diagnostics"))),
+        )
         .nest_service("/admin", ServeDir::new(admin_dir))
         .route("/rtc", get(sfu_proxy))
         .route("/sfu", get(sfu_proxy))

--- a/core/control/test-diagnostics-api.ps1
+++ b/core/control/test-diagnostics-api.ps1
@@ -38,6 +38,11 @@ $chatDir = Join-Path $logsDir 'chat'
 $uploadsDir = Join-Path $logsDir 'uploads'
 $soundDir = Join-Path $logsDir 'soundboard'
 New-Item -ItemType Directory -Force -Path $viewerDir, $adminDir, $diagDir, $chatDir, $uploadsDir, $soundDir | Out-Null
+$adminSource = Join-Path $coreDir 'admin'
+if (-not (Test-Path -LiteralPath (Join-Path $adminSource 'diagnostics\index.html'))) {
+    throw 'Missing owner diagnostics UI fixture'
+}
+Copy-Item -Path (Join-Path $adminSource '*') -Destination $adminDir -Recurse
 
 $environmentNames = @(
     'CORE_BIND', 'CORE_PORT', 'ECHO_CORE_VIEWER_DIR', 'ECHO_CORE_ADMIN_DIR',
@@ -98,7 +103,14 @@ function Invoke-EchoRequest {
     }
     try {
         $response = Invoke-WebRequest @parameters
-        return [pscustomobject]@{ StatusCode = [int]$response.StatusCode; Content = [string]$response.Content; CacheControl = [string]$response.Headers['Cache-Control'] }
+        return [pscustomobject]@{
+            StatusCode = [int]$response.StatusCode
+            Content = [string]$response.Content
+            CacheControl = [string]$response.Headers['Cache-Control']
+            ContentTypeOptions = [string]$response.Headers['X-Content-Type-Options']
+            ReferrerPolicy = [string]$response.Headers['Referrer-Policy']
+            FrameOptions = [string]$response.Headers['X-Frame-Options']
+        }
     }
     catch [System.Net.WebException] {
         $response = $_.Exception.Response
@@ -109,7 +121,14 @@ function Invoke-EchoRequest {
             $reader = New-Object IO.StreamReader($stream)
             try { $content = $reader.ReadToEnd() } finally { $reader.Dispose() }
         }
-        return [pscustomobject]@{ StatusCode = [int]$response.StatusCode; Content = $content; CacheControl = [string]$response.Headers['Cache-Control'] }
+        return [pscustomobject]@{
+            StatusCode = [int]$response.StatusCode
+            Content = $content
+            CacheControl = [string]$response.Headers['Cache-Control']
+            ContentTypeOptions = [string]$response.Headers['X-Content-Type-Options']
+            ReferrerPolicy = [string]$response.Headers['Referrer-Policy']
+            FrameOptions = [string]$response.Headers['X-Frame-Options']
+        }
     }
 }
 
@@ -151,6 +170,26 @@ try {
     }
     if ($process.HasExited -or $null -eq $health -or $health.StatusCode -ne 200) {
         throw ('Test server failed to start: ' + (Get-Content -Raw $stderr -ErrorAction SilentlyContinue))
+    }
+
+    $legacyAdmin = Invoke-EchoRequest GET '/admin/'
+    Assert-Status $legacyAdmin 200 'legacy admin asset'
+    if (-not $legacyAdmin.Content.Contains('Echo Chamber Admin')) {
+        throw 'Diagnostics asset routing replaced the legacy admin surface'
+    }
+    $legacyAdminScript = Invoke-EchoRequest GET '/admin/admin.js'
+    Assert-Status $legacyAdminScript 200 'legacy admin script'
+    if (-not $legacyAdminScript.Content.Contains('Echo Chamber Admin Dashboard')) {
+        throw 'Diagnostics asset routing replaced the legacy admin script'
+    }
+
+    foreach ($ownerAssetPath in @('/admin/diagnostics/', '/admin/diagnostics/diagnostics.js', '/admin/diagnostics/diagnostics.css')) {
+        $ownerAsset = Invoke-EchoRequest GET $ownerAssetPath
+        Assert-Status $ownerAsset 200 ('owner diagnostics asset ' + $ownerAssetPath)
+        if ($ownerAsset.CacheControl -ne 'no-store') { throw "Owner diagnostics asset was cacheable: $ownerAssetPath" }
+        if ($ownerAsset.ContentTypeOptions -ne 'nosniff') { throw "Owner diagnostics asset allowed MIME sniffing: $ownerAssetPath" }
+        if ($ownerAsset.ReferrerPolicy -ne 'no-referrer') { throw "Owner diagnostics asset allowed referrers: $ownerAssetPath" }
+        if ($ownerAsset.FrameOptions -ne 'DENY') { throw "Owner diagnostics asset allowed framing: $ownerAssetPath" }
     }
 
     $roomLogin = Invoke-EchoRequest POST '/v1/auth/login' @{ password = 'synthetic-room-password' }

--- a/core/viewer-tests/scripts/serve-viewer.mjs
+++ b/core/viewer-tests/scripts/serve-viewer.mjs
@@ -5,6 +5,7 @@ import { readFile, stat } from "node:fs/promises";
 
 const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
 const viewerRoot = path.resolve(scriptDirectory, "..", "..", "viewer");
+const adminRoot = path.resolve(scriptDirectory, "..", "..", "admin");
 const port = Number.parseInt(process.env.PORT || "4175", 10);
 
 const contentTypes = new Map([
@@ -29,14 +30,22 @@ function send(response, statusCode, body, contentType) {
   response.end(body);
 }
 
-function resolveViewerFile(requestUrl) {
+function resolveStaticFile(requestUrl) {
   const url = new URL(requestUrl, `http://127.0.0.1:${port}`);
   const pathname = decodeURIComponent(url.pathname);
-  const relativePath = pathname === "/" ? "index.html" : pathname.replace(/^\/+/, "");
-  const candidate = path.resolve(viewerRoot, relativePath);
-  const rootPrefix = `${viewerRoot}${path.sep}`;
+  const isAdminRequest = pathname === "/admin" || pathname.startsWith("/admin/");
+  const root = isAdminRequest ? adminRoot : viewerRoot;
+  let relativePath = isAdminRequest
+    ? pathname.slice("/admin".length).replace(/^\/+/, "")
+    : pathname === "/" ? "index.html" : pathname.replace(/^\/+/, "");
+  if (isAdminRequest && (!relativePath || pathname.endsWith("/"))) {
+    relativePath = path.join(relativePath, "index.html");
+  }
 
-  if (candidate !== viewerRoot && !candidate.startsWith(rootPrefix)) {
+  const candidate = path.resolve(root, relativePath);
+  const rootPrefix = `${root}${path.sep}`;
+
+  if (candidate !== root && !candidate.startsWith(rootPrefix)) {
     return null;
   }
   return candidate;
@@ -55,7 +64,7 @@ const server = http.createServer(async (request, response) => {
 
   let filePath;
   try {
-    filePath = resolveViewerFile(request.url || "/");
+    filePath = resolveStaticFile(request.url || "/");
   } catch {
     send(response, 400, "bad request", "text/plain; charset=utf-8");
     return;
@@ -83,7 +92,9 @@ const server = http.createServer(async (request, response) => {
 });
 
 server.listen(port, "127.0.0.1", () => {
-  console.log(`[viewer-tests] serving ${viewerRoot} at http://127.0.0.1:${port}`);
+  console.log(
+    `[viewer-tests] serving ${viewerRoot} and ${adminRoot} at http://127.0.0.1:${port}`,
+  );
 });
 
 for (const signal of ["SIGINT", "SIGTERM"]) {

--- a/core/viewer-tests/tests/admin-diagnostics.spec.js
+++ b/core/viewer-tests/tests/admin-diagnostics.spec.js
@@ -1,0 +1,860 @@
+import { readFile } from "node:fs/promises";
+
+import { expect, test } from "@playwright/test";
+
+const OWNER_SECRET = "correct horse battery staple owner secret!";
+const OWNER_TOKEN = "diagnostics-owner-token.header.signature";
+const HOSTILE_IDENTITY = '<img src=x onerror="window.__echoXss=1"><script>window.__echoXss=2</script>';
+const HOSTILE_DETAIL = '<img src=x onerror="window.__echoXss=3"><script>window.__echoXss=4</script>';
+const BASE_TIME = 1_753_110_000_000;
+
+function incidentId(index) {
+  return `inc_${index.toString(16).padStart(32, "0")}`;
+}
+
+function uuid(index) {
+  return `00000000-0000-4000-8000-${index.toString().padStart(12, "0")}`;
+}
+
+function deferred() {
+  let resolve;
+  const promise = new Promise((done) => { resolve = done; });
+  return { promise, resolve };
+}
+
+function summary(index, overrides = {}) {
+  return {
+    incident_id: incidentId(index),
+    envelope_id: uuid(index),
+    authenticated_identity: `identity-${index.toString().padStart(4, "0")}`,
+    received_at_ms: BASE_TIME - (index * 1_000),
+    captured_at_ms: BASE_TIME - (index * 1_000) - 500,
+    session_id: uuid(index + 1_000),
+    app_version: "0.6.33",
+    channel: "web-canary",
+    client_kind: "browser",
+    operating_system: "macos",
+    architecture: "aarch64",
+    event_count: 1,
+    highest_severity: "warning",
+    event_types: ["connection"],
+    ...overrides,
+  };
+}
+
+function storedIncident(item, overrides = {}) {
+  return {
+    record_version: 1,
+    incident_id: item.incident_id,
+    received_at_ms: item.received_at_ms,
+    authenticated_identity: item.authenticated_identity,
+    authenticated_identity_digest: "identity-hmac-must-never-render",
+    payload_digest: "payload-digest-must-never-render",
+    envelope: {
+      schema_version: 1,
+      envelope_id: item.envelope_id,
+      install_id: uuid(8_000),
+      session_id: item.session_id,
+      captured_at_ms: item.captured_at_ms,
+      sent_at_ms: item.captured_at_ms + 100,
+      app: {
+        version: item.app_version,
+        git_sha: "abcdef123456",
+        channel: item.channel,
+        runtimes: {
+          browser_name: "Safari",
+          browser_version: "18.5",
+        },
+      },
+      platform: {
+        client_kind: item.client_kind,
+        operating_system: item.operating_system,
+        architecture: item.architecture,
+      },
+      events: [{
+        sequence: 1,
+        timestamp_ms: item.captured_at_ms,
+        event_type: item.event_types[0],
+        severity: item.highest_severity,
+        code: "connection.failed",
+        fingerprint: "fingerprint-must-never-render",
+        message: "raw-message-must-never-render",
+        details: { state: HOSTILE_DETAIL },
+      }],
+    },
+    ...overrides,
+  };
+}
+
+async function fulfillJson(route, status, body, headers = {}) {
+  await route.fulfill({
+    status,
+    contentType: "application/json",
+    headers: { "Cache-Control": "no-store", ...headers },
+    body: JSON.stringify(body),
+  });
+}
+
+async function installApiMock(page, handlers = {}) {
+  await page.route("**/v1/auth/diagnostics/login", async (route) => {
+    if (handlers.login) {
+      await handlers.login(route);
+      return;
+    }
+    await fulfillJson(route, 200, {
+      ok: true,
+      token: OWNER_TOKEN,
+      expires_in_seconds: 3_600,
+    });
+  });
+
+  await page.route("**/admin/api/diagnostics**", async (route) => {
+    const request = route.request();
+    const url = new URL(request.url());
+    const path = url.pathname;
+
+    if (path === "/admin/api/diagnostics") {
+      if (handlers.list) {
+        await handlers.list(route, url);
+      } else {
+        await fulfillJson(route, 200, { incidents: [] });
+      }
+      return;
+    }
+    if (path.endsWith("/download")) {
+      if (handlers.download) {
+        await handlers.download(route, url);
+      } else {
+        await route.fulfill({ status: 404, body: "" });
+      }
+      return;
+    }
+    if (request.method() === "DELETE") {
+      if (handlers.delete) {
+        await handlers.delete(route, url);
+      } else {
+        await route.fulfill({ status: 404, body: "" });
+      }
+      return;
+    }
+    if (handlers.detail) {
+      await handlers.detail(route, url);
+    } else {
+      await route.fulfill({ status: 404, body: "" });
+    }
+  });
+}
+
+async function openAndLogin(page, secret = OWNER_SECRET) {
+  await page.goto("/admin/diagnostics/", { waitUntil: "domcontentloaded" });
+  await page.locator("#owner-secret").fill(secret);
+  await page.locator("#login-form").evaluate((form) => form.requestSubmit());
+  await expect(page.locator("#dashboard-view")).toBeVisible();
+  await expect(page.locator("#login-view")).toBeHidden();
+}
+
+function expectOpaqueBoundedStatus(locator) {
+  return Promise.all([
+    expect(locator).not.toContainText("SERVER_BODY_MUST_STAY_OPAQUE"),
+    expect(locator).toContainText(/try again|too many|rate limit/i),
+    expect.poll(async () => (await locator.textContent())?.length || 0).toBeLessThan(200),
+  ]);
+}
+
+test("owner diagnostics source bans injection sinks and browser persistence APIs", async () => {
+  const [html, script] = await Promise.all([
+    readFile(new URL("../../admin/diagnostics/index.html", import.meta.url), "utf8"),
+    readFile(new URL("../../admin/diagnostics/diagnostics.js", import.meta.url), "utf8"),
+  ]);
+  const source = `${html}\n${script}`;
+
+  expect(source).not.toMatch(/\b(?:innerHTML|outerHTML|insertAdjacentHTML)\b/);
+  expect(source).not.toMatch(/document\s*\.\s*write(?:ln)?\s*\(/);
+  expect(source).not.toMatch(/\beval\s*\(/);
+  expect(source).not.toMatch(/\b(?:localStorage|sessionStorage|indexedDB)\b/);
+  expect(source).not.toMatch(/window\s*\.\s*name\b/);
+  expect(script).not.toMatch(/\bconsole\s*\./);
+  expect(html).toContain('<meta http-equiv="Content-Security-Policy"');
+  expect(html).not.toMatch(/<script\b(?![^>]*\bsrc\s*=)[^>]*>/i);
+  expect(html).not.toMatch(/\s(?:style|on[a-z]+)\s*=/i);
+  for (const functionName of ["closeDetail", "loadDetail", "downloadSelected", "deleteSelected"]) {
+    const declarations = script.match(new RegExp(`function\\s+${functionName}\\s*\\(`, "g")) || [];
+    expect(declarations, `${functionName} must have one implementation`).toHaveLength(1);
+  }
+});
+
+test("test server keeps admin assets isolated while preserving the viewer root", async ({ request }) => {
+  const [viewer, diagnostics, escapedAdmin] = await Promise.all([
+    request.get("/"),
+    request.get("/admin/diagnostics/"),
+    request.get("/admin/%2e%2e%2fviewer/index.html"),
+  ]);
+
+  expect(viewer.status()).toBe(200);
+  expect(await viewer.text()).toContain("Echo Chamber");
+  expect(diagnostics.status()).toBe(200);
+  expect(await diagnostics.text()).toContain("Private Diagnostics");
+  expect(escapedAdmin.status()).toBe(403);
+});
+
+test("a blocked diagnostics script cannot serialize the owner secret into a request or URL", async ({
+  page,
+}) => {
+  const observedRequests = [];
+  page.on("request", (request) => {
+    observedRequests.push({ body: request.postData() || "", url: request.url() });
+  });
+  await page.route("**/admin/diagnostics/diagnostics.js", (route) => route.abort());
+  await page.goto("/admin/diagnostics/", { waitUntil: "domcontentloaded" });
+  await page.locator("#owner-secret").fill(OWNER_SECRET);
+
+  await Promise.all([
+    page.waitForNavigation({ waitUntil: "domcontentloaded" }),
+    page.locator("#login-button").click(),
+  ]);
+
+  const finalUrl = new URL(page.url());
+  expect(`${finalUrl.origin}${finalUrl.pathname}`).toBe(
+    "http://127.0.0.1:4175/admin/diagnostics/",
+  );
+  expect([...finalUrl.searchParams]).toHaveLength(0);
+  expect(finalUrl.hash).toBe("");
+  expect(JSON.stringify(observedRequests)).not.toContain(OWNER_SECRET);
+  await expect(page.locator("#owner-secret")).toHaveValue("");
+});
+
+test("credentials stay memory-only, exact, omitted from cookies, and clear on lifecycle boundaries", async ({
+  page,
+}) => {
+  const loginBodies = [];
+  const listRequests = [];
+
+  await page.context().addCookies([{
+    name: "unrelated-cookie",
+    value: "must-not-be-sent",
+    url: "http://127.0.0.1:4175",
+  }]);
+  await installApiMock(page, {
+    login: async (route) => {
+      const request = route.request();
+      loginBodies.push(request.postDataJSON());
+      expect(request.headers().cookie).toBeUndefined();
+      expect(request.headers().authorization).toBeUndefined();
+      await fulfillJson(route, 200, {
+        ok: true,
+        token: OWNER_TOKEN,
+        expires_in_seconds: 3_600,
+      });
+    },
+    list: async (route) => {
+      const request = route.request();
+      listRequests.push(request.url());
+      expect(request.headers().authorization).toBe(`Bearer ${OWNER_TOKEN}`);
+      expect(request.headers().cookie).toBeUndefined();
+      await fulfillJson(route, 200, { incidents: [] });
+    },
+  });
+
+  await openAndLogin(page);
+  expect(loginBodies).toEqual([{ secret: OWNER_SECRET }]);
+  await expect(page.locator("#owner-secret")).toHaveValue("");
+  expect(listRequests).toHaveLength(1);
+
+  const persisted = await page.evaluate(async () => ({
+    cookie: document.cookie,
+    databases: typeof indexedDB.databases === "function"
+      ? (await indexedDB.databases()).map((database) => database.name)
+      : [],
+    href: location.href,
+    local: { ...localStorage },
+    name: window.name,
+    session: { ...sessionStorage },
+  }));
+  expect(JSON.stringify(persisted)).not.toContain(OWNER_SECRET);
+  expect(JSON.stringify(persisted)).not.toContain(OWNER_TOKEN);
+
+  await page.reload({ waitUntil: "domcontentloaded" });
+  await expect(page.locator("#login-view")).toBeVisible();
+  await expect(page.locator("#dashboard-view")).toBeHidden();
+  await expect(page.locator("#owner-secret")).toHaveValue("");
+  expect(listRequests).toHaveLength(1);
+
+  await openAndLogin(page);
+  expect(listRequests).toHaveLength(2);
+  await page.evaluate(() => {
+    window.dispatchEvent(new PageTransitionEvent("pagehide", { persisted: false }));
+  });
+  await expect(page.locator("#login-view")).toBeVisible();
+  await expect(page.locator("#dashboard-view")).toBeHidden();
+});
+
+test("hostile summary and detail strings render literally while private fields remain hidden", async ({
+  page,
+}) => {
+  const item = summary(1, { authenticated_identity: HOSTILE_IDENTITY });
+  await installApiMock(page, {
+    list: async (route) => {
+      expect(route.request().headers().authorization).toBe(`Bearer ${OWNER_TOKEN}`);
+      await fulfillJson(route, 200, { incidents: [item] });
+    },
+    detail: async (route) => {
+      expect(route.request().headers().authorization).toBe(`Bearer ${OWNER_TOKEN}`);
+      await fulfillJson(route, 200, storedIncident(item));
+    },
+  });
+
+  await openAndLogin(page);
+  await expect(page.locator("#incident-rows")).toContainText(HOSTILE_IDENTITY);
+  await expect(page.locator("#incident-rows img, #incident-rows script")).toHaveCount(0);
+  await page.locator("#incident-rows button").first().click();
+
+  await expect(page.locator("#detail-panel")).toBeVisible();
+  await expect(page.locator("#detail-content")).toContainText("<img src=x onerror=");
+  await expect(page.locator("#detail-content")).toContainText(
+    "<script>window.__echoXss=4</script>",
+  );
+  await expect(page.locator("#detail-content img, #detail-content script")).toHaveCount(0);
+  await expect(page.locator("#detail-content")).not.toContainText("identity-hmac-must-never-render");
+  await expect(page.locator("#detail-content")).not.toContainText("payload-digest-must-never-render");
+  await expect(page.locator("#detail-content")).not.toContainText("raw-message-must-never-render");
+  await expect(page.locator("#detail-content")).not.toContainText("fingerprint-must-never-render");
+  expect(await page.evaluate(() => window.__echoXss)).toBeUndefined();
+});
+
+test("detail actions stay disabled until a matching detail is verified and disable again on close", async ({
+  page,
+}) => {
+  const item = summary(4);
+  const firstDetail = deferred();
+  const secondDetail = deferred();
+  const gates = [firstDetail, secondDetail];
+  let detailRequests = 0;
+  await installApiMock(page, {
+    list: async (route) => fulfillJson(route, 200, { incidents: [item] }),
+    detail: async (route) => {
+      const attempt = detailRequests;
+      detailRequests += 1;
+      await gates[attempt].promise;
+      if (attempt === 0) {
+        await fulfillJson(route, 200, storedIncident(summary(999)));
+      } else {
+        await fulfillJson(route, 200, storedIncident(item));
+      }
+    },
+  });
+
+  await openAndLogin(page);
+  await expect(page.locator("#download-button")).toBeDisabled();
+  await expect(page.locator("#delete-button")).toBeDisabled();
+
+  await page.locator("#incident-rows button").click();
+  await expect.poll(() => detailRequests).toBe(1);
+  await expect(page.locator("#download-button")).toBeDisabled();
+  await expect(page.locator("#delete-button")).toBeDisabled();
+  firstDetail.resolve();
+  await expect(page.locator("#detail-status")).toContainText(/could not be verified/i);
+  await expect(page.locator("#download-button")).toBeDisabled();
+  await expect(page.locator("#delete-button")).toBeDisabled();
+
+  await page.locator("#incident-rows button").click();
+  await expect.poll(() => detailRequests).toBe(2);
+  await expect(page.locator("#download-button")).toBeDisabled();
+  secondDetail.resolve();
+  await expect(page.locator("#download-button")).toBeEnabled();
+  await expect(page.locator("#delete-button")).toBeEnabled();
+  await expect(page.locator("#detail-title")).toBeFocused();
+
+  await page.locator("#close-detail-button").click();
+  await expect(page.locator("#detail-panel")).toBeHidden();
+  await expect(page.locator("#download-button")).toBeDisabled();
+  await expect(page.locator("#delete-button")).toBeDisabled();
+  await expect(page.locator("#incident-rows button")).toBeFocused();
+});
+
+test("pagehide erases private DOM and fences a late incident response", async ({ page }) => {
+  const item = summary(5, { authenticated_identity: "identity-must-be-erased" });
+  await page.addInitScript((lateItem) => {
+    const originalFetch = window.fetch.bind(window);
+    window.__lateListStarted = false;
+    window.fetch = function (input, options) {
+      const rawUrl = typeof input === "string" ? input : input.url;
+      const url = new URL(rawUrl, location.href);
+      if (url.pathname !== "/admin/api/diagnostics") return originalFetch(input, options);
+      window.__lateListStarted = true;
+      return new Promise((resolve) => {
+        window.__resolveLateList = () => resolve(new Response(
+          JSON.stringify({ incidents: [lateItem] }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ));
+      });
+    };
+  }, item);
+  await installApiMock(page, {
+    list: async (route) => fulfillJson(route, 500, { unexpected: true }),
+  });
+
+  await page.goto("/admin/diagnostics/", { waitUntil: "domcontentloaded" });
+  await page.locator("#owner-secret").fill(OWNER_SECRET);
+  await page.locator("#login-form").evaluate((form) => form.requestSubmit());
+  await expect.poll(() => page.evaluate(() => window.__lateListStarted)).toBe(true);
+  await expect(page.locator("#dashboard-view")).toBeVisible();
+  await page.locator("#search-filter").fill("private-search-must-be-erased");
+
+  await page.evaluate(() => {
+    window.dispatchEvent(new PageTransitionEvent("pagehide", { persisted: false }));
+  });
+  await page.evaluate(() => window.__resolveLateList());
+  await page.waitForTimeout(50);
+
+  await expect(page.locator("#login-view")).toBeVisible();
+  await expect(page.locator("#dashboard-view")).toBeHidden();
+  await expect(page.locator("#incident-rows tr")).toHaveCount(0);
+  await expect(page.locator("#search-filter")).toHaveValue("");
+  await expect(page.locator("#detail-title")).toHaveText("Selected incident");
+  await expect(page.locator("body")).not.toContainText("identity-must-be-erased");
+});
+
+test("token expiry ends the session and erases the private view", async ({ page }) => {
+  const item = summary(6, { authenticated_identity: "expiry-private-identity" });
+  await installApiMock(page, {
+    login: async (route) => fulfillJson(route, 200, {
+      ok: true,
+      token: OWNER_TOKEN,
+      expires_in_seconds: 1,
+    }),
+    list: async (route) => fulfillJson(route, 200, { incidents: [item] }),
+  });
+
+  await openAndLogin(page);
+  await expect(page.locator("#incident-rows")).toContainText("expiry-private-identity");
+  await page.locator("#search-filter").fill("expiry-private-identity");
+
+  await expect(page.locator("#login-view")).toBeVisible({ timeout: 3_000 });
+  await expect(page.locator("#dashboard-view")).toBeHidden();
+  await expect(page.locator("#login-status")).toContainText(/session expired/i);
+  await expect(page.locator("#incident-rows tr")).toHaveCount(0);
+  await expect(page.locator("#search-filter")).toHaveValue("");
+  await expect(page.locator("#owner-secret")).toBeFocused();
+});
+
+test("fetches 51, renders 50, paginates with the displayed cursor, and restores Previous in memory", async ({
+  page,
+}) => {
+  const firstPage = Array.from({ length: 51 }, (_, index) => summary(index + 1));
+  const secondPage = [summary(100), summary(101)];
+  const listUrls = [];
+
+  await installApiMock(page, {
+    list: async (route, url) => {
+      listUrls.push(url);
+      expect(url.searchParams.get("limit")).toBe("51");
+      const hasCursor = url.searchParams.has("before_received_at_ms");
+      await fulfillJson(route, 200, { incidents: hasCursor ? secondPage : firstPage });
+    },
+  });
+
+  await openAndLogin(page);
+  await expect(page.locator("#incident-rows tr")).toHaveCount(50);
+  await expect(page.locator("#incident-rows button").first()).toHaveAttribute(
+    "aria-label",
+    "View details for incident 00000001",
+  );
+  await expect(page.locator("#incident-rows button").nth(1)).toHaveAttribute(
+    "aria-label",
+    "View details for incident 00000002",
+  );
+  await expect(page.locator("#page-label")).toHaveText("Page 1");
+  await expect(page.locator("#previous-button")).toBeDisabled();
+  await expect(page.locator("#next-button")).toBeEnabled();
+
+  await page.locator("#next-button").click();
+  await expect(page.locator("#incident-rows tr")).toHaveCount(2);
+  await expect(page.locator("#page-label")).toHaveText("Page 2");
+  expect(listUrls).toHaveLength(2);
+  expect(listUrls[1].searchParams.get("before_received_at_ms")).toBe(
+    String(firstPage[49].received_at_ms),
+  );
+  expect(listUrls[1].searchParams.get("before_incident_id")).toBe(firstPage[49].incident_id);
+
+  await page.locator("#previous-button").click();
+  await expect(page.locator("#incident-rows tr")).toHaveCount(50);
+  await expect(page.locator("#page-label")).toHaveText("Page 1");
+  expect(listUrls).toHaveLength(2);
+});
+
+test("a late Next response cannot overwrite a newer Previous navigation", async ({ page }) => {
+  const firstPage = Array.from({ length: 51 }, (_, index) => summary(index + 1));
+  const secondPage = Array.from({ length: 51 }, (_, index) => summary(index + 101));
+  const thirdPage = [summary(301)];
+  const thirdStarted = deferred();
+  const releaseThird = deferred();
+  const thirdFulfilled = deferred();
+  let listRequests = 0;
+  await installApiMock(page, {
+    list: async (route) => {
+      listRequests += 1;
+      if (listRequests === 1) {
+        await fulfillJson(route, 200, { incidents: firstPage });
+      } else if (listRequests === 2) {
+        await fulfillJson(route, 200, { incidents: secondPage });
+      } else {
+        thirdStarted.resolve();
+        await releaseThird.promise;
+        await fulfillJson(route, 200, { incidents: thirdPage });
+        thirdFulfilled.resolve();
+      }
+    },
+  });
+
+  await openAndLogin(page);
+  await page.locator("#next-button").click();
+  await expect(page.locator("#page-label")).toHaveText("Page 2");
+  await expect(page.locator("#previous-button")).toBeEnabled();
+
+  await page.locator("#next-button").click();
+  await thirdStarted.promise;
+  await page.locator("#previous-button").click();
+  await expect(page.locator("#page-label")).toHaveText("Page 1");
+  await expect(page.locator("#previous-button")).toBeDisabled();
+
+  releaseThird.resolve();
+  await thirdFulfilled.promise;
+  await page.waitForTimeout(50);
+  await expect(page.locator("#page-label")).toHaveText("Page 1");
+  await expect(page.locator("#incident-rows")).toContainText(firstPage[0].authenticated_identity);
+  await expect(page.locator("#incident-rows")).not.toContainText(thirdPage[0].authenticated_identity);
+  await expect(page.locator("#previous-button")).toBeDisabled();
+  expect(listRequests).toBe(3);
+});
+
+test("identity, OS, severity, and event filters affect only the loaded page", async ({ page }) => {
+  const incidents = [
+    summary(1, {
+      authenticated_identity: "mac-error-person",
+      highest_severity: "error",
+      event_types: ["connection"],
+    }),
+    summary(2, {
+      authenticated_identity: "unique-windows-person",
+      operating_system: "windows",
+      architecture: "x86_64",
+      highest_severity: "info",
+      event_types: ["media"],
+    }),
+    summary(3, {
+      authenticated_identity: "mac-fatal-person",
+      highest_severity: "fatal",
+      event_types: ["javascript_error"],
+    }),
+  ];
+  let listRequests = 0;
+  await installApiMock(page, {
+    list: async (route) => {
+      listRequests += 1;
+      await fulfillJson(route, 200, { incidents });
+    },
+  });
+
+  await openAndLogin(page);
+  await expect(page.locator("#incident-rows tr")).toHaveCount(3);
+
+  await page.locator("#search-filter").fill("web-canary");
+  await expect(page.locator("#incident-rows tr")).toHaveCount(0);
+  await page.locator("#search-filter").fill("unique-windows");
+  await expect(page.locator("#incident-rows tr")).toHaveCount(1);
+  await page.locator("#search-filter").fill("");
+
+  await page.locator("#os-filter").selectOption("macos");
+  await expect(page.locator("#incident-rows tr")).toHaveCount(2);
+  await page.locator("#severity-filter").selectOption("fatal");
+  await expect(page.locator("#incident-rows tr")).toHaveCount(1);
+  await page.locator("#event-filter").selectOption("javascript_error");
+  await expect(page.locator("#incident-rows tr")).toHaveCount(1);
+
+  await page.locator("#clear-filters-button").click();
+  await expect(page.locator("#incident-rows tr")).toHaveCount(3);
+  expect(listRequests).toBe(1);
+});
+
+test("401 logs out and disabled or rate-limited endpoints expose only bounded status", async ({ page }) => {
+  let listStatus = 200;
+  await installApiMock(page, {
+    list: async (route) => {
+      if (listStatus === 200) {
+        await fulfillJson(route, 200, { incidents: [] });
+      } else {
+        await route.fulfill({
+          status: listStatus,
+          headers: { "Retry-After": "999999" },
+          body: "SERVER_BODY_MUST_STAY_OPAQUE",
+        });
+      }
+    },
+  });
+
+  await openAndLogin(page);
+  listStatus = 429;
+  await page.locator("#refresh-button").click();
+  await expectOpaqueBoundedStatus(page.locator("#dashboard-status"));
+
+  listStatus = 401;
+  await page.locator("#refresh-button").click();
+  await expect(page.locator("#login-view")).toBeVisible();
+  await expect(page.locator("#dashboard-view")).toBeHidden();
+  await expect(page.locator("#login-status")).not.toContainText("SERVER_BODY_MUST_STAY_OPAQUE");
+});
+
+for (const endpoint of ["login", "list"]) {
+  test(`${endpoint} 404 reports that private diagnostics are disabled`, async ({ page }) => {
+    await installApiMock(page, {
+      login: async (route) => {
+        if (endpoint === "login") {
+          await route.fulfill({ status: 404, body: "SERVER_BODY_MUST_STAY_OPAQUE" });
+        } else {
+          await fulfillJson(route, 200, {
+            ok: true,
+            token: OWNER_TOKEN,
+            expires_in_seconds: 3_600,
+          });
+        }
+      },
+      list: async (route) => {
+        await route.fulfill({
+          status: endpoint === "list" ? 404 : 200,
+          contentType: "application/json",
+          body: endpoint === "list"
+            ? "SERVER_BODY_MUST_STAY_OPAQUE"
+            : JSON.stringify({ incidents: [] }),
+        });
+      },
+    });
+
+    await page.goto("/admin/diagnostics/", { waitUntil: "domcontentloaded" });
+    await page.locator("#owner-secret").fill(OWNER_SECRET);
+    await page.locator("#login-form").evaluate((form) => form.requestSubmit());
+    await expect(page.locator("#login-view")).toBeVisible();
+    await expect(page.locator("#login-status")).toContainText(/not available|not enabled|disabled/i);
+    await expect(page.locator("#login-status")).not.toContainText("SERVER_BODY_MUST_STAY_OPAQUE");
+  });
+}
+
+test("login 429 exposes a bounded opaque retry message", async ({ page }) => {
+  await installApiMock(page, {
+    login: async (route) => {
+      await route.fulfill({
+        status: 429,
+        headers: { "Retry-After": "999999" },
+        body: "SERVER_BODY_MUST_STAY_OPAQUE",
+      });
+    },
+  });
+
+  await page.goto("/admin/diagnostics/", { waitUntil: "domcontentloaded" });
+  await page.locator("#owner-secret").fill(OWNER_SECRET);
+  await page.locator("#login-form").evaluate((form) => form.requestSubmit());
+  await expect(page.locator("#login-view")).toBeVisible();
+  await expectOpaqueBoundedStatus(page.locator("#login-status"));
+});
+
+test("download is authenticated, uses a local safe filename, and revokes its blob URL", async ({
+  page,
+}) => {
+  const item = summary(42);
+  const downloadRequests = [];
+  await page.addInitScript(() => {
+    const create = URL.createObjectURL.bind(URL);
+    const revoke = URL.revokeObjectURL.bind(URL);
+    window.__blobUrlAudit = { created: [], revoked: [] };
+    URL.createObjectURL = (blob) => {
+      const value = create(blob);
+      window.__blobUrlAudit.created.push(value);
+      return value;
+    };
+    URL.revokeObjectURL = (value) => {
+      window.__blobUrlAudit.revoked.push(value);
+      revoke(value);
+    };
+  });
+  await installApiMock(page, {
+    list: async (route) => fulfillJson(route, 200, { incidents: [item] }),
+    detail: async (route) => fulfillJson(route, 200, storedIncident(item)),
+    download: async (route) => {
+      downloadRequests.push(route.request());
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        headers: {
+          "Content-Disposition": 'attachment; filename="../../hostile<script>.json"',
+        },
+        body: JSON.stringify({ incident_id: item.incident_id, redacted: true }),
+      });
+    },
+  });
+
+  await openAndLogin(page);
+  await page.locator("#incident-rows button").first().click();
+  const downloadPromise = page.waitForEvent("download");
+  await page.locator("#download-button").click();
+  const download = await downloadPromise;
+
+  expect(downloadRequests).toHaveLength(1);
+  expect(downloadRequests[0].headers().authorization).toBe(`Bearer ${OWNER_TOKEN}`);
+  expect(downloadRequests[0].headers().cookie).toBeUndefined();
+  expect(download.suggestedFilename()).toBe(`echo-diagnostic-${item.incident_id}.json`);
+  await expect.poll(() => page.evaluate(() => window.__blobUrlAudit)).toEqual({
+    created: [expect.stringMatching(/^blob:/)],
+    revoked: [expect.stringMatching(/^blob:/)],
+  });
+  const audit = await page.evaluate(() => window.__blobUrlAudit);
+  expect(audit.revoked).toEqual(audit.created);
+});
+
+test("download ceiling rejects oversized streams with absent or lying Content-Length", async ({
+  page,
+}) => {
+  const item = summary(43);
+  const downloads = [];
+  page.on("download", (download) => downloads.push(download));
+  await page.addInitScript(() => {
+    const originalFetch = window.fetch.bind(window);
+    window.__diagnosticsLengthMode = "absent";
+    window.__downloadStreamAudits = [];
+    window.fetch = function (input, options) {
+      const rawUrl = typeof input === "string" ? input : input.url;
+      const url = new URL(rawUrl, location.href);
+      if (!url.pathname.endsWith("/download")) return originalFetch(input, options);
+
+      const audit = {
+        cancelled: false,
+        mode: window.__diagnosticsLengthMode,
+        pulls: 0,
+      };
+      window.__downloadStreamAudits.push(audit);
+      const body = new ReadableStream({
+        pull(controller) {
+          audit.pulls += 1;
+          if (audit.pulls <= 100) {
+            controller.enqueue(new Uint8Array(64 * 1024));
+          } else {
+            controller.close();
+          }
+        },
+        cancel() {
+          audit.cancelled = true;
+        },
+      });
+      const headers = { "Content-Type": "application/json" };
+      if (window.__diagnosticsLengthMode === "lying") headers["Content-Length"] = "1";
+      if (window.__diagnosticsLengthMode === "declared-oversize") {
+        headers["Content-Length"] = String(1024 * 1024);
+      }
+      return Promise.resolve(new Response(body, { status: 200, headers }));
+    };
+  });
+  await installApiMock(page, {
+    list: async (route) => fulfillJson(route, 200, { incidents: [item] }),
+    detail: async (route) => fulfillJson(route, 200, storedIncident(item)),
+  });
+
+  await openAndLogin(page);
+  await page.locator("#incident-rows button").click();
+  await expect(page.locator("#download-button")).toBeEnabled();
+
+  await page.locator("#download-button").click();
+  await expect(page.locator("#download-button")).toBeEnabled();
+  await expect(page.locator("#detail-status")).toContainText(/temporarily unavailable|safe browser limit/i);
+  expect(downloads).toHaveLength(0);
+  await expect.poll(() => page.evaluate(() => window.__downloadStreamAudits[0])).toMatchObject({
+    cancelled: true,
+    mode: "absent",
+  });
+  expect(await page.evaluate(() => window.__downloadStreamAudits[0].pulls)).toBeLessThan(20);
+
+  await page.evaluate(() => { window.__diagnosticsLengthMode = "lying"; });
+  await page.locator("#download-button").click();
+  await expect(page.locator("#download-button")).toBeEnabled();
+  await expect(page.locator("#detail-status")).toContainText(/temporarily unavailable|safe browser limit/i);
+  expect(downloads).toHaveLength(0);
+  await expect.poll(() => page.evaluate(() => window.__downloadStreamAudits[1])).toMatchObject({
+    cancelled: true,
+    mode: "lying",
+  });
+  expect(await page.evaluate(() => window.__downloadStreamAudits[1].pulls)).toBeLessThan(20);
+
+  await page.evaluate(() => { window.__diagnosticsLengthMode = "declared-oversize"; });
+  await page.locator("#download-button").click();
+  await expect(page.locator("#download-button")).toBeEnabled();
+  expect(downloads).toHaveLength(0);
+  await expect.poll(() => page.evaluate(() => window.__downloadStreamAudits[2])).toMatchObject({
+    cancelled: true,
+    mode: "declared-oversize",
+  });
+  expect(await page.evaluate(() => window.__downloadStreamAudits[2].pulls)).toBeLessThan(3);
+});
+
+test("delete cancellation sends nothing and confirmed 204 refreshes the current page", async ({
+  page,
+}) => {
+  const item = summary(7);
+  let deleteRequests = 0;
+  let listRequests = 0;
+  await installApiMock(page, {
+    list: async (route) => {
+      listRequests += 1;
+      await fulfillJson(route, 200, { incidents: listRequests === 1 ? [item] : [] });
+    },
+    detail: async (route) => fulfillJson(route, 200, storedIncident(item)),
+    delete: async (route) => {
+      deleteRequests += 1;
+      expect(route.request().headers().authorization).toBe(`Bearer ${OWNER_TOKEN}`);
+      await route.fulfill({ status: 204, body: "" });
+    },
+  });
+
+  await openAndLogin(page);
+  await page.locator("#incident-rows button").first().click();
+  await expect(page.locator("#detail-panel")).toBeVisible();
+
+  page.once("dialog", (dialog) => dialog.dismiss());
+  await page.locator("#delete-button").click();
+  expect(deleteRequests).toBe(0);
+  expect(listRequests).toBe(1);
+
+  page.once("dialog", (dialog) => dialog.accept());
+  await page.locator("#delete-button").click();
+  await expect(page.locator("#incident-rows tr")).toHaveCount(0);
+  await expect(page.locator("#detail-panel")).toBeHidden();
+  await expect(page.locator("#results-summary")).toBeFocused();
+  expect(deleteRequests).toBe(1);
+  expect(listRequests).toBe(2);
+});
+
+test("a confirmed delete stays removed locally when the follow-up refresh fails", async ({ page }) => {
+  const item = summary(8);
+  let listRequests = 0;
+  await installApiMock(page, {
+    list: async (route) => {
+      listRequests += 1;
+      if (listRequests === 1) {
+        await fulfillJson(route, 200, { incidents: [item] });
+      } else {
+        await route.fulfill({ status: 500, body: "SERVER_BODY_MUST_STAY_OPAQUE" });
+      }
+    },
+    detail: async (route) => fulfillJson(route, 200, storedIncident(item)),
+    delete: async (route) => route.fulfill({ status: 204, body: "" }),
+  });
+
+  await openAndLogin(page);
+  await page.locator("#incident-rows button").click();
+  await expect(page.locator("#delete-button")).toBeEnabled();
+  page.once("dialog", (dialog) => dialog.accept());
+  await page.locator("#delete-button").click();
+
+  await expect(page.locator("#incident-rows tr")).toHaveCount(0);
+  await expect(page.locator("#detail-panel")).toBeHidden();
+  await expect(page.locator("#results-summary")).toBeFocused();
+  await expect(page.locator("#dashboard-status")).toContainText(/temporarily unavailable/i);
+  await expect(page.locator("#dashboard-status")).not.toContainText("SERVER_BODY_MUST_STAY_OPAQUE");
+  expect(listRequests).toBe(2);
+});

--- a/docs/WEB-DIAGNOSTICS-OWNER-UI.md
+++ b/docs/WEB-DIAGNOSTICS-OWNER-UI.md
@@ -1,0 +1,106 @@
+# Private Diagnostics Owner UI
+
+The diagnostics owner surface is available at:
+
+```text
+/admin/diagnostics/
+```
+
+It is a dedicated page, separate from the ordinary Echo Chamber admin
+dashboard. It does not reuse ordinary admin authentication, room credentials,
+or the legacy admin page's browser state.
+
+## Authentication boundary
+
+Set a unique `CORE_DIAGNOSTICS_OWNER_SECRET` of at least 32 random bytes to
+enable private diagnostics. The UI sends that exact secret in a same-origin
+`POST /v1/auth/diagnostics/login` request. It does not trim or otherwise alter
+the secret.
+
+A successful login returns a diagnostics-only bearer token with a maximum
+one-hour lifetime. The secret and token are held only in the page's JavaScript
+memory and are never placed in cookies, web storage, IndexedDB, `window.name`,
+URLs, DOM attributes, or logs. Incident data and pagination history are also
+memory-only and are erased at session boundaries; vetted incident fields are
+rendered only as text or constrained presentation/accessibility attributes.
+The password input is cleared as soon as a login attempt begins.
+
+Signing out, reloading, leaving the page, receiving an authentication failure,
+or reaching the token expiry clears the token and private view. A new login is
+required after any of those events.
+
+## Browsing incidents
+
+The page loads incidents only when the owner signs in, selects Refresh, or
+uses a pagination control. There is no polling or automatic refresh.
+
+Each request asks for 51 summaries and renders at most 50. The extra summary
+only determines whether a next page exists. Next-page requests use the last
+rendered incident's compound `(received_at_ms, incident_id)` cursor; Previous
+uses an in-memory cursor stack and never puts cursor state into browser
+storage.
+
+Identity/incident search, operating-system, minimum-severity, and event-type
+filters apply only to the currently loaded page. They do not issue server
+queries and are cleared on sign-out.
+
+Incident detail is rendered from an explicit set of structured fields using
+text-only DOM operations. Store-local identity digests, payload digests,
+fingerprints, and free-form message fields are not shown. Untrusted strings are
+never interpreted as HTML. Download and delete controls stay disabled until a
+matching detail response has been validated, and disable again when that detail
+is closed or cleared.
+
+## Download and deletion
+
+Download uses an authenticated same-origin fetch. The browser reads the
+response as a bounded stream and cancels it once a conservative size ceiling is
+crossed, even when `Content-Length` is absent or incorrect. It then parses the
+response as JSON, verifies that its incident ID matches the selected record,
+and creates a local file named:
+
+```text
+echo-diagnostic-inc_<32 lowercase hex characters>.json
+```
+
+The temporary blob URL is revoked after the browser receives the download.
+The bearer token is never included in the URL or filename.
+
+Deletion always requires an explicit browser confirmation. A confirmed delete
+uses the owner-authenticated `DELETE /admin/api/diagnostics/{incidentId}`
+endpoint, removes the confirmed record from the in-memory page, and only then
+refreshes the current server page. A failed refresh cannot restore the stale
+row. There is no automatic GitHub issue creation or other publishing path.
+
+## Network and failure behavior
+
+All requests are same-origin with credentials omitted, caching disabled,
+referrers suppressed, and redirects rejected. Failure response bodies are not
+read or displayed. The page maps HTTP status codes to short local messages:
+
+- `401` and `403` end the owner session.
+- `404` during login or listing reports that private diagnostics are disabled
+  or unavailable.
+- `429` shows a bounded delay derived from `Retry-After` when it is valid.
+- Other client and server failures use opaque local wording.
+
+Every asynchronous operation is fenced to the active login generation.
+Signing out or leaving the page aborts in-flight requests and prevents late
+responses from restoring private state.
+
+## Static asset boundary
+
+The control plane scopes `Cache-Control: no-store`, `X-Content-Type-Options:
+nosniff`, `Referrer-Policy: no-referrer`, and `X-Frame-Options: DENY` to the
+dedicated `/admin/diagnostics/` static tree. The existing `/admin/` application
+keeps its original static route and behavior. The diagnostics HTML also carries
+a restrictive page-local Content Security Policy and has no inline scripts,
+styles, or event handlers.
+
+## Release boundary
+
+The owner page is served by the control plane from `core/admin/diagnostics/`.
+Changes to it are server-side/static-asset changes; they do not require a new
+Windows desktop binary. Enabling or changing the owner secret is an operations
+change and still follows the service verification and restart rules in
+`docs/OPERATIONS.md`.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Echo Chamber repo metadata. Active development lives under core/.",
   "scripts": {
     "verify:guardrails": "node tools/verify/guardrails.mjs",
-    "verify:viewer": "node --check core/viewer/app.js && node --check core/viewer/jam.js && node --check core/viewer/ui-shell.js && node --test core/viewer/*.test.js",
+    "verify:viewer": "node --check core/viewer/app.js && node --check core/viewer/jam.js && node --check core/viewer/ui-shell.js && node --check core/admin/diagnostics/diagnostics.js && node --test core/viewer/*.test.js",
     "verify:viewer:layout": "npm --prefix core/viewer-tests test",
     "verify:quick": "npm run verify:guardrails && npm run verify:viewer"
   }

--- a/tools/verify/quick.sh
+++ b/tools/verify/quick.sh
@@ -12,6 +12,7 @@ node tools/verify/guardrails.mjs
 echo "[verify] JS syntax checks"
 node --check core/viewer/app.js
 node --check core/viewer/jam.js
+node --check core/admin/diagnostics/diagnostics.js
 
 echo "[verify] JS deterministic tests"
 node --test core/viewer/*.test.js


### PR DESCRIPTION
## Summary
- add a dedicated `/admin/diagnostics/` owner surface, separate from the legacy admin app and its authentication state
- keep the diagnostics secret/token in memory only; fence late responses; render vetted incident data with text-only DOM operations
- provide manual refresh, current-page filters, compound-cursor pagination, verified bounded downloads, and confirmation-gated deletion
- scope no-store/nosniff/no-referrer/DENY headers and a diagnostics-only CSP without changing legacy `/admin/` routing
- document the owner boundary and extend real-control/browser regression coverage

## Security boundary
- exact owner secret; cookies omitted; redirects rejected; no URL/storage/DOM-attribute/log persistence
- no-script fallback cannot serialize the secret into a request or URL
- logout, reload/pagehide, expiry, and 401/403 clear token, private DOM, cursors, requests, and blob URLs
- non-success response bodies remain opaque
- hostile strings never become HTML; digests, message, and fingerprint fields stay hidden
- downloads stream through a conservative ceiling and cancel early for absent, false, or oversized `Content-Length`
- page/detail navigation races are independently fenced

## Release impact
- **Server-only/static assets**: deploy the matching control binary and `core/admin/diagnostics/` assets together
- **No desktop binary required**
- no macOS build/release work and no change to the Windows installer pipeline
- no live service restart or production deploy performed

## Verification
- `npm run verify:quick` — 231/231 passed
- `npm --prefix core/viewer-tests test` — 89/89 passed
- `cargo check -p echo-core-control --locked` — passed (two pre-existing warnings)
- `rustfmt --edition 2021 --check --config skip_children=true control/src/main.rs` — passed
- isolated `core/control/test-diagnostics-api.ps1 -SkipBuild` — health/static isolation/auth boundary/body limits/ingest/idempotency/stale/malformed/oversized/redaction/rate-limit/delete all passed
- `git diff --check` — passed
- desktop dashboard/detail and 390px login visually inspected
- two independent read-only security/diff audits — clean

## ELI5
**What broke:** Diagnostics collection existed, but Sam had no hardened browser page to safely inspect private incidents.

**Why it broke:** The owner API intentionally shipped before its isolated UI so the authentication and storage boundaries could be reviewed separately.

**What changed:** A separate memory-only owner dashboard now lists, filters, opens, downloads, and deletes redacted incidents without reusing legacy admin state.

**How we know it works:** Unit, full-browser, adversarial race/XSS/lifecycle/download tests, real-control smoke tests, visual QA, and independent audits all pass.

**Does this need a desktop update:** No. This is a server/control/static-admin change.

**What could still go wrong:** The web collector remains best-effort under browser storage/process limits; real Mac/Safari canary behavior still needs the approved manual test window after server rollout.