### PR TITLE
Fix Chrome canary diagnostics version metadata

### DIFF
--- a/core/control/src/diagnostics.rs
+++ b/core/control/src/diagnostics.rs
@@ -2678,6 +2678,50 @@ mod tests {
     }
 
     #[test]
+    fn ip_shaped_browser_version_stays_redacted_across_ingest_and_restart() {
+        let directory = TestDirectory::new();
+        let store = DiagnosticStore::open(&directory.0).expect("open store");
+        let raw_ip = "192.0.2.77";
+        let mut value = envelope(1);
+        value.app.runtimes.browser_version = Some(raw_ip.to_owned());
+        let raw = serde_json::to_vec(&value).expect("serialize envelope");
+        let incident_id = match store
+            .ingest("Example Tester", &raw, NOW)
+            .expect("ingest incident")
+        {
+            AppendOutcome::Stored { incident_id } => incident_id,
+            other => panic!("unexpected outcome: {other:?}"),
+        };
+
+        let stored = store
+            .get_incident(&incident_id)
+            .expect("read incident")
+            .expect("incident exists");
+        assert_ne!(
+            stored.envelope.app.runtimes.browser_version.as_deref(),
+            Some(raw_ip)
+        );
+        let persisted = fs::read_to_string(
+            storage_files(&directory.0).expect("list storage files")[0]
+                .2
+                .clone(),
+        )
+        .expect("read JSONL");
+        assert!(!persisted.contains(raw_ip));
+
+        drop(store);
+        let reopened = DiagnosticStore::open(&directory.0).expect("reopen store");
+        let stored = reopened
+            .get_incident(&incident_id)
+            .expect("read reopened incident")
+            .expect("reopened incident exists");
+        assert_ne!(
+            stored.envelope.app.runtimes.browser_version.as_deref(),
+            Some(raw_ip)
+        );
+    }
+
+    #[test]
     fn rejects_invalid_ids_timestamps_order_counts_and_strings() {
         let mut value = envelope(1);
         value.envelope_id = "not-an-id".to_owned();

--- a/core/control/test-diagnostics-api.ps1
+++ b/core/control/test-diagnostics-api.ps1
@@ -234,7 +234,7 @@ try {
         session_id = '00000000-0000-4000-8000-000000000103'
         captured_at_ms = $now - 1000
         sent_at_ms = $now
-        app = @{ version = '0.6.33'; git_sha = 'd6191a5f'; channel = 'web-smoke'; runtimes = @{ browser_name = 'Chromium'; browser_version = 'smoke' } }
+        app = @{ version = '0.6.33'; git_sha = 'd6191a5f'; channel = 'web-smoke'; runtimes = @{ browser_name = 'Chromium'; browser_version = '152.0.8123.44' } }
         platform = @{ client_kind = 'browser'; operating_system = 'macos'; architecture = 'aarch64'; os_version = '15.5'; os_build = '24F74' }
         events = @(
             @{
@@ -282,7 +282,12 @@ try {
     if ($badQuery.CacheControl -ne 'no-store') { throw 'Owner query rejection was cacheable' }
     $listCount = @(($list.Content | ConvertFrom-Json).incidents).Count
     if ($listCount -ne 1) { throw "Owner list expected one incident, got $listCount" }
-    Assert-Status (Invoke-EchoRequest GET ('/admin/api/diagnostics/' + $incidentId) $null $ownerToken) 200 'owner detail'
+    $detail = Invoke-EchoRequest GET ('/admin/api/diagnostics/' + $incidentId) $null $ownerToken
+    Assert-Status $detail 200 'owner detail'
+    $detailPayload = $detail.Content | ConvertFrom-Json
+    if ($detailPayload.envelope.app.runtimes.browser_version -ne '152.0.8123.44') {
+        throw 'Owner detail did not preserve the Chrome full version'
+    }
     $download = Invoke-EchoRequest GET ('/admin/api/diagnostics/' + $incidentId + '/download') $null $ownerToken
     Assert-Status $download 200 'owner download'
     foreach ($forbidden in @('forbidden-value', 'person@example.invalid', '192.0.2.77', 'F:\private', 'candidate:', 'ice-ufrag private')) {
@@ -314,6 +319,7 @@ try {
         CanonicalUuid = 'uppercase rejected'
         Oversized = $oversized.StatusCode
         Redaction = 'verified in owner download'
+        BrowserVersion = $detailPayload.envelope.app.runtimes.browser_version
         RateLimitedAtRetry = $rateLimitedAt
         Delete = 204
     }

--- a/core/viewer-tests/tests/web-diagnostics-consent.spec.js
+++ b/core/viewer-tests/tests/web-diagnostics-consent.spec.js
@@ -1,9 +1,9 @@
 import { expect, test } from "@playwright/test";
 
-const MAC_SAFARI_USER_AGENT = [
+const MAC_CHROME_USER_AGENT = [
   "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)",
-  "AppleWebKit/605.1.15 (KHTML, like Gecko)",
-  "Version/18.5 Safari/605.1.15",
+  "AppleWebKit/537.36 (KHTML, like Gecko)",
+  "Chrome/152.0.0.0 Safari/537.36",
 ].join(" ");
 
 const DIAGNOSTICS_PREFIX = "echo-web-diagnostics-";
@@ -13,7 +13,7 @@ const QUEUE_KEY = `${DIAGNOSTICS_PREFIX}queue-v1`;
 const STATUS_KEY = `${DIAGNOSTICS_PREFIX}status-v1`;
 const ACTIVE_KEY = `${DIAGNOSTICS_PREFIX}active-v1`;
 
-test.use({ userAgent: MAC_SAFARI_USER_AGENT });
+test.use({ userAgent: MAC_CHROME_USER_AGENT });
 
 async function readStorage(page) {
   return page.evaluate(() => Object.fromEntries(
@@ -25,9 +25,24 @@ async function readStorage(page) {
 
 async function installDesktopMacNavigator(page) {
   await page.addInitScript(() => {
+    window.__echoUaHintRequests = 0;
+    const userAgentData = {
+      async getHighEntropyValues(hints) {
+        window.__echoUaHintRequests += 1;
+        return {
+          fullVersionList: hints.includes("fullVersionList")
+            ? [
+              { brand: "Chromium", version: "152.0.8123.44" },
+              { brand: "Google Chrome", version: "152.0.8123.44" },
+            ]
+            : [],
+        };
+      },
+    };
     Object.defineProperties(window.navigator, {
       maxTouchPoints: { configurable: true, get: () => 0 },
       platform: { configurable: true, get: () => "MacIntel" },
+      userAgentData: { configurable: true, get: () => userAgentData },
     });
   });
 }
@@ -137,6 +152,7 @@ test("fresh Mac stays inert until an exact canary invite, then remains data-free
   });
 
   await page.goto("/", { waitUntil: "domcontentloaded" });
+  await page.evaluate(() => localStorage.setItem("echo-changelog-seen", CHANGELOG_LATEST));
 
   const consentModal = page.locator("#diagnostics-consent-modal");
   await expect(consentModal).toBeHidden();
@@ -145,6 +161,7 @@ test("fresh Mac stays inert until an exact canary invite, then remains data-free
   expect(diagnosticsState(await readStorage(page))).toEqual({});
   expect(versionRequests).toHaveLength(0);
   expect(diagnosticsUploads).toHaveLength(0);
+  expect(await page.evaluate(() => window.__echoUaHintRequests)).toBe(0);
 
   await page.goto("/?echoWebDiagnosticsCanary=1&echoWebDiagnosticsCanary=1", {
     waitUntil: "domcontentloaded",
@@ -171,11 +188,12 @@ test("fresh Mac stays inert until an exact canary invite, then remains data-free
     consent: "unset",
     platform: "MacIntel",
     touchPoints: 0,
-    userAgent: MAC_SAFARI_USER_AGENT,
+    userAgent: MAC_CHROME_USER_AGENT,
   });
   expect(diagnosticsState(await readStorage(page))).toEqual({});
   expect(versionRequests).toHaveLength(0);
   expect(diagnosticsUploads).toHaveLength(0);
+  expect(await page.evaluate(() => window.__echoUaHintRequests)).toBe(0);
   expect(new URL(page.url()).searchParams.get("echoWebDiagnosticsCanary")).toBe("1");
 
   await page.getByRole("button", { name: "Keep Off" }).click();
@@ -199,6 +217,7 @@ test("fresh Mac stays inert until an exact canary invite, then remains data-free
   });
   expect(versionRequests).toHaveLength(0);
   expect(diagnosticsUploads).toHaveLength(0);
+  expect(await page.evaluate(() => window.__echoUaHintRequests)).toBe(0);
 
   const storageBeforeEnable = await readStorage(page);
   await page.evaluate(() => setSettingsPanelOpen(true));
@@ -208,13 +227,14 @@ test("fresh Mac stays inert until an exact canary invite, then remains data-free
   await expect(page.locator("#diagnostics-action-status")).toHaveText("Diagnostics are on.");
   await expect(page.locator("#diagnostics-enabled-toggle")).toBeChecked();
   await expect.poll(() => versionRequests.length).toBe(1);
+  await expect.poll(() => page.evaluate(() => window.__echoUaHintRequests)).toBe(1);
 
   const storageAfterEnable = await readStorage(page);
   const changedKeys = Array.from(new Set([
     ...Object.keys(storageBeforeEnable),
     ...Object.keys(storageAfterEnable),
   ])).filter((key) => storageBeforeEnable[key] !== storageAfterEnable[key]);
-  expect(changedKeys.every((key) => key.startsWith(DIAGNOSTICS_PREFIX))).toBe(true);
+  expect(changedKeys.filter((key) => !key.startsWith(DIAGNOSTICS_PREFIX))).toEqual([]);
 
   const enabledState = diagnosticsState(storageAfterEnable);
   expect(Object.keys(enabledState).sort()).toEqual([

--- a/core/viewer/diagnostics-client.js
+++ b/core/viewer/diagnostics-client.js
@@ -176,9 +176,11 @@
     if (["Browser", "Edge", "Chrome", "Firefox", "Safari"].indexOf(sourceRuntimes.browser_name) >= 0) {
       runtimes.browser_name = sourceRuntimes.browser_name;
     }
-    if (typeof sourceRuntimes.browser_version === "string" &&
-        (/^[0-9]+(?:\.[0-9]+){0,5}$/.test(sourceRuntimes.browser_version) || sourceRuntimes.browser_version === "unknown")) {
-      runtimes.browser_version = sourceRuntimes.browser_version;
+    if (sourceRuntimes.browser_version === "unknown") {
+      runtimes.browser_version = "unknown";
+    } else {
+      var safeBrowserVersion = browserVersionForDiagnostics(sourceRuntimes.browser_version);
+      if (safeBrowserVersion) runtimes.browser_version = safeBrowserVersion;
     }
     if (typeof sourceRuntimes.livekit_version === "string" &&
         /^[0-9A-Za-z][0-9A-Za-z.+-]{0,63}$/.test(sourceRuntimes.livekit_version)) {
@@ -1140,8 +1142,70 @@
     else if ((match = userAgent.match(/Chrome\/([0-9.]+)/))) { browserName = "Chrome"; browserVersion = match[1]; }
     else if ((match = userAgent.match(/Firefox\/([0-9.]+)/))) { browserName = "Firefox"; browserVersion = match[1]; }
     else if ((match = userAgent.match(/Version\/([0-9.]+).*Safari/))) { browserName = "Safari"; browserVersion = match[1]; }
-    var runtimes = { browser_name: browserName, browser_version: browserVersion };
+    var safeBrowserVersion = browserVersion === "unknown"
+      ? "unknown"
+      : browserVersionForDiagnostics(browserVersion);
+    var runtimes = { browser_name: browserName, browser_version: safeBrowserVersion || "unknown" };
     if (livekit && typeof livekit.version === "string") runtimes.livekit_version = livekit.version;
+    return runtimes;
+  }
+
+  function validBrowserVersion(value) {
+    return typeof value === "string" && value.length <= 64 &&
+      /^[0-9]+(?:\.[0-9]+){0,5}$/.test(value);
+  }
+
+  function browserVersionForDiagnostics(value) {
+    if (!validBrowserVersion(value)) return null;
+    var components = value.split(".");
+    if (components.length === 4 && components.every(function (component) {
+      return Number(component) <= 255;
+    })) {
+      // A numeric four-part version can be indistinguishable from an IPv4
+      // address. Keep only the browser major rather than weakening the server's
+      // generic IP redaction boundary. Current Chromium full builds normally
+      // contain a build component above 255; reduced UA values become major-only.
+      return components[0];
+    }
+    return value;
+  }
+
+  function fullVersionFromClientHints(browserName, fullVersionList) {
+    if (!Array.isArray(fullVersionList)) return null;
+    var preferredBrands = browserName === "Edge"
+      ? ["Microsoft Edge"]
+      : browserName === "Chrome"
+        ? ["Google Chrome", "Chromium"]
+        : [];
+    for (var preferredIndex = 0; preferredIndex < preferredBrands.length; preferredIndex += 1) {
+      for (var entryIndex = 0; entryIndex < fullVersionList.length; entryIndex += 1) {
+        var entry = fullVersionList[entryIndex];
+        var safeVersion = entry && entry.brand === preferredBrands[preferredIndex]
+          ? browserVersionForDiagnostics(entry.version)
+          : null;
+        if (safeVersion) {
+          return safeVersion;
+        }
+      }
+    }
+    return null;
+  }
+
+  async function detectBrowserRuntimeWithClientHints(navigatorObject, livekit) {
+    var runtimes = detectBrowserRuntime(navigatorObject, livekit);
+    var userAgentData = navigatorObject && navigatorObject.userAgentData;
+    if ((runtimes.browser_name !== "Chrome" && runtimes.browser_name !== "Edge") ||
+        !userAgentData || typeof userAgentData.getHighEntropyValues !== "function") {
+      return runtimes;
+    }
+    try {
+      var hints = await userAgentData.getHighEntropyValues(["fullVersionList"]);
+      var fullVersion = fullVersionFromClientHints(
+        runtimes.browser_name,
+        hints && hints.fullVersionList,
+      );
+      if (fullVersion) runtimes.browser_version = fullVersion;
+    } catch (_) {}
     return runtimes;
   }
 
@@ -1156,7 +1220,10 @@
           version: payload.version,
           git_sha: payload.git_sha,
           channel: "web-canary",
-          runtimes: detectBrowserRuntime(environment.navigator, environment.LivekitClient),
+          runtimes: await detectBrowserRuntimeWithClientHints(
+            environment.navigator,
+            environment.LivekitClient,
+          ),
         },
         platform: { client_kind: "browser", operating_system: "macos", architecture: "unknown" },
       };
@@ -1286,6 +1353,8 @@
     isWebDiagnosticsCanaryEnrolled: isWebDiagnosticsCanaryEnrolled,
     clearWebDiagnosticsCanaryInvite: clearWebDiagnosticsCanaryInvite,
     detectBrowserRuntime: detectBrowserRuntime,
+    detectBrowserRuntimeWithClientHints: detectBrowserRuntimeWithClientHints,
+    browserMetadataProvider: browserMetadataProvider,
     safeMetadata: safeMetadata,
     sanitizeEvent: sanitizeEvent,
     validateSealedBody: validateSealedBody,

--- a/core/viewer/diagnostics-client.test.js
+++ b/core/viewer/diagnostics-client.test.js
@@ -305,6 +305,156 @@ function interceptNextStorageMutation(storage, method, key, afterMutation) {
   };
 }
 
+test("Chrome diagnostics prefer the full UA Client Hints version", async () => {
+  const requestedHints = [];
+  const navigatorObject = {
+    userAgent: "Mozilla/5.0 (Macintosh) AppleWebKit/537.36 Chrome/152.0.0.0 Safari/537.36",
+    userAgentData: {
+      async getHighEntropyValues(hints) {
+        requestedHints.push(hints);
+        return {
+          fullVersionList: [
+            { brand: "Not_A Brand", version: "99.0.0.0" },
+            { brand: "Chromium", version: "152.0.8123.44" },
+            { brand: "Google Chrome", version: "152.0.8123.44" },
+          ],
+        };
+      },
+    },
+  };
+
+  assert.deepEqual(
+    await diagnostics.detectBrowserRuntimeWithClientHints(navigatorObject, { version: "2.17.0" }),
+    {
+      browser_name: "Chrome",
+      browser_version: "152.0.8123.44",
+      livekit_version: "2.17.0",
+    },
+  );
+  assert.deepEqual(requestedHints, [["fullVersionList"]]);
+});
+
+test("Chrome diagnostics safely fall back to the reduced UA version", async () => {
+  const navigatorObject = {
+    userAgent: "Mozilla/5.0 (Macintosh) AppleWebKit/537.36 Chrome/152.0.0.0 Safari/537.36",
+    userAgentData: {
+      async getHighEntropyValues() {
+        throw new Error("client hints unavailable");
+      },
+    },
+  };
+
+  assert.deepEqual(
+    await diagnostics.detectBrowserRuntimeWithClientHints(navigatorObject, null),
+    { browser_name: "Chrome", browser_version: "152" },
+  );
+});
+
+test("Chrome diagnostics ignore malformed client-hint versions", async () => {
+  const navigatorObject = {
+    userAgent: "Mozilla/5.0 (Macintosh) AppleWebKit/537.36 Chrome/152.0.0.0 Safari/537.36",
+    userAgentData: {
+      async getHighEntropyValues() {
+        return {
+          fullVersionList: [
+            { brand: "Google Chrome", version: "152.0.8123.44/forbidden" },
+          ],
+        };
+      },
+    },
+  };
+
+  assert.deepEqual(
+    await diagnostics.detectBrowserRuntimeWithClientHints(navigatorObject, null),
+    { browser_name: "Chrome", browser_version: "152" },
+  );
+});
+
+test("Chrome diagnostics collapse IP-shaped versions instead of weakening server redaction", async () => {
+  const navigatorObject = {
+    userAgent: "Mozilla/5.0 (Macintosh) AppleWebKit/537.36 Chrome/152.0.0.0 Safari/537.36",
+    userAgentData: {
+      async getHighEntropyValues() {
+        return {
+          fullVersionList: [
+            { brand: "Google Chrome", version: "192.0.2.77" },
+          ],
+        };
+      },
+    },
+  };
+
+  assert.deepEqual(
+    await diagnostics.detectBrowserRuntimeWithClientHints(navigatorObject, null),
+    { browser_name: "Chrome", browser_version: "192" },
+  );
+
+  const metadata = validMetadata();
+  metadata.app.runtimes.browser_version = "192.0.2.77";
+  assert.equal(diagnostics.safeMetadata(metadata).app.runtimes.browser_version, "192");
+});
+
+test("browser metadata provider waits for and uses Chrome's full client-hint version", async () => {
+  let resolveHints;
+  let requestedHints;
+  let settled = false;
+  const environment = {
+    apiUrl(pathname) { return `https://echo.example.test${pathname}`; },
+    async fetch(url, init) {
+      assert.equal(url, "https://echo.example.test/api/version");
+      assert.deepEqual(init, { cache: "no-store" });
+      return {
+        ok: true,
+        async json() {
+          return { version: "0.6.33", git_sha: "abcdef123456" };
+        },
+      };
+    },
+    navigator: {
+      userAgent: "Mozilla/5.0 (Macintosh) AppleWebKit/537.36 Chrome/152.0.0.0 Safari/537.36",
+      userAgentData: {
+        getHighEntropyValues(hints) {
+          requestedHints = hints;
+          return new Promise((resolve) => { resolveHints = resolve; });
+        },
+      },
+    },
+    LivekitClient: { version: "2.17.0" },
+  };
+
+  const pending = diagnostics.browserMetadataProvider(environment)();
+  pending.then(() => { settled = true; });
+  while (!resolveHints) await Promise.resolve();
+  assert.equal(settled, false);
+  assert.deepEqual(requestedHints, ["fullVersionList"]);
+  resolveHints({
+    fullVersionList: [
+      { brand: "Chromium", version: "152.0.8123.44" },
+      { brand: "Google Chrome", version: "152.0.8123.44" },
+    ],
+  });
+
+  const metadata = await pending;
+  assert.equal(settled, true);
+  assert.deepEqual(metadata, {
+    app: {
+      version: "0.6.33",
+      git_sha: "abcdef123456",
+      channel: "web-canary",
+      runtimes: {
+        browser_name: "Chrome",
+        browser_version: "152.0.8123.44",
+        livekit_version: "2.17.0",
+      },
+    },
+    platform: {
+      client_kind: "browser",
+      operating_system: "macos",
+      architecture: "unknown",
+    },
+  });
+});
+
 function utf8Bytes(value) {
   return new TextEncoder().encode(value).length;
 }
@@ -1380,6 +1530,13 @@ test("exported sealed-body validator accepts the deterministic JS fixture", () =
   const parsed = JSON.parse(body);
   parsed.events[0].message = "FORBIDDEN";
   assert.equal(diagnostics.validateSealedBody(JSON.stringify(parsed), uuidFor(200)), false);
+
+  const ipShapedVersion = JSON.parse(body);
+  ipShapedVersion.app.runtimes.browser_version = "192.0.2.77";
+  assert.equal(
+    diagnostics.validateSealedBody(JSON.stringify(ipShapedVersion), uuidFor(200)),
+    false,
+  );
 });
 
 test("the shared browser envelope fixture matches the JS wire contract", () => {

--- a/docs/WEB-DIAGNOSTICS-TESTING.md
+++ b/docs/WEB-DIAGNOSTICS-TESTING.md
@@ -5,7 +5,7 @@ Release impact: coordinated control-plane, server-served viewer, and admin-stati
 
 ## Purpose and status
 
-This is the go/no-go checklist for the first approved desktop Safari canary of
+This is the go/no-go checklist for the first approved desktop Chrome canary of
 Echo's private web diagnostics. It covers the browser collector, private owner
 page, and control-plane boundary as one release unit.
 
@@ -23,7 +23,7 @@ uses the private owner page to find the matching structured incident.
 | Area | Canary behavior |
 | --- | --- |
 | Enrollment | Disabled by default; one profile is invited with the exact non-secret `?echoWebDiagnosticsCanary=1` flag |
-| Browser | Enrolled desktop macOS browsers; the first real-engine canary is Safari |
+| Browser | Enrolled desktop macOS browsers; the first real-engine canary is current Chrome, with Safari as a separate follow-up |
 | Consent | Off until the tester explicitly accepts; reversible in Settings |
 | Collection | Closed-schema browser/session, JavaScript, permission/media, and connection/reconnect events |
 | Upload | Only after a current authenticated participant heartbeat |
@@ -38,16 +38,16 @@ normal viewer URL remains completely inert: no prompt, settings section,
 diagnostics storage, version lookup, or upload. After **Allow Diagnostics** or
 **Keep Off**, the exact existing consent value becomes that profile's durable
 enrollment marker and the invitation flag is removed from the URL. Do not
-publish or broadly share the canary link. Once invited, this code supports any
-desktop macOS browser, not only Safari.
+publish or broadly share the canary link. Once invited, this code supports other
+desktop macOS browsers too; each engine still needs its own physical canary.
 
 The web fallback deliberately cannot provide native/Tauri/Rust panic capture,
 an Application Support crash spool, updater/notarization evidence, DMG launch
 coverage, exact Apple Silicon architecture, or the exact macOS build. Record
-the Mac model/chip and OS build manually. Safari also cannot promise lossless
-multi-tab storage coordination, so use exactly one Echo tab for the primary
-canary. System-audio, native screen-capture, and output-device behavior remain
-browser capability questions rather than diagnostics guarantees.
+the Mac model/chip and OS build manually. Use exactly one Echo tab in a fresh,
+persistent Chrome profile for the primary canary. Screen-share system audio may
+work in Chrome, but capture and output-device behavior remain browser capability
+questions rather than diagnostics guarantees.
 
 ## Information required before scheduling
 
@@ -59,15 +59,15 @@ Record these facts before the outage or tester session:
 | Primary tester | |
 | Mac model and Apple chip | |
 | Exact macOS version/build | |
-| Exact Safari version | |
-| Tester comfortable opening Safari Web Inspector? | |
+| Exact Chrome version (`chrome://version`) | |
+| Tester comfortable opening Chrome DevTools? | |
 | Test room and participant display name | |
 | Planned deployed Echo version and Git SHA | |
 | Exact invited canary URL and approved recipients | |
 | Any prior ungated collector exposure/accounted profiles | |
 | Rollback control binary, viewer snapshot, and admin snapshot/path | |
 
-Use a fresh Safari profile or a dedicated macOS test account for the initial
+Use a fresh persistent Chrome profile or a dedicated macOS test account for the initial
 consent pass. Do not clear all site data from a tester's normal profile. The
 unclean-session scenario must use a normal persistent profile, not a private
 window whose storage disappears when the window closes.
@@ -108,9 +108,9 @@ duplicate/idempotent, rate-limited, redacted, download, deletion,
 storage-isolation, owner-auth, and client participant/origin queue-scoping
 cases. Do not replay hostile or load-oriented variants against production.
 
-Playwright runs Chromium. Its consent test uses a Safari user agent and Mac
-platform values to exercise the browser gate, but that is not Safari/WebKit
-evidence. The controlled pass on the physical Mac is the real Safari gate.
+Playwright runs Chromium, but it cannot prove physical-Mac permissions, capture,
+or process behavior. The controlled pass in current Chrome on the physical Mac
+is the real Chrome/macOS gate. Safari/WebKit remains a separate follow-up.
 
 ## 2. Approved-window deployment gate
 
@@ -164,7 +164,7 @@ This is a no-go if any of the following is true:
   been approved;
 - any prior ungated collector exposure is unknown or its enrolled profiles are
   unaccounted for;
-- the primary tester cannot perform the required Safari Web Inspector privacy
+- the primary tester cannot perform the required Chrome DevTools privacy
   check with Sam's guidance;
 - a complete rollback unit is not ready;
 - the offline readiness gate is not green.
@@ -200,17 +200,18 @@ After the coordinated restart, but before inviting a tester:
 Do not place the owner secret in command-line probes. Enter it only into the
 dedicated page over the verified HTTPS origin.
 
-## 4. One-tab Safari canary
+## 4. One-tab Chrome canary
 
 Keep the owner page on Sam's machine and the viewer on the tester's Mac. Record
 UTC timestamps and incident IDs throughout.
 
 ### A. Consent stays off
 
-1. Open the normal `/viewer/` HTTPS URL in a fresh desktop Safari profile with
-   one Echo tab. Confirm there is no diagnostics prompt or Settings section and
-   no `echo-web-diagnostics-*` browser storage.
-2. In Safari Web Inspector's Network view, confirm neither `/api/version` nor
+1. Open the normal `/viewer/` HTTPS URL in a fresh desktop Chrome profile with
+   one Echo tab. Confirm there is no diagnostics prompt and no
+   `echo-web-diagnostics-*` browser storage. The bottom **Output** control is not
+   active before connecting, so inspect Settings only after step 6.
+2. In Chrome DevTools' Network view, confirm neither `/api/version` nor
    `/api/diagnostics/v1/envelopes` was initiated by `diagnostics-client.js`.
    Other existing viewer code may independently check `/api/version`.
 3. Open the explicitly approved invitation by appending the exact flag to the
@@ -227,29 +228,31 @@ UTC timestamps and incident IDs throughout.
    remains in the URL so an undecided reload can show the invitation again.
 5. Select **Keep Off**. Confirm the flag disappears while any unrelated query
    parameters and fragment remain, then reload the normal `/viewer/` URL.
-6. In Settings, confirm **Private Web Diagnostics** remains enrolled but off,
-   with zero queued reports and no successful delivery status.
+6. Join the designated room once with the normal microphone/camera choices so
+   Echo's bottom controls are active. Click **Output** at the bottom; it opens
+   **Settings** directly.
+7. Confirm **Private Web Diagnostics** remains enrolled but off, with delivery
+   status **Never** and **0 reports** queued.
 
 ### B. Opt in and baseline delivery
 
-1. Turn on **Send technical diagnostics to Sam's Echo server** in Settings.
-2. Join the designated room. On the first microphone permission request, choose
-   Safari's deny option and record the UTC time for section C. Echo requests the
-   camera separately immediately afterward; allow that camera request. Then
-   wait for the normal Echo heartbeat to succeed.
+1. While still in **Settings**, turn on **Send technical diagnostics to Sam's
+   Echo server**.
+2. Close **Settings**, leave, and rejoin the designated room. Allow microphone
+   and camera, then wait for the normal Echo heartbeat to succeed.
 3. Wait for **Accepted** or **Already received**. If the queued count is still
    nonzero and **Send Now** is enabled, select it; an already drained queue is
    success and does not require Send Now.
 4. In the owner page, refresh and open the matching `session.start` incident.
-   Confirm the Echo version, exact Git SHA, Safari/LiveKit versions, `macos`,
+   Confirm the Echo version, exact Git SHA, Chrome/LiveKit versions, `macos`,
    participant, and timestamps are coherent. Architecture may correctly be
    `unknown`; compare against the manually recorded hardware facts.
 
 ### C. Permission denial
 
-1. Inspect the permission denial created during the baseline join. If Safari
-   did not prompt because the origin already had a decision, reset only that
-   origin's microphone permission, reload, and repeat the join/deny action.
+1. In Chrome's site settings for the Echo origin, reset only microphone access,
+   reload, rejoin, and choose **Block** at the microphone prompt. Record the UTC
+   time. Leave camera access unchanged.
 2. Wait for heartbeat, then select **Send Now** only if the queued count is
    nonzero and the button is enabled.
 3. Confirm the owner detail contains a microphone/permission denied event with
@@ -258,7 +261,8 @@ UTC timestamps and incident IDs throughout.
 
 ### D. JavaScript privacy canary
 
-With diagnostics on and Web Inspector open, run exactly this synthetic error:
+With diagnostics on and Chrome DevTools' **Console** open, run exactly this
+synthetic error:
 
 ```javascript
 setTimeout(() => { throw new TypeError("ECHO_CANARY_DO_NOT_STORE"); }, 0)
@@ -286,12 +290,12 @@ absent. Any appearance of that marker or message is an immediate stop/rollback.
    five minutes, and confirm the prior clean session does not produce
    `session.unclean_shutdown`.
 2. Confirm diagnostics are on, the tester is authenticated, and a heartbeat
-   has succeeded in a persistent Safari profile. Save/close unrelated Safari
-   work because the next command terminates every Safari process immediately.
+   has succeeded in a persistent Chrome profile. Save/close unrelated Chrome
+   work because the next command terminates every Chrome process immediately.
 3. In Terminal on the tester's Mac, perform the exact hard kill:
 
    ```bash
-   killall -9 Safari
+   killall -9 "Google Chrome"
    ```
 
    A normal tab close or Command-Q is a clean shutdown and is not this test.
@@ -302,7 +306,7 @@ absent. Any appearance of that marker or message is an immediate stop/rollback.
    server-derived authenticated participant, but the event details must not
    contain a URL, window/tab title, or raw browser-provided identity.
 
-This sentinel is intentionally best effort because Safari owns process and
+This sentinel is intentionally best effort because the browser owns process and
 storage semantics. Record whether it appeared, but absence by itself is not a
 release blocker when all hard gates pass. Cross-user attribution, upload before
 heartbeat, or leaked raw data is always a blocker.
@@ -322,7 +326,7 @@ heartbeat, or leaked raw data is always a blocker.
 4. Sign out and confirm the private list/detail disappears and a new owner
    login is required.
 
-### H. Safari product smoke and soak
+### H. Chrome product smoke and soak
 
 Diagnostics are useful only if the browser fallback itself remains usable.
 Reset the test origin's microphone permission and allow it; confirm camera
@@ -337,12 +341,12 @@ complete:
 - when a Jam source is available, join, hear it, and exercise the controls
   permitted to that participant;
 - sleep/wake the Mac once and confirm the viewer reconnects;
-- record Safari's system-output selection behavior and screen-share video
-  behavior without treating unsupported output selection or missing system
-  audio as a diagnostics failure.
+- record Chrome's system-output selection and screen-share video/audio behavior
+  without treating unsupported output selection or missing system audio as a
+  diagnostics failure.
 
 Successful receive, chat, and Jam actions often produce no diagnostic event;
-that absence is expected. Safari screen publishing, system audio, and output
+that absence is expected. Browser screen publishing, system audio, and output
 device selection are capability-limited and non-blocking when the UI explains
 the limitation. Failure of core join, microphone, camera, receive, chat, or
 reconnect behavior is blocking. Record Jam as N/A only when no test source is
@@ -351,9 +355,10 @@ available.
 ### I. Existing-user isolation
 
 Use a tester-owned Windows browser session, not SAM-PC and not a shared client.
-Confirm the normal viewer shows no diagnostics prompt or Settings section,
-creates no `echo-web-diagnostics-*` keys or diagnostics requests, and still
-connects, publishes microphone/camera, receives media, and uses chat normally.
+Confirm the normal viewer shows no diagnostics prompt and creates no
+`echo-web-diagnostics-*` keys or diagnostics requests. Join, click bottom
+**Output** to open **Settings**, and confirm there is no diagnostics section.
+Then confirm microphone/camera publishing, media receive, and chat still work.
 Do not close, reload, or alter Sam's local Echo client without separate explicit
 approval.
 
@@ -378,7 +383,7 @@ privacy canary fields rather than treating a digest as raw identity leakage.
 | Unclean session (best effort) | | | Observed/not observed | |
 | Delete queued data and opt-out | | N/A | | |
 | Owner download/delete/sign-out | | | | |
-| Safari product smoke and 30-minute soak | | N/A | | |
+| Chrome product smoke and 30-minute soak | | N/A | | |
 | Tester-owned Windows isolation/regression | | N/A | | |
 | Existing admin regression check | | N/A | | |
 
@@ -398,7 +403,7 @@ or viewer/admin regression.
    closing the current Echo tab. While offline, have the tester turn diagnostics
    off and confirm its queue is empty; do not ask them to collect files or edit
    browser storage. Keep the Mac offline until Sam clears the incident response.
-   If the toggle cannot be reached, close Safari while still offline and do not
+   If the toggle cannot be reached, close Chrome while still offline and do not
    reopen the canary profile until Sam decides how to handle its queue.
 2. To disable server ingestion and owner access while retaining automatic
    pruning, remove `CORE_DIAGNOSTICS_OWNER_SECRET` from the protected control


### PR DESCRIPTION
## What changed

- Prefer Chromium UA Client Hints `fullVersionList` after explicit diagnostics consent so Chrome/Edge can report their full runtime build.
- Collapse any four-part numeric browser version that is indistinguishable from IPv4 to the browser major before queue sealing.
- Keep the control plane's existing generic IP sanitizer unchanged as the final defense-in-depth boundary.
- Add unit, Chromium consent, ingest/storage/restart, and isolated owner-detail regressions.
- Update the Mac web canary runbook for Chrome and the actual bottom **Output** interaction that opens Settings.

## Root cause

Chrome's reduced user agent exposed a value shaped like `152.0.0.0`. The control-plane privacy sanitizer correctly interpreted that as IPv4, replaced it with `[REDACTED_IP]`, and bounded the replacement to the original byte length. Owner diagnostics therefore showed a truncated `[REDACTED` value instead of useful browser metadata.

## Impact

- Full Chrome builds such as `152.0.8123.44` are retained automatically when Chrome exposes them.
- Reduced/IP-shaped values degrade safely to major-only, such as `152`.
- No pre-consent Client Hints access.
- No relaxation of server redaction.
- Release impact: coordinated server/control + complete viewer snapshot deploy; no desktop binary.

## Verification

- `npm run verify:quick`: 237 viewer tests passed.
- Playwright Chromium regression suite: 90/90 passed.
- Locked control-plane suite: 117/117 passed.
- Control formatting, atomic viewer deployment/rollback tests, locked build, and isolated diagnostics API/privacy smoke passed.
- Independent code, privacy/security, and runbook reviews approved.
- Jeff's live baseline delivered 6 incidents / 10 events with no URLs, paths, credentials, chat, device labels, SDP, ICE data, or raw errors persisted.

## ELI5

**What broke:** Chrome's privacy-reduced version looked like an IP address, so Echo hid it.

**Why it broke:** Browser versions and IP addresses can have the same four-number shape.

**What changed:** Echo asks Chrome for the real full build after consent. If a value still looks like an IP, Echo keeps only the safe browser major and leaves server redaction untouched.

**How we know it works:** Full automated readiness passed, privacy regressions cover queue, ingest, storage, restart, and owner detail, and three independent reviews approved it.

**Does this need a desktop update:** No.

**What could still go wrong:** If Chrome withholds high-entropy hints, diagnostics show only the major version; the tester can confirm the exact build manually at `chrome://version`.
