### PR TITLE
Complete Jam library, queue, history, and Echo Pulse

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -1341,6 +1341,7 @@ dependencies = [
  "rustls",
  "serde",
  "serde_json",
+ "sha1",
  "sha2",
  "tokio",
  "tokio-tungstenite 0.21.0",

--- a/core/control/Cargo.toml
+++ b/core/control/Cargo.toml
@@ -14,6 +14,7 @@ tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
 argon2 = "0.5"
 rand = "0.8"
 hmac = "0.12"
+sha1 = "0.10"
 sha2 = "0.10"
 tower = "0.4"
 tower-http = { version = "0.5", features = ["fs", "cors", "set-header"] }

--- a/core/control/src/jam_history.rs
+++ b/core/control/src/jam_history.rs
@@ -15,7 +15,10 @@ use std::{
     fs::{self, OpenOptions},
     io::{self, BufRead, BufReader, Read, Seek, SeekFrom, Write},
     path::{Path, PathBuf},
-    sync::Mutex,
+    sync::{
+        atomic::{AtomicU64, Ordering as AtomicOrdering},
+        Mutex,
+    },
 };
 use tracing::warn;
 
@@ -77,6 +80,7 @@ pub(crate) struct JamHistoryStore {
     dir: PathBuf,
     enabled: bool,
     lock: Mutex<()>,
+    revision: AtomicU64,
 }
 
 impl JamHistoryStore {
@@ -87,6 +91,7 @@ impl JamHistoryStore {
             dir,
             enabled: true,
             lock: Mutex::new(()),
+            revision: AtomicU64::new(0),
         };
         store.prune(now_ms)?;
         Ok(store)
@@ -97,7 +102,12 @@ impl JamHistoryStore {
             dir,
             enabled: false,
             lock: Mutex::new(()),
+            revision: AtomicU64::new(0),
         }
+    }
+
+    pub(crate) fn revision(&self) -> u64 {
+        self.revision.load(AtomicOrdering::Relaxed)
     }
 
     pub(crate) fn append_observation(
@@ -135,6 +145,7 @@ impl JamHistoryStore {
             .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
         file.write_all(b"\n")?;
         file.sync_data()?;
+        self.revision.fetch_add(1, AtomicOrdering::Relaxed);
         Ok(entry)
     }
 
@@ -287,28 +298,42 @@ fn replace_jsonl(path: &Path, lines: &[String]) -> io::Result<()> {
 pub(crate) struct HistoryObservation {
     pub(crate) spotify_id: String,
     pub(crate) queued_track: Option<QueuedTrack>,
+    pub(crate) echo_run: bool,
 }
 
 /// Decide whether a bound-device observation starts a new Spotify run. Every
 /// playing Spotify ID advances the run, but only matching Echo entries persist.
 pub(crate) fn new_history_observation(
     last_spotify_id: Option<&str>,
+    last_run_was_echo: bool,
     observed_spotify_id: Option<&str>,
     queued_track: Option<&QueuedTrack>,
     is_playing: bool,
+    same_track_occurrence_restarted: bool,
 ) -> Option<HistoryObservation> {
     if !is_playing {
         return None;
     }
     let spotify_id = observed_spotify_id.filter(|id| !id.is_empty())?;
-    if last_spotify_id == Some(spotify_id) {
+    let matching_echo_track = queued_track
+        .filter(|track| track.spotify_id == spotify_id)
+        .cloned();
+    let same_spotify_id = last_spotify_id == Some(spotify_id);
+    let external_run_became_echo =
+        same_spotify_id && !last_run_was_echo && matching_echo_track.is_some();
+    if same_spotify_id && !same_track_occurrence_restarted && !external_run_became_echo {
         return None;
     }
+    let echo_run = matching_echo_track.is_some();
+    // Consecutive Echo occurrences of the same song stay one history run, even
+    // when they were intentionally queued twice. A confirmed external->Echo
+    // boundary for the same URI is persisted because the prior run was not an
+    // Echo queue occurrence.
+    let queued_track = matching_echo_track.filter(|_| !same_spotify_id || !last_run_was_echo);
     Some(HistoryObservation {
         spotify_id: spotify_id.to_string(),
-        queued_track: queued_track
-            .filter(|track| track.spotify_id == spotify_id)
-            .cloned(),
+        queued_track,
+        echo_run,
     })
 }
 
@@ -495,6 +520,7 @@ mod tests {
             added_by_actor_id: "ea1_actor".to_string(),
             added_by_name: "Sam".to_string(),
             playlist: None,
+            playlist_position: None,
             added_by: "Sam".to_string(),
         }
     }
@@ -504,16 +530,22 @@ mod tests {
         let a = track("AAAAAAAAAAAAAAAAAAAAAA");
         let b = track("BBBBBBBBBBBBBBBBBBBBBB");
         let mut last = None::<String>;
+        let mut last_was_echo = false;
         let mut recorded = Vec::new();
         for current in [&a, &a, &a, &b, &a] {
             if let Some(observed) = new_history_observation(
                 last.as_deref(),
+                last_was_echo,
                 Some(&current.spotify_id),
                 Some(current),
                 true,
+                false,
             ) {
                 last = Some(observed.spotify_id.clone());
-                recorded.push(observed.spotify_id);
+                last_was_echo = observed.echo_run;
+                if observed.queued_track.is_some() {
+                    recorded.push(observed.spotify_id);
+                }
             }
         }
         assert_eq!(
@@ -529,39 +561,106 @@ mod tests {
     #[test]
     fn pause_and_resume_do_not_create_a_second_history_row() {
         let a = track("AAAAAAAAAAAAAAAAAAAAAA");
-        let first = new_history_observation(None, Some(&a.spotify_id), Some(&a), true).unwrap();
+        let first =
+            new_history_observation(None, false, Some(&a.spotify_id), Some(&a), true, false)
+                .unwrap();
         let last = Some(first.spotify_id);
-        assert!(
-            new_history_observation(last.as_deref(), Some(&a.spotify_id), Some(&a), false)
-                .is_none()
-        );
-        assert!(
-            new_history_observation(last.as_deref(), Some(&a.spotify_id), Some(&a), true).is_none()
-        );
-        assert!(new_history_observation(last.as_deref(), None, None, true).is_none());
+        assert!(new_history_observation(
+            last.as_deref(),
+            true,
+            Some(&a.spotify_id),
+            Some(&a),
+            false,
+            false,
+        )
+        .is_none());
+        assert!(new_history_observation(
+            last.as_deref(),
+            true,
+            Some(&a.spotify_id),
+            Some(&a),
+            true,
+            false,
+        )
+        .is_none());
+        assert!(new_history_observation(last.as_deref(), true, None, None, true, false).is_none());
     }
 
     #[test]
     fn external_track_breaks_an_echo_track_run_without_being_persisted() {
         let a = track("AAAAAAAAAAAAAAAAAAAAAA");
-        let first = new_history_observation(None, Some(&a.spotify_id), Some(&a), true).unwrap();
+        let first =
+            new_history_observation(None, false, Some(&a.spotify_id), Some(&a), true, false)
+                .unwrap();
         assert!(first.queued_track.is_some());
         let external = new_history_observation(
             Some(&first.spotify_id),
+            first.echo_run,
             Some("BBBBBBBBBBBBBBBBBBBBBB"),
             None,
             true,
+            false,
         )
         .unwrap();
         assert!(external.queued_track.is_none());
+        assert!(!external.echo_run);
         let repeated_a = new_history_observation(
             Some(&external.spotify_id),
+            external.echo_run,
             Some(&a.spotify_id),
             Some(&a),
             true,
+            false,
         )
         .unwrap();
         assert!(repeated_a.queued_track.is_some());
+    }
+
+    #[test]
+    fn external_same_track_then_queued_echo_occurrence_is_persisted_once() {
+        let a = track("AAAAAAAAAAAAAAAAAAAAAA");
+        let external =
+            new_history_observation(None, false, Some(&a.spotify_id), None, true, false).unwrap();
+        assert!(!external.echo_run);
+        assert!(external.queued_track.is_none());
+
+        let queued_echo = new_history_observation(
+            Some(&external.spotify_id),
+            external.echo_run,
+            Some(&a.spotify_id),
+            Some(&a),
+            true,
+            true,
+        )
+        .unwrap();
+        assert!(queued_echo.echo_run);
+        assert_eq!(
+            queued_echo
+                .queued_track
+                .as_ref()
+                .map(|track| track.queue_entry_id.as_str()),
+            Some(a.queue_entry_id.as_str())
+        );
+    }
+
+    #[test]
+    fn confirmed_echo_same_song_restart_updates_the_run_without_persisting_again() {
+        let a = track("AAAAAAAAAAAAAAAAAAAAAA");
+        let first =
+            new_history_observation(None, false, Some(&a.spotify_id), Some(&a), true, false)
+                .unwrap();
+        let looped = new_history_observation(
+            Some(&first.spotify_id),
+            first.echo_run,
+            Some(&a.spotify_id),
+            Some(&a),
+            true,
+            true,
+        )
+        .unwrap();
+
+        assert!(looped.echo_run);
+        assert!(looped.queued_track.is_none());
     }
 
     #[test]
@@ -578,6 +677,31 @@ mod tests {
         let entries = store.list(now).unwrap();
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].spotify_id, "AAAAAAAAAAAAAAAAAAAAAA");
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn store_revision_advances_only_after_successful_appends() {
+        let dir = std::env::temp_dir().join(format!("echo-jam-history-{}", random_secret()));
+        let now = 50 * DAY_MS;
+        let store = JamHistoryStore::open(dir.clone(), now).unwrap();
+        assert_eq!(store.revision(), 0);
+
+        store
+            .append_observation(&track("AAAAAAAAAAAAAAAAAAAAAA"), now)
+            .unwrap();
+        assert_eq!(store.revision(), 1);
+        assert_eq!(store.list(now).unwrap().len(), 1);
+        assert_eq!(
+            store.revision(),
+            1,
+            "reads do not invalidate viewer history"
+        );
+
+        store
+            .append_observation(&track("BBBBBBBBBBBBBBBBBBBBBB"), now + 1)
+            .unwrap();
+        assert_eq!(store.revision(), 2);
         let _ = fs::remove_dir_all(dir);
     }
 

--- a/core/control/src/jam_library.rs
+++ b/core/control/src/jam_library.rs
@@ -1,28 +1,50 @@
 use crate::auth::{bounded_jam_actor_display_name, ensure_admin, ensure_jam_actor, JamActor};
 use crate::config::{now_ts_ms, urlencoded};
-use crate::jam_session::spotify_api_request;
+use crate::jam_playlist_cache::PLAYLIST_ITEMS_CACHE_CHUNK_SIZE;
+use crate::jam_session::{
+    remember_spotify_rate_limit_seconds, spotify_api_request, spotify_library_scope_required_error,
+    spotify_library_scopes_authorized, spotify_rate_limit_error, spotify_retry_after_seconds,
+};
+use crate::spotify_public_catalog::{
+    fetch_public_playlist_chunk, PublicCatalogError, PublicPlaylistPositionOutcome,
+};
 use crate::AppState;
 
 use axum::extract::{Json, Path, Query, State};
 use axum::http::{header::RETRY_AFTER, HeaderMap, HeaderValue, StatusCode};
 use axum::response::{IntoResponse, Response};
+use futures_util::{stream, StreamExt};
 use rand::{rngs::OsRng, RngCore};
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
 use std::fs::{self, OpenOptions};
+use std::future::Future;
 use std::io::{self, Write};
 use std::path::{Path as FsPath, PathBuf};
 use std::str::FromStr;
-use std::sync::Mutex;
+use std::sync::{
+    atomic::{AtomicU64, Ordering as AtomicOrdering},
+    Mutex,
+};
+use std::time::Duration;
 use tracing::warn;
 
 pub(crate) const FAVORITES_SCHEMA_VERSION: u16 = 1;
 pub(crate) const CATALOG_SCHEMA_VERSION: u16 = 1;
 const MAX_SEARCH_LIMIT: usize = 10;
 const MAX_PLAYLIST_ITEMS_LIMIT: usize = 50;
+const SPOTIFY_PLAYLIST_ITEMS_LIMIT: usize = 50;
+const MAX_PLAYLIST_ITEMS_OFFSET: usize = 100_000;
+pub(crate) const MAX_PLAYLIST_QUEUE_TRACKS: usize = 1_000;
 const MAX_CATALOG_OFFSET: usize = 1_000;
 const MAX_FAVORITES_LIMIT: usize = 200;
+const PLAYLIST_ARTWORK_CACHE_MAX_ENTRIES: usize = 512;
+const PLAYLIST_ARTWORK_CACHE_TTL_MS: u64 = 60 * 60 * 1_000;
+const PLAYLIST_ARTWORK_NEGATIVE_TTL_MS: u64 = 5 * 60 * 1_000;
+const PLAYLIST_ARTWORK_REFRESH_CONCURRENCY: usize = 4;
+const PLAYLIST_ARTWORK_REFRESH_MAX_IDS: usize = 50;
+const PLAYLIST_ARTWORK_REFRESH_TIMEOUT: Duration = Duration::from_secs(5);
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -130,6 +152,16 @@ pub(crate) struct FavoriteStore {
     path: PathBuf,
     writable: bool,
     inner: Mutex<FavoriteFile>,
+    playlist_artwork: Mutex<HashMap<String, PlaylistArtworkCacheEntry>>,
+    playlist_artwork_generation: AtomicU64,
+    playlist_artwork_refresh: tokio::sync::Mutex<()>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+struct PlaylistArtworkCacheEntry {
+    artwork_url: Option<String>,
+    expires_at_ms: u64,
+    last_accessed_at_ms: u64,
 }
 
 impl FavoriteStore {
@@ -155,6 +187,9 @@ impl FavoriteStore {
             path,
             writable: true,
             inner: Mutex::new(data),
+            playlist_artwork: Mutex::new(HashMap::new()),
+            playlist_artwork_generation: AtomicU64::new(0),
+            playlist_artwork_refresh: tokio::sync::Mutex::new(()),
         })
     }
 
@@ -164,6 +199,9 @@ impl FavoriteStore {
             path,
             writable: true,
             inner: Mutex::new(FavoriteFile::default()),
+            playlist_artwork: Mutex::new(HashMap::new()),
+            playlist_artwork_generation: AtomicU64::new(0),
+            playlist_artwork_refresh: tokio::sync::Mutex::new(()),
         }
     }
 
@@ -176,6 +214,9 @@ impl FavoriteStore {
             path,
             writable: false,
             inner: Mutex::new(data),
+            playlist_artwork: Mutex::new(HashMap::new()),
+            playlist_artwork_generation: AtomicU64::new(0),
+            playlist_artwork_refresh: tokio::sync::Mutex::new(()),
         }
     }
 
@@ -184,6 +225,9 @@ impl FavoriteStore {
             path,
             writable: false,
             inner: Mutex::new(FavoriteFile::default()),
+            playlist_artwork: Mutex::new(HashMap::new()),
+            playlist_artwork_generation: AtomicU64::new(0),
+            playlist_artwork_refresh: tokio::sync::Mutex::new(()),
         }
     }
 
@@ -208,6 +252,109 @@ impl FavoriteStore {
             .unwrap_or((false, 0))
     }
 
+    fn remember_playlist_artwork(&self, spotify_id: &str, artwork_url: Option<&str>, now_ms: u64) {
+        let generation = self.playlist_artwork_generation();
+        self.remember_playlist_artwork_if_generation(spotify_id, artwork_url, now_ms, generation);
+    }
+
+    fn remember_playlist_artwork_if_generation(
+        &self,
+        spotify_id: &str,
+        artwork_url: Option<&str>,
+        now_ms: u64,
+        expected_generation: u64,
+    ) {
+        if !valid_spotify_id(spotify_id) {
+            return;
+        }
+        if self.playlist_artwork_generation() != expected_generation {
+            return;
+        }
+        let artwork_url = artwork_url.and_then(safe_spotify_playlist_artwork_url);
+        let ttl_ms = if artwork_url.is_some() {
+            PLAYLIST_ARTWORK_CACHE_TTL_MS
+        } else {
+            PLAYLIST_ARTWORK_NEGATIVE_TTL_MS
+        };
+        let mut cache = self
+            .playlist_artwork
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        if self.playlist_artwork_generation() != expected_generation {
+            return;
+        }
+        if !cache.contains_key(spotify_id) && cache.len() >= PLAYLIST_ARTWORK_CACHE_MAX_ENTRIES {
+            if let Some(oldest_id) = cache
+                .iter()
+                .min_by_key(|(_, entry)| entry.last_accessed_at_ms)
+                .map(|(id, _)| id.clone())
+            {
+                cache.remove(&oldest_id);
+            }
+        }
+        cache.insert(
+            spotify_id.to_string(),
+            PlaylistArtworkCacheEntry {
+                artwork_url,
+                expires_at_ms: now_ms.saturating_add(ttl_ms),
+                last_accessed_at_ms: now_ms,
+            },
+        );
+    }
+
+    fn playlist_artwork_generation(&self) -> u64 {
+        self.playlist_artwork_generation
+            .load(AtomicOrdering::SeqCst)
+    }
+
+    fn cached_playlist_artwork(&self, spotify_id: &str, now_ms: u64) -> Option<Option<String>> {
+        let mut cache = self
+            .playlist_artwork
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        if cache
+            .get(spotify_id)
+            .is_some_and(|entry| entry.expires_at_ms <= now_ms)
+        {
+            cache.remove(spotify_id);
+            return None;
+        }
+        let entry = cache.get_mut(spotify_id)?;
+        entry.last_accessed_at_ms = now_ms;
+        Some(entry.artwork_url.clone())
+    }
+
+    fn apply_cached_playlist_artwork(
+        &self,
+        views: &mut [FavoriteView],
+        now_ms: u64,
+    ) -> Vec<String> {
+        let mut missing = Vec::new();
+        let mut seen = HashSet::new();
+        for view in views {
+            if view.kind != FavoriteKind::Playlist {
+                continue;
+            }
+            match self.cached_playlist_artwork(&view.summary.spotify_id, now_ms) {
+                Some(artwork_url) => view.summary.artwork_url = artwork_url,
+                None if seen.insert(view.summary.spotify_id.clone()) => {
+                    missing.push(view.summary.spotify_id.clone());
+                }
+                None => {}
+            }
+        }
+        missing
+    }
+
+    pub(crate) fn clear_playlist_artwork_cache(&self) {
+        self.playlist_artwork_generation
+            .fetch_add(1, AtomicOrdering::SeqCst);
+        self.playlist_artwork
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .clear();
+    }
+
     pub(crate) fn upsert(
         &self,
         kind: FavoriteKind,
@@ -216,6 +363,8 @@ impl FavoriteStore {
         source: &str,
         added_at_ms: u64,
     ) -> io::Result<(FavoriteItem, FavoriteMutation)> {
+        let playlist_artwork = (kind == FavoriteKind::Playlist)
+            .then(|| (summary.spotify_id.clone(), summary.artwork_url.clone()));
         let mut data = self.inner.lock().unwrap_or_else(|error| error.into_inner());
         let mut candidate = data.clone();
         let summary = summary_for_persistence(kind, summary);
@@ -264,6 +413,10 @@ impl FavoriteStore {
         };
         self.persist_locked(&candidate)?;
         *data = candidate;
+        drop(data);
+        if let Some((spotify_id, artwork_url)) = playlist_artwork {
+            self.remember_playlist_artwork(&spotify_id, artwork_url.as_deref(), now_ts_ms());
+        }
         Ok((item, mutation))
     }
 
@@ -277,6 +430,7 @@ impl FavoriteStore {
         let mut candidate = data.clone();
         let mut items_created = 0;
         let mut attributions_added = 0;
+        let mut playlist_artwork = Vec::new();
         let mut indices = candidate
             .items
             .iter()
@@ -284,6 +438,9 @@ impl FavoriteStore {
             .map(|(index, item)| ((item.kind, item.summary.spotify_id.clone()), index))
             .collect::<HashMap<_, _>>();
         for (kind, summary, source) in entries {
+            if kind == FavoriteKind::Playlist {
+                playlist_artwork.push((summary.spotify_id.clone(), summary.artwork_url.clone()));
+            }
             let summary = summary_for_persistence(kind, summary);
             let key = (kind, summary.spotify_id.clone());
             if let Some(index) = indices.get(&key).copied() {
@@ -322,6 +479,11 @@ impl FavoriteStore {
         }
         self.persist_locked(&candidate)?;
         *data = candidate;
+        drop(data);
+        let now_ms = now_ts_ms();
+        for (spotify_id, artwork_url) in playlist_artwork {
+            self.remember_playlist_artwork(&spotify_id, artwork_url.as_deref(), now_ms);
+        }
         Ok((items_created, attributions_added))
     }
 
@@ -383,6 +545,23 @@ fn summary_for_persistence(kind: FavoriteKind, mut summary: FavoriteSummary) -> 
         summary.artwork_url = None;
     }
     summary
+}
+
+fn safe_spotify_playlist_artwork_url(value: &str) -> Option<String> {
+    let parsed = reqwest::Url::parse(value.trim()).ok()?;
+    if parsed.scheme() != "https"
+        || !parsed.username().is_empty()
+        || parsed.password().is_some()
+        || parsed.port().is_some()
+    {
+        return None;
+    }
+    let host = parsed.host_str()?.to_ascii_lowercase();
+    let spotify_cdn = host == "scdn.co"
+        || host.ends_with(".scdn.co")
+        || host == "spotifycdn.com"
+        || host.ends_with(".spotifycdn.com");
+    spotify_cdn.then(|| parsed.to_string())
 }
 
 fn load_favorite_file(path: &FsPath) -> io::Result<FavoriteFile> {
@@ -620,6 +799,13 @@ fn first_image(value: &serde_json::Value) -> Option<String> {
         .and_then(|image| string_at(image, &["url"]))
 }
 
+fn playlist_artwork_from_images_response(value: &serde_json::Value) -> Option<String> {
+    value
+        .as_array()
+        .and_then(|images| images.first())
+        .and_then(|image| string_at(image, &["url"]))
+}
+
 fn artists(value: &serde_json::Value) -> Option<String> {
     let names = value
         .get("artists")
@@ -783,10 +969,39 @@ fn validate_playlist_items_page(offset: usize, limit: usize) -> Result<(), JamAp
             "playlist item limit must be between 1 and {MAX_PLAYLIST_ITEMS_LIMIT}"
         )));
     }
-    if offset > 100_000 {
+    if offset > MAX_PLAYLIST_ITEMS_OFFSET {
         return Err(JamApiError::bad_request("offset is too large"));
     }
     Ok(())
+}
+
+pub(crate) fn validate_selected_playlist_positions(
+    positions: &[usize],
+) -> Result<Vec<usize>, JamApiError> {
+    if positions.is_empty() {
+        return Err(JamApiError::bad_request(
+            "selected_positions must contain at least one playlist position",
+        ));
+    }
+    if positions.len() > MAX_PLAYLIST_QUEUE_TRACKS {
+        return Err(playlist_batch_too_large_error(positions.len()));
+    }
+    if positions
+        .iter()
+        .any(|position| *position > MAX_PLAYLIST_ITEMS_OFFSET)
+    {
+        return Err(JamApiError::bad_request(format!(
+            "selected playlist positions must be at most {MAX_PLAYLIST_ITEMS_OFFSET}"
+        )));
+    }
+    let mut canonical = positions.to_vec();
+    canonical.sort_unstable();
+    if canonical.windows(2).any(|pair| pair[0] == pair[1]) {
+        return Err(JamApiError::bad_request(
+            "selected_positions must not contain duplicate positions",
+        ));
+    }
+    Ok(canonical)
 }
 
 fn favorite_track(
@@ -813,6 +1028,11 @@ fn favorite_playlist(
     actor_id: &str,
     summary: FavoriteSummary,
 ) -> CatalogPlaylist {
+    state.jam_favorites.remember_playlist_artwork(
+        &summary.spotify_id,
+        summary.artwork_url.as_deref(),
+        now_ts_ms(),
+    );
     let (favorited_by_me, favorite_contributor_count) =
         state
             .jam_favorites
@@ -922,6 +1142,22 @@ pub(crate) struct PlaylistItemsPage {
     pub(crate) limit: usize,
     pub(crate) total: u64,
     pub(crate) next_offset: Option<usize>,
+    pub(crate) items_source: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) local_cache: Option<PlaylistItemsCacheView>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub(crate) struct PlaylistItemsCacheView {
+    pub(crate) chunk_size: usize,
+    pub(crate) cached_count: usize,
+    pub(crate) cached_chunk_offsets: Vec<usize>,
+    pub(crate) next_missing_chunk_offset: Option<usize>,
+    pub(crate) total: u64,
+    pub(crate) complete: bool,
+    pub(crate) position_limit: usize,
+    pub(crate) truncated: bool,
+    pub(crate) updated_at_ms: u64,
 }
 
 pub(crate) async fn fetch_playlist_summary(
@@ -933,21 +1169,43 @@ pub(crate) async fn fetch_playlist_summary(
     }
     let url = format!("https://api.spotify.com/v1/playlists/{playlist_id}");
     let data = spotify_json_request(state, reqwest::Method::GET, &url, None).await?;
-    normalize_playlist(&data).map_err(|reason| JamApiError {
+    let summary = normalize_playlist(&data).map_err(|reason| JamApiError {
         status: StatusCode::BAD_GATEWAY,
         code: "spotify_invalid_playlist",
         message: format!("Spotify playlist was malformed: {reason}"),
         retry_after: None,
-    })
+    })?;
+    state.jam_favorites.remember_playlist_artwork(
+        &summary.spotify_id,
+        summary.artwork_url.as_deref(),
+        now_ts_ms(),
+    );
+    Ok(summary)
 }
 
-async fn fetch_playlist_items_page(
+async fn fetch_playlist_artwork_url(
+    state: &AppState,
+    playlist_id: &str,
+) -> Result<Option<String>, JamApiError> {
+    if !valid_spotify_id(playlist_id) {
+        return Err(JamApiError::bad_request("invalid Spotify playlist ID"));
+    }
+    let url = format!("https://api.spotify.com/v1/playlists/{playlist_id}/images");
+    let data = spotify_json_request(state, reqwest::Method::GET, &url, None).await?;
+    Ok(playlist_artwork_from_images_response(&data))
+}
+
+async fn fetch_spotify_playlist_items_page(
     state: &AppState,
     playlist_id: &str,
     offset: usize,
     limit: usize,
 ) -> Result<(Vec<(usize, FavoriteSummary)>, Vec<SkippedPlaylistItem>, u64), JamApiError> {
-    validate_playlist_items_page(offset, limit)?;
+    if !(1..=SPOTIFY_PLAYLIST_ITEMS_LIMIT).contains(&limit) {
+        return Err(JamApiError::bad_request(format!(
+            "Spotify playlist item limit must be between 1 and {SPOTIFY_PLAYLIST_ITEMS_LIMIT}"
+        )));
+    }
     if !valid_spotify_id(playlist_id) {
         return Err(JamApiError::bad_request("invalid Spotify playlist ID"));
     }
@@ -958,6 +1216,289 @@ async fn fetch_playlist_items_page(
         .await
         .map_err(map_playlist_items_error)?;
     Ok(normalize_playlist_items_page(&data, offset))
+}
+
+async fn fetch_official_playlist_items_window(
+    state: &AppState,
+    playlist: &FavoriteSummary,
+    offset: usize,
+    limit: usize,
+) -> Result<(Vec<(usize, FavoriteSummary)>, Vec<SkippedPlaylistItem>, u64), JamApiError> {
+    validate_playlist_items_page(offset, limit)?;
+    let playlist_id = &playlist.spotify_id;
+    let mut tracks = Vec::new();
+    let mut skipped = Vec::new();
+    let mut observed_total = None;
+    let requested_end = offset.saturating_add(limit);
+    let mut page_offset = offset;
+
+    while page_offset < requested_end {
+        let page_limit = (requested_end - page_offset).min(SPOTIFY_PLAYLIST_ITEMS_LIMIT);
+        let (page_tracks, page_skipped, total) =
+            fetch_spotify_playlist_items_page(state, playlist_id, page_offset, page_limit).await?;
+        if observed_total.is_some_and(|expected| expected != total) {
+            return Err(playlist_changed_error());
+        }
+        observed_total = Some(total);
+        let returned = page_tracks.len() + page_skipped.len();
+        tracks.extend(page_tracks);
+        skipped.extend(page_skipped);
+        if returned < page_limit || page_offset.saturating_add(returned) >= total as usize {
+            break;
+        }
+        page_offset = page_offset
+            .checked_add(returned)
+            .ok_or_else(playlist_changed_error)?;
+    }
+
+    Ok((tracks, skipped, observed_total.unwrap_or(0)))
+}
+
+fn public_catalog_error(error: PublicCatalogError) -> JamApiError {
+    let retry_after = error.retry_after_seconds.map(|seconds| seconds.to_string());
+    if error.code == "spotify_rate_limited" {
+        return JamApiError {
+            status: StatusCode::TOO_MANY_REQUESTS,
+            code: "spotify_rate_limited",
+            message: error.message,
+            retry_after,
+        };
+    }
+    let status = match error.code {
+        "invalid_spotify_playlist_id" | "invalid_spotify_playlist_offset" => {
+            StatusCode::BAD_REQUEST
+        }
+        "spotify_public_playlist_not_found" => StatusCode::NOT_FOUND,
+        "spotify_public_playlist_unavailable" => StatusCode::FORBIDDEN,
+        _ => StatusCode::BAD_GATEWAY,
+    };
+    JamApiError {
+        status,
+        code: "playlist_catalog_unavailable",
+        message: error.message,
+        retry_after,
+    }
+}
+
+fn cached_playlist_window(
+    state: &AppState,
+    playlist: &FavoriteSummary,
+    offset: usize,
+    limit: usize,
+) -> Option<(Vec<(usize, FavoriteSummary)>, Vec<SkippedPlaylistItem>, u64)> {
+    let snapshot_id = playlist.snapshot_id.as_deref()?;
+    state
+        .jam_playlist_cache
+        .window(&playlist.spotify_id, snapshot_id, offset, limit)
+        .map(|window| {
+            debug_assert_eq!(window.playlist_id, playlist.spotify_id);
+            debug_assert_eq!(window.snapshot_id, snapshot_id);
+            debug_assert_eq!(window.offset, offset);
+            debug_assert_eq!(window.limit, limit);
+            let _ = (window.next_offset, window.complete, window.fetched_at_ms);
+            (window.tracks, window.skipped, window.total)
+        })
+}
+
+async fn fetch_public_playlist_items_window(
+    state: &AppState,
+    playlist: &FavoriteSummary,
+    offset: usize,
+    limit: usize,
+) -> Result<(Vec<(usize, FavoriteSummary)>, Vec<SkippedPlaylistItem>, u64), JamApiError> {
+    validate_public_playlist_items_window(offset, limit)?;
+    let snapshot_id = playlist.snapshot_id.as_deref().ok_or_else(|| JamApiError {
+        status: StatusCode::BAD_GATEWAY,
+        code: "playlist_catalog_unavailable",
+        message:
+            "Spotify did not provide a playlist revision, so Echo cannot safely cache its songs"
+                .to_string(),
+        retry_after: None,
+    })?;
+    if let Some(window) = cached_playlist_window(state, playlist, offset, limit) {
+        return Ok(window);
+    }
+
+    let requested_end = offset.saturating_add(limit);
+    let mut chunk_offset =
+        offset / PLAYLIST_ITEMS_CACHE_CHUNK_SIZE * PLAYLIST_ITEMS_CACHE_CHUNK_SIZE;
+    while chunk_offset < requested_end {
+        if let Some(coverage) = state
+            .jam_playlist_cache
+            .coverage(&playlist.spotify_id, snapshot_id)
+        {
+            if chunk_offset >= coverage.total as usize {
+                return Ok((Vec::new(), Vec::new(), coverage.total));
+            }
+        }
+        if !state
+            .jam_playlist_cache
+            .has_chunk(&playlist.spotify_id, snapshot_id, chunk_offset)
+        {
+            // Only one bounded catalog chunk may be acquired at a time. Recheck
+            // after acquiring the gate so concurrent viewers never fetch the
+            // same 50-position chunk twice.
+            let _refresh = state.jam_playlist_cache_refresh.lock().await;
+            if !state
+                .jam_playlist_cache
+                .has_chunk(&playlist.spotify_id, snapshot_id, chunk_offset)
+            {
+                if let Some((status, message)) = spotify_rate_limit_error(state) {
+                    return Err(JamApiError {
+                        status,
+                        code: "spotify_rate_limited",
+                        message,
+                        retry_after: spotify_retry_after_seconds(state),
+                    });
+                }
+                let _permit =
+                    state
+                        .spotify_request_limit
+                        .acquire()
+                        .await
+                        .map_err(|_| JamApiError {
+                            status: StatusCode::SERVICE_UNAVAILABLE,
+                            code: "playlist_catalog_unavailable",
+                            message: "Spotify request gate is unavailable".to_string(),
+                            retry_after: None,
+                        })?;
+                let chunk = match fetch_public_playlist_chunk(
+                    &state.http_client,
+                    &playlist.spotify_id,
+                    chunk_offset,
+                )
+                .await
+                {
+                    Ok(chunk) => chunk,
+                    Err(error) => {
+                        if error.code == "spotify_rate_limited" {
+                            if let Some(seconds) = error.retry_after_seconds {
+                                remember_spotify_rate_limit_seconds(state, seconds);
+                            }
+                        }
+                        return Err(public_catalog_error(error));
+                    }
+                };
+                drop(_permit);
+                debug_assert_eq!(
+                    chunk.truncated_at_position_limit,
+                    chunk.total_count
+                        > crate::jam_playlist_cache::MAX_PLAYLIST_ITEMS_CACHE_TOTAL as u64
+                );
+                verify_playlist_still_matches_snapshot(
+                    state,
+                    &playlist.spotify_id,
+                    Some(snapshot_id),
+                )
+                .await?;
+                verify_public_playlist_total(playlist, chunk.total_count)?;
+                if chunk.total_count as usize <= chunk_offset && chunk.positions.is_empty() {
+                    return Ok((Vec::new(), Vec::new(), chunk.total_count));
+                }
+                let mut tracks = Vec::new();
+                let mut skipped = Vec::new();
+                for position in chunk.positions {
+                    match position.outcome {
+                        PublicPlaylistPositionOutcome::Track { summary } => {
+                            tracks.push((position.position, summary));
+                        }
+                        PublicPlaylistPositionOutcome::Skipped { reason } => {
+                            skipped.push(SkippedPlaylistItem {
+                                position: position.position,
+                                reason,
+                            });
+                        }
+                    }
+                }
+                state
+                    .jam_playlist_cache
+                    .merge_chunk(
+                        playlist,
+                        chunk.offset,
+                        chunk.total_count,
+                        tracks,
+                        skipped,
+                        now_ts_ms(),
+                    )
+                    .map_err(|error| {
+                        JamApiError::internal(format!(
+                            "Could not persist the private playlist cache: {error}"
+                        ))
+                    })?;
+            }
+        }
+        chunk_offset = chunk_offset.saturating_add(PLAYLIST_ITEMS_CACHE_CHUNK_SIZE);
+    }
+
+    cached_playlist_window(state, playlist, offset, limit).ok_or_else(|| JamApiError {
+        status: StatusCode::BAD_GATEWAY,
+        code: "playlist_catalog_unavailable",
+        message: "Echo could not assemble the requested 50-song playlist chunk".to_string(),
+        retry_after: None,
+    })
+}
+
+fn validate_public_playlist_items_window(offset: usize, limit: usize) -> Result<(), JamApiError> {
+    if offset % PLAYLIST_ITEMS_CACHE_CHUNK_SIZE == 0
+        && limit == PLAYLIST_ITEMS_CACHE_CHUNK_SIZE
+        && offset < crate::jam_playlist_cache::MAX_PLAYLIST_ITEMS_CACHE_TOTAL
+    {
+        Ok(())
+    } else {
+        Err(JamApiError::bad_request(
+            "restricted public playlists must be loaded in one aligned 50-song chunk within Echo's 1,000-position browse limit",
+        ))
+    }
+}
+
+fn playlist_items_next_offset(items_source: &str, total: u64, consumed: usize) -> Option<usize> {
+    let available = if items_source == "local_cache" {
+        total.min(crate::jam_playlist_cache::MAX_PLAYLIST_ITEMS_CACHE_TOTAL as u64)
+    } else {
+        total
+    };
+    let available = usize::try_from(available).unwrap_or(usize::MAX);
+    (consumed < available).then_some(consumed)
+}
+
+async fn fetch_playlist_items_page_with_source(
+    state: &AppState,
+    playlist: &FavoriteSummary,
+    offset: usize,
+    limit: usize,
+) -> Result<
+    (
+        Vec<(usize, FavoriteSummary)>,
+        Vec<SkippedPlaylistItem>,
+        u64,
+        &'static str,
+    ),
+    JamApiError,
+> {
+    validate_playlist_items_page(offset, limit)?;
+    if let Some((tracks, skipped, total)) = cached_playlist_window(state, playlist, offset, limit) {
+        return Ok((tracks, skipped, total, "local_cache"));
+    }
+    match fetch_official_playlist_items_window(state, playlist, offset, limit).await {
+        Ok((tracks, skipped, total)) => Ok((tracks, skipped, total, "spotify")),
+        Err(error) if error.code == "playlist_items_forbidden" => {
+            let (tracks, skipped, total) =
+                fetch_public_playlist_items_window(state, playlist, offset, limit).await?;
+            Ok((tracks, skipped, total, "local_cache"))
+        }
+        Err(error) => Err(error),
+    }
+}
+
+async fn fetch_playlist_items_page(
+    state: &AppState,
+    playlist: &FavoriteSummary,
+    offset: usize,
+    limit: usize,
+) -> Result<(Vec<(usize, FavoriteSummary)>, Vec<SkippedPlaylistItem>, u64), JamApiError> {
+    let (tracks, skipped, total, _) =
+        fetch_playlist_items_page_with_source(state, playlist, offset, limit).await?;
+    Ok((tracks, skipped, total))
 }
 
 fn map_playlist_items_error(error: JamApiError) -> JamApiError {
@@ -1033,13 +1574,35 @@ pub(crate) async fn jam_playlist_items(
         retry_after: None,
     })?;
     let summary = fetch_playlist_summary(&state, &playlist_id).await?;
-    let (tracks, skipped, total) =
-        fetch_playlist_items_page(&state, &playlist_id, query.offset, query.limit).await?;
+    let (tracks, skipped, total, items_source) =
+        fetch_playlist_items_page_with_source(&state, &summary, query.offset, query.limit).await?;
+    let local_cache = (items_source == "local_cache")
+        .then(|| {
+            summary.snapshot_id.as_deref().and_then(|snapshot_id| {
+                state
+                    .jam_playlist_cache
+                    .coverage(&summary.spotify_id, snapshot_id)
+            })
+        })
+        .flatten()
+        .map(|coverage| PlaylistItemsCacheView {
+            chunk_size: PLAYLIST_ITEMS_CACHE_CHUNK_SIZE,
+            cached_count: coverage.cached_count,
+            cached_chunk_offsets: coverage.cached_chunk_offsets,
+            next_missing_chunk_offset: coverage.next_missing_chunk_offset,
+            total: coverage.total,
+            complete: coverage.complete,
+            position_limit: crate::jam_playlist_cache::MAX_PLAYLIST_ITEMS_CACHE_TOTAL,
+            truncated: coverage.total
+                > crate::jam_playlist_cache::MAX_PLAYLIST_ITEMS_CACHE_TOTAL as u64,
+            updated_at_ms: coverage.updated_at_ms,
+        });
     let items = tracks
         .into_iter()
         .map(|(position, summary)| favorite_track(&state, &actor.actor_id, summary, Some(position)))
         .collect();
     let consumed = query.offset.saturating_add(query.limit);
+    let next_offset = playlist_items_next_offset(items_source, total, consumed);
     Ok(Json(PlaylistItemsPage {
         schema_version: CATALOG_SCHEMA_VERSION,
         playlist: favorite_playlist(&state, &actor.actor_id, summary),
@@ -1048,7 +1611,9 @@ pub(crate) async fn jam_playlist_items(
         offset: query.offset,
         limit: query.limit,
         total,
-        next_offset: (consumed < total as usize).then_some(consumed),
+        next_offset,
+        items_source,
+        local_cache,
     }))
 }
 
@@ -1059,33 +1624,217 @@ pub(crate) struct PlaylistExpansion {
     pub(crate) skipped: Vec<SkippedPlaylistItem>,
 }
 
+fn playlist_changed_error() -> JamApiError {
+    JamApiError {
+        status: StatusCode::CONFLICT,
+        code: "playlist_changed",
+        message: "The Spotify playlist changed after it was opened; reload it before queueing"
+            .to_string(),
+        retry_after: None,
+    }
+}
+
+fn verify_public_playlist_total(
+    playlist: &FavoriteSummary,
+    public_total: u64,
+) -> Result<(), JamApiError> {
+    if playlist
+        .track_count
+        .is_some_and(|expected| expected != public_total)
+    {
+        Err(playlist_changed_error())
+    } else {
+        Ok(())
+    }
+}
+
+fn playlist_batch_too_large_error(item_count: usize) -> JamApiError {
+    JamApiError {
+        status: StatusCode::PAYLOAD_TOO_LARGE,
+        code: "playlist_batch_too_large",
+        message: format!(
+            "This playlist operation contains {item_count} items; Echo supports at most {MAX_PLAYLIST_QUEUE_TRACKS} at once. Open the playlist and select a smaller group."
+        ),
+        retry_after: None,
+    }
+}
+
+fn verify_playlist_snapshot(
+    playlist: &FavoriteSummary,
+    expected_snapshot_id: Option<&str>,
+) -> Result<(), JamApiError> {
+    if expected_snapshot_id.is_some() && playlist.snapshot_id.as_deref() != expected_snapshot_id {
+        return Err(playlist_changed_error());
+    }
+    Ok(())
+}
+
+async fn verify_playlist_still_matches_snapshot(
+    state: &AppState,
+    playlist_id: &str,
+    expected_snapshot_id: Option<&str>,
+) -> Result<(), JamApiError> {
+    let Some(expected_snapshot_id) = expected_snapshot_id else {
+        return Ok(());
+    };
+    let latest = fetch_playlist_summary(state, playlist_id).await?;
+    verify_playlist_snapshot(&latest, Some(expected_snapshot_id))
+}
+
 pub(crate) async fn fetch_playlist_expansion(
     state: &AppState,
     playlist_id: &str,
+    expected_snapshot_id: Option<&str>,
 ) -> Result<PlaylistExpansion, JamApiError> {
     let playlist = fetch_playlist_summary(state, playlist_id).await?;
+    verify_playlist_snapshot(&playlist, expected_snapshot_id)?;
+    let consistency_snapshot = expected_snapshot_id.or(playlist.snapshot_id.as_deref());
+    let (tracks, skipped) = collect_playlist_item_pages(|offset| {
+        fetch_playlist_items_page(state, &playlist, offset, MAX_PLAYLIST_ITEMS_LIMIT)
+    })
+    .await?;
+    verify_playlist_still_matches_snapshot(state, playlist_id, consistency_snapshot).await?;
+    Ok(PlaylistExpansion {
+        playlist,
+        tracks,
+        skipped,
+    })
+}
+
+async fn collect_playlist_item_pages<F, Fut>(
+    mut fetch_page: F,
+) -> Result<(Vec<(usize, FavoriteSummary)>, Vec<SkippedPlaylistItem>), JamApiError>
+where
+    F: FnMut(usize) -> Fut,
+    Fut: Future<
+        Output = Result<
+            (Vec<(usize, FavoriteSummary)>, Vec<SkippedPlaylistItem>, u64),
+            JamApiError,
+        >,
+    >,
+{
     let mut offset = 0usize;
+    let mut expected_total = None;
     let mut tracks = Vec::new();
     let mut skipped = Vec::new();
     loop {
-        let (page_tracks, page_skipped, page_total) =
-            fetch_playlist_items_page(state, playlist_id, offset, MAX_PLAYLIST_ITEMS_LIMIT).await?;
-        if page_total > 50 {
-            return Err(JamApiError {
-                status: StatusCode::UNPROCESSABLE_ENTITY,
-                code: "playlist_too_large",
-                message: format!("Playlist has {page_total} items; Echo queues at most 50"),
-                retry_after: None,
-            });
+        let (page_tracks, page_skipped, page_total) = fetch_page(offset).await?;
+        if expected_total.is_some_and(|total| total != page_total) {
+            return Err(playlist_changed_error());
+        }
+        expected_total = Some(page_total);
+        let page_total = usize::try_from(page_total).map_err(|_| playlist_changed_error())?;
+        if page_total > MAX_PLAYLIST_QUEUE_TRACKS {
+            return Err(playlist_batch_too_large_error(page_total));
         }
         let returned = page_tracks.len() + page_skipped.len();
+        if returned == 0 {
+            if offset < page_total {
+                return Err(playlist_changed_error());
+            }
+            break;
+        }
+        let next_offset = offset
+            .checked_add(returned)
+            .filter(|next| *next <= page_total)
+            .ok_or_else(playlist_changed_error)?;
         tracks.extend(page_tracks);
         skipped.extend(page_skipped);
-        offset = offset.saturating_add(returned);
-        if returned == 0 || offset >= page_total as usize {
+        offset = next_offset;
+        if offset == page_total {
             break;
         }
     }
+    Ok((tracks, skipped))
+}
+
+fn selected_playlist_page_offsets(positions: &[usize]) -> Vec<usize> {
+    let mut offsets = positions
+        .iter()
+        .map(|position| position / MAX_PLAYLIST_ITEMS_LIMIT * MAX_PLAYLIST_ITEMS_LIMIT)
+        .collect::<Vec<_>>();
+    offsets.dedup();
+    offsets
+}
+
+fn order_selected_playlist_items(
+    positions: &[usize],
+    tracks: Vec<(usize, FavoriteSummary)>,
+    skipped: Vec<SkippedPlaylistItem>,
+) -> Result<(Vec<(usize, FavoriteSummary)>, Vec<SkippedPlaylistItem>), JamApiError> {
+    let mut tracks_by_position = tracks.into_iter().collect::<HashMap<_, _>>();
+    let mut skipped_by_position = skipped
+        .into_iter()
+        .map(|item| (item.position, item))
+        .collect::<HashMap<_, _>>();
+    let mut selected_tracks = Vec::with_capacity(positions.len());
+    let mut selected_skipped = Vec::new();
+    for position in positions {
+        if let Some(track) = tracks_by_position.remove(position) {
+            selected_tracks.push((*position, track));
+        } else if let Some(item) = skipped_by_position.remove(position) {
+            selected_skipped.push(item);
+        } else {
+            return Err(JamApiError {
+                status: StatusCode::CONFLICT,
+                code: "playlist_changed",
+                message: format!(
+                    "Playlist position {position} is no longer available; reload the playlist before queueing"
+                ),
+                retry_after: None,
+            });
+        }
+    }
+    Ok((selected_tracks, selected_skipped))
+}
+
+pub(crate) async fn fetch_playlist_selection(
+    state: &AppState,
+    playlist_id: &str,
+    selected_positions: &[usize],
+    expected_snapshot_id: Option<&str>,
+) -> Result<PlaylistExpansion, JamApiError> {
+    let positions = validate_selected_playlist_positions(selected_positions)?;
+    let playlist = fetch_playlist_summary(state, playlist_id).await?;
+    verify_playlist_snapshot(&playlist, expected_snapshot_id)?;
+    let consistency_snapshot = expected_snapshot_id.or(playlist.snapshot_id.as_deref());
+    let selected = positions.iter().copied().collect::<HashSet<_>>();
+    let mut tracks = Vec::with_capacity(positions.len());
+    let mut skipped = Vec::new();
+    let mut observed_total = None;
+
+    for offset in selected_playlist_page_offsets(&positions) {
+        let (page_tracks, page_skipped, page_total) =
+            fetch_playlist_items_page(state, &playlist, offset, MAX_PLAYLIST_ITEMS_LIMIT).await?;
+        if observed_total.is_some_and(|total| total != page_total) {
+            return Err(playlist_changed_error());
+        }
+        observed_total = Some(page_total);
+        if positions
+            .iter()
+            .any(|position| *position >= page_total as usize)
+        {
+            return Err(JamApiError {
+                status: StatusCode::UNPROCESSABLE_ENTITY,
+                code: "playlist_position_out_of_range",
+                message: format!("The playlist currently contains {page_total} items"),
+                retry_after: None,
+            });
+        }
+        tracks.extend(
+            page_tracks
+                .into_iter()
+                .filter(|(position, _)| selected.contains(position)),
+        );
+        skipped.extend(
+            page_skipped
+                .into_iter()
+                .filter(|item| selected.contains(&item.position)),
+        );
+    }
+
+    verify_playlist_still_matches_snapshot(state, playlist_id, consistency_snapshot).await?;
+    let (tracks, skipped) = order_selected_playlist_items(&positions, tracks, skipped)?;
     Ok(PlaylistExpansion {
         playlist,
         tracks,
@@ -1217,6 +1966,91 @@ fn validate_favorite_query(query: &FavoriteListQuery) -> Result<(), JamApiError>
     Ok(())
 }
 
+fn bounded_playlist_artwork_misses(mut missing: Vec<String>) -> Vec<String> {
+    missing.truncate(PLAYLIST_ARTWORK_REFRESH_MAX_IDS);
+    missing
+}
+
+async fn hydrate_favorite_playlist_artwork(state: &AppState, views: &mut [FavoriteView]) {
+    let mut missing = state
+        .jam_favorites
+        .apply_cached_playlist_artwork(views, now_ts_ms());
+    if missing.is_empty() {
+        return;
+    }
+    let spotify_connected = state
+        .jam
+        .lock()
+        .unwrap_or_else(|error| error.into_inner())
+        .spotify_token
+        .is_some();
+    if !spotify_connected {
+        return;
+    }
+
+    let deadline = tokio::time::Instant::now() + PLAYLIST_ARTWORK_REFRESH_TIMEOUT;
+    // Multiple viewers can open Library together. Serialize only cache-miss
+    // discovery so a burst does not fetch the same visible covers repeatedly.
+    // Waiting for that lock shares the same short deadline as the optional
+    // Spotify calls, preventing queued viewers from stacking five-second waits.
+    let Ok(_refresh) = tokio::time::timeout_at(
+        deadline,
+        state.jam_favorites.playlist_artwork_refresh.lock(),
+    )
+    .await
+    else {
+        return;
+    };
+    missing = bounded_playlist_artwork_misses(
+        state
+            .jam_favorites
+            .apply_cached_playlist_artwork(views, now_ts_ms()),
+    );
+    if missing.is_empty() {
+        return;
+    }
+
+    let artwork_generation = state.jam_favorites.playlist_artwork_generation();
+    let mut requests = Box::pin(
+        stream::iter(missing.into_iter().map(|spotify_id| async move {
+            let result = fetch_playlist_artwork_url(state, &spotify_id).await;
+            (spotify_id, result)
+        }))
+        .buffer_unordered(PLAYLIST_ARTWORK_REFRESH_CONCURRENCY),
+    );
+    // Covers are optional presentation metadata. Preserve results that arrive
+    // promptly, but never let Spotify's per-request timeout multiply across a
+    // full Favorites page and hold the Library open.
+    loop {
+        let next = tokio::time::timeout_at(deadline, requests.next()).await;
+        let Ok(Some((spotify_id, result))) = next else {
+            break;
+        };
+        match result {
+            Ok(artwork_url) => state.jam_favorites.remember_playlist_artwork_if_generation(
+                &spotify_id,
+                artwork_url.as_deref(),
+                now_ts_ms(),
+                artwork_generation,
+            ),
+            // Cover art is presentation-only. A private/public access change,
+            // expired authorization, or Spotify failure must never fail the
+            // durable Favorites list. The global 429 cooldown already prevents
+            // repeated network requests while Spotify asks Echo to wait.
+            Err(error) if error.status == StatusCode::TOO_MANY_REQUESTS => {}
+            Err(_) => state.jam_favorites.remember_playlist_artwork_if_generation(
+                &spotify_id,
+                None,
+                now_ts_ms(),
+                artwork_generation,
+            ),
+        }
+    }
+    state
+        .jam_favorites
+        .apply_cached_playlist_artwork(views, now_ts_ms());
+}
+
 pub(crate) async fn jam_favorites_list(
     State(state): State<AppState>,
     headers: HeaderMap,
@@ -1300,7 +2134,7 @@ pub(crate) async fn jam_favorites_list(
         .iter()
         .filter(|item| item.kind == FavoriteKind::Playlist)
         .count();
-    let views = items
+    let mut views = items
         .into_iter()
         .skip(query.offset)
         .take(query.limit)
@@ -1314,7 +2148,8 @@ pub(crate) async fn jam_favorites_list(
                 .any(|entry| entry.actor_id == actor.actor_id),
             attributions: item.attributions,
         })
-        .collect();
+        .collect::<Vec<_>>();
+    hydrate_favorite_playlist_artwork(&state, &mut views).await;
     Ok(Json(FavoriteListResponse {
         schema_version: FAVORITES_SCHEMA_VERSION,
         items: views,
@@ -1393,15 +2228,19 @@ pub(crate) async fn jam_favorite_put(
     .await
     .map_err(|error| JamApiError::internal(format!("Favorite storage task failed: {error}")))?
     .map_err(|error| JamApiError::internal(format!("Could not persist favorite: {error}")))?;
+    let mut view = FavoriteView {
+        kind: item.kind,
+        summary: item.summary,
+        contributor_count: item.attributions.len(),
+        favorited_by_me: true,
+        attributions: item.attributions,
+    };
+    state
+        .jam_favorites
+        .apply_cached_playlist_artwork(std::slice::from_mut(&mut view), now_ts_ms());
     Ok(Json(FavoriteMutationResponse {
         ok: true,
-        item: Some(FavoriteView {
-            kind: item.kind,
-            summary: item.summary,
-            contributor_count: item.attributions.len(),
-            favorited_by_me: true,
-            attributions: item.attributions,
-        }),
+        item: Some(view),
     }))
 }
 
@@ -1481,6 +2320,20 @@ pub(crate) async fn jam_favorites_import_spotify(
         message: "A current Echo participant token is required".to_string(),
         retry_after: None,
     })?;
+    {
+        let jam = state.jam.lock().unwrap_or_else(|error| error.into_inner());
+        if jam.spotify_token.is_none() {
+            return Err(JamApiError {
+                status: StatusCode::BAD_REQUEST,
+                code: "spotify_not_connected",
+                message: "Connect Spotify before importing favorites".to_string(),
+                retry_after: None,
+            });
+        }
+        if !spotify_library_scopes_authorized(jam.spotify_token.as_ref()) {
+            return Err(spotify_library_scope_required_error());
+        }
+    }
     let imported_at_ms = now_ts_ms();
     let mut tracks_seen = 0;
     let mut playlists_seen = 0;
@@ -1659,9 +2512,44 @@ mod tests {
         assert_eq!(playlist.track_count, Some(42));
         assert_eq!(playlist.owner.as_deref(), Some("Sam"));
         assert_eq!(
+            playlist.artwork_url.as_deref(),
+            Some("https://image.example/p.jpg")
+        );
+        assert_eq!(
             playlist.spotify_url,
             format!("https://open.spotify.com/playlist/{ID_B}")
         );
+    }
+
+    #[test]
+    fn playlist_artwork_accepts_only_https_spotify_cdn_urls() {
+        for value in [
+            "https://i.scdn.co/image/cover",
+            "https://mosaic.scdn.co/640/cover",
+            "https://image-cdn-ak.spotifycdn.com/image/cover?sig=temporary",
+        ] {
+            assert_eq!(
+                safe_spotify_playlist_artwork_url(value).as_deref(),
+                Some(value)
+            );
+        }
+        for value in [
+            "http://i.scdn.co/image/cover",
+            "https://evilscdn.co/image/cover",
+            "https://spotifycdn.com.evil.example/image/cover",
+            "https://user@i.scdn.co/image/cover",
+            "https://i.scdn.co:8443/image/cover",
+        ] {
+            assert!(safe_spotify_playlist_artwork_url(value).is_none());
+        }
+        assert_eq!(
+            playlist_artwork_from_images_response(&serde_json::json!([
+                {"url":"https://i.scdn.co/image/cover"}
+            ]))
+            .as_deref(),
+            Some("https://i.scdn.co/image/cover")
+        );
+        assert!(playlist_artwork_from_images_response(&serde_json::json!([])).is_none());
     }
 
     #[test]
@@ -1696,6 +2584,130 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec![(11, "unplayable"), (12, "local_track"), (14, "malformed")]
         );
+    }
+
+    #[tokio::test]
+    async fn full_playlist_expansion_fetches_every_page_and_preserves_cross_page_occurrences() {
+        let seen_offsets = Mutex::new(Vec::new());
+        let (tracks, skipped) = collect_playlist_item_pages(|offset| {
+            seen_offsets
+                .lock()
+                .unwrap_or_else(|error| error.into_inner())
+                .push(offset);
+            let result = match offset {
+                0 => {
+                    let tracks = (0..50)
+                        .filter(|position| *position != 10)
+                        .map(|position| {
+                            let id = if position == 49 { ID_A } else { ID_B };
+                            (position, summary(id, &format!("Song {position}")))
+                        })
+                        .collect();
+                    let skipped = vec![SkippedPlaylistItem {
+                        position: 10,
+                        reason: "local_track".to_string(),
+                    }];
+                    Ok((tracks, skipped, 120))
+                }
+                50 => Ok((
+                    (50..100)
+                        .map(|position| {
+                            let id = if position == 50 { ID_A } else { ID_C };
+                            (position, summary(id, &format!("Song {position}")))
+                        })
+                        .collect(),
+                    Vec::new(),
+                    120,
+                )),
+                100 => Ok((
+                    (100..119)
+                        .map(|position| (position, summary(ID_B, &format!("Song {position}"))))
+                        .collect(),
+                    vec![SkippedPlaylistItem {
+                        position: 119,
+                        reason: "unplayable".to_string(),
+                    }],
+                    120,
+                )),
+                _ => panic!("unexpected playlist page offset {offset}"),
+            };
+            std::future::ready(result)
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(
+            seen_offsets
+                .lock()
+                .unwrap_or_else(|error| error.into_inner())
+                .clone(),
+            vec![0, 50, 100]
+        );
+        assert_eq!(tracks.len(), 118);
+        assert_eq!(
+            skipped.iter().map(|item| item.position).collect::<Vec<_>>(),
+            vec![10, 119]
+        );
+        let boundary = tracks
+            .iter()
+            .filter(|(position, _)| matches!(*position, 49 | 50))
+            .map(|(position, track)| (*position, track.spotify_id.as_str()))
+            .collect::<Vec<_>>();
+        assert_eq!(boundary, vec![(49, ID_A), (50, ID_A)]);
+    }
+
+    #[tokio::test]
+    async fn full_playlist_expansion_rejects_changing_totals_and_premature_empty_pages() {
+        let changing_total = collect_playlist_item_pages(|offset| {
+            std::future::ready(match offset {
+                0 => Ok((
+                    (0..50)
+                        .map(|position| (position, summary(ID_A, "Song")))
+                        .collect(),
+                    Vec::new(),
+                    120,
+                )),
+                50 => Ok((
+                    (50..100)
+                        .map(|position| (position, summary(ID_B, "Song")))
+                        .collect(),
+                    Vec::new(),
+                    121,
+                )),
+                _ => panic!("unexpected playlist page offset {offset}"),
+            })
+        })
+        .await
+        .unwrap_err();
+        assert_eq!(changing_total.status, StatusCode::CONFLICT);
+        assert_eq!(changing_total.code, "playlist_changed");
+
+        let premature_empty = collect_playlist_item_pages(|offset| {
+            std::future::ready(match offset {
+                0 => Ok((
+                    (0..50)
+                        .map(|position| (position, summary(ID_A, "Song")))
+                        .collect(),
+                    Vec::new(),
+                    120,
+                )),
+                50 => Ok((Vec::new(), Vec::new(), 120)),
+                _ => panic!("unexpected playlist page offset {offset}"),
+            })
+        })
+        .await
+        .unwrap_err();
+        assert_eq!(premature_empty.status, StatusCode::CONFLICT);
+        assert_eq!(premature_empty.code, "playlist_changed");
+
+        let oversized = collect_playlist_item_pages(|offset| {
+            assert_eq!(offset, 0);
+            std::future::ready(Ok((Vec::new(), Vec::new(), 1_001)))
+        })
+        .await
+        .unwrap_err();
+        assert_eq!(oversized.status, StatusCode::PAYLOAD_TOO_LARGE);
+        assert_eq!(oversized.code, "playlist_batch_too_large");
     }
 
     #[test]
@@ -1791,6 +2803,7 @@ mod tests {
         let mut playlist = summary(ID_B, "Mix");
         playlist.spotify_uri = format!("spotify:playlist:{ID_B}");
         playlist.spotify_url = format!("https://open.spotify.com/playlist/{ID_B}");
+        playlist.artwork_url = Some("https://i.scdn.co/image/temporary-cover".to_string());
         store
             .upsert(
                 FavoriteKind::Playlist,
@@ -1800,10 +2813,80 @@ mod tests {
                 10,
             )
             .unwrap();
-        assert!(store.snapshot()[0].summary.artwork_url.is_none());
+        let item = store.snapshot().remove(0);
+        assert!(item.summary.artwork_url.is_none());
+        let mut views = vec![FavoriteView {
+            kind: item.kind,
+            summary: item.summary,
+            contributor_count: item.attributions.len(),
+            favorited_by_me: true,
+            attributions: item.attributions,
+        }];
+        assert!(store
+            .apply_cached_playlist_artwork(&mut views, now_ts_ms())
+            .is_empty());
+        assert_eq!(
+            views[0].summary.artwork_url.as_deref(),
+            Some("https://i.scdn.co/image/temporary-cover")
+        );
         let persisted = fs::read_to_string(path).unwrap();
-        assert!(!persisted.contains("image.example"));
+        assert!(!persisted.contains("i.scdn.co"));
         let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn playlist_artwork_cache_is_bounded_expires_and_clears() {
+        let store = FavoriteStore::empty(PathBuf::from("unused-favorites.json"));
+        assert_eq!(PLAYLIST_ARTWORK_REFRESH_TIMEOUT, Duration::from_secs(5));
+        assert_eq!(PLAYLIST_ARTWORK_REFRESH_MAX_IDS, 50);
+        assert_eq!(
+            bounded_playlist_artwork_misses((0..200).map(|index| format!("{index:022}")).collect())
+                .len(),
+            PLAYLIST_ARTWORK_REFRESH_MAX_IDS
+        );
+        for index in 0..=PLAYLIST_ARTWORK_CACHE_MAX_ENTRIES {
+            let spotify_id = format!("{index:022}");
+            store.remember_playlist_artwork(
+                &spotify_id,
+                Some("https://mosaic.scdn.co/640/cover"),
+                index as u64,
+            );
+        }
+        assert_eq!(
+            store
+                .playlist_artwork
+                .lock()
+                .unwrap_or_else(|error| error.into_inner())
+                .len(),
+            PLAYLIST_ARTWORK_CACHE_MAX_ENTRIES
+        );
+        store.remember_playlist_artwork(
+            ID_B,
+            Some("https://i.scdn.co/image/temporary-cover"),
+            1_000,
+        );
+        assert!(store.cached_playlist_artwork(ID_B, 1_000).is_some());
+        assert!(store
+            .cached_playlist_artwork(
+                ID_B,
+                1_000_u64.saturating_add(PLAYLIST_ARTWORK_CACHE_TTL_MS)
+            )
+            .is_none());
+        store.remember_playlist_artwork(
+            ID_B,
+            Some("https://i.scdn.co/image/temporary-cover"),
+            2_000,
+        );
+        let stale_generation = store.playlist_artwork_generation();
+        store.clear_playlist_artwork_cache();
+        assert!(store.cached_playlist_artwork(ID_B, 2_000).is_none());
+        store.remember_playlist_artwork_if_generation(
+            ID_B,
+            Some("https://i.scdn.co/image/old-account-cover"),
+            2_001,
+            stale_generation,
+        );
+        assert!(store.cached_playlist_artwork(ID_B, 2_001).is_none());
     }
 
     #[test]
@@ -1915,6 +2998,123 @@ mod tests {
         assert!(validate_search_page(0, 11).is_err());
         assert!(validate_playlist_items_page(0, 50).is_ok());
         assert!(validate_playlist_items_page(0, 51).is_err());
+    }
+
+    #[test]
+    fn restricted_public_windows_are_one_aligned_chunk_within_the_browse_cap() {
+        assert!(validate_public_playlist_items_window(0, 50).is_ok());
+        assert!(validate_public_playlist_items_window(950, 50).is_ok());
+        assert!(validate_public_playlist_items_window(25, 50).is_err());
+        assert!(validate_public_playlist_items_window(0, 100).is_err());
+        assert!(validate_public_playlist_items_window(1_000, 50).is_err());
+    }
+
+    #[test]
+    fn restricted_public_paging_stops_at_one_thousand_without_hiding_the_source_total() {
+        assert_eq!(
+            playlist_items_next_offset("local_cache", 1_200, 900),
+            Some(900)
+        );
+        assert_eq!(
+            playlist_items_next_offset("local_cache", 1_200, 1_000),
+            None
+        );
+        assert_eq!(
+            playlist_items_next_offset("local_cache", 268, 200),
+            Some(200)
+        );
+        assert_eq!(playlist_items_next_offset("local_cache", 268, 300), None);
+        assert_eq!(
+            playlist_items_next_offset("spotify", 1_200, 1_000),
+            Some(1_000)
+        );
+    }
+
+    #[test]
+    fn selected_playlist_positions_are_nonempty_unique_bounded_and_canonical() {
+        assert_eq!(
+            validate_selected_playlist_positions(&[50, 0, 49, 100_000]).unwrap(),
+            vec![0, 49, 50, 100_000]
+        );
+        assert!(validate_selected_playlist_positions(&[]).is_err());
+        assert!(validate_selected_playlist_positions(&[7, 7]).is_err());
+        assert!(validate_selected_playlist_positions(&[100_001]).is_err());
+        assert!(validate_selected_playlist_positions(
+            &(0..=MAX_PLAYLIST_QUEUE_TRACKS).collect::<Vec<_>>()
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn selected_playlist_pages_only_cover_requested_positions() {
+        assert_eq!(
+            selected_playlist_page_offsets(&[0, 49, 50, 51, 100]),
+            vec![0, 50, 100]
+        );
+    }
+
+    #[test]
+    fn selected_playlist_items_preserve_occurrences_and_playlist_order() {
+        let tracks = vec![
+            (9, summary(ID_A, "Later duplicate")),
+            (2, summary(ID_A, "Earlier duplicate")),
+            (4, summary(ID_B, "Not selected")),
+        ];
+        let skipped = vec![
+            SkippedPlaylistItem {
+                position: 5,
+                reason: "local_track".to_string(),
+            },
+            SkippedPlaylistItem {
+                position: 8,
+                reason: "unplayable".to_string(),
+            },
+        ];
+        let (selected_tracks, selected_skipped) =
+            order_selected_playlist_items(&[2, 5, 9], tracks, skipped).unwrap();
+        assert_eq!(
+            selected_tracks
+                .iter()
+                .map(|(position, track)| (*position, track.name.as_str()))
+                .collect::<Vec<_>>(),
+            vec![(2, "Earlier duplicate"), (9, "Later duplicate")]
+        );
+        assert_eq!(selected_skipped.len(), 1);
+        assert_eq!(selected_skipped[0].position, 5);
+    }
+
+    #[test]
+    fn selected_playlist_items_reject_a_missing_occurrence() {
+        let error = order_selected_playlist_items(
+            &[2, 3],
+            vec![(2, summary(ID_A, "Available"))],
+            Vec::new(),
+        )
+        .unwrap_err();
+        assert_eq!(error.status, StatusCode::CONFLICT);
+        assert_eq!(error.code, "playlist_changed");
+    }
+
+    #[test]
+    fn playlist_snapshot_validation_rejects_stale_selections() {
+        let mut playlist = summary(ID_A, "Mix");
+        playlist.snapshot_id = Some("current".to_string());
+        assert!(verify_playlist_snapshot(&playlist, Some("current")).is_ok());
+        let error = verify_playlist_snapshot(&playlist, Some("stale")).unwrap_err();
+        assert_eq!(error.status, StatusCode::CONFLICT);
+        assert_eq!(error.code, "playlist_changed");
+    }
+
+    #[test]
+    fn public_catalog_total_must_match_the_official_playlist_summary() {
+        let mut playlist = summary(ID_A, "Mix");
+        playlist.track_count = Some(268);
+        assert!(verify_public_playlist_total(&playlist, 268).is_ok());
+        let error = verify_public_playlist_total(&playlist, 267).unwrap_err();
+        assert_eq!(error.status, StatusCode::CONFLICT);
+        assert_eq!(error.code, "playlist_changed");
+        playlist.track_count = None;
+        assert!(verify_public_playlist_total(&playlist, 999).is_ok());
     }
 
     #[test]

--- a/core/control/src/jam_playlist_cache.rs
+++ b/core/control/src/jam_playlist_cache.rs
@@ -1,0 +1,1213 @@
+use crate::jam_library::{valid_spotify_id, FavoriteSummary, SkippedPlaylistItem};
+
+use rand::{rngs::OsRng, RngCore};
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+use std::fs::{self, OpenOptions};
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+use tracing::warn;
+
+pub(crate) const PLAYLIST_ITEMS_CACHE_SCHEMA_VERSION: u16 = 2;
+pub(crate) const PLAYLIST_ITEMS_CACHE_CHUNK_SIZE: usize = 50;
+pub(crate) const MAX_PLAYLIST_ITEMS_CACHE_TOTAL: usize = 1_000;
+const MAX_PLAYLIST_ITEMS_SOURCE_TOTAL: usize = 100_000;
+
+// Keep this derived cache useful without letting rarely opened playlists grow
+// the control-plane data directory forever.
+const MAX_CACHE_ENTRIES: usize = 64;
+const MAX_CACHE_POSITIONS: usize = 10_000;
+const MAX_SNAPSHOT_ID_LEN: usize = 512;
+const MAX_SKIP_REASON_LEN: usize = 256;
+
+#[derive(Clone, Debug)]
+pub(crate) struct CachedPlaylistWindow {
+    pub(crate) playlist_id: String,
+    pub(crate) snapshot_id: String,
+    pub(crate) tracks: Vec<(usize, FavoriteSummary)>,
+    pub(crate) skipped: Vec<SkippedPlaylistItem>,
+    pub(crate) offset: usize,
+    pub(crate) limit: usize,
+    pub(crate) total: u64,
+    pub(crate) next_offset: Option<usize>,
+    pub(crate) complete: bool,
+    pub(crate) fetched_at_ms: u64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct PlaylistCacheCoverage {
+    pub(crate) total: u64,
+    pub(crate) cached_count: usize,
+    pub(crate) cached_chunk_offsets: Vec<usize>,
+    pub(crate) next_missing_chunk_offset: Option<usize>,
+    pub(crate) complete: bool,
+    pub(crate) updated_at_ms: u64,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct PlaylistCacheFile {
+    schema_version: u16,
+    entries: Vec<PlaylistCacheEntry>,
+}
+
+impl Default for PlaylistCacheFile {
+    fn default() -> Self {
+        Self {
+            schema_version: PLAYLIST_ITEMS_CACHE_SCHEMA_VERSION,
+            entries: Vec::new(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct PlaylistCacheEntry {
+    playlist_id: String,
+    snapshot_id: String,
+    total: usize,
+    updated_at_ms: u64,
+    chunks: Vec<PersistedChunk>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct PersistedChunk {
+    offset: usize,
+    fetched_at_ms: u64,
+    slots: Vec<PersistedSlot>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+enum PersistedSlot {
+    Track { summary: FavoriteSummary },
+    Skipped { reason: String },
+}
+
+/// Persistent, process-thread-safe storage for user-requested Spotify playlist
+/// pages. The store performs no network I/O; callers provide one complete,
+/// aligned chunk and the store validates it before replacing the durable file.
+pub(crate) struct PlaylistItemsCache {
+    path: PathBuf,
+    writable: bool,
+    inner: Mutex<PlaylistCacheFile>,
+}
+
+impl PlaylistItemsCache {
+    pub(crate) fn open(path: PathBuf) -> io::Result<Self> {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        let backup = backup_path(&path);
+        let data = if path.exists() {
+            load_file(&path)?
+        } else if backup.exists() {
+            let recovered = load_file(&backup)?;
+            fs::rename(&backup, &path)?;
+            warn!(
+                "Recovered Jam playlist-items cache from {:?} after an interrupted atomic write",
+                backup
+            );
+            recovered
+        } else {
+            PlaylistCacheFile::default()
+        };
+        Ok(Self {
+            path,
+            writable: true,
+            inner: Mutex::new(data),
+        })
+    }
+
+    /// Preserve an unreadable primary file while exposing its last valid
+    /// atomic backup. Mutations remain disabled so neither copy is overwritten.
+    pub(crate) fn recover_read_only(path: PathBuf) -> Self {
+        let data = load_file(&backup_path(&path)).unwrap_or_default();
+        Self {
+            path,
+            writable: false,
+            inner: Mutex::new(data),
+        }
+    }
+
+    pub(crate) fn disabled(path: PathBuf) -> Self {
+        Self {
+            path,
+            writable: false,
+            inner: Mutex::new(PlaylistCacheFile::default()),
+        }
+    }
+
+    /// Return a requested window only when every playlist position in that
+    /// window is cached. Windows may cross the fixed 50-position chunk
+    /// boundary; tracks and skipped positions are returned in playlist order.
+    pub(crate) fn window(
+        &self,
+        playlist_id: &str,
+        snapshot_id: &str,
+        offset: usize,
+        limit: usize,
+    ) -> Option<CachedPlaylistWindow> {
+        if !valid_key(playlist_id, snapshot_id) || limit > MAX_PLAYLIST_ITEMS_CACHE_TOTAL {
+            return None;
+        }
+        let data = self.inner.lock().unwrap_or_else(|error| error.into_inner());
+        let entry = find_entry(&data, playlist_id, snapshot_id)?;
+        let cacheable_total = cacheable_total(entry.total);
+        if offset > cacheable_total {
+            return None;
+        }
+        let end = offset.checked_add(limit)?.min(cacheable_total);
+        let mut tracks = Vec::new();
+        let mut skipped = Vec::new();
+        let mut fetched_at_ms = 0;
+        for position in offset..end {
+            let chunk_offset = aligned_offset(position);
+            let chunk = entry
+                .chunks
+                .iter()
+                .find(|chunk| chunk.offset == chunk_offset)?;
+            let slot = chunk.slots.get(position - chunk_offset)?;
+            fetched_at_ms = fetched_at_ms.max(chunk.fetched_at_ms);
+            match slot {
+                PersistedSlot::Track { summary } => tracks.push((position, summary.clone())),
+                PersistedSlot::Skipped { reason } => skipped.push(SkippedPlaylistItem {
+                    position,
+                    reason: reason.clone(),
+                }),
+            }
+        }
+        let complete = entry_complete(entry);
+        Some(CachedPlaylistWindow {
+            playlist_id: playlist_id.to_string(),
+            snapshot_id: snapshot_id.to_string(),
+            tracks,
+            skipped,
+            offset,
+            limit,
+            total: entry.total as u64,
+            next_offset: (end < cacheable_total).then_some(end),
+            complete,
+            fetched_at_ms,
+        })
+    }
+
+    pub(crate) fn has_chunk(&self, playlist_id: &str, snapshot_id: &str, offset: usize) -> bool {
+        if !valid_key(playlist_id, snapshot_id) || offset % PLAYLIST_ITEMS_CACHE_CHUNK_SIZE != 0 {
+            return false;
+        }
+        let data = self.inner.lock().unwrap_or_else(|error| error.into_inner());
+        find_entry(&data, playlist_id, snapshot_id)
+            .is_some_and(|entry| entry.chunks.iter().any(|chunk| chunk.offset == offset))
+    }
+
+    pub(crate) fn coverage(
+        &self,
+        playlist_id: &str,
+        snapshot_id: &str,
+    ) -> Option<PlaylistCacheCoverage> {
+        if !valid_key(playlist_id, snapshot_id) {
+            return None;
+        }
+        let data = self.inner.lock().unwrap_or_else(|error| error.into_inner());
+        let entry = find_entry(&data, playlist_id, snapshot_id)?;
+        Some(entry_coverage(entry))
+    }
+
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) fn cached_count(&self, playlist_id: &str, snapshot_id: &str) -> usize {
+        self.coverage(playlist_id, snapshot_id)
+            .map(|coverage| coverage.cached_count)
+            .unwrap_or(0)
+    }
+
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) fn complete(&self, playlist_id: &str, snapshot_id: &str) -> bool {
+        self.coverage(playlist_id, snapshot_id)
+            .is_some_and(|coverage| coverage.complete)
+    }
+
+    /// Validate and merge exactly one aligned chunk. Every expected position
+    /// must appear once, as either a track or a skipped item. Duplicate songs
+    /// are intentionally retained because positions, not Spotify IDs, are the
+    /// cache identity.
+    pub(crate) fn merge_chunk(
+        &self,
+        playlist: &FavoriteSummary,
+        offset: usize,
+        total: u64,
+        tracks: Vec<(usize, FavoriteSummary)>,
+        skipped: Vec<SkippedPlaylistItem>,
+        fetched_at_ms: u64,
+    ) -> io::Result<()> {
+        self.ensure_writable()?;
+        let snapshot_id = playlist.snapshot_id.as_deref().ok_or_else(|| {
+            invalid_input("playlist cache requires a nonempty Spotify snapshot ID")
+        })?;
+        validate_key(&playlist.spotify_id, snapshot_id)?;
+        let total = usize::try_from(total)
+            .ok()
+            .filter(|total| *total <= MAX_PLAYLIST_ITEMS_SOURCE_TOTAL)
+            .ok_or_else(|| {
+                invalid_input(format!(
+                    "playlist source total must be at most {MAX_PLAYLIST_ITEMS_SOURCE_TOTAL}"
+                ))
+            })?;
+        let chunk = build_chunk(offset, total, tracks, skipped, fetched_at_ms)?;
+
+        let mut data = self.inner.lock().unwrap_or_else(|error| error.into_inner());
+        let mut candidate = data.clone();
+
+        // A Spotify snapshot is immutable. Once a newer snapshot for the same
+        // playlist is merged, its stale cache can never satisfy a current read.
+        candidate.entries.retain(|entry| {
+            entry.playlist_id != playlist.spotify_id || entry.snapshot_id == snapshot_id
+        });
+        let entry = if let Some(entry) = candidate.entries.iter_mut().find(|entry| {
+            entry.playlist_id == playlist.spotify_id && entry.snapshot_id == snapshot_id
+        }) {
+            if entry.total != total {
+                return Err(invalid_input(
+                    "playlist total changed without a new Spotify snapshot ID",
+                ));
+            }
+            entry
+        } else {
+            candidate.entries.push(PlaylistCacheEntry {
+                playlist_id: playlist.spotify_id.clone(),
+                snapshot_id: snapshot_id.to_string(),
+                total,
+                updated_at_ms: fetched_at_ms,
+                chunks: Vec::new(),
+            });
+            candidate
+                .entries
+                .last_mut()
+                .expect("entry was just inserted")
+        };
+        entry.updated_at_ms = entry.updated_at_ms.max(fetched_at_ms);
+        if let Some(existing) = entry
+            .chunks
+            .iter_mut()
+            .find(|existing| existing.offset == offset)
+        {
+            *existing = chunk;
+        } else {
+            entry.chunks.push(chunk);
+            entry.chunks.sort_by_key(|chunk| chunk.offset);
+        }
+
+        let protected = (playlist.spotify_id.as_str(), snapshot_id);
+        prune_to_limits(&mut candidate, protected);
+        self.persist_locked(&candidate)?;
+        *data = candidate;
+        Ok(())
+    }
+
+    /// Remove one exact playlist/snapshot cache key.
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) fn invalidate_snapshot(
+        &self,
+        playlist_id: &str,
+        snapshot_id: &str,
+    ) -> io::Result<bool> {
+        self.ensure_writable()?;
+        validate_key(playlist_id, snapshot_id)?;
+        let mut data = self.inner.lock().unwrap_or_else(|error| error.into_inner());
+        let mut candidate = data.clone();
+        let before = candidate.entries.len();
+        candidate
+            .entries
+            .retain(|entry| entry.playlist_id != playlist_id || entry.snapshot_id != snapshot_id);
+        if candidate.entries.len() == before {
+            return Ok(false);
+        }
+        self.persist_locked(&candidate)?;
+        *data = candidate;
+        Ok(true)
+    }
+
+    /// Remove cached snapshots for a playlist other than the supplied current
+    /// snapshot. This is useful immediately after fetching playlist metadata.
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) fn invalidate_stale_snapshots(
+        &self,
+        playlist_id: &str,
+        current_snapshot_id: &str,
+    ) -> io::Result<usize> {
+        self.ensure_writable()?;
+        validate_key(playlist_id, current_snapshot_id)?;
+        let mut data = self.inner.lock().unwrap_or_else(|error| error.into_inner());
+        let mut candidate = data.clone();
+        let before = candidate.entries.len();
+        candidate.entries.retain(|entry| {
+            entry.playlist_id != playlist_id || entry.snapshot_id == current_snapshot_id
+        });
+        let removed = before - candidate.entries.len();
+        if removed == 0 {
+            return Ok(0);
+        }
+        self.persist_locked(&candidate)?;
+        *data = candidate;
+        Ok(removed)
+    }
+
+    fn ensure_writable(&self) -> io::Result<()> {
+        if self.writable {
+            Ok(())
+        } else {
+            Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "playlist-items cache is unavailable or read-only",
+            ))
+        }
+    }
+
+    fn persist_locked(&self, data: &PlaylistCacheFile) -> io::Result<()> {
+        let bytes = serde_json::to_vec_pretty(data)
+            .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+        write_atomic(&self.path, &bytes)
+    }
+}
+
+fn build_chunk(
+    offset: usize,
+    total: usize,
+    tracks: Vec<(usize, FavoriteSummary)>,
+    skipped: Vec<SkippedPlaylistItem>,
+    fetched_at_ms: u64,
+) -> io::Result<PersistedChunk> {
+    if offset % PLAYLIST_ITEMS_CACHE_CHUNK_SIZE != 0 {
+        return Err(invalid_input(format!(
+            "playlist cache offset must be aligned to {PLAYLIST_ITEMS_CACHE_CHUNK_SIZE}"
+        )));
+    }
+    let cacheable_total = cacheable_total(total);
+    if (total == 0 && offset != 0) || (total > 0 && offset >= cacheable_total) {
+        return Err(invalid_input(
+            "playlist cache offset is outside the playlist",
+        ));
+    }
+    let expected_len = total
+        .saturating_sub(offset)
+        .min(PLAYLIST_ITEMS_CACHE_CHUNK_SIZE);
+    let mut slots = vec![None; expected_len];
+    for (position, summary) in tracks {
+        validate_position(position, offset, expected_len)?;
+        validate_track_summary(&summary)?;
+        let index = position - offset;
+        if slots[index].is_some() {
+            return Err(invalid_input(format!(
+                "playlist cache position {position} was supplied more than once"
+            )));
+        }
+        slots[index] = Some(PersistedSlot::Track { summary });
+    }
+    for item in skipped {
+        validate_position(item.position, offset, expected_len)?;
+        validate_skip_reason(&item.reason)?;
+        let index = item.position - offset;
+        if slots[index].is_some() {
+            return Err(invalid_input(format!(
+                "playlist cache position {} was supplied more than once",
+                item.position
+            )));
+        }
+        slots[index] = Some(PersistedSlot::Skipped {
+            reason: item.reason,
+        });
+    }
+    let slots = slots
+        .into_iter()
+        .enumerate()
+        .map(|(index, slot)| {
+            slot.ok_or_else(|| {
+                invalid_input(format!(
+                    "playlist cache chunk is missing position {}",
+                    offset + index
+                ))
+            })
+        })
+        .collect::<io::Result<Vec<_>>>()?;
+    Ok(PersistedChunk {
+        offset,
+        fetched_at_ms,
+        slots,
+    })
+}
+
+fn validate_position(position: usize, offset: usize, expected_len: usize) -> io::Result<()> {
+    if position < offset || position >= offset.saturating_add(expected_len) {
+        Err(invalid_input(format!(
+            "playlist cache position {position} is outside this chunk"
+        )))
+    } else {
+        Ok(())
+    }
+}
+
+fn validate_track_summary(summary: &FavoriteSummary) -> io::Result<()> {
+    let expected_uri = format!("spotify:track:{}", summary.spotify_id);
+    let expected_url = format!("https://open.spotify.com/track/{}", summary.spotify_id);
+    if !valid_spotify_id(&summary.spotify_id)
+        || summary.spotify_uri != expected_uri
+        || summary.spotify_url != expected_url
+        || summary.name.trim().is_empty()
+        || summary
+            .artist
+            .as_deref()
+            .is_none_or(|artist| artist.trim().is_empty())
+    {
+        return Err(invalid_input(
+            "playlist cache contains a malformed Spotify track summary",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_skip_reason(reason: &str) -> io::Result<()> {
+    if reason.trim().is_empty()
+        || reason.len() > MAX_SKIP_REASON_LEN
+        || reason.chars().any(char::is_control)
+    {
+        Err(invalid_input(
+            "playlist cache contains an invalid skip reason",
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+fn aligned_offset(position: usize) -> usize {
+    position / PLAYLIST_ITEMS_CACHE_CHUNK_SIZE * PLAYLIST_ITEMS_CACHE_CHUNK_SIZE
+}
+
+fn cacheable_total(total: usize) -> usize {
+    total.min(MAX_PLAYLIST_ITEMS_CACHE_TOTAL)
+}
+
+fn find_entry<'a>(
+    data: &'a PlaylistCacheFile,
+    playlist_id: &str,
+    snapshot_id: &str,
+) -> Option<&'a PlaylistCacheEntry> {
+    data.entries
+        .iter()
+        .find(|entry| entry.playlist_id == playlist_id && entry.snapshot_id == snapshot_id)
+}
+
+fn entry_complete(entry: &PlaylistCacheEntry) -> bool {
+    if entry.total > MAX_PLAYLIST_ITEMS_CACHE_TOTAL {
+        return false;
+    }
+    if entry.total == 0 {
+        return entry
+            .chunks
+            .iter()
+            .any(|chunk| chunk.offset == 0 && chunk.slots.is_empty());
+    }
+    (0..entry.total)
+        .step_by(PLAYLIST_ITEMS_CACHE_CHUNK_SIZE)
+        .all(|offset| entry.chunks.iter().any(|chunk| chunk.offset == offset))
+}
+
+fn entry_coverage(entry: &PlaylistCacheEntry) -> PlaylistCacheCoverage {
+    let mut cached_chunk_offsets = entry
+        .chunks
+        .iter()
+        .map(|chunk| chunk.offset)
+        .collect::<Vec<_>>();
+    cached_chunk_offsets.sort_unstable();
+    let next_missing_chunk_offset = if entry.total == 0 {
+        (!entry_complete(entry)).then_some(0)
+    } else {
+        (0..cacheable_total(entry.total))
+            .step_by(PLAYLIST_ITEMS_CACHE_CHUNK_SIZE)
+            .find(|offset| !cached_chunk_offsets.contains(offset))
+    };
+    PlaylistCacheCoverage {
+        total: entry.total as u64,
+        cached_count: entry.chunks.iter().map(|chunk| chunk.slots.len()).sum(),
+        cached_chunk_offsets,
+        next_missing_chunk_offset,
+        complete: entry_complete(entry),
+        updated_at_ms: entry.updated_at_ms,
+    }
+}
+
+fn valid_key(playlist_id: &str, snapshot_id: &str) -> bool {
+    valid_spotify_id(playlist_id)
+        && !snapshot_id.trim().is_empty()
+        && snapshot_id.len() <= MAX_SNAPSHOT_ID_LEN
+        && !snapshot_id.chars().any(char::is_control)
+}
+
+fn validate_key(playlist_id: &str, snapshot_id: &str) -> io::Result<()> {
+    if valid_key(playlist_id, snapshot_id) {
+        Ok(())
+    } else {
+        Err(invalid_input(
+            "playlist cache requires a valid playlist ID and nonempty snapshot ID",
+        ))
+    }
+}
+
+fn prune_to_limits(data: &mut PlaylistCacheFile, protected: (&str, &str)) {
+    while data.entries.len() > MAX_CACHE_ENTRIES
+        || data
+            .entries
+            .iter()
+            .map(|entry| {
+                entry
+                    .chunks
+                    .iter()
+                    .map(|chunk| chunk.slots.len())
+                    .sum::<usize>()
+            })
+            .sum::<usize>()
+            > MAX_CACHE_POSITIONS
+    {
+        let Some(index) = data
+            .entries
+            .iter()
+            .enumerate()
+            .filter(|(_, entry)| {
+                entry.playlist_id != protected.0 || entry.snapshot_id != protected.1
+            })
+            .min_by_key(|(_, entry)| entry.updated_at_ms)
+            .map(|(index, _)| index)
+        else {
+            break;
+        };
+        data.entries.remove(index);
+    }
+}
+
+fn load_file(path: &Path) -> io::Result<PlaylistCacheFile> {
+    let bytes = fs::read(path)?;
+    let parsed: PlaylistCacheFile = serde_json::from_slice(&bytes)
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+    validate_file(parsed)
+}
+
+fn validate_file(mut data: PlaylistCacheFile) -> io::Result<PlaylistCacheFile> {
+    if data.schema_version != PLAYLIST_ITEMS_CACHE_SCHEMA_VERSION {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "unsupported playlist-items cache schema {}",
+                data.schema_version
+            ),
+        ));
+    }
+    if data.entries.len() > MAX_CACHE_ENTRIES {
+        return Err(invalid_data("playlist-items cache has too many entries"));
+    }
+    let mut keys = HashSet::new();
+    let mut cached_positions = 0usize;
+    for entry in &mut data.entries {
+        validate_key(&entry.playlist_id, &entry.snapshot_id)
+            .map_err(|error| invalid_data(error.to_string()))?;
+        if entry.total > MAX_PLAYLIST_ITEMS_SOURCE_TOTAL
+            || !keys.insert((entry.playlist_id.clone(), entry.snapshot_id.clone()))
+            || entry.chunks.is_empty()
+        {
+            return Err(invalid_data(
+                "playlist-items cache contains an invalid or duplicate entry",
+            ));
+        }
+        let mut offsets = HashSet::new();
+        for chunk in &entry.chunks {
+            if chunk.offset % PLAYLIST_ITEMS_CACHE_CHUNK_SIZE != 0
+                || !offsets.insert(chunk.offset)
+                || (entry.total == 0 && chunk.offset != 0)
+                || (entry.total > 0 && chunk.offset >= cacheable_total(entry.total))
+            {
+                return Err(invalid_data(
+                    "playlist-items cache contains an invalid chunk offset",
+                ));
+            }
+            let expected_len = entry
+                .total
+                .saturating_sub(chunk.offset)
+                .min(PLAYLIST_ITEMS_CACHE_CHUNK_SIZE);
+            if chunk.slots.len() != expected_len {
+                return Err(invalid_data(
+                    "playlist-items cache chunk does not cover every expected position",
+                ));
+            }
+            for slot in &chunk.slots {
+                match slot {
+                    PersistedSlot::Track { summary } => validate_track_summary(summary),
+                    PersistedSlot::Skipped { reason } => validate_skip_reason(reason),
+                }
+                .map_err(|error| invalid_data(error.to_string()))?;
+            }
+            cached_positions = cached_positions.saturating_add(chunk.slots.len());
+        }
+        entry.chunks.sort_by_key(|chunk| chunk.offset);
+        entry.updated_at_ms = entry
+            .chunks
+            .iter()
+            .map(|chunk| chunk.fetched_at_ms)
+            .max()
+            .unwrap_or(entry.updated_at_ms)
+            .max(entry.updated_at_ms);
+    }
+    if cached_positions > MAX_CACHE_POSITIONS {
+        return Err(invalid_data(
+            "playlist-items cache contains too many positions",
+        ));
+    }
+    Ok(data)
+}
+
+fn backup_path(path: &Path) -> PathBuf {
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("playlist-items-cache-v2.json");
+    parent.join(format!("{file_name}.bak"))
+}
+
+fn write_atomic(path: &Path, bytes: &[u8]) -> io::Result<()> {
+    let parent = path.parent().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "playlist-items cache path has no parent",
+        )
+    })?;
+    fs::create_dir_all(parent)?;
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| invalid_input("invalid playlist-items cache filename"))?;
+    let mut random = [0u8; 8];
+    OsRng.fill_bytes(&mut random);
+    let suffix = random
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>();
+    let temp = parent.join(format!("{file_name}.{suffix}.tmp"));
+    let backup = backup_path(path);
+    let mut output = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&temp)?;
+    output.write_all(bytes)?;
+    output.sync_all()?;
+    drop(output);
+
+    if backup.exists() {
+        fs::remove_file(&backup)?;
+    }
+    let had_original = path.exists();
+    if had_original {
+        fs::rename(path, &backup)?;
+    }
+    if let Err(error) = fs::rename(&temp, path) {
+        if had_original {
+            let _ = fs::rename(&backup, path);
+        }
+        let _ = fs::remove_file(&temp);
+        return Err(error);
+    }
+    Ok(())
+}
+
+fn invalid_input(message: impl Into<String>) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidInput, message.into())
+}
+
+fn invalid_data(message: impl Into<String>) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, message.into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    const PLAYLIST_A: &str = "2a514BsnnFkgMBxVrCAOEj";
+    const PLAYLIST_B: &str = "37i9dQZF1DXcBWIGoYBM5M";
+    const TRACK_A: &str = "0VjIjW4GlUZAMYd2vXMi3b";
+    const TRACK_B: &str = "4cOdK2wGLETKBW3PvgPWqT";
+
+    fn temp_path(label: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "echo-playlist-cache-{label}-{}",
+            crate::config::random_secret()
+        ));
+        fs::create_dir_all(&dir).unwrap();
+        dir.join("playlist-items-cache-v2.json")
+    }
+
+    fn playlist(id: &str, snapshot_id: &str) -> FavoriteSummary {
+        FavoriteSummary {
+            spotify_id: id.to_string(),
+            spotify_uri: format!("spotify:playlist:{id}"),
+            spotify_url: format!("https://open.spotify.com/playlist/{id}"),
+            name: "Test playlist".to_string(),
+            snapshot_id: Some(snapshot_id.to_string()),
+            ..FavoriteSummary::default()
+        }
+    }
+
+    fn track(id: &str, name: &str) -> FavoriteSummary {
+        FavoriteSummary {
+            spotify_id: id.to_string(),
+            spotify_uri: format!("spotify:track:{id}"),
+            spotify_url: format!("https://open.spotify.com/track/{id}"),
+            name: name.to_string(),
+            artist: Some("Test Artist".to_string()),
+            duration_ms: Some(180_000),
+            ..FavoriteSummary::default()
+        }
+    }
+
+    fn full_tracks(offset: usize, count: usize) -> Vec<(usize, FavoriteSummary)> {
+        (offset..offset + count)
+            .map(|position| {
+                let id = if position % 2 == 0 { TRACK_A } else { TRACK_B };
+                (position, track(id, &format!("Track {position}")))
+            })
+            .collect()
+    }
+
+    #[test]
+    fn persists_order_duplicates_and_skipped_positions() {
+        let path = temp_path("roundtrip");
+        let cache = PlaylistItemsCache::open(path.clone()).unwrap();
+        let mut tracks = full_tracks(0, 50);
+        tracks.retain(|(position, _)| *position != 17);
+        cache
+            .merge_chunk(
+                &playlist(PLAYLIST_A, "snapshot-a"),
+                0,
+                50,
+                tracks,
+                vec![SkippedPlaylistItem {
+                    position: 17,
+                    reason: "local_track".to_string(),
+                }],
+                111,
+            )
+            .unwrap();
+        drop(cache);
+
+        let reopened = PlaylistItemsCache::open(path).unwrap();
+        let window = reopened.window(PLAYLIST_A, "snapshot-a", 15, 5).unwrap();
+        assert_eq!(
+            window.tracks.iter().map(|item| item.0).collect::<Vec<_>>(),
+            vec![15, 16, 18, 19]
+        );
+        assert_eq!(window.tracks[0].1.spotify_id, TRACK_B);
+        assert_eq!(window.tracks[2].1.spotify_id, TRACK_A);
+        assert_eq!(window.skipped.len(), 1);
+        assert_eq!(window.skipped[0].position, 17);
+        assert_eq!(window.total, 50);
+        assert!(window.complete);
+        assert_eq!(window.fetched_at_ms, 111);
+    }
+
+    #[test]
+    fn partial_cache_reports_coverage_and_only_serves_covered_windows() {
+        let path = temp_path("coverage");
+        let cache = PlaylistItemsCache::open(path).unwrap();
+        let summary = playlist(PLAYLIST_A, "snapshot-a");
+        cache
+            .merge_chunk(&summary, 100, 268, full_tracks(100, 50), vec![], 200)
+            .unwrap();
+
+        assert!(cache.window(PLAYLIST_A, "snapshot-a", 100, 50).is_some());
+        assert!(cache.window(PLAYLIST_A, "snapshot-a", 90, 20).is_none());
+        assert!(cache.has_chunk(PLAYLIST_A, "snapshot-a", 100));
+        assert!(!cache.has_chunk(PLAYLIST_A, "snapshot-a", 0));
+        let coverage = cache.coverage(PLAYLIST_A, "snapshot-a").unwrap();
+        assert_eq!(coverage.total, 268);
+        assert_eq!(coverage.cached_count, 50);
+        assert_eq!(coverage.cached_chunk_offsets, vec![100]);
+        assert_eq!(coverage.next_missing_chunk_offset, Some(0));
+        assert!(!coverage.complete);
+    }
+
+    #[test]
+    fn six_chunks_complete_a_268_position_playlist() {
+        let path = temp_path("complete");
+        let cache = PlaylistItemsCache::open(path).unwrap();
+        let summary = playlist(PLAYLIST_A, "snapshot-a");
+        cache
+            .merge_chunk(&summary, 0, 268, full_tracks(0, 50), vec![], 100)
+            .unwrap();
+        cache
+            .merge_chunk(&summary, 50, 268, full_tracks(50, 50), vec![], 150)
+            .unwrap();
+        cache
+            .merge_chunk(&summary, 100, 268, full_tracks(100, 50), vec![], 200)
+            .unwrap();
+        cache
+            .merge_chunk(&summary, 150, 268, full_tracks(150, 50), vec![], 250)
+            .unwrap();
+        cache
+            .merge_chunk(&summary, 200, 268, full_tracks(200, 50), vec![], 300)
+            .unwrap();
+        cache
+            .merge_chunk(&summary, 250, 268, full_tracks(250, 18), vec![], 350)
+            .unwrap();
+
+        assert!(cache.complete(PLAYLIST_A, "snapshot-a"));
+        assert_eq!(cache.cached_count(PLAYLIST_A, "snapshot-a"), 268);
+        let coverage = cache.coverage(PLAYLIST_A, "snapshot-a").unwrap();
+        assert_eq!(
+            coverage.cached_chunk_offsets,
+            vec![0, 50, 100, 150, 200, 250]
+        );
+        assert_eq!(coverage.next_missing_chunk_offset, None);
+        let window = cache.window(PLAYLIST_A, "snapshot-a", 190, 50).unwrap();
+        assert_eq!(window.tracks.len(), 50);
+        assert_eq!(window.next_offset, Some(240));
+    }
+
+    #[test]
+    fn oversized_playlist_caches_only_the_first_thousand_positions() {
+        let path = temp_path("position-limit");
+        let cache = PlaylistItemsCache::open(path).unwrap();
+        let summary = playlist(PLAYLIST_A, "snapshot-large");
+        for offset in (0..MAX_PLAYLIST_ITEMS_CACHE_TOTAL).step_by(PLAYLIST_ITEMS_CACHE_CHUNK_SIZE) {
+            cache
+                .merge_chunk(
+                    &summary,
+                    offset,
+                    1_200,
+                    full_tracks(offset, PLAYLIST_ITEMS_CACHE_CHUNK_SIZE),
+                    vec![],
+                    offset as u64,
+                )
+                .unwrap();
+        }
+
+        let coverage = cache.coverage(PLAYLIST_A, "snapshot-large").unwrap();
+        assert_eq!(coverage.total, 1_200);
+        assert_eq!(coverage.cached_count, 1_000);
+        assert_eq!(coverage.next_missing_chunk_offset, None);
+        assert!(!coverage.complete);
+        let last = cache.window(PLAYLIST_A, "snapshot-large", 950, 50).unwrap();
+        assert_eq!(last.tracks.len(), 50);
+        assert_eq!(last.next_offset, None);
+        assert!(cache
+            .merge_chunk(
+                &summary,
+                1_000,
+                1_200,
+                full_tracks(1_000, 50),
+                vec![],
+                1_000,
+            )
+            .is_err());
+    }
+
+    #[test]
+    fn merge_rejects_unaligned_incomplete_duplicate_and_oversized_chunks() {
+        let path = temp_path("validation");
+        let cache = PlaylistItemsCache::open(path).unwrap();
+        let summary = playlist(PLAYLIST_A, "snapshot-a");
+        assert_eq!(
+            cache
+                .merge_chunk(&summary, 1, 100, full_tracks(1, 49), vec![], 1)
+                .unwrap_err()
+                .kind(),
+            io::ErrorKind::InvalidInput
+        );
+        assert!(cache
+            .merge_chunk(&summary, 0, 100, full_tracks(0, 49), vec![], 1)
+            .is_err());
+        let mut duplicate = full_tracks(0, 50);
+        duplicate.push((0, track(TRACK_A, "Duplicate position")));
+        assert!(cache
+            .merge_chunk(&summary, 0, 100, duplicate, vec![], 1)
+            .is_err());
+        assert!(cache
+            .merge_chunk(&summary, 0, 100_001, full_tracks(0, 50), vec![], 1)
+            .is_err());
+        assert!(cache.coverage(PLAYLIST_A, "snapshot-a").is_none());
+    }
+
+    #[test]
+    fn final_chunk_must_cover_exact_remaining_positions() {
+        let path = temp_path("final-chunk");
+        let cache = PlaylistItemsCache::open(path).unwrap();
+        let summary = playlist(PLAYLIST_A, "snapshot-a");
+        assert!(cache
+            .merge_chunk(&summary, 250, 268, full_tracks(250, 17), vec![], 1)
+            .is_err());
+        assert!(cache
+            .merge_chunk(&summary, 250, 268, full_tracks(250, 19), vec![], 1)
+            .is_err());
+        cache
+            .merge_chunk(&summary, 250, 268, full_tracks(250, 18), vec![], 1)
+            .unwrap();
+        assert!(cache.has_chunk(PLAYLIST_A, "snapshot-a", 250));
+    }
+
+    #[test]
+    fn empty_playlist_has_a_complete_zero_length_chunk() {
+        let path = temp_path("empty");
+        let cache = PlaylistItemsCache::open(path).unwrap();
+        cache
+            .merge_chunk(
+                &playlist(PLAYLIST_A, "snapshot-empty"),
+                0,
+                0,
+                vec![],
+                vec![],
+                5,
+            )
+            .unwrap();
+        assert!(cache.complete(PLAYLIST_A, "snapshot-empty"));
+        let window = cache.window(PLAYLIST_A, "snapshot-empty", 0, 50).unwrap();
+        assert!(window.tracks.is_empty());
+        assert!(window.skipped.is_empty());
+        assert_eq!(window.next_offset, None);
+    }
+
+    #[test]
+    fn snapshot_is_required_and_new_snapshot_prunes_old_snapshot() {
+        let path = temp_path("snapshots");
+        let cache = PlaylistItemsCache::open(path).unwrap();
+        let mut missing = playlist(PLAYLIST_A, "unused");
+        missing.snapshot_id = None;
+        assert!(cache
+            .merge_chunk(&missing, 0, 1, full_tracks(0, 1), vec![], 1)
+            .is_err());
+
+        cache
+            .merge_chunk(
+                &playlist(PLAYLIST_A, "snapshot-a"),
+                0,
+                1,
+                full_tracks(0, 1),
+                vec![],
+                1,
+            )
+            .unwrap();
+        cache
+            .merge_chunk(
+                &playlist(PLAYLIST_A, "snapshot-b"),
+                0,
+                1,
+                full_tracks(0, 1),
+                vec![],
+                2,
+            )
+            .unwrap();
+        assert!(cache.coverage(PLAYLIST_A, "snapshot-a").is_none());
+        assert!(cache.coverage(PLAYLIST_A, "snapshot-b").is_some());
+    }
+
+    #[test]
+    fn total_mismatch_does_not_mutate_existing_snapshot() {
+        let path = temp_path("total-mismatch");
+        let cache = PlaylistItemsCache::open(path.clone()).unwrap();
+        let summary = playlist(PLAYLIST_A, "snapshot-a");
+        cache
+            .merge_chunk(&summary, 0, 100, full_tracks(0, 50), vec![], 1)
+            .unwrap();
+        let error = cache
+            .merge_chunk(&summary, 0, 99, full_tracks(0, 50), vec![], 2)
+            .unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            "playlist total changed without a new Spotify snapshot ID"
+        );
+        assert_eq!(cache.coverage(PLAYLIST_A, "snapshot-a").unwrap().total, 100);
+        drop(cache);
+        assert_eq!(
+            PlaylistItemsCache::open(path)
+                .unwrap()
+                .coverage(PLAYLIST_A, "snapshot-a")
+                .unwrap()
+                .total,
+            100
+        );
+    }
+
+    #[test]
+    fn exact_and_stale_snapshot_invalidation_are_durable() {
+        let path = temp_path("invalidate");
+        let cache = PlaylistItemsCache::open(path.clone()).unwrap();
+        cache
+            .merge_chunk(
+                &playlist(PLAYLIST_A, "snapshot-a"),
+                0,
+                1,
+                full_tracks(0, 1),
+                vec![],
+                1,
+            )
+            .unwrap();
+        cache
+            .merge_chunk(
+                &playlist(PLAYLIST_B, "snapshot-b"),
+                0,
+                1,
+                full_tracks(0, 1),
+                vec![],
+                2,
+            )
+            .unwrap();
+        assert_eq!(
+            cache
+                .invalidate_stale_snapshots(PLAYLIST_A, "snapshot-current")
+                .unwrap(),
+            1
+        );
+        assert!(cache.invalidate_snapshot(PLAYLIST_B, "snapshot-b").unwrap());
+        assert!(!cache.invalidate_snapshot(PLAYLIST_B, "snapshot-b").unwrap());
+        drop(cache);
+        let reopened = PlaylistItemsCache::open(path).unwrap();
+        assert!(reopened.coverage(PLAYLIST_A, "snapshot-a").is_none());
+        assert!(reopened.coverage(PLAYLIST_B, "snapshot-b").is_none());
+    }
+
+    #[test]
+    fn missing_primary_recovers_last_atomic_backup() {
+        let path = temp_path("backup-recovery");
+        let cache = PlaylistItemsCache::open(path.clone()).unwrap();
+        let summary = playlist(PLAYLIST_A, "snapshot-a");
+        cache
+            .merge_chunk(&summary, 0, 100, full_tracks(0, 50), vec![], 1)
+            .unwrap();
+        cache
+            .merge_chunk(&summary, 50, 100, full_tracks(50, 50), vec![], 2)
+            .unwrap();
+        drop(cache);
+        fs::remove_file(&path).unwrap();
+        assert!(backup_path(&path).exists());
+
+        let recovered = PlaylistItemsCache::open(path.clone()).unwrap();
+        assert!(path.exists());
+        assert!(!backup_path(&path).exists());
+        assert!(recovered.has_chunk(PLAYLIST_A, "snapshot-a", 0));
+        assert!(!recovered.has_chunk(PLAYLIST_A, "snapshot-a", 50));
+    }
+
+    #[test]
+    fn corrupt_primary_can_use_valid_backup_read_only() {
+        let path = temp_path("readonly-recovery");
+        let cache = PlaylistItemsCache::open(path.clone()).unwrap();
+        let summary = playlist(PLAYLIST_A, "snapshot-a");
+        cache
+            .merge_chunk(&summary, 0, 100, full_tracks(0, 50), vec![], 1)
+            .unwrap();
+        cache
+            .merge_chunk(&summary, 50, 100, full_tracks(50, 50), vec![], 2)
+            .unwrap();
+        drop(cache);
+        fs::write(&path, b"not json").unwrap();
+        assert_eq!(
+            PlaylistItemsCache::open(path.clone()).err().unwrap().kind(),
+            io::ErrorKind::InvalidData
+        );
+
+        let recovered = PlaylistItemsCache::recover_read_only(path.clone());
+        assert!(recovered.has_chunk(PLAYLIST_A, "snapshot-a", 0));
+        assert!(!recovered.has_chunk(PLAYLIST_A, "snapshot-a", 50));
+        assert_eq!(
+            recovered
+                .merge_chunk(&summary, 50, 100, full_tracks(50, 50), vec![], 3)
+                .unwrap_err()
+                .kind(),
+            io::ErrorKind::PermissionDenied
+        );
+        assert_eq!(fs::read(&path).unwrap(), b"not json");
+    }
+
+    #[test]
+    fn unsupported_schema_is_rejected() {
+        let path = temp_path("schema");
+        fs::write(&path, br#"{"schema_version":3,"entries":[]}"#).unwrap();
+        assert_eq!(
+            PlaylistItemsCache::open(path).err().unwrap().kind(),
+            io::ErrorKind::InvalidData
+        );
+    }
+
+    #[test]
+    fn disabled_cache_serves_no_data_and_rejects_mutation() {
+        let path = temp_path("disabled");
+        let cache = PlaylistItemsCache::disabled(path);
+        assert!(cache.window(PLAYLIST_A, "snapshot-a", 0, 50).is_none());
+        assert_eq!(
+            cache
+                .merge_chunk(
+                    &playlist(PLAYLIST_A, "snapshot-a"),
+                    0,
+                    1,
+                    full_tracks(0, 1),
+                    vec![],
+                    1,
+                )
+                .unwrap_err()
+                .kind(),
+            io::ErrorKind::PermissionDenied
+        );
+    }
+
+    #[test]
+    fn concurrent_chunk_merges_are_serialized_without_lost_updates() {
+        let path = temp_path("concurrent");
+        let cache = Arc::new(PlaylistItemsCache::open(path).unwrap());
+        let summary = Arc::new(playlist(PLAYLIST_A, "snapshot-a"));
+        let mut workers = Vec::new();
+        for chunk_index in 0..(MAX_PLAYLIST_ITEMS_CACHE_TOTAL / PLAYLIST_ITEMS_CACHE_CHUNK_SIZE) {
+            let cache = Arc::clone(&cache);
+            let summary = Arc::clone(&summary);
+            workers.push(std::thread::spawn(move || {
+                let offset = chunk_index * PLAYLIST_ITEMS_CACHE_CHUNK_SIZE;
+                cache
+                    .merge_chunk(
+                        &summary,
+                        offset,
+                        1_000,
+                        full_tracks(offset, PLAYLIST_ITEMS_CACHE_CHUNK_SIZE),
+                        vec![],
+                        chunk_index as u64,
+                    )
+                    .unwrap();
+            }));
+        }
+        for worker in workers {
+            worker.join().unwrap();
+        }
+        assert!(cache.complete(PLAYLIST_A, "snapshot-a"));
+        assert_eq!(cache.cached_count(PLAYLIST_A, "snapshot-a"), 1_000);
+    }
+
+    #[test]
+    fn cache_prunes_least_recently_used_entries_at_its_bound() {
+        let path = temp_path("bounded");
+        let cache = PlaylistItemsCache::open(path).unwrap();
+        for index in 0..=MAX_CACHE_ENTRIES {
+            let id = format!("{:022}", index);
+            cache
+                .merge_chunk(
+                    &playlist(&id, &format!("snapshot-{index}")),
+                    0,
+                    1,
+                    full_tracks(0, 1),
+                    vec![],
+                    index as u64,
+                )
+                .unwrap();
+        }
+        assert!(cache
+            .coverage(&format!("{:022}", 0), "snapshot-0")
+            .is_none());
+        assert!(cache
+            .coverage(
+                &format!("{:022}", MAX_CACHE_ENTRIES),
+                &format!("snapshot-{MAX_CACHE_ENTRIES}")
+            )
+            .is_some());
+    }
+}

--- a/core/control/src/jam_session.rs
+++ b/core/control/src/jam_session.rs
@@ -3,10 +3,11 @@ use crate::auth::{
     RevokedParticipantBinding,
 };
 use crate::config::*;
-use crate::jam_history::new_history_observation;
+use crate::jam_history::{new_history_observation, HistoryObservation};
 use crate::jam_library::{
-    fetch_favorite_summary, fetch_playlist_expansion, valid_spotify_id, FavoriteKind,
-    FavoriteSummary, JamApiError, SkippedPlaylistItem,
+    fetch_favorite_summary, fetch_playlist_expansion, fetch_playlist_selection, valid_spotify_id,
+    validate_selected_playlist_positions, FavoriteKind, FavoriteSummary, JamApiError,
+    SkippedPlaylistItem,
 };
 use crate::rooms::schedule_jam_auto_end;
 use crate::AppState;
@@ -19,7 +20,7 @@ use axum::{
 };
 use serde::{Deserialize, Serialize};
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     fs,
     future::Future,
     time::{Duration, SystemTime, UNIX_EPOCH},
@@ -30,6 +31,14 @@ const SPOTIFY_RELEASE_PAUSE_TIMEOUT: Duration = Duration::from_secs(15);
 const SPOTIFY_START_BIND_TIMEOUT: Duration = Duration::from_secs(15);
 const SPOTIFY_RECOVERY_OPERATION_TIMEOUT: Duration = Duration::from_secs(15);
 const SOURCE_START_RECHECK_INTERVAL: Duration = Duration::from_millis(100);
+const SPOTIFY_COMMITTED_QUEUE_FRONTIER: usize = 2;
+const MAX_QUEUE_REMOVAL_ENTRIES: usize = 1_000;
+const SPOTIFY_LIBRARY_SCOPES: [&str; 3] = [
+    "user-library-read",
+    "playlist-read-private",
+    "playlist-read-collaborative",
+];
+const SPOTIFY_CALLBACK_RECEIVED_HTML: &str = "<html><body><h1>Spotify authorization received</h1><p>Return to Echo Chamber while it verifies the connection. You can close this tab.</p></body></html>";
 
 // ── Structs ──────────────────────────────────────────────────────────────
 
@@ -38,6 +47,26 @@ pub(crate) struct SpotifyToken {
     pub(crate) access_token: String,
     pub(crate) refresh_token: String,
     pub(crate) expires_at: u64, // unix timestamp
+    #[serde(default)]
+    pub(crate) scope: String,
+}
+
+fn spotify_scope_from_token_response(data: &serde_json::Value, fallback: Option<&str>) -> String {
+    data.get("scope")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_else(|| fallback.unwrap_or_default())
+        .to_string()
+}
+
+pub(crate) fn spotify_library_scopes_authorized(token: Option<&SpotifyToken>) -> bool {
+    token.is_some_and(|token| {
+        SPOTIFY_LIBRARY_SCOPES.iter().all(|required_scope| {
+            token
+                .scope
+                .split_ascii_whitespace()
+                .any(|granted_scope| granted_scope == *required_scope)
+        })
+    })
 }
 
 pub(crate) struct SpotifyPending {
@@ -53,11 +82,20 @@ pub(crate) struct JamState {
     pub(crate) host_identity: String,
     pub(crate) host_participant_auth_id: String,
     pub(crate) spotify_token: Option<SpotifyToken>,
-    pub(crate) queue: Vec<QueuedTrack>,
+    pub(crate) queue: Vec<JamQueueEntry>,
+    pub(crate) queue_revision: u64,
+    pub(crate) track_queue_receipts: HashMap<String, TrackQueueReceipt>,
     pub(crate) playlist_queue_receipts: HashMap<String, PlaylistQueueReceipt>,
+    pub(crate) queue_removal_receipts: HashMap<String, QueueRemovalReceipt>,
     pub(crate) queue_control_epoch: u64,
+    // Monotonic admission fence for any transition into a stopped queue. Unlike
+    // `queue_control_stopped`, this is not cleared when a later explicit add
+    // resumes playback, so work admitted before Stop cannot reappear afterward.
+    pub(crate) queue_stop_epoch: u64,
     pub(crate) queue_control_stopped: bool,
+    pub(crate) uncertain_skip: Option<UncertainSkipBoundary>,
     pub(crate) last_history_spotify_id: Option<String>,
+    pub(crate) last_history_was_echo: bool,
     pub(crate) now_playing: Option<NowPlayingInfo>,
     pub(crate) listeners: HashMap<String, String>,
     pub(crate) audio_connections: HashMap<String, JamAudioConnection>,
@@ -67,6 +105,32 @@ pub(crate) struct JamState {
     pub(crate) last_error: Option<String>,
     pub(crate) spotify_is_playing: bool,
     pub(crate) audio_expected_since: Option<std::time::Instant>,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum QueueDeliveryState {
+    Pending,
+    #[default]
+    SpotifyCommitted,
+    CommitUnknown,
+}
+
+impl QueueDeliveryState {
+    fn is_removable(self) -> bool {
+        self == Self::Pending
+    }
+
+    fn occupies_spotify_frontier(self) -> bool {
+        matches!(self, Self::SpotifyCommitted | Self::CommitUnknown)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+enum QueueCurrentMatchState {
+    #[default]
+    Eligible,
+    AwaitingTransition,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -107,14 +171,90 @@ pub(crate) struct QueuedTrack {
     pub(crate) added_by_name: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) playlist: Option<QueuedPlaylistProvenance>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) playlist_position: Option<usize>,
     // Kept for compatibility with the existing viewer during rollout.
     pub(crate) added_by: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub(crate) struct JamQueueEntry {
+    #[serde(flatten)]
+    pub(crate) track: QueuedTrack,
+    #[serde(default)]
+    pub(crate) delivery_state: QueueDeliveryState,
+    #[serde(default)]
+    pub(crate) can_remove: bool,
+    // A track placed through Spotify's Add to Queue endpoint is not the current
+    // occurrence yet. Keep that distinction internal so an already-playing
+    // track with the same URI cannot steal this queue entry's provenance.
+    #[serde(skip)]
+    current_match_state: QueueCurrentMatchState,
+}
+
+fn pending_queue_entry(track: QueuedTrack) -> JamQueueEntry {
+    JamQueueEntry {
+        track,
+        delivery_state: QueueDeliveryState::Pending,
+        can_remove: true,
+        current_match_state: QueueCurrentMatchState::Eligible,
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct TrackQueueReceipt {
+    actor_id: String,
+    spotify_id: String,
+    generation: u64,
+    created_at_ms: u64,
+    track: JamQueueEntry,
+}
+
+fn insert_track_queue_receipt(jam: &mut JamState, request_id: String, receipt: TrackQueueReceipt) {
+    if jam.track_queue_receipts.len() >= 128 {
+        let oldest = jam
+            .track_queue_receipts
+            .iter()
+            .min_by_key(|(_, receipt)| receipt.created_at_ms)
+            .map(|(request_id, _)| request_id.clone());
+        if let Some(oldest) = oldest {
+            jam.track_queue_receipts.remove(&oldest);
+        }
+    }
+    jam.track_queue_receipts.insert(request_id, receipt);
+}
+
+fn track_queue_receipt_response(
+    jam: &JamState,
+    request_id: &str,
+    actor_id: &str,
+    spotify_id: &str,
+    generation: u64,
+) -> Result<Option<JamQueueEntry>, ()> {
+    let Some(receipt) = jam.track_queue_receipts.get(request_id) else {
+        return Ok(None);
+    };
+    if receipt.actor_id == actor_id
+        && receipt.spotify_id == spotify_id
+        && receipt.generation == generation
+    {
+        Ok(Some(receipt.track.clone()))
+    } else {
+        Err(())
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct PlaylistQueueSelectionFingerprint {
+    selected_positions: Option<Vec<usize>>,
+    snapshot_id: Option<String>,
 }
 
 #[derive(Clone, Debug)]
 pub(crate) struct PlaylistQueueReceipt {
     actor_id: String,
     playlist_id: String,
+    selection: PlaylistQueueSelectionFingerprint,
     generation: u64,
     created_at_ms: u64,
     response: PlaylistQueueResponse,
@@ -143,6 +283,7 @@ fn playlist_queue_receipt_response(
     request_id: &str,
     actor_id: &str,
     playlist_id: &str,
+    selection: &PlaylistQueueSelectionFingerprint,
     generation: u64,
 ) -> Result<Option<PlaylistQueueResponse>, ()> {
     let Some(receipt) = jam.playlist_queue_receipts.get(request_id) else {
@@ -150,7 +291,90 @@ fn playlist_queue_receipt_response(
     };
     if receipt.actor_id == actor_id
         && receipt.playlist_id == playlist_id
+        && &receipt.selection == selection
         && receipt.generation == generation
+    {
+        Ok(Some(receipt.response.clone()))
+    } else {
+        Err(())
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct QueueRemovalFingerprint {
+    expected_queue_revision: u64,
+    queue_entry_ids: Vec<String>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum QueueRemovalMutationError {
+    QueueChanged,
+    NotRemovable,
+}
+
+fn remove_pending_queue_entries(
+    jam: &mut JamState,
+    queue_entry_ids: &[String],
+) -> Result<(), QueueRemovalMutationError> {
+    for entry_id in queue_entry_ids {
+        let Some(entry) = jam
+            .queue
+            .iter()
+            .find(|entry| entry.track.queue_entry_id == *entry_id)
+        else {
+            return Err(QueueRemovalMutationError::QueueChanged);
+        };
+        if !entry.delivery_state.is_removable() || !entry.can_remove {
+            return Err(QueueRemovalMutationError::NotRemovable);
+        }
+    }
+    let selected = queue_entry_ids.iter().cloned().collect::<HashSet<_>>();
+    jam.queue
+        .retain(|entry| !selected.contains(&entry.track.queue_entry_id));
+    jam.queue_revision = jam.queue_revision.wrapping_add(1);
+    Ok(())
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct QueueRemovalReceipt {
+    actor_id: String,
+    generation: u64,
+    fingerprint: QueueRemovalFingerprint,
+    created_at_ms: u64,
+    response: JamQueueRemoveResponse,
+}
+
+fn insert_queue_removal_receipt(
+    jam: &mut JamState,
+    request_id: String,
+    receipt: QueueRemovalReceipt,
+) {
+    if jam.queue_removal_receipts.len() >= 128 {
+        let oldest = jam
+            .queue_removal_receipts
+            .iter()
+            .min_by_key(|(_, receipt)| receipt.created_at_ms)
+            .map(|(request_id, _)| request_id.clone());
+        if let Some(oldest) = oldest {
+            jam.queue_removal_receipts.remove(&oldest);
+        }
+    }
+    jam.queue_removal_receipts.insert(request_id, receipt);
+}
+
+fn queue_removal_receipt_response(
+    jam: &JamState,
+    request_id: &str,
+    actor_id: &str,
+    generation: u64,
+    fingerprint: &QueueRemovalFingerprint,
+) -> Result<Option<JamQueueRemoveResponse>, ()> {
+    let Some(receipt) = jam.queue_removal_receipts.get(request_id) else {
+        return Ok(None);
+    };
+    if receipt.actor_id == actor_id
+        && receipt.generation == generation
+        && &receipt.fingerprint == fingerprint
     {
         Ok(Some(receipt.response.clone()))
     } else {
@@ -214,6 +438,8 @@ pub(crate) struct JamSearchRequest {
 #[derive(Deserialize)]
 pub(crate) struct JamQueueRequest {
     generation: u64,
+    #[serde(default)]
+    request_id: Option<String>,
     spotify_uri: String,
     #[serde(rename = "name")]
     _name: String,
@@ -226,12 +452,33 @@ pub(crate) struct JamQueueRequest {
 }
 
 #[derive(Debug, Deserialize)]
+pub(crate) struct JamQueueRemoveRequest {
+    generation: u64,
+    request_id: String,
+    expected_queue_revision: u64,
+    queue_entry_ids: Vec<String>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub(crate) struct JamQueueRemoveResponse {
+    ok: bool,
+    generation: u64,
+    queue_revision: u64,
+    removed_entry_ids: Vec<String>,
+    removed_count: usize,
+}
+
+#[derive(Debug, Deserialize)]
 pub(crate) struct PlaylistQueueRequest {
     generation: u64,
     playlist_id: String,
     request_id: String,
     #[serde(default)]
     confirmed: bool,
+    #[serde(default)]
+    selected_positions: Option<Vec<usize>>,
+    #[serde(default)]
+    snapshot_id: Option<String>,
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -254,7 +501,8 @@ pub(crate) struct PlaylistQueueResponse {
     batch_id: String,
     generation: u64,
     playlist: QueuedPlaylistProvenance,
-    queued: Vec<QueuedTrack>,
+    queued_positions: Vec<usize>,
+    remaining_positions: Vec<usize>,
     queued_count: usize,
     skipped: Vec<SkippedPlaylistItem>,
     skipped_count: usize,
@@ -335,7 +583,7 @@ pub(crate) async fn jam_spotify_callback(
         return Err(StatusCode::BAD_REQUEST);
     }
     p.code = Some(params.code);
-    Ok(Html("<html><body><h1>Spotify Connected!</h1><p>You can close this tab and return to Echo Chamber.</p></body></html>".to_string()))
+    Ok(Html(SPOTIFY_CALLBACK_RECEIVED_HTML.to_string()))
 }
 
 pub(crate) async fn jam_spotify_code(
@@ -358,16 +606,186 @@ pub(crate) async fn jam_spotify_code(
     Err(StatusCode::NOT_FOUND)
 }
 
+fn spotify_upstream_message(body: &str) -> String {
+    serde_json::from_str::<serde_json::Value>(body)
+        .ok()
+        .and_then(|value| {
+            value["error"]["message"]
+                .as_str()
+                .or_else(|| value["error_description"].as_str())
+                .map(str::to_string)
+        })
+        .filter(|message| !message.is_empty())
+        .unwrap_or_else(|| {
+            let message = body.chars().take(300).collect::<String>();
+            if message.trim().is_empty() {
+                "Spotify request failed".to_string()
+            } else {
+                message
+            }
+        })
+}
+
+pub(crate) fn spotify_library_scope_required_error() -> JamApiError {
+    JamApiError {
+        status: StatusCode::FORBIDDEN,
+        code: "spotify_library_scope_required",
+        message: "Spotify Library access is missing. Use Refresh Spotify Access, then try again."
+            .to_string(),
+        retry_after: None,
+    }
+}
+
+fn spotify_token_exchange_error(
+    upstream: reqwest::StatusCode,
+    body: &str,
+    retry_after: Option<String>,
+) -> JamApiError {
+    let upstream_message = spotify_upstream_message(body);
+    let (status, code, message) = if upstream == reqwest::StatusCode::FORBIDDEN {
+        (
+            StatusCode::FORBIDDEN,
+            "spotify_account_forbidden",
+            format!(
+                "Spotify rejected this account for the Echo Chamber app: {upstream_message}. If the app is in Development Mode, add this exact Spotify account under User Management, then reconnect."
+            ),
+        )
+    } else if upstream == reqwest::StatusCode::TOO_MANY_REQUESTS {
+        (
+            StatusCode::TOO_MANY_REQUESTS,
+            "spotify_rate_limited",
+            format!("Spotify token exchange was rate limited: {upstream_message}"),
+        )
+    } else {
+        (
+            StatusCode::BAD_GATEWAY,
+            "spotify_token_exchange_failed",
+            format!("Spotify token exchange failed (Spotify {upstream}): {upstream_message}"),
+        )
+    };
+    JamApiError {
+        status,
+        code,
+        message,
+        retry_after,
+    }
+}
+
+fn spotify_access_validation_error(
+    upstream: reqwest::StatusCode,
+    body: &str,
+    retry_after: Option<String>,
+) -> JamApiError {
+    let upstream_message = spotify_upstream_message(body);
+    let (status, code, message) = match upstream {
+        reqwest::StatusCode::FORBIDDEN => (
+            StatusCode::FORBIDDEN,
+            "spotify_account_forbidden",
+            format!(
+                "Spotify rejected this account for the Echo Chamber app: {upstream_message}. If the app is in Development Mode, add this exact Spotify account under User Management, then reconnect."
+            ),
+        ),
+        reqwest::StatusCode::TOO_MANY_REQUESTS => (
+            StatusCode::TOO_MANY_REQUESTS,
+            "spotify_rate_limited",
+            format!("Spotify could not verify this connection yet: {upstream_message}"),
+        ),
+        reqwest::StatusCode::UNAUTHORIZED => (
+            StatusCode::BAD_GATEWAY,
+            "spotify_token_rejected",
+            format!("Spotify rejected the new access token: {upstream_message}"),
+        ),
+        _ => (
+            StatusCode::BAD_GATEWAY,
+            "spotify_connection_validation_failed",
+            format!(
+                "Spotify connection validation failed (Spotify {upstream}): {upstream_message}"
+            ),
+        ),
+    };
+    JamApiError {
+        status,
+        code,
+        message,
+        retry_after,
+    }
+}
+
+async fn validate_spotify_access_token(
+    state: &AppState,
+    token: &SpotifyToken,
+) -> Result<(), JamApiError> {
+    if let Some((status, message)) = spotify_rate_limit_error(state) {
+        return Err(JamApiError {
+            status,
+            code: "spotify_rate_limited",
+            message,
+            retry_after: spotify_retry_after_seconds(state),
+        });
+    }
+    let response = {
+        let _permit = state
+            .spotify_request_limit
+            .acquire()
+            .await
+            .map_err(|_| JamApiError {
+                status: StatusCode::SERVICE_UNAVAILABLE,
+                code: "spotify_request_failed",
+                message: "Spotify request gate is unavailable".to_string(),
+                retry_after: None,
+            })?;
+        state
+            .http_client
+            .get("https://api.spotify.com/v1/me")
+            .bearer_auth(&token.access_token)
+            .send()
+            .await
+            .map_err(|error| JamApiError {
+                status: StatusCode::BAD_GATEWAY,
+                code: "spotify_connection_validation_failed",
+                message: format!("Could not validate the Spotify connection: {error}"),
+                retry_after: None,
+            })?
+    };
+    remember_spotify_rate_limit(state, &response);
+    let upstream = response.status();
+    let retry_after = response
+        .headers()
+        .get(RETRY_AFTER)
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_string);
+    let body = response.text().await.unwrap_or_default();
+    if !upstream.is_success() {
+        return Err(spotify_access_validation_error(
+            upstream,
+            &body,
+            retry_after,
+        ));
+    }
+    serde_json::from_str::<serde_json::Value>(&body).map_err(|error| JamApiError {
+        status: StatusCode::BAD_GATEWAY,
+        code: "spotify_connection_validation_failed",
+        message: format!("Spotify returned an invalid account response: {error}"),
+        retry_after: None,
+    })?;
+    Ok(())
+}
+
 pub(crate) async fn jam_spotify_token(
     State(state): State<AppState>,
     headers: HeaderMap,
     Json(payload): Json<SpotifyTokenRequest>,
-) -> Result<Json<serde_json::Value>, StatusCode> {
-    ensure_admin(&state, &headers)?;
+) -> Result<Json<serde_json::Value>, JamApiError> {
+    ensure_admin(&state, &headers).map_err(|status| JamApiError {
+        status,
+        code: "unauthorized",
+        message: "Authentication required".to_string(),
+        retry_after: None,
+    })?;
 
     let client_id = state.spotify_client_id.clone();
     if client_id.is_empty() {
-        return Err(StatusCode::BAD_REQUEST);
+        return Err(JamApiError::bad_request("Spotify is not configured"));
     }
 
     let redirect_uri = format!(
@@ -388,21 +806,51 @@ pub(crate) async fn jam_spotify_token(
         .await
         .map_err(|e| {
             warn!("Spotify token exchange failed: {}", e);
-            StatusCode::BAD_GATEWAY
+            JamApiError {
+                status: StatusCode::BAD_GATEWAY,
+                code: "spotify_token_exchange_failed",
+                message: format!("Could not exchange the Spotify authorization code: {e}"),
+                retry_after: None,
+            }
         })?;
 
-    let data: serde_json::Value = resp.json().await.map_err(|e| {
+    let upstream = resp.status();
+    let retry_after = resp
+        .headers()
+        .get(RETRY_AFTER)
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_string);
+    let body = resp.text().await.unwrap_or_default();
+    if !upstream.is_success() {
+        return Err(spotify_token_exchange_error(upstream, &body, retry_after));
+    }
+    let data: serde_json::Value = serde_json::from_str(&body).map_err(|e| {
         warn!("Spotify token response parse failed: {}", e);
-        StatusCode::BAD_GATEWAY
+        JamApiError {
+            status: StatusCode::BAD_GATEWAY,
+            code: "spotify_token_exchange_failed",
+            message: format!("Spotify returned an invalid token response: {e}"),
+            retry_after: None,
+        }
     })?;
 
     let access_token = data["access_token"]
         .as_str()
-        .ok_or(StatusCode::BAD_GATEWAY)?
+        .ok_or_else(|| JamApiError {
+            status: StatusCode::BAD_GATEWAY,
+            code: "spotify_token_exchange_failed",
+            message: "Spotify token response did not include an access token".to_string(),
+            retry_after: None,
+        })?
         .to_string();
     let refresh_token = data["refresh_token"]
         .as_str()
-        .ok_or(StatusCode::BAD_GATEWAY)?
+        .ok_or_else(|| JamApiError {
+            status: StatusCode::BAD_GATEWAY,
+            code: "spotify_token_exchange_failed",
+            message: "Spotify token response did not include a refresh token".to_string(),
+            retry_after: None,
+        })?
         .to_string();
     let expires_in = data["expires_in"].as_u64().unwrap_or(3600);
 
@@ -415,12 +863,24 @@ pub(crate) async fn jam_spotify_token(
         access_token,
         refresh_token,
         expires_at: now_secs + expires_in,
+        scope: spotify_scope_from_token_response(&data, None),
     };
 
+    if !spotify_library_scopes_authorized(Some(&token)) {
+        return Err(spotify_library_scope_required_error());
+    }
+    validate_spotify_access_token(&state, &token).await?;
+
+    // Do not replace a previously working token until the candidate has passed
+    // both scope inspection and a real Spotify Web API request.
     {
         let mut jam = state.jam.lock().unwrap_or_else(|e| e.into_inner());
         jam.spotify_token = Some(token.clone());
     }
+    // A new authorization may belong to a different Spotify account. Playlist
+    // covers are process-memory-only, but private artwork must not survive that
+    // account boundary.
+    state.jam_favorites.clear_playlist_artwork_cache();
     {
         let mut pending = state
             .spotify_pending
@@ -470,7 +930,7 @@ pub(crate) fn persist_spotify_token(
 
 // ── Spotify API proxy helper ─────────────────────────────────────────────
 
-fn spotify_rate_limit_error(state: &AppState) -> Option<(StatusCode, String)> {
+pub(crate) fn spotify_rate_limit_error(state: &AppState) -> Option<(StatusCode, String)> {
     let seconds = spotify_retry_after_seconds(state)?;
     Some((
         StatusCode::TOO_MANY_REQUESTS,
@@ -490,6 +950,10 @@ fn remember_spotify_rate_limit(state: &AppState, response: &reqwest::Response) {
     else {
         return;
     };
+    remember_spotify_rate_limit_seconds(state, seconds);
+}
+
+pub(crate) fn remember_spotify_rate_limit_seconds(state: &AppState, seconds: u64) {
     let until = std::time::Instant::now() + Duration::from_secs(seconds.min(24 * 60 * 60));
     let mut guard = state
         .spotify_rate_limit_until
@@ -636,6 +1100,7 @@ async fn refresh_spotify_token(state: &AppState, old: &SpotifyToken) -> Option<S
             .to_string(),
         expires_at: SystemTime::now().duration_since(UNIX_EPOCH).ok()?.as_secs()
             + data["expires_in"].as_u64().unwrap_or(3600),
+        scope: spotify_scope_from_token_response(&data, Some(&old.scope)),
     };
 
     {
@@ -754,10 +1219,16 @@ async fn resolve_spotify_device(state: &AppState) -> Result<SpotifyDevice, (Stat
     )
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct SpotifyBoundPlayback {
+    is_playing: bool,
+    current_uri: Option<String>,
+}
+
 async fn bind_spotify_playback_to_device(
     state: &AppState,
     device: &SpotifyDevice,
-) -> Result<bool, (StatusCode, String)> {
+) -> Result<SpotifyBoundPlayback, (StatusCode, String)> {
     let response = spotify_api_request(
         state,
         reqwest::Method::GET,
@@ -765,8 +1236,11 @@ async fn bind_spotify_playback_to_device(
         None,
     )
     .await?;
-    let was_playing = if response.status() == reqwest::StatusCode::NO_CONTENT {
-        false
+    let playback = if response.status() == reqwest::StatusCode::NO_CONTENT {
+        SpotifyBoundPlayback {
+            is_playing: false,
+            current_uri: None,
+        }
     } else if response.status().is_success() {
         let playback: serde_json::Value = response.json().await.map_err(|error| {
             (
@@ -774,10 +1248,17 @@ async fn bind_spotify_playback_to_device(
                 format!("Spotify playback response was invalid: {}", error),
             )
         })?;
+        let bound_playback = SpotifyBoundPlayback {
+            is_playing: playback["is_playing"].as_bool().unwrap_or(false),
+            current_uri: playback["item"]["uri"]
+                .as_str()
+                .filter(|uri| !uri.trim().is_empty())
+                .map(str::to_string),
+        };
         if playback["device"]["id"].as_str() == Some(device.id.as_str()) {
-            return Ok(playback["is_playing"].as_bool().unwrap_or(false));
+            return Ok(bound_playback);
         }
-        playback["is_playing"].as_bool().unwrap_or(false)
+        bound_playback
     } else {
         return Err(spotify_response_error(response, "Read Spotify playback").await);
     };
@@ -787,14 +1268,14 @@ async fn bind_spotify_playback_to_device(
         "https://api.spotify.com/v1/me/player",
         Some(serde_json::json!({
             "device_ids": [device.id],
-            "play": was_playing,
+            "play": playback.is_playing,
         })),
     )
     .await?;
     if !response.status().is_success() {
         return Err(spotify_response_error(response, "Transfer Spotify playback").await);
     }
-    Ok(was_playing)
+    Ok(playback)
 }
 
 fn spotify_pause_url(device_id: &str) -> String {
@@ -829,15 +1310,7 @@ async fn spotify_response_error(
 ) -> (StatusCode, String) {
     let upstream_status = response.status();
     let body = response.text().await.unwrap_or_default();
-    let message = serde_json::from_str::<serde_json::Value>(&body)
-        .ok()
-        .and_then(|value| {
-            value["error"]["message"]
-                .as_str()
-                .or_else(|| value["error_description"].as_str())
-                .map(str::to_string)
-        })
-        .unwrap_or_else(|| body.chars().take(300).collect());
+    let message = spotify_upstream_message(&body);
     let status = match upstream_status {
         reqwest::StatusCode::TOO_MANY_REQUESTS => StatusCode::TOO_MANY_REQUESTS,
         reqwest::StatusCode::FORBIDDEN => StatusCode::FORBIDDEN,
@@ -861,8 +1334,12 @@ pub(crate) fn clear_active_jam_state(jam: &mut JamState) {
     jam.host_identity.clear();
     jam.host_participant_auth_id.clear();
     jam.queue.clear();
+    jam.queue_revision = jam.queue_revision.wrapping_add(1);
+    jam.track_queue_receipts.clear();
     jam.playlist_queue_receipts.clear();
+    jam.queue_removal_receipts.clear();
     jam.last_history_spotify_id = None;
+    jam.last_history_was_echo = false;
     jam.listeners.clear();
     jam.audio_connections.clear();
     jam.now_playing = None;
@@ -871,6 +1348,7 @@ pub(crate) fn clear_active_jam_state(jam: &mut JamState) {
     jam.spotify_is_playing = false;
     jam.queue_control_epoch = jam.queue_control_epoch.wrapping_add(1);
     jam.queue_control_stopped = false;
+    jam.uncertain_skip = None;
     jam.audio_expected_since = None;
 }
 
@@ -1330,7 +1808,7 @@ pub(crate) async fn jam_start(
         )),
     };
     let spotify_is_playing = match spotify_bind {
-        Ok(is_playing) => is_playing,
+        Ok(playback) => playback.is_playing,
         Err(error) => {
             // The transfer request may have reached Spotify before a timeout
             // or source-loss cancellation. Pause the exact target before the
@@ -1585,23 +2063,37 @@ where
 
     match guarded_result {
         Err(safety_error) => {
-            pause_bound_spotify_before_release(state, generation, Some(device)).await;
+            pause_and_mark_spotify_safety_stop(state, generation, device, &safety_error.1).await;
             Err(safety_error)
         }
         Ok(operation_result) => match ensure_jam_recovery_controls_ready(state).await {
             Ok(current_generation) if current_generation == generation => operation_result,
             Ok(_) => {
-                pause_bound_spotify_before_release(state, generation, Some(device)).await;
-                Err((
-                    StatusCode::CONFLICT,
-                    "Jam generation changed during Spotify control".to_string(),
-                ))
+                let message = "Jam generation changed during Spotify control".to_string();
+                pause_and_mark_spotify_safety_stop(state, generation, device, &message).await;
+                Err((StatusCode::CONFLICT, message))
             }
             Err(error) => {
-                pause_bound_spotify_before_release(state, generation, Some(device)).await;
+                pause_and_mark_spotify_safety_stop(state, generation, device, &error.1).await;
                 Err(error)
             }
         },
+    }
+}
+
+async fn pause_and_mark_spotify_safety_stop(
+    state: &AppState,
+    generation: u64,
+    device: &SpotifyDevice,
+    error: &str,
+) {
+    pause_bound_spotify_before_release(state, generation, Some(device)).await;
+    let mut jam = state
+        .jam
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner());
+    if apply_spotify_pause_result(&mut jam, generation, device) {
+        jam.last_error = Some(error.to_string());
     }
 }
 
@@ -1614,6 +2106,7 @@ fn apply_spotify_pause_result(jam: &mut JamState, generation: u64, device: &Spot
 
     jam.spotify_is_playing = false;
     jam.queue_control_epoch = jam.queue_control_epoch.wrapping_add(1);
+    jam.queue_stop_epoch = jam.queue_stop_epoch.wrapping_add(1);
     jam.queue_control_stopped = true;
     jam.audio_expected_since = None;
     jam.last_error = None;
@@ -1692,19 +2185,745 @@ fn playback_fetch_matches(jam: &JamState, generation: u64, device_id: &str) -> b
         && jam.spotify_device_id.as_deref() == Some(device_id)
 }
 
-fn reconcile_queue_to_current(queue: &mut Vec<QueuedTrack>, current_uri: &str) -> Vec<QueuedTrack> {
-    if current_uri.is_empty() || !queue.iter().any(|track| track.spotify_uri == current_uri) {
+fn reconcile_queue_to_current(
+    queue: &mut Vec<JamQueueEntry>,
+    current_uri: &str,
+) -> Vec<QueuedTrack> {
+    if current_uri.is_empty() {
+        return Vec::new();
+    }
+    let Some(target_index) = queue.iter().position(|entry| {
+        entry.track.spotify_uri == current_uri
+            && entry.delivery_state == QueueDeliveryState::SpotifyCommitted
+            && entry.current_match_state == QueueCurrentMatchState::Eligible
+    }) else {
+        return Vec::new();
+    };
+    if queue[..target_index]
+        .iter()
+        .any(|entry| entry.delivery_state == QueueDeliveryState::CommitUnknown)
+    {
         return Vec::new();
     }
     let mut removed = Vec::new();
     while queue
         .first()
-        .map(|track| track.spotify_uri.as_str() != current_uri)
+        .map(|entry| entry.track.spotify_uri.as_str() != current_uri)
         .unwrap_or(false)
     {
-        removed.push(queue.remove(0));
+        removed.push(queue.remove(0).track);
     }
     removed
+}
+
+fn committed_queue_track_matching_current(
+    queue: &[JamQueueEntry],
+    current_uri: &str,
+) -> Option<QueuedTrack> {
+    queue
+        .first()
+        .filter(|entry| {
+            entry.track.spotify_uri == current_uri
+                && entry.delivery_state == QueueDeliveryState::SpotifyCommitted
+                && entry.current_match_state == QueueCurrentMatchState::Eligible
+        })
+        .map(|entry| entry.track.clone())
+}
+
+fn observe_queue_current_transition(
+    queue: &mut [JamQueueEntry],
+    current_uri: &str,
+    repeated_occurrence: bool,
+) -> bool {
+    let mut changed = false;
+    for entry in queue.iter_mut().filter(|entry| {
+        entry.delivery_state == QueueDeliveryState::SpotifyCommitted
+            && entry.current_match_state == QueueCurrentMatchState::AwaitingTransition
+            && entry.track.spotify_uri != current_uri
+    }) {
+        entry.current_match_state = QueueCurrentMatchState::Eligible;
+        changed = true;
+    }
+    let matching_transition = queue.iter().enumerate().find_map(|(index, entry)| {
+        (entry.delivery_state == QueueDeliveryState::SpotifyCommitted
+            && entry.current_match_state == QueueCurrentMatchState::AwaitingTransition
+            && entry.track.spotify_uri == current_uri
+            && queue[..index].iter().any(|earlier| {
+                earlier.delivery_state.occupies_spotify_frontier()
+                    && earlier.track.spotify_uri != current_uri
+            }))
+        .then_some(index)
+    });
+    let unlocked_matching_transition = if let Some(index) = matching_transition {
+        queue[index].current_match_state = QueueCurrentMatchState::Eligible;
+        changed = true;
+        true
+    } else {
+        false
+    };
+    if repeated_occurrence && !unlocked_matching_transition {
+        if let Some(entry) = queue.iter_mut().find(|entry| {
+            entry.delivery_state == QueueDeliveryState::SpotifyCommitted
+                && entry.current_match_state == QueueCurrentMatchState::AwaitingTransition
+                && entry.track.spotify_uri == current_uri
+        }) {
+            // One observed restart proves exactly one same-URI queue boundary.
+            // Leave later identical occurrences blocked for their own boundary.
+            entry.current_match_state = QueueCurrentMatchState::Eligible;
+            changed = true;
+        }
+    }
+    changed
+}
+
+fn same_track_occurrence_restarted(
+    previous: Option<&NowPlayingInfo>,
+    current: &NowPlayingInfo,
+) -> bool {
+    let Some(previous) = previous else {
+        return false;
+    };
+    if !previous.is_playing
+        || !current.is_playing
+        || current.spotify_uri.is_empty()
+        || previous.spotify_uri != current.spotify_uri
+        || previous.duration_ms == 0
+        || current.duration_ms != previous.duration_ms
+    {
+        return false;
+    }
+    let edge_window_ms = (previous.duration_ms / 10).clamp(2_000, 15_000);
+    previous.progress_ms.saturating_add(edge_window_ms) >= previous.duration_ms
+        && current.progress_ms <= edge_window_ms
+        && current.progress_ms.saturating_add(edge_window_ms) < previous.progress_ms
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct SpotifyQueueObservation {
+    current_uri: String,
+    next_uri: Option<String>,
+}
+
+fn repeated_occurrence_advance_confirmed(
+    previous: Option<&NowPlayingInfo>,
+    current: &NowPlayingInfo,
+    repeat_state: &str,
+    queue_observation: Option<&SpotifyQueueObservation>,
+) -> bool {
+    let Some(queue_observation) = queue_observation else {
+        return false;
+    };
+    matches!(repeat_state, "off" | "context")
+        && queue_observation.current_uri == current.spotify_uri
+        && queue_observation.next_uri.as_deref() != Some(current.spotify_uri.as_str())
+        && same_track_occurrence_restarted(previous, current)
+}
+
+async fn spotify_queue_observation_strict(
+    state: &AppState,
+) -> Result<SpotifyQueueObservation, (StatusCode, String)> {
+    let response = spotify_api_request(
+        state,
+        reqwest::Method::GET,
+        "https://api.spotify.com/v1/me/player/queue",
+        None,
+    )
+    .await?;
+    if !response.status().is_success() {
+        return Err(spotify_response_error(response, "Read Spotify queue").await);
+    }
+    let data = response
+        .json::<serde_json::Value>()
+        .await
+        .map_err(|error| {
+            (
+                StatusCode::BAD_GATEWAY,
+                format!("Spotify queue response was invalid: {error}"),
+            )
+        })?;
+    let current_uri = data
+        .get("currently_playing")
+        .and_then(|current| current.get("uri"))
+        .and_then(serde_json::Value::as_str)
+        .filter(|uri| !uri.trim().is_empty())
+        .ok_or_else(|| {
+            (
+                StatusCode::BAD_GATEWAY,
+                "Spotify queue response did not identify the current track".to_string(),
+            )
+        })?
+        .to_string();
+    let queue = data
+        .get("queue")
+        .and_then(serde_json::Value::as_array)
+        .ok_or_else(|| {
+            (
+                StatusCode::BAD_GATEWAY,
+                "Spotify queue response did not contain a queue array".to_string(),
+            )
+        })?;
+    let Some(first) = queue.first() else {
+        return Ok(SpotifyQueueObservation {
+            current_uri,
+            next_uri: None,
+        });
+    };
+    let uri = first
+        .get("uri")
+        .and_then(serde_json::Value::as_str)
+        .filter(|uri| !uri.trim().is_empty())
+        .ok_or_else(|| {
+            (
+                StatusCode::BAD_GATEWAY,
+                "Spotify queue response did not identify its next track".to_string(),
+            )
+        })?;
+    Ok(SpotifyQueueObservation {
+        current_uri,
+        next_uri: Some(uri.to_string()),
+    })
+}
+
+async fn spotify_queue_observation(state: &AppState) -> Option<SpotifyQueueObservation> {
+    spotify_queue_observation_strict(state).await.ok()
+}
+
+fn advance_repeated_committed_occurrence(
+    queue: &mut Vec<JamQueueEntry>,
+    current_uri: &str,
+) -> Option<QueuedTrack> {
+    let front = queue.first()?;
+    if front.track.spotify_uri != current_uri
+        || front.delivery_state != QueueDeliveryState::SpotifyCommitted
+        || front.current_match_state != QueueCurrentMatchState::Eligible
+    {
+        return None;
+    }
+    Some(queue.remove(0).track)
+}
+
+fn retire_skipped_queue_frontier(
+    queue: &mut Vec<JamQueueEntry>,
+    current_uri: Option<&str>,
+) -> Option<QueuedTrack> {
+    let current_uri = current_uri.filter(|uri| !uri.trim().is_empty())?;
+    let front = queue.first()?;
+    if front.track.spotify_uri != current_uri
+        || front.delivery_state != QueueDeliveryState::SpotifyCommitted
+        || front.current_match_state != QueueCurrentMatchState::Eligible
+    {
+        return None;
+    }
+    Some(queue.remove(0).track)
+}
+
+#[derive(Debug, Default)]
+struct SuccessfulSkipQueueTransition {
+    removed_before_current: Vec<QueuedTrack>,
+    removed: Option<QueuedTrack>,
+    unlocked_successor: bool,
+    pre_skip_changed: bool,
+}
+
+impl SuccessfulSkipQueueTransition {
+    fn changed(&self) -> bool {
+        self.pre_skip_changed || self.removed.is_some() || self.unlocked_successor
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+enum PreSkipSameUriResolution {
+    #[default]
+    NotNeeded,
+    AwaitingStillNext,
+    AwaitingIsCurrent,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct UncertainSkipBoundary {
+    pre_skip_current_uri: String,
+    previous_uri: Option<String>,
+    same_uri_resolution: PreSkipSameUriResolution,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum UncertainSkipObservationResult {
+    Accepted,
+    Rejected,
+    Pending,
+}
+
+impl UncertainSkipBoundary {
+    fn queue_observation_required(&self, current_uri: &str) -> bool {
+        current_uri == self.pre_skip_current_uri
+            && self.same_uri_resolution == PreSkipSameUriResolution::AwaitingStillNext
+    }
+
+    fn resolve_observation(
+        &self,
+        current_uri: Option<&str>,
+        queue_observation: Option<&SpotifyQueueObservation>,
+    ) -> UncertainSkipObservationResult {
+        let Some(current_uri) = current_uri.filter(|uri| !uri.trim().is_empty()) else {
+            // Player 204 is not proof that /next was accepted: the device or
+            // session may have disappeared after the ambiguous transport
+            // result. Preserve the fence until a bound-device item is seen.
+            return UncertainSkipObservationResult::Pending;
+        };
+        if current_uri != self.pre_skip_current_uri {
+            return UncertainSkipObservationResult::Accepted;
+        }
+        if !self.queue_observation_required(current_uri) {
+            return UncertainSkipObservationResult::Rejected;
+        }
+        let Some(queue_observation) = queue_observation
+            .filter(|observation| observation.current_uri == self.pre_skip_current_uri)
+        else {
+            return UncertainSkipObservationResult::Pending;
+        };
+        if queue_observation.next_uri.as_deref() == Some(self.pre_skip_current_uri.as_str()) {
+            UncertainSkipObservationResult::Rejected
+        } else {
+            UncertainSkipObservationResult::Accepted
+        }
+    }
+}
+
+fn same_uri_skip_observation_required(
+    queue: &[JamQueueEntry],
+    current_uri: Option<&str>,
+    previous_uri: Option<&str>,
+) -> bool {
+    let Some(current_uri) = current_uri.filter(|uri| !uri.trim().is_empty()) else {
+        return false;
+    };
+    let Some(awaiting_index) = queue.iter().position(|entry| {
+        entry.track.spotify_uri == current_uri
+            && entry.delivery_state.occupies_spotify_frontier()
+            && entry.current_match_state == QueueCurrentMatchState::AwaitingTransition
+    }) else {
+        return false;
+    };
+    let earlier_frontier = queue[..awaiting_index]
+        .iter()
+        .filter(|entry| entry.delivery_state.occupies_spotify_frontier())
+        .collect::<Vec<_>>();
+    if earlier_frontier
+        .iter()
+        .any(|entry| entry.track.spotify_uri == current_uri)
+    {
+        // [A eligible, A awaiting] cannot identify the current occurrence from
+        // the player URI alone. Spotify's next item is the discriminator.
+        return true;
+    }
+    if !earlier_frontier.is_empty() {
+        // A different Echo predecessor proves that the matching awaiting entry
+        // is the occurrence Spotify advanced to between Echo observations.
+        return false;
+    }
+    // When the first Echo occurrence is still awaiting behind an external
+    // track with the same URI, the URI alone cannot distinguish them. A prior
+    // different bound-device observation proves the transition; otherwise the
+    // Spotify queue must show whether Echo's occurrence is still next.
+    previous_uri
+        .filter(|uri| !uri.trim().is_empty())
+        .is_none_or(|previous_uri| previous_uri == current_uri)
+}
+
+fn resolve_same_uri_skip_observation(
+    queue: &[JamQueueEntry],
+    observation: &SpotifyQueueObservation,
+    current_uri: &str,
+    previous_uri: Option<&str>,
+) -> Result<PreSkipSameUriResolution, SameUriSkipObservationError> {
+    if observation.current_uri != current_uri {
+        return Err(SameUriSkipObservationError::PlaybackChanged);
+    }
+    let resolution = if observation.next_uri.as_deref() == Some(current_uri) {
+        PreSkipSameUriResolution::AwaitingStillNext
+    } else {
+        PreSkipSameUriResolution::AwaitingIsCurrent
+    };
+    reject_commit_unknown_pre_skip_target(queue, current_uri, previous_uri, resolution)?;
+    Ok(resolution)
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum SameUriSkipObservationError {
+    PlaybackChanged,
+    CommitUnknown,
+}
+
+fn authoritative_pre_skip_target_index(
+    queue: &[JamQueueEntry],
+    current_uri: &str,
+    previous_uri: Option<&str>,
+    resolution: PreSkipSameUriResolution,
+) -> Option<usize> {
+    let matching = |entry: &JamQueueEntry| {
+        entry.track.spotify_uri == current_uri && entry.delivery_state.occupies_spotify_frontier()
+    };
+    match resolution {
+        PreSkipSameUriResolution::AwaitingStillNext => queue.iter().position(|entry| {
+            matching(entry) && entry.current_match_state == QueueCurrentMatchState::Eligible
+        }),
+        PreSkipSameUriResolution::AwaitingIsCurrent => queue.iter().rposition(|entry| {
+            matching(entry)
+                && entry.current_match_state == QueueCurrentMatchState::AwaitingTransition
+        }),
+        PreSkipSameUriResolution::NotNeeded => {
+            let awaiting_current = queue.iter().enumerate().find_map(|(index, entry)| {
+                if !matching(entry)
+                    || entry.current_match_state != QueueCurrentMatchState::AwaitingTransition
+                {
+                    return None;
+                }
+                let earlier_frontier = queue[..index]
+                    .iter()
+                    .filter(|earlier| earlier.delivery_state.occupies_spotify_frontier())
+                    .collect::<Vec<_>>();
+                let preceded_by_different_echo = !earlier_frontier.is_empty()
+                    && earlier_frontier
+                        .iter()
+                        .all(|earlier| earlier.track.spotify_uri != current_uri);
+                let preceded_by_different_observation = earlier_frontier.is_empty()
+                    && previous_uri
+                        .filter(|uri| !uri.trim().is_empty())
+                        .is_some_and(|previous_uri| previous_uri != current_uri);
+                (preceded_by_different_echo || preceded_by_different_observation).then_some(index)
+            });
+            awaiting_current.or_else(|| {
+                queue.iter().position(|entry| {
+                    matching(entry) && entry.current_match_state == QueueCurrentMatchState::Eligible
+                })
+            })
+        }
+    }
+}
+
+fn reject_commit_unknown_pre_skip_target(
+    queue: &[JamQueueEntry],
+    current_uri: &str,
+    previous_uri: Option<&str>,
+    resolution: PreSkipSameUriResolution,
+) -> Result<(), SameUriSkipObservationError> {
+    if authoritative_pre_skip_target_index(queue, current_uri, previous_uri, resolution)
+        .is_some_and(|index| {
+            queue[..=index]
+                .iter()
+                .any(|entry| entry.delivery_state == QueueDeliveryState::CommitUnknown)
+        })
+    {
+        Err(SameUriSkipObservationError::CommitUnknown)
+    } else {
+        Ok(())
+    }
+}
+
+#[derive(Debug, Default)]
+struct PreSkipQueueReconciliation {
+    removed_before_current: Vec<QueuedTrack>,
+    changed: bool,
+}
+
+fn reconcile_authoritative_pre_skip_current(
+    queue: &mut Vec<JamQueueEntry>,
+    current_uri: Option<&str>,
+    previous_uri: Option<&str>,
+    same_uri_resolution: PreSkipSameUriResolution,
+) -> PreSkipQueueReconciliation {
+    let Some(current_uri) = current_uri.filter(|uri| !uri.trim().is_empty()) else {
+        return PreSkipQueueReconciliation::default();
+    };
+    let target_index =
+        authoritative_pre_skip_target_index(queue, current_uri, previous_uri, same_uri_resolution);
+    let Some(target_index) = target_index else {
+        return PreSkipQueueReconciliation::default();
+    };
+    if queue[..=target_index]
+        .iter()
+        .any(|entry| entry.delivery_state == QueueDeliveryState::CommitUnknown)
+    {
+        return PreSkipQueueReconciliation::default();
+    }
+
+    let mut changed = false;
+    if queue[target_index].current_match_state == QueueCurrentMatchState::AwaitingTransition {
+        queue[target_index].current_match_state = QueueCurrentMatchState::Eligible;
+        changed = true;
+    }
+    let removed_before_current = queue
+        .drain(..target_index)
+        .map(|entry| entry.track)
+        .collect::<Vec<_>>();
+    changed |= !removed_before_current.is_empty();
+    PreSkipQueueReconciliation {
+        removed_before_current,
+        changed,
+    }
+}
+
+fn authoritative_pre_skip_echo_track(
+    queue: &[JamQueueEntry],
+    current_uri: Option<&str>,
+    previous_uri: Option<&str>,
+    same_uri_resolution: PreSkipSameUriResolution,
+) -> Option<QueuedTrack> {
+    let current_uri = current_uri.filter(|uri| !uri.trim().is_empty())?;
+    reject_commit_unknown_pre_skip_target(queue, current_uri, previous_uri, same_uri_resolution)
+        .ok()?;
+    let mut aligned = queue.to_vec();
+    reconcile_authoritative_pre_skip_current(
+        &mut aligned,
+        Some(current_uri),
+        previous_uri,
+        same_uri_resolution,
+    );
+    committed_queue_track_matching_current(&aligned, current_uri)
+}
+
+fn apply_successful_skip_to_queue(
+    queue: &mut Vec<JamQueueEntry>,
+    current_uri: Option<&str>,
+    previous_uri: Option<&str>,
+    same_uri_resolution: PreSkipSameUriResolution,
+) -> SuccessfulSkipQueueTransition {
+    if let Some(current_uri) = current_uri.filter(|uri| !uri.trim().is_empty()) {
+        if reject_commit_unknown_pre_skip_target(
+            queue,
+            current_uri,
+            previous_uri,
+            same_uri_resolution,
+        )
+        .is_err()
+        {
+            return SuccessfulSkipQueueTransition::default();
+        }
+    }
+    let reconciliation = reconcile_authoritative_pre_skip_current(
+        queue,
+        current_uri,
+        previous_uri,
+        same_uri_resolution,
+    );
+    let removed = retire_skipped_queue_frontier(queue, current_uri);
+    let unlocked_successor = queue.first_mut().is_some_and(|successor| {
+        if successor.delivery_state == QueueDeliveryState::SpotifyCommitted
+            && successor.current_match_state == QueueCurrentMatchState::AwaitingTransition
+        {
+            // A successful Spotify /next proves exactly one queued-next
+            // occurrence boundary for an accepted Spotify entry. An ambiguous
+            // entry remains locked for the rest of the Jam generation.
+            successor.current_match_state = QueueCurrentMatchState::Eligible;
+            true
+        } else {
+            false
+        }
+    });
+    SuccessfulSkipQueueTransition {
+        removed_before_current: reconciliation.removed_before_current,
+        removed,
+        unlocked_successor,
+        pre_skip_changed: reconciliation.changed,
+    }
+}
+
+fn reconcile_uncertain_skip_boundary(
+    jam: &mut JamState,
+    observed_current_uri: Option<&str>,
+    queue_observation: Option<&SpotifyQueueObservation>,
+) -> Option<UncertainSkipObservationResult> {
+    let boundary = jam.uncertain_skip.clone()?;
+    let result = boundary.resolve_observation(observed_current_uri, queue_observation);
+    let changed = match result {
+        UncertainSkipObservationResult::Accepted => apply_successful_skip_to_queue(
+            &mut jam.queue,
+            Some(&boundary.pre_skip_current_uri),
+            boundary.previous_uri.as_deref(),
+            boundary.same_uri_resolution,
+        )
+        .changed(),
+        UncertainSkipObservationResult::Rejected => {
+            reconcile_authoritative_pre_skip_current(
+                &mut jam.queue,
+                Some(&boundary.pre_skip_current_uri),
+                boundary.previous_uri.as_deref(),
+                boundary.same_uri_resolution,
+            )
+            .changed
+        }
+        UncertainSkipObservationResult::Pending => return Some(result),
+    };
+    if changed {
+        jam.queue_revision = jam.queue_revision.wrapping_add(1);
+    }
+    jam.uncertain_skip = None;
+    Some(result)
+}
+
+fn uncertain_skip_blocks_ordinary_queue_update(
+    result: Option<UncertainSkipObservationResult>,
+) -> bool {
+    result.is_some()
+}
+
+#[derive(Debug, Default)]
+struct NoContentQueueReconciliation {
+    uncertain_skip: Option<UncertainSkipObservationResult>,
+    naturally_finished: Option<QueuedTrack>,
+}
+
+fn reconcile_queue_after_no_content(jam: &mut JamState) -> NoContentQueueReconciliation {
+    let uncertain_skip = reconcile_uncertain_skip_boundary(jam, None, None);
+    if uncertain_skip.is_some() {
+        return NoContentQueueReconciliation {
+            uncertain_skip,
+            naturally_finished: None,
+        };
+    }
+    let finished_uri = jam.now_playing.as_ref().and_then(|now_playing| {
+        let elapsed = now_playing.fetched_at.map(|at| at.elapsed())?;
+        prior_playback_finished_before_no_content(now_playing, elapsed)
+            .then(|| now_playing.spotify_uri.clone())
+    });
+    let naturally_finished = finished_uri
+        .as_deref()
+        .and_then(|uri| retire_finished_queue_frontier(&mut jam.queue, uri));
+    if naturally_finished.is_some() {
+        jam.queue_revision = jam.queue_revision.wrapping_add(1);
+    }
+    NoContentQueueReconciliation {
+        uncertain_skip: None,
+        naturally_finished,
+    }
+}
+
+fn stopped_playback_reached_track_end(now_playing: &NowPlayingInfo) -> bool {
+    !now_playing.is_playing
+        && now_playing.duration_ms > 0
+        && now_playing.progress_ms >= now_playing.duration_ms
+}
+
+fn prior_playback_finished_before_no_content(
+    now_playing: &NowPlayingInfo,
+    elapsed: Duration,
+) -> bool {
+    now_playing.is_playing
+        && now_playing.duration_ms > 0
+        && now_playing
+            .progress_ms
+            .saturating_add(elapsed.as_millis().min(u64::MAX as u128) as u64)
+            >= now_playing.duration_ms
+}
+
+fn prior_playback_corroborates_track_end(previous: &NowPlayingInfo, current_uri: &str) -> bool {
+    previous.spotify_uri == current_uri
+        && previous
+            .fetched_at
+            .is_some_and(|at| prior_playback_finished_before_no_content(previous, at.elapsed()))
+}
+
+fn retire_finished_queue_frontier(
+    queue: &mut Vec<JamQueueEntry>,
+    current_uri: &str,
+) -> Option<QueuedTrack> {
+    let front = queue.first()?;
+    if current_uri.is_empty()
+        || front.track.spotify_uri != current_uri
+        || front.delivery_state != QueueDeliveryState::SpotifyCommitted
+        || front.current_match_state != QueueCurrentMatchState::Eligible
+    {
+        return None;
+    }
+    Some(queue.remove(0).track)
+}
+
+fn mark_observed_queue_stopped(jam: &mut JamState) -> bool {
+    if jam.queue_control_stopped
+        || !jam
+            .queue
+            .iter()
+            .any(|entry| entry.delivery_state.occupies_spotify_frontier())
+    {
+        return false;
+    }
+    jam.queue_control_epoch = jam.queue_control_epoch.wrapping_add(1);
+    jam.queue_stop_epoch = jam.queue_stop_epoch.wrapping_add(1);
+    jam.queue_control_stopped = true;
+    true
+}
+
+fn retire_stale_frontier_for_queue_placement(
+    jam: &mut JamState,
+    observation: &SpotifyPlacementObservation,
+) -> Option<QueuedTrack> {
+    // An intentional Stop or safety stop is an explicit fence. A queue add may
+    // resume that preserved frontier, but it must never reinterpret it as a
+    // naturally completed occurrence and delete its provenance.
+    if jam.queue_control_stopped {
+        return None;
+    }
+    let finished_uri = if observation.bound_playback_stopped_at_end() {
+        observation.current_uri.as_ref().and_then(|current_uri| {
+            jam.now_playing
+                .as_ref()
+                .filter(|previous| prior_playback_corroborates_track_end(previous, current_uri))
+                .map(|_| current_uri.clone())
+        })
+    } else if !observation.playback_present {
+        jam.now_playing.as_ref().and_then(|now_playing| {
+            let elapsed = now_playing.fetched_at.map(|at| at.elapsed())?;
+            prior_playback_finished_before_no_content(now_playing, elapsed)
+                .then(|| now_playing.spotify_uri.clone())
+        })
+    } else {
+        None
+    }?;
+    let removed = retire_finished_queue_frontier(&mut jam.queue, &finished_uri)?;
+    jam.queue_revision = jam.queue_revision.wrapping_add(1);
+    jam.now_playing = None;
+    Some(removed)
+}
+
+async fn persist_jam_history_observation(
+    state: &AppState,
+    observation_generation: u64,
+    observation: HistoryObservation,
+) {
+    if let Some(track) = observation.queued_track {
+        let history = std::sync::Arc::clone(&state.jam_history);
+        let jam_state = std::sync::Arc::clone(&state.jam);
+        let observed_spotify_id = observation.spotify_id;
+        let observed_echo_run = observation.echo_run;
+        let played_at_ms = now_ts_ms();
+        match tokio::task::spawn_blocking(move || {
+            let entry = history.append_observation(&track, played_at_ms)?;
+            let mut jam = jam_state.lock().unwrap_or_else(|error| error.into_inner());
+            if active_generation_matches(&jam, observation_generation) {
+                jam.last_history_spotify_id = Some(observed_spotify_id);
+                jam.last_history_was_echo = observed_echo_run;
+            }
+            Ok::<_, std::io::Error>(entry)
+        })
+        .await
+        {
+            Ok(Ok(_)) => {}
+            Ok(Err(error)) => {
+                warn!("Jam history observation could not be persisted: {}", error);
+            }
+            Err(error) => {
+                warn!("Jam history persistence task failed: {}", error);
+            }
+        }
+    } else {
+        // External Spotify playback and intentionally deduped same-song Echo
+        // occurrences advance run provenance without appending.
+        let mut jam = state.jam.lock().unwrap_or_else(|error| error.into_inner());
+        if active_generation_matches(&jam, observation_generation) {
+            jam.last_history_spotify_id = Some(observation.spotify_id);
+            jam.last_history_was_echo = observation.echo_run;
+        }
+    }
 }
 
 pub(crate) async fn jam_state(
@@ -1724,13 +2943,14 @@ pub(crate) async fn jam_state(
         if !jam.active || jam.spotify_token.is_none() {
             None
         } else {
-            let due = match &jam.now_playing {
-                None => true,
-                Some(np) => match np.fetched_at {
+            let due = jam.uncertain_skip.is_some()
+                || match &jam.now_playing {
                     None => true,
-                    Some(t) => t.elapsed() > Duration::from_secs(5),
-                },
-            };
+                    Some(np) => match np.fetched_at {
+                        None => true,
+                        Some(t) => t.elapsed() > Duration::from_secs(5),
+                    },
+                };
             if due {
                 jam.spotify_device_id
                     .clone()
@@ -1755,9 +2975,20 @@ pub(crate) async fn jam_state(
             if resp.status() == reqwest::StatusCode::NO_CONTENT {
                 let mut jam = state.jam.lock().unwrap_or_else(|e| e.into_inner());
                 if playback_fetch_matches(&jam, fetch_generation, &fetch_device_id) {
+                    let reconciliation = reconcile_queue_after_no_content(&mut jam);
+                    if let Some(result) = reconciliation.uncertain_skip {
+                        info!("Jam: reconciled uncertain Spotify Skip as {:?}", result);
+                    }
+                    if let Some(removed) = reconciliation.naturally_finished {
+                        info!(
+                            "Jam: retired naturally finished queue track '{}'",
+                            removed.name
+                        );
+                    }
                     jam.spotify_is_playing = false;
                     jam.audio_expected_since = None;
                     jam.now_playing = None;
+                    mark_observed_queue_stopped(&mut jam);
                 }
             } else if resp.status().is_success() {
                 if let Ok(data) = resp.json::<serde_json::Value>().await {
@@ -1787,6 +3018,21 @@ pub(crate) async fn jam_state(
                         is_playing: data["is_playing"].as_bool().unwrap_or(false),
                         fetched_at: Some(std::time::Instant::now()),
                     };
+                    let repeat_state = data["repeat_state"].as_str().unwrap_or("").to_string();
+                    let should_observe_next_queue = {
+                        let jam = state.jam.lock().unwrap_or_else(|error| error.into_inner());
+                        playback_fetch_matches(&jam, fetch_generation, &fetch_device_id)
+                            && ((matches!(repeat_state.as_str(), "off" | "context")
+                                && same_track_occurrence_restarted(jam.now_playing.as_ref(), &np))
+                                || jam.uncertain_skip.as_ref().is_some_and(|boundary| {
+                                    boundary.queue_observation_required(&current_uri)
+                                }))
+                    };
+                    let queue_observation = if should_observe_next_queue {
+                        spotify_queue_observation(&state).await
+                    } else {
+                        None
+                    };
                     let mut jam = state.jam.lock().unwrap_or_else(|e| e.into_inner());
                     let actual_device_id = data["device"]["id"].as_str();
                     if !playback_fetch_matches(&jam, fetch_generation, &fetch_device_id) {
@@ -1800,36 +3046,111 @@ pub(crate) async fn jam_state(
                             jam.spotify_device_name.as_deref().unwrap_or("unknown")
                         ));
                     } else {
+                        let repeated_occurrence = repeated_occurrence_advance_confirmed(
+                            jam.now_playing.as_ref(),
+                            &np,
+                            &repeat_state,
+                            queue_observation.as_ref(),
+                        );
+                        let uncertain_skip_result = reconcile_uncertain_skip_boundary(
+                            &mut jam,
+                            Some(&current_uri),
+                            queue_observation.as_ref(),
+                        );
+                        let uncertain_skip_pending = matches!(
+                            uncertain_skip_result,
+                            Some(UncertainSkipObservationResult::Pending)
+                        );
+                        let uncertain_skip_observed =
+                            uncertain_skip_blocks_ordinary_queue_update(uncertain_skip_result);
+                        if let Some(result) = uncertain_skip_result {
+                            info!("Jam: uncertain Spotify Skip observation is {:?}", result);
+                        }
+                        if uncertain_skip_observed && !uncertain_skip_pending {
+                            jam.last_error = None;
+                        }
                         jam.spotify_is_playing = np.is_playing;
                         if np.is_playing {
                             jam.audio_expected_since
                                 .get_or_insert_with(std::time::Instant::now);
-                            jam.last_error = None;
+                            if !uncertain_skip_pending {
+                                jam.last_error = None;
+                            }
                         } else {
                             jam.audio_expected_since = None;
                         }
                         // Only observed playback on the bound device can advance Echo's
                         // display queue. External items never drain queued Echo tracks.
-                        for removed in reconcile_queue_to_current(&mut jam.queue, &current_uri) {
+                        if repeated_occurrence && !uncertain_skip_observed {
+                            if let Some(removed) =
+                                advance_repeated_committed_occurrence(&mut jam.queue, &current_uri)
+                            {
+                                jam.queue_revision = jam.queue_revision.wrapping_add(1);
+                                info!("Jam: advanced repeated queue occurrence '{}'", removed.name);
+                            }
+                        }
+                        if !uncertain_skip_observed
+                            && observe_queue_current_transition(
+                                &mut jam.queue,
+                                &current_uri,
+                                repeated_occurrence,
+                            )
+                        {
+                            jam.queue_revision = jam.queue_revision.wrapping_add(1);
+                        }
+                        let removed_tracks = if uncertain_skip_observed {
+                            Vec::new()
+                        } else {
+                            reconcile_queue_to_current(&mut jam.queue, &current_uri)
+                        };
+                        if !removed_tracks.is_empty() {
+                            jam.queue_revision = jam.queue_revision.wrapping_add(1);
+                        }
+                        for removed in removed_tracks {
                             info!(
                                 "Jam: auto-removed finished track '{}' from queue",
                                 removed.name
                             );
                         }
+                        let stopped_at_track_end = !uncertain_skip_observed
+                            && stopped_playback_reached_track_end(&np)
+                            && jam.now_playing.as_ref().is_some_and(|previous| {
+                                prior_playback_corroborates_track_end(previous, &current_uri)
+                            });
+                        if stopped_at_track_end {
+                            if let Some(removed) =
+                                retire_finished_queue_frontier(&mut jam.queue, &current_uri)
+                            {
+                                jam.queue_revision = jam.queue_revision.wrapping_add(1);
+                                info!(
+                                    "Jam: retired naturally finished queue track '{}'",
+                                    removed.name
+                                );
+                            }
+                        }
+                        if stopped_at_track_end {
+                            mark_observed_queue_stopped(&mut jam);
+                        }
                         let observed_spotify_id =
                             (!np.spotify_id.is_empty()).then_some(np.spotify_id.as_str());
-                        let queued_track = jam
-                            .queue
-                            .first()
-                            .filter(|track| track.spotify_uri == current_uri)
-                            .cloned();
-                        history_observation = new_history_observation(
-                            jam.last_history_spotify_id.as_deref(),
-                            observed_spotify_id,
-                            queued_track.as_ref(),
-                            np.is_playing,
-                        )
-                        .map(|observation| (fetch_generation, observation));
+                        let queued_track = (!uncertain_skip_pending)
+                            .then(|| {
+                                committed_queue_track_matching_current(&jam.queue, &current_uri)
+                            })
+                            .flatten();
+                        history_observation = (!uncertain_skip_pending)
+                            .then(|| {
+                                new_history_observation(
+                                    jam.last_history_spotify_id.as_deref(),
+                                    jam.last_history_was_echo,
+                                    observed_spotify_id,
+                                    queued_track.as_ref(),
+                                    np.is_playing,
+                                    repeated_occurrence && !uncertain_skip_observed,
+                                )
+                            })
+                            .flatten()
+                            .map(|observation| (fetch_generation, observation));
                         jam.now_playing = Some(np);
                     }
                 }
@@ -1837,39 +3158,17 @@ pub(crate) async fn jam_state(
         }
     }
     if let Some((observation_generation, observation)) = history_observation {
-        if let Some(track) = observation.queued_track {
-            let history = std::sync::Arc::clone(&state.jam_history);
-            let jam_state = std::sync::Arc::clone(&state.jam);
-            let observed_spotify_id = observation.spotify_id;
-            let played_at_ms = now_ts_ms();
-            match tokio::task::spawn_blocking(move || {
-                let entry = history.append_observation(&track, played_at_ms)?;
-                let mut jam = jam_state.lock().unwrap_or_else(|error| error.into_inner());
-                if active_generation_matches(&jam, observation_generation) {
-                    jam.last_history_spotify_id = Some(observed_spotify_id);
-                }
-                Ok::<_, std::io::Error>(entry)
-            })
-            .await
-            {
-                Ok(Ok(_)) => {}
-                Ok(Err(error)) => {
-                    warn!("Jam history observation could not be persisted: {}", error);
-                }
-                Err(error) => {
-                    warn!("Jam history persistence task failed: {}", error);
-                }
-            }
-        } else {
-            // External Spotify playback is a run boundary, but is not itself
-            // part of Echo's history.
-            let mut jam = state.jam.lock().unwrap_or_else(|error| error.into_inner());
-            if active_generation_matches(&jam, observation_generation) {
-                jam.last_history_spotify_id = Some(observation.spotify_id);
-            }
-        }
+        persist_jam_history_observation(&state, observation_generation, observation).await;
     }
     drop(refresh_guard);
+
+    let pump_generation = {
+        let jam = state.jam.lock().unwrap_or_else(|error| error.into_inner());
+        jam.active.then_some(jam.generation)
+    };
+    if let Some(pump_generation) = pump_generation {
+        pump_queue_frontier(&state, pump_generation).await;
+    }
 
     // Build response (extract all data from std::sync::Mutex before awaiting)
     let (
@@ -1878,12 +3177,16 @@ pub(crate) async fn jam_state(
         generation,
         host_identity,
         queue,
+        queue_revision,
+        history_revision,
         now_playing,
         listeners,
         spotify_connected,
+        spotify_library_authorized,
         spotify_device_id,
         spotify_device_name,
         last_error,
+        skip_reconciliation_pending,
         spotify_is_playing,
         audio_expected_ms,
     ) = {
@@ -1894,12 +3197,16 @@ pub(crate) async fn jam_state(
             jam.generation,
             jam.host_identity.clone(),
             jam.queue.clone(),
+            jam.queue_revision,
+            state.jam_history.revision(),
             jam.now_playing.clone(),
             jam.listeners.keys().cloned().collect::<Vec<String>>(),
             jam.spotify_token.is_some(),
+            spotify_library_scopes_authorized(jam.spotify_token.as_ref()),
             jam.spotify_device_id.clone(),
             jam.spotify_device_name.clone(),
             jam.last_error.clone(),
+            jam.uncertain_skip.is_some(),
             jam.spotify_is_playing,
             jam.audio_expected_since
                 .map(|at| at.elapsed().as_millis().min(u64::MAX as u128) as u64),
@@ -1942,16 +3249,23 @@ pub(crate) async fn jam_state(
         "generation": generation,
         "host_identity": host_identity,
         "queue": queue,
+        "queue_revision": queue_revision,
+        "history_revision": history_revision,
+        "queue_removal_supported": true,
+        "track_queue_request_id_supported": true,
         "now_playing": now_playing,
         "listeners": listeners,
         "listener_count": listener_count,
         "spotify_connected": spotify_connected,
+        "spotify_library_authorized": spotify_library_authorized,
         "spotify_device_id": spotify_device_id,
         "spotify_device_name": spotify_device_name,
         "spotify_is_playing": spotify_is_playing,
         "playback_stop_supported": true,
+        "playlist_selection_supported": true,
         "bot_connected": bot_connected,
         "last_error": last_error,
+        "skip_reconciliation_pending": skip_reconciliation_pending,
         "jam_protocol_version": crate::jam_source::JAM_SOURCE_PROTOCOL_VERSION,
         "source_status": source_status,
         "source_error": source_error,
@@ -2065,6 +3379,14 @@ fn enqueue_interrupted_by_stop(
     current_control_epoch != expected_control_epoch && control_stopped
 }
 
+fn enqueue_admission_cancelled_by_stop(admitted_stop_epoch: u64, current_stop_epoch: u64) -> bool {
+    current_stop_epoch != admitted_stop_epoch
+}
+
+fn queue_control_stopped_after_skip(spotify_was_playing: bool) -> bool {
+    !spotify_was_playing
+}
+
 fn playlist_queue_request_id_valid(request_id: &str) -> bool {
     (8..=128).contains(&request_id.len())
         && request_id
@@ -2072,9 +3394,37 @@ fn playlist_queue_request_id_valid(request_id: &str) -> bool {
             .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
 }
 
-fn playlist_batch_flags(has_failure: bool, skipped_count: usize) -> (bool, bool) {
-    let partial = has_failure || skipped_count > 0;
-    (partial, !partial)
+fn playlist_queue_selection_fingerprint(
+    payload: &PlaylistQueueRequest,
+) -> Result<PlaylistQueueSelectionFingerprint, Response> {
+    if payload
+        .snapshot_id
+        .as_deref()
+        .is_some_and(|snapshot_id| snapshot_id.trim().is_empty() || snapshot_id.len() > 512)
+    {
+        return Err(playlist_queue_error_response(
+            StatusCode::BAD_REQUEST,
+            "invalid_snapshot_id",
+            "snapshot_id must be 1-512 non-whitespace characters when supplied",
+        ));
+    }
+    let selected_positions = payload
+        .selected_positions
+        .as_deref()
+        .map(validate_selected_playlist_positions)
+        .transpose()
+        .map_err(JamApiError::into_response)?;
+    if selected_positions.is_some() && payload.snapshot_id.is_none() {
+        return Err(playlist_queue_error_response(
+            StatusCode::BAD_REQUEST,
+            "playlist_snapshot_required",
+            "snapshot_id is required when queueing selected playlist positions",
+        ));
+    }
+    Ok(PlaylistQueueSelectionFingerprint {
+        selected_positions,
+        snapshot_id: payload.snapshot_id.clone(),
+    })
 }
 
 fn playlist_provenance(summary: &FavoriteSummary) -> QueuedPlaylistProvenance {
@@ -2091,6 +3441,7 @@ fn queued_track_from_summary(
     actor: &JamActor,
     batch_id: Option<&str>,
     playlist: Option<&QueuedPlaylistProvenance>,
+    playlist_position: Option<usize>,
     added_at_ms: u64,
 ) -> QueuedTrack {
     QueuedTrack {
@@ -2107,14 +3458,39 @@ fn queued_track_from_summary(
         added_by_actor_id: actor.actor_id.clone(),
         added_by_name: actor.display_name.clone(),
         playlist: playlist.cloned(),
+        playlist_position,
         added_by: actor.display_name.clone(),
     }
 }
 
-async fn spotify_playback_should_queue(
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+struct SpotifyPlacementObservation {
+    playback_present: bool,
+    bound_device: bool,
+    is_playing: bool,
+    current_uri: Option<String>,
+    progress_ms: u64,
+    duration_ms: u64,
+}
+
+impl SpotifyPlacementObservation {
+    fn should_queue(&self) -> bool {
+        self.playback_present && self.bound_device && self.is_playing
+    }
+
+    fn bound_playback_stopped_at_end(&self) -> bool {
+        self.playback_present
+            && self.bound_device
+            && !self.is_playing
+            && self.duration_ms > 0
+            && self.progress_ms >= self.duration_ms
+    }
+}
+
+async fn spotify_queue_placement_observation(
     state: &AppState,
     device: &SpotifyDevice,
-) -> Result<bool, (StatusCode, String)> {
+) -> Result<SpotifyPlacementObservation, (StatusCode, String)> {
     let response = spotify_api_request(
         state,
         reqwest::Method::GET,
@@ -2123,7 +3499,7 @@ async fn spotify_playback_should_queue(
     )
     .await?;
     if response.status() == reqwest::StatusCode::NO_CONTENT {
-        return Ok(false);
+        return Ok(SpotifyPlacementObservation::default());
     }
     if !response.status().is_success() {
         return Err(spotify_response_error(response, "Read Spotify playback").await);
@@ -2134,25 +3510,66 @@ async fn spotify_playback_should_queue(
             format!("Spotify playback response was invalid: {error}"),
         )
     })?;
-    Ok(playback["is_playing"].as_bool().unwrap_or(false)
-        && playback["device"]["id"].as_str() == Some(device.id.as_str()))
+    Ok(SpotifyPlacementObservation {
+        playback_present: true,
+        bound_device: playback["device"]["id"].as_str() == Some(device.id.as_str()),
+        is_playing: playback["is_playing"].as_bool().unwrap_or(false),
+        current_uri: playback["item"]["uri"]
+            .as_str()
+            .filter(|uri| !uri.trim().is_empty())
+            .map(str::to_string),
+        progress_ms: playback["progress_ms"].as_u64().unwrap_or(0),
+        duration_ms: playback["item"]["duration_ms"].as_u64().unwrap_or(0),
+    })
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum SpotifyTrackPlacement {
+    StartedCurrent,
+    QueuedNext,
+}
+
+impl SpotifyTrackPlacement {
+    fn current_match_state(self) -> QueueCurrentMatchState {
+        match self {
+            Self::StartedCurrent => QueueCurrentMatchState::Eligible,
+            Self::QueuedNext => QueueCurrentMatchState::AwaitingTransition,
+        }
+    }
+}
+
+fn spotify_track_placement(should_queue: bool) -> SpotifyTrackPlacement {
+    if should_queue {
+        SpotifyTrackPlacement::QueuedNext
+    } else {
+        SpotifyTrackPlacement::StartedCurrent
+    }
 }
 
 async fn place_spotify_track(
     state: &AppState,
     device: &SpotifyDevice,
     spotify_uri: &str,
-    should_queue: bool,
-) -> Result<(), (StatusCode, String)> {
-    if should_queue {
+    placement: SpotifyTrackPlacement,
+) -> Result<SpotifyTrackPlacement, QueueCommitError> {
+    if placement == SpotifyTrackPlacement::QueuedNext {
         let queue_url = format!(
             "https://api.spotify.com/v1/me/player/queue?uri={}&device_id={}",
             urlencoded(spotify_uri),
             urlencoded(&device.id),
         );
-        let response = spotify_api_request(state, reqwest::Method::POST, &queue_url, None).await?;
+        let response = spotify_api_request(state, reqwest::Method::POST, &queue_url, None)
+            .await
+            .map_err(|(status, message)| {
+                queue_mutation_request_error(status, message, placement)
+            })?;
         if !response.status().is_success() {
-            return Err(spotify_response_error(response, "Queue Spotify track").await);
+            return Err(spotify_queue_mutation_response_error(
+                response,
+                "Queue Spotify track",
+                placement,
+            )
+            .await);
         }
         info!("Track queued on configured Spotify device: {spotify_uri}");
     } else {
@@ -2161,25 +3578,534 @@ async fn place_spotify_track(
             urlencoded(&device.id)
         );
         let play_body = serde_json::json!({ "uris": [spotify_uri] });
-        let response =
-            spotify_api_request(state, reqwest::Method::PUT, &play_url, Some(play_body)).await?;
+        let response = spotify_api_request(state, reqwest::Method::PUT, &play_url, Some(play_body))
+            .await
+            .map_err(|(status, message)| {
+                queue_mutation_request_error(status, message, placement)
+            })?;
         if !response.status().is_success() {
-            return Err(spotify_response_error(response, "Start Spotify track").await);
+            return Err(spotify_queue_mutation_response_error(
+                response,
+                "Start Spotify track",
+                placement,
+            )
+            .await);
         }
         info!("Track started on configured Spotify device: {spotify_uri}");
+    }
+    Ok(placement)
+}
+
+async fn resume_spotify_playback_on_device(
+    state: &AppState,
+    device: &SpotifyDevice,
+) -> Result<(), (StatusCode, String)> {
+    let play_url = format!(
+        "https://api.spotify.com/v1/me/player/play?device_id={}",
+        urlencoded(&device.id)
+    );
+    let response = spotify_api_request(state, reqwest::Method::PUT, &play_url, None).await?;
+    if !response.status().is_success() {
+        return Err(spotify_response_error(response, "Resume Spotify playback").await);
     }
     Ok(())
 }
 
-async fn enqueue_playlist_track_guarded(
+#[derive(Debug)]
+struct QueueCommitError {
+    status: StatusCode,
+    message: String,
+    acceptance_ambiguous: bool,
+    intended_placement: Option<SpotifyTrackPlacement>,
+}
+
+fn definite_queue_commit_error(status: StatusCode, message: String) -> QueueCommitError {
+    QueueCommitError {
+        status,
+        message,
+        acceptance_ambiguous: false,
+        intended_placement: None,
+    }
+}
+
+fn queue_mutation_request_error(
+    status: StatusCode,
+    message: String,
+    placement: SpotifyTrackPlacement,
+) -> QueueCommitError {
+    QueueCommitError {
+        status,
+        message,
+        // BAD_GATEWAY is the transport-error channel from reqwest::send. The
+        // request may have reached Spotify. Rate-limit/gate/auth errors happen
+        // before a mutation can be accepted and remain definite.
+        acceptance_ambiguous: status == StatusCode::BAD_GATEWAY,
+        intended_placement: Some(placement),
+    }
+}
+
+fn spotify_mutation_response_is_ambiguous(status: reqwest::StatusCode) -> bool {
+    status.is_server_error()
+}
+
+#[derive(Debug)]
+struct SkipMutationError {
+    status: StatusCode,
+    message: String,
+    acceptance_ambiguous: bool,
+}
+
+fn skip_mutation_request_error(status: StatusCode, message: String) -> SkipMutationError {
+    SkipMutationError {
+        status,
+        message,
+        // BAD_GATEWAY is spotify_api_request's transport-error channel. Gate,
+        // rate-limit, and authentication failures happen before acceptance.
+        acceptance_ambiguous: status == StatusCode::BAD_GATEWAY,
+    }
+}
+
+async fn spotify_skip_mutation_response_error(response: reqwest::Response) -> SkipMutationError {
+    let upstream_status = response.status();
+    let (status, message) = spotify_response_error(response, "Skip Spotify track").await;
+    SkipMutationError {
+        status,
+        message,
+        acceptance_ambiguous: spotify_mutation_response_is_ambiguous(upstream_status),
+    }
+}
+
+async fn run_guarded_spotify_skip_mutation<T, F>(
     state: &AppState,
     generation: u64,
-    track: &QueuedTrack,
+    device: &SpotifyDevice,
+    operation: F,
+) -> Result<T, SkipMutationError>
+where
+    F: Future<Output = Result<T, SkipMutationError>>,
+{
+    let guarded_result: Result<Result<T, SkipMutationError>, SkipMutationError> = tokio::select! {
+        result = tokio::time::timeout(SPOTIFY_RECOVERY_OPERATION_TIMEOUT, operation) => {
+            match result {
+                Ok(result) => Ok(result),
+                Err(_) => Err(SkipMutationError {
+                    status: StatusCode::SERVICE_UNAVAILABLE,
+                    message: format!(
+                        "Skipping a Spotify track exceeded the {}s source-safety deadline",
+                        SPOTIFY_RECOVERY_OPERATION_TIMEOUT.as_secs(),
+                    ),
+                    acceptance_ambiguous: true,
+                }),
+            }
+        }
+        (status, message) = wait_for_jam_recovery_controls_loss(state, generation) => {
+            Err(SkipMutationError {
+                status,
+                message,
+                acceptance_ambiguous: true,
+            })
+        },
+    };
+
+    if let Ok(Err(error)) = &guarded_result {
+        if !error.acceptance_ambiguous {
+            return Err(SkipMutationError {
+                status: error.status,
+                message: error.message.clone(),
+                acceptance_ambiguous: false,
+            });
+        }
+    }
+    let operation_result = match guarded_result {
+        Err(error) => Err(error),
+        Ok(operation_result) => match ensure_jam_recovery_controls_ready(state).await {
+            Ok(current_generation) if current_generation == generation => operation_result,
+            Ok(_) => Err(SkipMutationError {
+                status: StatusCode::CONFLICT,
+                message: "Jam generation changed during Spotify Skip".to_string(),
+                acceptance_ambiguous: true,
+            }),
+            Err((status, message)) => Err(SkipMutationError {
+                status,
+                message,
+                acceptance_ambiguous: true,
+            }),
+        },
+    };
+    if let Err(error) = &operation_result {
+        if error.acceptance_ambiguous {
+            pause_and_mark_spotify_safety_stop(state, generation, device, &error.message).await;
+        }
+    }
+    operation_result
+}
+
+async fn spotify_queue_mutation_response_error(
+    response: reqwest::Response,
+    operation: &str,
+    placement: SpotifyTrackPlacement,
+) -> QueueCommitError {
+    let upstream_status = response.status();
+    let (status, message) = spotify_response_error(response, operation).await;
+    QueueCommitError {
+        status,
+        message,
+        acceptance_ambiguous: spotify_mutation_response_is_ambiguous(upstream_status),
+        intended_placement: Some(placement),
+    }
+}
+
+async fn run_guarded_spotify_recovery_read<T, F>(
+    state: &AppState,
+    generation: u64,
+    operation_name: &str,
+    operation: F,
+) -> Result<T, (StatusCode, String)>
+where
+    F: Future<Output = Result<T, (StatusCode, String)>>,
+{
+    let result = tokio::select! {
+        result = tokio::time::timeout(SPOTIFY_RECOVERY_OPERATION_TIMEOUT, operation) => {
+            result.map_err(|_| (
+                StatusCode::SERVICE_UNAVAILABLE,
+                format!(
+                    "{} exceeded the {}s source-safety deadline",
+                    operation_name,
+                    SPOTIFY_RECOVERY_OPERATION_TIMEOUT.as_secs(),
+                ),
+            ))?
+        }
+        error = wait_for_jam_recovery_controls_loss(state, generation) => return Err(error),
+    };
+    match ensure_jam_recovery_controls_ready(state).await {
+        Ok(current_generation) if current_generation == generation => result,
+        Ok(_) => Err((
+            StatusCode::CONFLICT,
+            "Jam generation changed during Spotify observation".to_string(),
+        )),
+        Err(error) => Err(error),
+    }
+}
+
+async fn run_guarded_spotify_queue_mutation<T, F>(
+    state: &AppState,
+    generation: u64,
+    device: &SpotifyDevice,
+    operation_name: &str,
+    placement: SpotifyTrackPlacement,
+    operation: F,
+) -> Result<T, QueueCommitError>
+where
+    F: Future<Output = Result<T, QueueCommitError>>,
+{
+    let guarded_result = tokio::select! {
+        result = tokio::time::timeout(SPOTIFY_RECOVERY_OPERATION_TIMEOUT, operation) => {
+            match result {
+                Ok(result) => Ok(result),
+                Err(_) => Err(QueueCommitError {
+                    status: StatusCode::SERVICE_UNAVAILABLE,
+                    message: format!(
+                        "{} exceeded the {}s source-safety deadline",
+                        operation_name,
+                        SPOTIFY_RECOVERY_OPERATION_TIMEOUT.as_secs(),
+                    ),
+                    acceptance_ambiguous: true,
+                    intended_placement: Some(placement),
+                }),
+            }
+        }
+        (status, message) = wait_for_jam_recovery_controls_loss(state, generation) => {
+            Err(QueueCommitError {
+                status,
+                message,
+                acceptance_ambiguous: true,
+                intended_placement: Some(placement),
+            })
+        },
+    };
+
+    if let Ok(Err(error)) = &guarded_result {
+        if !error.acceptance_ambiguous {
+            return Err(QueueCommitError {
+                status: error.status,
+                message: error.message.clone(),
+                acceptance_ambiguous: false,
+                intended_placement: error.intended_placement,
+            });
+        }
+    }
+    match guarded_result {
+        Err(error) => {
+            pause_and_mark_spotify_safety_stop(state, generation, device, &error.message).await;
+            Err(error)
+        }
+        Ok(operation_result) => match ensure_jam_recovery_controls_ready(state).await {
+            Ok(current_generation) if current_generation == generation => operation_result,
+            Ok(_) => {
+                let error = QueueCommitError {
+                    status: StatusCode::CONFLICT,
+                    message: "Jam generation changed during Spotify queue control".to_string(),
+                    acceptance_ambiguous: true,
+                    intended_placement: Some(placement),
+                };
+                pause_and_mark_spotify_safety_stop(state, generation, device, &error.message).await;
+                Err(error)
+            }
+            Err((status, message)) => {
+                let error = QueueCommitError {
+                    status,
+                    message,
+                    acceptance_ambiguous: true,
+                    intended_placement: Some(placement),
+                };
+                pause_and_mark_spotify_safety_stop(state, generation, device, &error.message).await;
+                Err(error)
+            }
+        },
+    }
+}
+
+fn queue_frontier_candidate(queue: &[JamQueueEntry]) -> Option<JamQueueEntry> {
+    let frontier_count = queue
+        .iter()
+        .filter(|entry| entry.delivery_state.occupies_spotify_frontier())
+        .count();
+    if frontier_count >= SPOTIFY_COMMITTED_QUEUE_FRONTIER || queue_has_commit_unknown(queue) {
+        return None;
+    }
+    queue
+        .iter()
+        .find(|entry| entry.delivery_state == QueueDeliveryState::Pending)
+        .cloned()
+}
+
+fn queue_has_commit_unknown(queue: &[JamQueueEntry]) -> bool {
+    queue
+        .iter()
+        .any(|entry| entry.delivery_state == QueueDeliveryState::CommitUnknown)
+}
+
+fn commit_unknown_queue_add_response() -> Response {
+    playlist_queue_error_response(
+        StatusCode::CONFLICT,
+        "queue_commit_unknown",
+        "Spotify acceptance of an earlier queue entry is unknown. End and restart the Jam before adding more songs",
+    )
+}
+
+fn has_existing_spotify_frontier(queue: &[JamQueueEntry], candidate_entry_id: &str) -> bool {
+    queue.iter().any(|queued| {
+        queued.track.queue_entry_id != candidate_entry_id
+            && queued.delivery_state.occupies_spotify_frontier()
+    })
+}
+
+async fn commit_pending_queue_track_guarded(
+    state: &AppState,
+    generation: u64,
+    entry: &JamQueueEntry,
     should_queue: Option<bool>,
     expected_control_epoch: u64,
-) -> Result<u64, (StatusCode, String)> {
+    allow_resume_stopped: bool,
+) -> Result<u64, QueueCommitError> {
     // Keep the global lifecycle fence to one Spotify mutation. Stop, skip, and
     // teardown may run between batch entries and the next entry revalidates.
+    let _refresh = state.jam_state_refresh.lock().await;
+    let _lifecycle = state.jam_lifecycle.lock().await;
+    let current_generation = ensure_jam_recovery_controls_ready(state)
+        .await
+        .map_err(|(status, message)| definite_queue_commit_error(status, message))?;
+    if current_generation != generation {
+        return Err(definite_queue_commit_error(
+            StatusCode::CONFLICT,
+            "Jam generation changed".to_string(),
+        ));
+    }
+    let (device, control_epoch, control_stopped, mut has_existing_frontier) = {
+        let jam = state.jam.lock().unwrap_or_else(|error| error.into_inner());
+        if jam.uncertain_skip.is_some() {
+            return Err(definite_queue_commit_error(
+                StatusCode::CONFLICT,
+                "Echo is reconciling an uncertain Spotify Skip".to_string(),
+            ));
+        }
+        (
+            bound_spotify_device(&jam, generation).ok_or_else(|| {
+                definite_queue_commit_error(
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    "The active Jam has no bound Spotify device".to_string(),
+                )
+            })?,
+            jam.queue_control_epoch,
+            jam.queue_control_stopped,
+            has_existing_spotify_frontier(&jam.queue, &entry.track.queue_entry_id),
+        )
+    };
+    if enqueue_interrupted_by_stop(expected_control_epoch, control_epoch, control_stopped) {
+        return Err(definite_queue_commit_error(
+            StatusCode::CONFLICT,
+            "Playlist enqueue was interrupted by Stop Music".to_string(),
+        ));
+    }
+    let cached_should_queue =
+        cached_queue_mode(expected_control_epoch, control_epoch, should_queue);
+    let should_queue = match cached_should_queue {
+        Some(should_queue) => should_queue,
+        None => {
+            let observation = run_guarded_spotify_recovery_read(
+                state,
+                generation,
+                "Reading Spotify playback before queue placement",
+                spotify_queue_placement_observation(state, &device),
+            )
+            .await
+            .map_err(|(status, message)| definite_queue_commit_error(status, message))?;
+            let retired = {
+                let mut jam = state.jam.lock().unwrap_or_else(|error| error.into_inner());
+                if !active_generation_matches(&jam, generation)
+                    || jam.spotify_device_id.as_deref() != Some(device.id.as_str())
+                    || jam.queue_control_epoch != control_epoch
+                {
+                    None
+                } else {
+                    let retired = retire_stale_frontier_for_queue_placement(&mut jam, &observation);
+                    has_existing_frontier =
+                        has_existing_spotify_frontier(&jam.queue, &entry.track.queue_entry_id);
+                    retired
+                }
+            };
+            if let Some(retired) = retired {
+                info!(
+                    "Jam: retired stale terminal queue track '{}' before placing a new entry",
+                    retired.name
+                );
+            }
+
+            let mut should_queue = observation.should_queue();
+            if has_existing_frontier && !should_queue {
+                if !allow_resume_stopped {
+                    let mut jam = state.jam.lock().unwrap_or_else(|error| error.into_inner());
+                    if active_generation_matches(&jam, generation)
+                        && jam.spotify_device_id.as_deref() == Some(device.id.as_str())
+                        && jam.queue_control_epoch == control_epoch
+                    {
+                        mark_observed_queue_stopped(&mut jam);
+                    }
+                    return Err(definite_queue_commit_error(
+                        StatusCode::CONFLICT,
+                        "Spotify playback is paused; waiting for an explicit queue action"
+                            .to_string(),
+                    ));
+                }
+                run_guarded_spotify_recovery_operation(
+                    state,
+                    generation,
+                    &device,
+                    "Resuming Spotify before queue placement",
+                    resume_spotify_playback_on_device(state, &device),
+                )
+                .await
+                .map_err(|(status, message)| definite_queue_commit_error(status, message))?;
+                let resumed = {
+                    let mut jam = state.jam.lock().unwrap_or_else(|error| error.into_inner());
+                    if !active_generation_matches(&jam, generation)
+                        || jam.spotify_device_id.as_deref() != Some(device.id.as_str())
+                        || jam.queue_control_epoch != control_epoch
+                        || jam.queue_control_stopped
+                    {
+                        false
+                    } else {
+                        jam.spotify_device_name = Some(device.name.clone());
+                        jam.spotify_is_playing = true;
+                        jam.audio_expected_since = Some(std::time::Instant::now());
+                        jam.last_error = None;
+                        jam.now_playing = None;
+                        true
+                    }
+                };
+                if !resumed {
+                    let message =
+                        "Jam changed after Spotify resumed before queue placement".to_string();
+                    pause_and_mark_spotify_safety_stop(state, generation, &device, &message).await;
+                    return Err(definite_queue_commit_error(StatusCode::CONFLICT, message));
+                }
+                should_queue = true;
+            }
+            should_queue
+        }
+    };
+    let intended_placement = spotify_track_placement(should_queue);
+    let placement = run_guarded_spotify_queue_mutation(
+        state,
+        generation,
+        &device,
+        "Queueing a Spotify playlist track",
+        intended_placement,
+        place_spotify_track(state, &device, &entry.track.spotify_uri, intended_placement),
+    )
+    .await?;
+
+    let applied = {
+        let mut jam = state.jam.lock().unwrap_or_else(|error| error.into_inner());
+        if !active_generation_matches(&jam, generation)
+            || jam.spotify_device_id.as_deref() != Some(device.id.as_str())
+        {
+            false
+        } else {
+            let queue_track = jam
+                .queue
+                .iter_mut()
+                .find(|queued| queued.track.queue_entry_id == entry.track.queue_entry_id);
+            match queue_track {
+                Some(queue_track) if queue_track.delivery_state == QueueDeliveryState::Pending => {
+                    queue_track.delivery_state = QueueDeliveryState::SpotifyCommitted;
+                    queue_track.can_remove = false;
+                    queue_track.current_match_state = placement.current_match_state();
+                    jam.spotify_device_name = Some(device.name.clone());
+                    jam.last_error = None;
+                    jam.queue_revision = jam.queue_revision.wrapping_add(1);
+                    if placement == SpotifyTrackPlacement::StartedCurrent {
+                        jam.spotify_is_playing = true;
+                        jam.audio_expected_since = Some(std::time::Instant::now());
+                        jam.queue_control_stopped = false;
+                        jam.now_playing = None;
+                    }
+                    true
+                }
+                _ => false,
+            }
+        }
+    };
+    if !applied {
+        let message = "Jam changed after Spotify accepted a queue track".to_string();
+        pause_and_mark_spotify_safety_stop(state, generation, &device, &message).await;
+        return Err(QueueCommitError {
+            status: StatusCode::CONFLICT,
+            message,
+            acceptance_ambiguous: true,
+            intended_placement: Some(placement),
+        });
+    }
+    Ok(control_epoch)
+}
+
+fn stopped_frontier_should_resume(
+    queue: &[JamQueueEntry],
+    control_stopped: bool,
+    allow_resume_stopped: bool,
+) -> bool {
+    control_stopped
+        && allow_resume_stopped
+        && queue
+            .iter()
+            .any(|entry| entry.delivery_state.occupies_spotify_frontier())
+}
+
+async fn resume_stopped_queue_frontier_guarded(
+    state: &AppState,
+    generation: u64,
+    expected_control_epoch: u64,
+) -> Result<u64, (StatusCode, String)> {
     let _refresh = state.jam_state_refresh.lock().await;
     let _lifecycle = state.jam_lifecycle.lock().await;
     let current_generation = ensure_jam_recovery_controls_ready(state).await?;
@@ -2188,6 +4114,12 @@ async fn enqueue_playlist_track_guarded(
     }
     let (device, control_epoch, control_stopped) = {
         let jam = state.jam.lock().unwrap_or_else(|error| error.into_inner());
+        if jam.uncertain_skip.is_some() {
+            return Err((
+                StatusCode::CONFLICT,
+                "Echo is reconciling an uncertain Spotify Skip".to_string(),
+            ));
+        }
         (
             bound_spotify_device(&jam, generation).ok_or((
                 StatusCode::SERVICE_UNAVAILABLE,
@@ -2200,22 +4132,18 @@ async fn enqueue_playlist_track_guarded(
     if enqueue_interrupted_by_stop(expected_control_epoch, control_epoch, control_stopped) {
         return Err((
             StatusCode::CONFLICT,
-            "Playlist enqueue was interrupted by Stop Music".to_string(),
+            "Queue resume was interrupted by a newer Stop Music action".to_string(),
         ));
     }
-    let should_queue = cached_queue_mode(expected_control_epoch, control_epoch, should_queue);
+    if !control_stopped {
+        return Ok(control_epoch);
+    }
     run_guarded_spotify_recovery_operation(
         state,
         generation,
         &device,
-        "Queueing a Spotify playlist track",
-        async {
-            let should_queue = match should_queue {
-                Some(should_queue) => should_queue,
-                None => spotify_playback_should_queue(state, &device).await?,
-            };
-            place_spotify_track(state, &device, &track.spotify_uri, should_queue).await
-        },
+        "Resuming the stopped Spotify queue",
+        resume_spotify_playback_on_device(state, &device),
     )
     .await?;
 
@@ -2223,6 +4151,7 @@ async fn enqueue_playlist_track_guarded(
         let mut jam = state.jam.lock().unwrap_or_else(|error| error.into_inner());
         if !active_generation_matches(&jam, generation)
             || jam.spotify_device_id.as_deref() != Some(device.id.as_str())
+            || jam.queue_control_epoch != control_epoch
         {
             false
         } else {
@@ -2231,7 +4160,6 @@ async fn enqueue_playlist_track_guarded(
             jam.audio_expected_since = Some(std::time::Instant::now());
             jam.last_error = None;
             jam.queue_control_stopped = false;
-            jam.queue.push(track.clone());
             jam.now_playing = None;
             true
         }
@@ -2240,10 +4168,117 @@ async fn enqueue_playlist_track_guarded(
         pause_bound_spotify_before_release(state, generation, Some(&device)).await;
         return Err((
             StatusCode::CONFLICT,
-            "Jam changed after Spotify accepted a playlist track".to_string(),
+            "Jam changed after Spotify resumed the queue".to_string(),
         ));
     }
     Ok(control_epoch)
+}
+
+async fn pump_queue_frontier_locked(
+    state: &AppState,
+    generation: u64,
+    expected_control_epoch: u64,
+    allow_resume_stopped: bool,
+) {
+    let mut should_queue = None;
+    let mut control_epoch = expected_control_epoch;
+    loop {
+        let (control_stopped, should_resume, track) = {
+            let jam = state.jam.lock().unwrap_or_else(|error| error.into_inner());
+            if !active_generation_matches(&jam, generation) {
+                return;
+            }
+            (
+                jam.queue_control_stopped,
+                stopped_frontier_should_resume(
+                    &jam.queue,
+                    jam.queue_control_stopped,
+                    allow_resume_stopped,
+                ),
+                queue_frontier_candidate(&jam.queue),
+            )
+        };
+        if should_resume {
+            match resume_stopped_queue_frontier_guarded(state, generation, control_epoch).await {
+                Ok(observed_control_epoch) => {
+                    control_epoch = observed_control_epoch;
+                    should_queue = Some(true);
+                    continue;
+                }
+                Err((status, message)) => {
+                    let mut jam = state.jam.lock().unwrap_or_else(|error| error.into_inner());
+                    if active_generation_matches(&jam, generation) {
+                        jam.last_error = Some(message.clone());
+                    }
+                    warn!(
+                        "Jam stopped queue resume failed status={}: {}",
+                        status, message
+                    );
+                    return;
+                }
+            }
+        }
+        if control_stopped && !allow_resume_stopped {
+            return;
+        }
+        let Some(track) = track else {
+            return;
+        };
+        match commit_pending_queue_track_guarded(
+            state,
+            generation,
+            &track,
+            should_queue,
+            control_epoch,
+            allow_resume_stopped,
+        )
+        .await
+        {
+            Ok(observed_control_epoch) => {
+                should_queue = Some(true);
+                control_epoch = observed_control_epoch;
+            }
+            Err(error) => {
+                let mut jam = state
+                    .jam
+                    .lock()
+                    .unwrap_or_else(|poison| poison.into_inner());
+                if active_generation_matches(&jam, generation) {
+                    if error.acceptance_ambiguous {
+                        if let Some(queue_track) = jam.queue.iter_mut().find(|queued| {
+                            queued.track.queue_entry_id == track.track.queue_entry_id
+                        }) {
+                            if queue_track.delivery_state == QueueDeliveryState::Pending {
+                                queue_track.delivery_state = QueueDeliveryState::CommitUnknown;
+                                queue_track.can_remove = false;
+                                if let Some(placement) = error.intended_placement {
+                                    queue_track.current_match_state =
+                                        placement.current_match_state();
+                                }
+                                jam.queue_revision = jam.queue_revision.wrapping_add(1);
+                            }
+                        }
+                    }
+                    jam.last_error = Some(error.message.clone());
+                }
+                warn!(
+                    "Jam queue frontier delivery failed status={} ambiguous={}: {}",
+                    error.status, error.acceptance_ambiguous, error.message
+                );
+                return;
+            }
+        }
+    }
+}
+
+async fn pump_queue_frontier(state: &AppState, generation: u64) {
+    let _queue_lifecycle = state.jam_queue_lifecycle.lock().await;
+    let expected_control_epoch = state
+        .jam
+        .lock()
+        .unwrap_or_else(|error| error.into_inner())
+        .queue_control_epoch;
+    pump_queue_frontier_locked(state, generation, expected_control_epoch, false).await;
 }
 
 pub(crate) async fn jam_queue_add(
@@ -2261,6 +4296,15 @@ pub(crate) async fn jam_queue_add(
             "A current Echo participant token is required",
         )
     })?;
+    if let Some(request_id) = payload.request_id.as_deref() {
+        if !playlist_queue_request_id_valid(request_id) {
+            return Err(playlist_queue_error_response(
+                StatusCode::BAD_REQUEST,
+                "invalid_request_id",
+                "request_id must be 8-128 ASCII letters, digits, dashes, or underscores",
+            ));
+        }
+    }
     let spotify_id = spotify_track_id_from_uri(&payload.spotify_uri)
         .ok_or_else(|| {
             playlist_queue_error_response(
@@ -2270,97 +4314,317 @@ pub(crate) async fn jam_queue_add(
             )
         })?
         .to_string();
-    let request_control_epoch = state
-        .jam
-        .lock()
-        .unwrap_or_else(|error| error.into_inner())
-        .queue_control_epoch;
+    if let Some(request_id) = payload.request_id.as_deref() {
+        let replay = {
+            let jam = state.jam.lock().unwrap_or_else(|error| error.into_inner());
+            track_queue_receipt_response(
+                &jam,
+                request_id,
+                &actor.actor_id,
+                &spotify_id,
+                payload.generation,
+            )
+        };
+        match replay {
+            Ok(Some(track)) => {
+                return Ok(Json(serde_json::json!({
+                    "ok": true,
+                    "request_id": request_id,
+                    "track": track,
+                })));
+            }
+            Ok(None) => {}
+            Err(()) => {
+                return Err(playlist_queue_error_response(
+                    StatusCode::CONFLICT,
+                    "request_id_conflict",
+                    "request_id was already used for a different track queue operation",
+                ));
+            }
+        }
+    }
+    if {
+        let jam = state.jam.lock().unwrap_or_else(|error| error.into_inner());
+        active_generation_matches(&jam, payload.generation) && queue_has_commit_unknown(&jam.queue)
+    } {
+        return Err(commit_unknown_queue_add_response());
+    }
+    let (request_control_epoch, request_stop_epoch) = {
+        let jam = state.jam.lock().unwrap_or_else(|error| error.into_inner());
+        (jam.queue_control_epoch, jam.queue_stop_epoch)
+    };
     let summary = fetch_favorite_summary(&state, FavoriteKind::Track, &spotify_id)
         .await
         .map_err(JamApiError::into_response)?;
     let _queue_lifecycle = state.jam_queue_lifecycle.lock().await;
-    let _refresh = state.jam_state_refresh.lock().await;
-    let _lifecycle = state.jam_lifecycle.lock().await;
-    let generation =
-        ensure_jam_recovery_controls_ready(&state)
-            .await
-            .map_err(|(status, message)| {
-                spotify_queue_error_response(&state, status, "jam_unavailable", message)
-            })?;
-    if generation != payload.generation {
-        return Err(playlist_queue_error_response(
-            StatusCode::CONFLICT,
-            "generation_changed",
-            "Jam generation changed",
-        ));
+    if let Some(request_id) = payload.request_id.as_deref() {
+        let replay = {
+            let jam = state.jam.lock().unwrap_or_else(|error| error.into_inner());
+            track_queue_receipt_response(
+                &jam,
+                request_id,
+                &actor.actor_id,
+                &spotify_id,
+                payload.generation,
+            )
+        };
+        match replay {
+            Ok(Some(track)) => {
+                return Ok(Json(serde_json::json!({
+                    "ok": true,
+                    "request_id": request_id,
+                    "track": track,
+                })));
+            }
+            Ok(None) => {}
+            Err(()) => {
+                return Err(playlist_queue_error_response(
+                    StatusCode::CONFLICT,
+                    "request_id_conflict",
+                    "request_id was already used for a different track queue operation",
+                ));
+            }
+        }
     }
-    {
-        let jam = state.jam.lock().unwrap_or_else(|error| error.into_inner());
-        if enqueue_interrupted_by_stop(
-            request_control_epoch,
-            jam.queue_control_epoch,
-            jam.queue_control_stopped,
-        ) {
+    let track = queued_track_from_summary(&summary, &actor, None, None, None, now_ts_ms());
+    let generation = {
+        let _refresh = state.jam_state_refresh.lock().await;
+        let _lifecycle = state.jam_lifecycle.lock().await;
+        let generation =
+            ensure_jam_recovery_controls_ready(&state)
+                .await
+                .map_err(|(status, message)| {
+                    spotify_queue_error_response(&state, status, "jam_unavailable", message)
+                })?;
+        if generation != payload.generation {
+            return Err(playlist_queue_error_response(
+                StatusCode::CONFLICT,
+                "generation_changed",
+                "Jam generation changed",
+            ));
+        }
+        let mut jam = state.jam.lock().unwrap_or_else(|error| error.into_inner());
+        if jam.uncertain_skip.is_some() {
+            return Err(playlist_queue_error_response(
+                StatusCode::CONFLICT,
+                "skip_reconciliation_required",
+                "Echo is reconciling the previous Spotify Skip; wait for fresh playback state",
+            ));
+        }
+        if queue_has_commit_unknown(&jam.queue) {
+            return Err(commit_unknown_queue_add_response());
+        }
+        if enqueue_admission_cancelled_by_stop(request_stop_epoch, jam.queue_stop_epoch)
+            || enqueue_interrupted_by_stop(
+                request_control_epoch,
+                jam.queue_control_epoch,
+                jam.queue_control_stopped,
+            )
+        {
             return Err(playlist_queue_error_response(
                 StatusCode::CONFLICT,
                 "queue_interrupted",
                 "Track enqueue was interrupted by Stop Music",
             ));
         }
-    }
-    let device = {
-        let jam = state.jam.lock().unwrap_or_else(|e| e.into_inner());
-        bound_spotify_device(&jam, generation).ok_or_else(|| {
-            playlist_queue_error_response(
+        if bound_spotify_device(&jam, generation).is_none() {
+            return Err(playlist_queue_error_response(
                 StatusCode::SERVICE_UNAVAILABLE,
                 "spotify_device_unavailable",
                 "The active Jam has no bound Spotify device",
-            )
-        })?
-    };
-
-    run_guarded_spotify_recovery_operation(
-        &state,
-        generation,
-        &device,
-        "Queueing a Spotify track",
-        async {
-            let should_queue = spotify_playback_should_queue(&state, &device).await?;
-            place_spotify_track(&state, &device, &payload.spotify_uri, should_queue).await
-        },
-    )
-    .await
-    .map_err(|(status, message)| {
-        spotify_queue_error_response(&state, status, "spotify_queue_failed", message)
-    })?;
-
-    let track = queued_track_from_summary(&summary, &actor, None, None, now_ts_ms());
-    let applied = {
-        let mut jam = state.jam.lock().unwrap_or_else(|e| e.into_inner());
-        if !active_generation_matches(&jam, generation)
-            || jam.spotify_device_id.as_deref() != Some(device.id.as_str())
-        {
-            false
-        } else {
-            jam.spotify_device_name = Some(device.name.clone());
-            jam.spotify_is_playing = true;
-            jam.audio_expected_since = Some(std::time::Instant::now());
-            jam.last_error = None;
-            jam.queue_control_stopped = false;
-            jam.queue.push(track.clone());
-            jam.now_playing = None;
-            true
+            ));
         }
+        jam.queue.push(pending_queue_entry(track.clone()));
+        jam.queue_revision = jam.queue_revision.wrapping_add(1);
+        generation
     };
-    if !applied {
-        pause_bound_spotify_before_release(&state, generation, Some(&device)).await;
+    pump_queue_frontier_locked(&state, generation, request_control_epoch, true).await;
+    let response_track = {
+        let mut jam = state.jam.lock().unwrap_or_else(|error| error.into_inner());
+        let response_track = jam
+            .queue
+            .iter()
+            .find(|queued| queued.track.queue_entry_id == track.queue_entry_id)
+            .cloned()
+            .ok_or_else(|| {
+                playlist_queue_error_response(
+                    StatusCode::CONFLICT,
+                    "generation_changed",
+                    "Jam changed while adding the track to Echo's queue",
+                )
+            })?;
+        if let Some(request_id) = payload.request_id.clone() {
+            insert_track_queue_receipt(
+                &mut jam,
+                request_id,
+                TrackQueueReceipt {
+                    actor_id: actor.actor_id.clone(),
+                    spotify_id: spotify_id.clone(),
+                    generation,
+                    created_at_ms: now_ts_ms(),
+                    track: response_track.clone(),
+                },
+            );
+        }
+        response_track
+    };
+    let mut response = serde_json::json!({ "ok": true, "track": response_track });
+    if let Some(request_id) = payload.request_id {
+        response["request_id"] = serde_json::Value::String(request_id);
+    }
+    Ok(Json(response))
+}
+
+fn queue_removal_fingerprint(
+    payload: &JamQueueRemoveRequest,
+) -> Result<QueueRemovalFingerprint, Response> {
+    if payload.queue_entry_ids.is_empty()
+        || payload.queue_entry_ids.len() > MAX_QUEUE_REMOVAL_ENTRIES
+    {
         return Err(playlist_queue_error_response(
-            StatusCode::CONFLICT,
-            "generation_changed",
-            "Jam changed while queueing the Spotify track",
+            StatusCode::BAD_REQUEST,
+            "invalid_queue_entry_ids",
+            format!("queue_entry_ids must contain 1-{MAX_QUEUE_REMOVAL_ENTRIES} entries"),
         ));
     }
-    Ok(Json(serde_json::json!({ "ok": true, "track": track })))
+    let mut canonical_ids = payload.queue_entry_ids.clone();
+    if canonical_ids.iter().any(|entry_id| {
+        !(8..=128).contains(&entry_id.len())
+            || !entry_id
+                .bytes()
+                .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
+    }) {
+        return Err(playlist_queue_error_response(
+            StatusCode::BAD_REQUEST,
+            "invalid_queue_entry_ids",
+            "queue_entry_ids contains an invalid Echo queue entry ID",
+        ));
+    }
+    canonical_ids.sort_unstable();
+    if canonical_ids.windows(2).any(|pair| pair[0] == pair[1]) {
+        return Err(playlist_queue_error_response(
+            StatusCode::BAD_REQUEST,
+            "invalid_queue_entry_ids",
+            "queue_entry_ids must not contain duplicates",
+        ));
+    }
+    Ok(QueueRemovalFingerprint {
+        expected_queue_revision: payload.expected_queue_revision,
+        queue_entry_ids: canonical_ids,
+    })
+}
+
+fn queue_removal_conflict_response(
+    code: &'static str,
+    message: impl Into<String>,
+    queue_revision: u64,
+) -> Response {
+    (
+        StatusCode::CONFLICT,
+        Json(serde_json::json!({
+            "error": code,
+            "message": message.into(),
+            "queue_revision": queue_revision,
+        })),
+    )
+        .into_response()
+}
+
+pub(crate) async fn jam_queue_remove(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Json(payload): Json<JamQueueRemoveRequest>,
+) -> Result<Json<JamQueueRemoveResponse>, Response> {
+    ensure_admin(&state, &headers).map_err(|status| {
+        playlist_queue_error_response(status, "unauthorized", "Authentication required")
+    })?;
+    let actor = ensure_jam_actor(&state, &headers).map_err(|status| {
+        playlist_queue_error_response(
+            status,
+            "actor_required",
+            "A current Echo participant token is required",
+        )
+    })?;
+    if !playlist_queue_request_id_valid(&payload.request_id) {
+        return Err(playlist_queue_error_response(
+            StatusCode::BAD_REQUEST,
+            "invalid_request_id",
+            "request_id must be 8-128 ASCII letters, digits, dashes, or underscores",
+        ));
+    }
+    let fingerprint = queue_removal_fingerprint(&payload)?;
+    let _queue_lifecycle = state.jam_queue_lifecycle.lock().await;
+    let mut jam = state.jam.lock().unwrap_or_else(|error| error.into_inner());
+
+    match queue_removal_receipt_response(
+        &jam,
+        &payload.request_id,
+        &actor.actor_id,
+        payload.generation,
+        &fingerprint,
+    ) {
+        Ok(Some(response)) => return Ok(Json(response)),
+        Ok(None) => {}
+        Err(()) => {
+            return Err(queue_removal_conflict_response(
+                "request_id_conflict",
+                "request_id was already used for a different queue removal",
+                jam.queue_revision,
+            ));
+        }
+    }
+
+    if !active_generation_matches(&jam, payload.generation) {
+        return Err(queue_removal_conflict_response(
+            "generation_changed",
+            "Jam generation changed",
+            jam.queue_revision,
+        ));
+    }
+    if jam.queue_revision != payload.expected_queue_revision {
+        return Err(queue_removal_conflict_response(
+            "queue_changed",
+            "The Jam queue changed; refresh it before removing songs",
+            jam.queue_revision,
+        ));
+    }
+
+    match remove_pending_queue_entries(&mut jam, &fingerprint.queue_entry_ids) {
+        Ok(()) => {}
+        Err(QueueRemovalMutationError::QueueChanged) => {
+            return Err(queue_removal_conflict_response(
+                "queue_changed",
+                "One or more selected songs are no longer in the Jam queue",
+                jam.queue_revision,
+            ));
+        }
+        Err(QueueRemovalMutationError::NotRemovable) => {
+            return Err(queue_removal_conflict_response(
+                "queue_entries_not_removable",
+                "One or more selected songs were already handed to Spotify and cannot be removed",
+                jam.queue_revision,
+            ));
+        }
+    }
+    let response = JamQueueRemoveResponse {
+        ok: true,
+        generation: payload.generation,
+        queue_revision: jam.queue_revision,
+        removed_entry_ids: payload.queue_entry_ids.clone(),
+        removed_count: payload.queue_entry_ids.len(),
+    };
+    insert_queue_removal_receipt(
+        &mut jam,
+        payload.request_id,
+        QueueRemovalReceipt {
+            actor_id: actor.actor_id,
+            generation: payload.generation,
+            fingerprint,
+            created_at_ms: now_ts_ms(),
+            response: response.clone(),
+        },
+    );
+    Ok(Json(response))
 }
 
 fn playlist_queue_error_response(
@@ -2395,33 +4659,40 @@ fn spotify_queue_error_response(
     response
 }
 
-fn playlist_queue_failure(
-    state: &AppState,
-    status: StatusCode,
-    message: String,
-) -> PlaylistQueueFailure {
-    let error = match status {
-        StatusCode::TOO_MANY_REQUESTS => "spotify_rate_limited",
-        StatusCode::UNAUTHORIZED => "spotify_unauthorized",
-        StatusCode::FORBIDDEN => "spotify_forbidden",
-        StatusCode::CONFLICT => "jam_conflict",
-        StatusCode::SERVICE_UNAVAILABLE => "jam_unavailable",
-        _ => "spotify_queue_failed",
-    };
-    PlaylistQueueFailure {
-        status: status.as_u16(),
-        error: error.to_string(),
-        message,
-        retry_after: (status == StatusCode::TOO_MANY_REQUESTS)
-            .then(|| spotify_retry_after_seconds(state))
-            .flatten(),
-    }
-}
-
 pub(crate) async fn jam_queue_playlist(
     State(state): State<AppState>,
     headers: HeaderMap,
     Json(payload): Json<PlaylistQueueRequest>,
+) -> Result<Json<PlaylistQueueResponse>, Response> {
+    if payload.selected_positions.is_some() {
+        return Err(playlist_queue_error_response(
+            StatusCode::BAD_REQUEST,
+            "playlist_selection_endpoint_required",
+            "Queue selected playlist songs through the playlist selection endpoint",
+        ));
+    }
+    jam_queue_playlist_impl(state, headers, payload).await
+}
+
+pub(crate) async fn jam_queue_playlist_selection(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Json(payload): Json<PlaylistQueueRequest>,
+) -> Result<Json<PlaylistQueueResponse>, Response> {
+    if payload.selected_positions.is_none() {
+        return Err(playlist_queue_error_response(
+            StatusCode::BAD_REQUEST,
+            "selected_positions_required",
+            "selected_positions is required for the playlist selection endpoint",
+        ));
+    }
+    jam_queue_playlist_impl(state, headers, payload).await
+}
+
+async fn jam_queue_playlist_impl(
+    state: AppState,
+    headers: HeaderMap,
+    payload: PlaylistQueueRequest,
 ) -> Result<Json<PlaylistQueueResponse>, Response> {
     ensure_admin(&state, &headers).map_err(|status| {
         playlist_queue_error_response(status, "unauthorized", "Authentication required")
@@ -2447,10 +4718,8 @@ pub(crate) async fn jam_queue_playlist(
             "request_id must be 8-128 ASCII letters, digits, dashes, or underscores",
         ));
     }
+    let selection = playlist_queue_selection_fingerprint(&payload)?;
 
-    // Serialize enqueue requests without blocking stop/skip/teardown while
-    // Spotify playlist metadata is fetched or a large batch is in progress.
-    let _queue_lifecycle = state.jam_queue_lifecycle.lock().await;
     let generation =
         ensure_jam_recovery_controls_ready(&state)
             .await
@@ -2472,6 +4741,7 @@ pub(crate) async fn jam_queue_playlist(
             &payload.request_id,
             &actor.actor_id,
             &payload.playlist_id,
+            &selection,
             generation,
         )
     };
@@ -2482,19 +4752,41 @@ pub(crate) async fn jam_queue_playlist(
             return Err(playlist_queue_error_response(
                 StatusCode::CONFLICT,
                 "request_id_conflict",
-                "request_id was already used for a different playlist enqueue",
+                "request_id was already used for a different playlist queue operation",
             ));
         }
     }
-    let request_control_epoch = state
-        .jam
-        .lock()
-        .unwrap_or_else(|error| error.into_inner())
-        .queue_control_epoch;
+    if {
+        let jam = state.jam.lock().unwrap_or_else(|error| error.into_inner());
+        queue_has_commit_unknown(&jam.queue)
+    } {
+        return Err(commit_unknown_queue_add_response());
+    }
+    let (request_control_epoch, request_stop_epoch) = {
+        let jam = state.jam.lock().unwrap_or_else(|error| error.into_inner());
+        (jam.queue_control_epoch, jam.queue_stop_epoch)
+    };
 
-    let expansion = fetch_playlist_expansion(&state, &payload.playlist_id)
-        .await
-        .map_err(JamApiError::into_response)?;
+    let expansion = match selection.selected_positions.as_deref() {
+        Some(selected_positions) => {
+            fetch_playlist_selection(
+                &state,
+                &payload.playlist_id,
+                selected_positions,
+                selection.snapshot_id.as_deref(),
+            )
+            .await
+        }
+        None => {
+            fetch_playlist_expansion(
+                &state,
+                &payload.playlist_id,
+                selection.snapshot_id.as_deref(),
+            )
+            .await
+        }
+    }
+    .map_err(JamApiError::into_response)?;
     if expansion.tracks.is_empty() {
         return Err(playlist_queue_error_response(
             StatusCode::UNPROCESSABLE_ENTITY,
@@ -2519,92 +4811,151 @@ pub(crate) async fn jam_queue_playlist(
             .into_response());
     }
 
+    // Playlist metadata can take several Spotify requests. Serialize only the
+    // short Echo queue mutation and frontier delivery so queue reads/removals
+    // are not blocked while the catalog is loading.
+    let _queue_lifecycle = state.jam_queue_lifecycle.lock().await;
+    let cached_receipt = {
+        let jam = state.jam.lock().unwrap_or_else(|error| error.into_inner());
+        playlist_queue_receipt_response(
+            &jam,
+            &payload.request_id,
+            &actor.actor_id,
+            &payload.playlist_id,
+            &selection,
+            generation,
+        )
+    };
+    match cached_receipt {
+        Ok(Some(response)) => return Ok(Json(response)),
+        Ok(None) => {}
+        Err(()) => {
+            return Err(playlist_queue_error_response(
+                StatusCode::CONFLICT,
+                "request_id_conflict",
+                "request_id was already used for a different playlist queue operation",
+            ));
+        }
+    }
+
     let batch_id = format!("qb1_{}", random_secret());
     let batch_added_at_ms = now_ts_ms();
     let provenance = playlist_provenance(&expansion.playlist);
-    let mut queued = Vec::with_capacity(expansion.tracks.len());
-    let mut failure = None;
-    let mut should_queue = None;
-    let mut control_epoch = request_control_epoch;
-    for (_, summary) in &expansion.tracks {
-        let track = queued_track_from_summary(
-            summary,
-            &actor,
-            Some(&batch_id),
-            Some(&provenance),
-            batch_added_at_ms,
-        );
-        let result =
-            enqueue_playlist_track_guarded(&state, generation, &track, should_queue, control_epoch)
-                .await;
-        let observed_control_epoch = match result {
-            Ok(control_epoch) => control_epoch,
-            Err((status, message)) => {
-                if queued.is_empty() {
-                    return Err(spotify_queue_error_response(
-                        &state,
-                        status,
-                        if status == StatusCode::TOO_MANY_REQUESTS {
-                            "spotify_rate_limited"
-                        } else {
-                            "spotify_queue_failed"
-                        },
-                        message,
-                    ));
-                }
-                failure = Some(playlist_queue_failure(&state, status, message));
-                break;
-            }
-        };
-        queued.push(track);
-        should_queue = Some(true);
-        control_epoch = observed_control_epoch;
+    let queued_positions = expansion
+        .tracks
+        .iter()
+        .map(|(position, _)| *position)
+        .collect::<Vec<_>>();
+    let tracks = expansion
+        .tracks
+        .iter()
+        .map(|(position, summary)| {
+            pending_queue_entry(queued_track_from_summary(
+                summary,
+                &actor,
+                Some(&batch_id),
+                Some(&provenance),
+                Some(*position),
+                batch_added_at_ms,
+            ))
+        })
+        .collect::<Vec<_>>();
+    {
+        let _refresh = state.jam_state_refresh.lock().await;
+        let _lifecycle = state.jam_lifecycle.lock().await;
+        let current_generation =
+            ensure_jam_recovery_controls_ready(&state)
+                .await
+                .map_err(|(status, message)| {
+                    spotify_queue_error_response(&state, status, "jam_unavailable", message)
+                })?;
+        if current_generation != generation {
+            return Err(playlist_queue_error_response(
+                StatusCode::CONFLICT,
+                "generation_changed",
+                "Jam generation changed while the playlist was loading",
+            ));
+        }
+        let mut jam = state.jam.lock().unwrap_or_else(|error| error.into_inner());
+        if jam.uncertain_skip.is_some() {
+            return Err(playlist_queue_error_response(
+                StatusCode::CONFLICT,
+                "skip_reconciliation_required",
+                "Echo is reconciling the previous Spotify Skip; wait for fresh playback state",
+            ));
+        }
+        if queue_has_commit_unknown(&jam.queue) {
+            return Err(commit_unknown_queue_add_response());
+        }
+        if enqueue_admission_cancelled_by_stop(request_stop_epoch, jam.queue_stop_epoch)
+            || enqueue_interrupted_by_stop(
+                request_control_epoch,
+                jam.queue_control_epoch,
+                jam.queue_control_stopped,
+            )
+        {
+            return Err(playlist_queue_error_response(
+                StatusCode::CONFLICT,
+                "queue_interrupted",
+                "Playlist enqueue was interrupted by Stop Music",
+            ));
+        }
+        if bound_spotify_device(&jam, generation).is_none() {
+            return Err(playlist_queue_error_response(
+                StatusCode::SERVICE_UNAVAILABLE,
+                "spotify_device_unavailable",
+                "The active Jam has no bound Spotify device",
+            ));
+        }
+        jam.queue.extend(tracks);
+        jam.queue_revision = jam.queue_revision.wrapping_add(1);
     }
+    pump_queue_frontier_locked(&state, generation, request_control_epoch, true).await;
 
     let _receipt_lifecycle = state.jam_lifecycle.lock().await;
     let can_store_receipt = {
         let jam = state.jam.lock().unwrap_or_else(|error| error.into_inner());
         active_generation_matches(&jam, generation)
     };
-    if !can_store_receipt && failure.is_none() {
-        failure = Some(playlist_queue_failure(
-            &state,
+    if !can_store_receipt {
+        return Err(playlist_queue_error_response(
             StatusCode::CONFLICT,
-            "Jam ended before the playlist enqueue receipt was committed".to_string(),
+            "generation_changed",
+            "Jam ended before the playlist enqueue receipt was committed",
         ));
     }
     let skipped = expansion.skipped;
-    let (partial, complete) = playlist_batch_flags(failure.is_some(), skipped.len());
+    let queued_count = queued_positions.len();
     let response = PlaylistQueueResponse {
         schema_version: 1,
         ok: true,
-        partial,
+        partial: false,
         request_id: payload.request_id.clone(),
         queue_batch_id: batch_id.clone(),
         batch_id,
         generation,
         playlist: provenance,
-        queued_count: queued.len(),
+        queued_positions,
+        remaining_positions: Vec::new(),
+        queued_count,
         skipped_count: skipped.len(),
-        queued,
         skipped,
-        complete,
-        failure,
+        complete: true,
+        failure: None,
     };
-    if can_store_receipt {
-        let mut jam = state.jam.lock().unwrap_or_else(|error| error.into_inner());
-        insert_playlist_queue_receipt(
-            &mut jam,
-            payload.request_id,
-            PlaylistQueueReceipt {
-                actor_id: actor.actor_id,
-                playlist_id: payload.playlist_id,
-                generation,
-                created_at_ms: now_ts_ms(),
-                response: response.clone(),
-            },
-        );
-    }
+    let mut jam = state.jam.lock().unwrap_or_else(|error| error.into_inner());
+    insert_playlist_queue_receipt(
+        &mut jam,
+        payload.request_id,
+        PlaylistQueueReceipt {
+            actor_id: actor.actor_id,
+            playlist_id: payload.playlist_id,
+            selection,
+            generation,
+            created_at_ms: now_ts_ms(),
+            response: response.clone(),
+        },
+    );
     Ok(Json(response))
 }
 
@@ -2690,79 +5041,295 @@ pub(crate) async fn jam_skip(
             "A current Echo participant token is required",
         )
     })?;
-    let _lifecycle = state.jam_lifecycle.lock().await;
-    let generation =
-        ensure_jam_recovery_controls_ready(&state)
+    let _queue_lifecycle = state.jam_queue_lifecycle.lock().await;
+    let (generation, next_control_epoch) = {
+        let _refresh = state.jam_state_refresh.lock().await;
+        let _lifecycle = state.jam_lifecycle.lock().await;
+        let generation =
+            ensure_jam_recovery_controls_ready(&state)
+                .await
+                .map_err(|(status, message)| {
+                    spotify_queue_error_response(&state, status, "jam_unavailable", message)
+                })?;
+        if generation != payload.generation {
+            return Err(playlist_queue_error_response(
+                StatusCode::CONFLICT,
+                "generation_changed",
+                "Jam generation changed",
+            ));
+        }
+        let device = {
+            let jam = state.jam.lock().unwrap_or_else(|e| e.into_inner());
+            if jam.uncertain_skip.is_some() {
+                return Err(playlist_queue_error_response(
+                    StatusCode::CONFLICT,
+                    "skip_reconciliation_required",
+                    "Echo is reconciling the previous Spotify Skip; wait for fresh playback state",
+                ));
+            }
+            bound_spotify_device(&jam, generation).ok_or_else(|| {
+                playlist_queue_error_response(
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    "spotify_device_unavailable",
+                    "The active Jam has no bound Spotify device",
+                )
+            })?
+        };
+        let (spotify_playback, previous_uri, same_uri_resolution) =
+            run_guarded_spotify_recovery_operation(
+                &state,
+                generation,
+                &device,
+                "Skipping a Spotify track",
+                async {
+                    let spotify_playback = bind_spotify_playback_to_device(&state, &device).await?;
+                    if spotify_playback.current_uri.is_none() {
+                        return Err((
+                            StatusCode::CONFLICT,
+                            "Spotify has no current track to skip".to_string(),
+                        ));
+                    }
+                    let (previous_uri, same_uri_observation_required) = {
+                        let jam = state.jam.lock().unwrap_or_else(|error| error.into_inner());
+                        if !active_generation_matches(&jam, generation)
+                            || jam.spotify_device_id.as_deref() != Some(device.id.as_str())
+                        {
+                            return Err((
+                                StatusCode::CONFLICT,
+                                "Jam changed while preparing to skip the Spotify track".to_string(),
+                            ));
+                        }
+                        let previous_uri = jam
+                            .now_playing
+                            .as_ref()
+                            .map(|playing| playing.spotify_uri.clone());
+                        let observation_required = same_uri_skip_observation_required(
+                            &jam.queue,
+                            spotify_playback.current_uri.as_deref(),
+                            previous_uri.as_deref(),
+                        );
+                        (previous_uri, observation_required)
+                    };
+                    let same_uri_resolution = if same_uri_observation_required {
+                        let current_uri =
+                            spotify_playback.current_uri.as_deref().ok_or_else(|| {
+                                (
+                            StatusCode::CONFLICT,
+                            "Spotify playback changed while resolving the queued occurrence"
+                                .to_string(),
+                        )
+                            })?;
+                        let queue_observation = spotify_queue_observation_strict(&state).await?;
+                        let resolution = {
+                            let jam =
+                                state.jam.lock().unwrap_or_else(|error| error.into_inner());
+                            if !active_generation_matches(&jam, generation)
+                                || jam.spotify_device_id.as_deref() != Some(device.id.as_str())
+                            {
+                                return Err((
+                                    StatusCode::CONFLICT,
+                                    "Jam changed while resolving the queued occurrence".to_string(),
+                                ));
+                            }
+                            resolve_same_uri_skip_observation(
+                                &jam.queue,
+                                &queue_observation,
+                                current_uri,
+                                previous_uri.as_deref(),
+                            )
+                        };
+                        resolution.map_err(|error| match error {
+                            SameUriSkipObservationError::PlaybackChanged => (
+                                StatusCode::CONFLICT,
+                                "Spotify playback changed while resolving the queued occurrence"
+                                    .to_string(),
+                            ),
+                            SameUriSkipObservationError::CommitUnknown => (
+                                StatusCode::CONFLICT,
+                                "Echo cannot safely Skip because Spotify acceptance of this same-song queue entry is unknown"
+                                    .to_string(),
+                            ),
+                        })?
+                    } else {
+                        PreSkipSameUriResolution::NotNeeded
+                    };
+                    let current_uri = spotify_playback.current_uri.as_deref().ok_or_else(|| {
+                        (
+                            StatusCode::CONFLICT,
+                            "Spotify playback changed while resolving the queued occurrence"
+                                .to_string(),
+                        )
+                    })?;
+                    {
+                        let jam = state.jam.lock().unwrap_or_else(|error| error.into_inner());
+                        if !active_generation_matches(&jam, generation)
+                            || jam.spotify_device_id.as_deref() != Some(device.id.as_str())
+                        {
+                            return Err((
+                                StatusCode::CONFLICT,
+                                "Jam changed while resolving the queued occurrence".to_string(),
+                            ));
+                        }
+                        reject_commit_unknown_pre_skip_target(
+                            &jam.queue,
+                            current_uri,
+                            previous_uri.as_deref(),
+                            same_uri_resolution,
+                        )
+                        .map_err(|error| match error {
+                            SameUriSkipObservationError::PlaybackChanged => (
+                                StatusCode::CONFLICT,
+                                "Spotify playback changed while resolving the queued occurrence"
+                                    .to_string(),
+                            ),
+                            SameUriSkipObservationError::CommitUnknown => (
+                                StatusCode::CONFLICT,
+                                "Echo cannot safely Skip because Spotify acceptance of this queue entry is unknown"
+                                    .to_string(),
+                            ),
+                        })?;
+                    }
+                    Ok((spotify_playback, previous_uri, same_uri_resolution))
+                },
+            )
             .await
             .map_err(|(status, message)| {
-                spotify_queue_error_response(&state, status, "jam_unavailable", message)
+                spotify_queue_error_response(&state, status, "spotify_skip_failed", message)
             })?;
-    if generation != payload.generation {
-        return Err(playlist_queue_error_response(
-            StatusCode::CONFLICT,
-            "generation_changed",
-            "Jam generation changed",
-        ));
-    }
-    let device = {
-        let jam = state.jam.lock().unwrap_or_else(|e| e.into_inner());
-        bound_spotify_device(&jam, generation).ok_or_else(|| {
-            playlist_queue_error_response(
-                StatusCode::SERVICE_UNAVAILABLE,
-                "spotify_device_unavailable",
-                "The active Jam has no bound Spotify device",
-            )
-        })?
-    };
-    let spotify_is_playing = run_guarded_spotify_recovery_operation(
-        &state,
-        generation,
-        &device,
-        "Skipping a Spotify track",
-        async {
-            let spotify_is_playing = bind_spotify_playback_to_device(&state, &device).await?;
-            let next_url = format!(
-                "https://api.spotify.com/v1/me/player/next?device_id={}",
-                urlencoded(&device.id)
-            );
-            let response =
-                spotify_api_request(&state, reqwest::Method::POST, &next_url, None).await?;
-            if !response.status().is_success() {
-                return Err(spotify_response_error(response, "Skip Spotify track").await);
-            }
-            Ok(spotify_is_playing)
-        },
-    )
-    .await
-    .map_err(|(status, message)| {
-        spotify_queue_error_response(&state, status, "spotify_skip_failed", message)
-    })?;
 
-    let applied = {
-        let mut jam = state.jam.lock().unwrap_or_else(|e| e.into_inner());
-        if !active_generation_matches(&jam, generation)
-            || jam.spotify_device_id.as_deref() != Some(device.id.as_str())
-        {
-            false
-        } else {
-            jam.spotify_device_name = Some(device.name.clone());
-            jam.spotify_is_playing = spotify_is_playing;
-            jam.audio_expected_since = spotify_is_playing.then(std::time::Instant::now);
-            jam.last_error = None;
-            jam.queue_control_epoch = jam.queue_control_epoch.wrapping_add(1);
-            jam.queue_control_stopped = false;
-            jam.now_playing = None;
-            true
+        let pre_skip_history = {
+            let jam = state.jam.lock().unwrap_or_else(|error| error.into_inner());
+            let current_uri = spotify_playback.current_uri.as_deref();
+            let queued_track = authoritative_pre_skip_echo_track(
+                &jam.queue,
+                current_uri,
+                previous_uri.as_deref(),
+                same_uri_resolution,
+            );
+            new_history_observation(
+                jam.last_history_spotify_id.as_deref(),
+                jam.last_history_was_echo,
+                current_uri.and_then(spotify_track_id_from_uri),
+                queued_track.as_ref(),
+                spotify_playback.is_playing,
+                same_uri_resolution == PreSkipSameUriResolution::AwaitingIsCurrent,
+            )
+        };
+        if let Some(observation) = pre_skip_history {
+            // The bound-device preflight definitively observed this occurrence
+            // playing even if the following /next response becomes ambiguous.
+            persist_jam_history_observation(&state, generation, observation).await;
         }
+
+        let next_url = format!(
+            "https://api.spotify.com/v1/me/player/next?device_id={}",
+            urlencoded(&device.id)
+        );
+        let skip_result = run_guarded_spotify_skip_mutation(&state, generation, &device, async {
+            let response = spotify_api_request(&state, reqwest::Method::POST, &next_url, None)
+                .await
+                .map_err(|(status, message)| skip_mutation_request_error(status, message))?;
+            if !response.status().is_success() {
+                return Err(spotify_skip_mutation_response_error(response).await);
+            }
+            Ok(())
+        })
+        .await;
+        if let Err(error) = skip_result {
+            if error.acceptance_ambiguous {
+                let mut jam = state
+                    .jam
+                    .lock()
+                    .unwrap_or_else(|poison| poison.into_inner());
+                if active_generation_matches(&jam, generation)
+                    && jam.spotify_device_id.as_deref() == Some(device.id.as_str())
+                {
+                    jam.uncertain_skip = Some(UncertainSkipBoundary {
+                        pre_skip_current_uri: spotify_playback
+                            .current_uri
+                            .clone()
+                            .expect("Skip preflight requires a current URI"),
+                        previous_uri: previous_uri.clone(),
+                        same_uri_resolution,
+                    });
+                    jam.last_error = Some(error.message.clone());
+                }
+            }
+            let code = if error.acceptance_ambiguous {
+                "spotify_skip_unknown"
+            } else {
+                "spotify_skip_failed"
+            };
+            return Err(spotify_queue_error_response(
+                &state,
+                error.status,
+                code,
+                error.message,
+            ));
+        }
+
+        let next_control_epoch = {
+            let mut jam = state.jam.lock().unwrap_or_else(|e| e.into_inner());
+            if !active_generation_matches(&jam, generation)
+                || jam.spotify_device_id.as_deref() != Some(device.id.as_str())
+            {
+                None
+            } else {
+                let queue_transition = apply_successful_skip_to_queue(
+                    &mut jam.queue,
+                    spotify_playback.current_uri.as_deref(),
+                    previous_uri.as_deref(),
+                    same_uri_resolution,
+                );
+                if queue_transition.changed() {
+                    jam.queue_revision = jam.queue_revision.wrapping_add(1);
+                }
+                for removed in queue_transition.removed_before_current {
+                    info!(
+                        "Jam: reconciled naturally advanced queue track '{}' before Skip",
+                        removed.name
+                    );
+                }
+                if let Some(removed) = queue_transition.removed {
+                    info!(
+                        "Jam: retired explicitly skipped queue track '{}'",
+                        removed.name
+                    );
+                }
+                jam.spotify_device_name = Some(device.name.clone());
+                jam.spotify_is_playing = spotify_playback.is_playing;
+                jam.audio_expected_since =
+                    spotify_playback.is_playing.then(std::time::Instant::now);
+                jam.last_error = None;
+                jam.queue_control_epoch = jam.queue_control_epoch.wrapping_add(1);
+                jam.queue_control_stopped =
+                    queue_control_stopped_after_skip(spotify_playback.is_playing);
+                if jam.queue_control_stopped {
+                    jam.queue_stop_epoch = jam.queue_stop_epoch.wrapping_add(1);
+                }
+                jam.now_playing = None;
+                Some(jam.queue_control_epoch)
+            }
+        };
+        let Some(next_control_epoch) = next_control_epoch else {
+            pause_and_mark_spotify_safety_stop(
+                &state,
+                generation,
+                &device,
+                "Jam changed while skipping the Spotify track",
+            )
+            .await;
+            return Err(playlist_queue_error_response(
+                StatusCode::CONFLICT,
+                "generation_changed",
+                "Jam changed while skipping the Spotify track",
+            ));
+        };
+        (generation, next_control_epoch)
     };
-    if !applied {
-        pause_bound_spotify_before_release(&state, generation, Some(&device)).await;
-        return Err(playlist_queue_error_response(
-            StatusCode::CONFLICT,
-            "generation_changed",
-            "Jam changed while skipping the Spotify track",
-        ));
-    }
+    // Refill before releasing the queue lifecycle so two rapid Skip requests
+    // cannot outrun Echo's two-track Spotify frontier.
+    pump_queue_frontier_locked(&state, generation, next_control_epoch, false).await;
     Ok(Json(serde_json::json!({ "ok": true })))
 }
 
@@ -3165,7 +5732,109 @@ mod tests {
             access_token: "access".to_string(),
             refresh_token: "refresh".to_string(),
             expires_at: 999_999,
+            scope: "user-read-private user-modify-playback-state user-read-currently-playing user-read-playback-state user-library-read playlist-read-private playlist-read-collaborative".to_string(),
         }
+    }
+
+    #[test]
+    fn spotify_token_deserializes_legacy_payload_without_scope() {
+        let token: SpotifyToken = serde_json::from_value(serde_json::json!({
+            "access_token": "legacy-access",
+            "refresh_token": "legacy-refresh",
+            "expires_at": 1234
+        }))
+        .expect("legacy Spotify token should deserialize");
+
+        assert!(token.scope.is_empty());
+        assert!(!spotify_library_scopes_authorized(Some(&token)));
+    }
+
+    #[test]
+    fn spotify_callback_does_not_claim_connection_before_validation() {
+        assert!(SPOTIFY_CALLBACK_RECEIVED_HTML.contains("Spotify authorization received"));
+        assert!(!SPOTIFY_CALLBACK_RECEIVED_HTML.contains("Spotify Connected"));
+        assert!(SPOTIFY_CALLBACK_RECEIVED_HTML.contains("verifies the connection"));
+    }
+
+    #[test]
+    fn spotify_library_authorization_requires_every_library_scope() {
+        let mut token = spotify_token();
+        assert!(spotify_library_scopes_authorized(Some(&token)));
+
+        token.scope = "user-library-read playlist-read-private".to_string();
+        assert!(!spotify_library_scopes_authorized(Some(&token)));
+        assert!(!spotify_library_scopes_authorized(None));
+    }
+
+    #[test]
+    fn spotify_library_scope_error_has_a_stable_machine_code() {
+        let error = spotify_library_scope_required_error();
+        assert_eq!(error.status, StatusCode::FORBIDDEN);
+        assert_eq!(error.code, "spotify_library_scope_required");
+        assert!(error.message.contains("Refresh Spotify Access"));
+    }
+
+    #[test]
+    fn spotify_account_validation_distinguishes_forbidden_and_rate_limited() {
+        let forbidden = spotify_access_validation_error(
+            reqwest::StatusCode::FORBIDDEN,
+            r#"{"error":{"status":403,"message":"User is not registered for this application"}}"#,
+            None,
+        );
+        assert_eq!(forbidden.status, StatusCode::FORBIDDEN);
+        assert_eq!(forbidden.code, "spotify_account_forbidden");
+        assert!(forbidden
+            .message
+            .contains("not registered for this application"));
+        assert!(forbidden.message.contains("User Management"));
+
+        let rate_limited = spotify_access_validation_error(
+            reqwest::StatusCode::TOO_MANY_REQUESTS,
+            r#"{"error":{"status":429,"message":"Slow down"}}"#,
+            Some("17".to_string()),
+        );
+        assert_eq!(rate_limited.status, StatusCode::TOO_MANY_REQUESTS);
+        assert_eq!(rate_limited.code, "spotify_rate_limited");
+        assert_eq!(rate_limited.retry_after.as_deref(), Some("17"));
+    }
+
+    #[test]
+    fn spotify_token_exchange_forbidden_preserves_account_allowlist_guidance() {
+        let forbidden = spotify_token_exchange_error(
+            reqwest::StatusCode::FORBIDDEN,
+            r#"{"error":"access_denied","error_description":"User is not registered for this application"}"#,
+            None,
+        );
+
+        assert_eq!(forbidden.status, StatusCode::FORBIDDEN);
+        assert_eq!(forbidden.code, "spotify_account_forbidden");
+        assert!(forbidden
+            .message
+            .contains("User is not registered for this application"));
+        assert!(forbidden.message.contains("User Management"));
+    }
+
+    #[test]
+    fn spotify_refresh_scope_is_preserved_or_updated_from_response() {
+        let old_scope = "user-library-read playlist-read-private";
+        let omitted = serde_json::json!({
+            "access_token": "new-access",
+            "expires_in": 3600
+        });
+        assert_eq!(
+            spotify_scope_from_token_response(&omitted, Some(old_scope)),
+            old_scope
+        );
+
+        let updated = serde_json::json!({
+            "access_token": "new-access",
+            "expires_in": 3600,
+            "scope": "user-library-read playlist-read-private playlist-read-collaborative"
+        });
+        assert_eq!(
+            spotify_scope_from_token_response(&updated, Some(old_scope)),
+            "user-library-read playlist-read-private playlist-read-collaborative"
+        );
     }
 
     fn queued_track(uri: &str) -> QueuedTrack {
@@ -3183,8 +5852,24 @@ mod tests {
             added_by_actor_id: "actor".to_string(),
             added_by_name: "sam-7475".to_string(),
             playlist: None,
+            playlist_position: None,
             added_by: "sam-7475".to_string(),
         }
+    }
+
+    fn committed_queue_entry(uri: &str) -> JamQueueEntry {
+        JamQueueEntry {
+            track: queued_track(uri),
+            delivery_state: QueueDeliveryState::SpotifyCommitted,
+            can_remove: false,
+            current_match_state: QueueCurrentMatchState::Eligible,
+        }
+    }
+
+    fn pending_queue_entry_with_id(uri: &str, entry_id: &str) -> JamQueueEntry {
+        let mut track = queued_track(uri);
+        track.queue_entry_id = entry_id.to_string();
+        pending_queue_entry(track)
     }
 
     fn spotify_device(id: &str, name: &str) -> SpotifyDevice {
@@ -3395,7 +6080,7 @@ mod tests {
             generation: 42,
             host_identity: "sam-7475".to_string(),
             host_participant_auth_id: "binding-a".to_string(),
-            queue: vec![queued_track("spotify:track:one")],
+            queue: vec![committed_queue_entry("spotify:track:one")],
             now_playing: Some(now_playing(true)),
             listeners,
             spotify_device_id: Some("device-a".to_string()),
@@ -3426,10 +6111,12 @@ mod tests {
             Some("binding-a")
         );
         assert_eq!(jam.queue.len(), 1);
-        assert_eq!(jam.queue[0].spotify_uri, "spotify:track:one");
+        assert_eq!(jam.queue[0].track.spotify_uri, "spotify:track:one");
         assert_eq!(jam.spotify_device_id.as_deref(), Some("device-a"));
         assert_eq!(jam.spotify_device_name.as_deref(), Some("Echo PC"));
         assert!(!jam.spotify_is_playing);
+        assert_eq!(jam.queue_stop_epoch, 1);
+        assert!(jam.queue_control_stopped);
         assert!(jam.audio_expected_since.is_none());
         assert!(jam.last_error.is_none());
         assert_eq!(
@@ -3781,7 +6468,7 @@ mod tests {
 
     #[test]
     fn queue_only_advances_to_an_observed_echo_track() {
-        let mut queue = vec![queued_track("one"), queued_track("two")];
+        let mut queue = vec![committed_queue_entry("one"), committed_queue_entry("two")];
 
         assert!(reconcile_queue_to_current(&mut queue, "external").is_empty());
         assert_eq!(queue.len(), 2);
@@ -3789,7 +6476,1231 @@ mod tests {
         let removed = reconcile_queue_to_current(&mut queue, "two");
         assert_eq!(removed.len(), 1);
         assert_eq!(removed[0].spotify_uri, "one");
-        assert_eq!(queue[0].spotify_uri, "two");
+        assert_eq!(queue[0].track.spotify_uri, "two");
+    }
+
+    #[test]
+    fn pending_track_matching_external_playback_does_not_advance_queue() {
+        let mut queue = vec![
+            committed_queue_entry("one"),
+            pending_queue_entry_with_id("pending", "qe_pending_track"),
+        ];
+
+        assert!(reconcile_queue_to_current(&mut queue, "pending").is_empty());
+        assert_eq!(queue.len(), 2);
+        assert_eq!(queue[0].track.spotify_uri, "one");
+    }
+
+    #[test]
+    fn commit_unknown_started_current_never_adopts_matching_paused_external_playback() {
+        let mut paused = now_playing(false);
+        paused.spotify_uri = "one".to_string();
+        let mut entry = committed_queue_entry("one");
+        entry.delivery_state = QueueDeliveryState::CommitUnknown;
+        let mut queue = vec![entry];
+
+        assert!(reconcile_queue_to_current(&mut queue, &paused.spotify_uri).is_empty());
+        assert!(committed_queue_track_matching_current(&queue, &paused.spotify_uri).is_none());
+        assert!(advance_repeated_committed_occurrence(&mut queue, &paused.spotify_uri).is_none());
+        assert!(retire_skipped_queue_frontier(&mut queue, Some(&paused.spotify_uri)).is_none());
+        assert!(retire_finished_queue_frontier(&mut queue, &paused.spotify_uri).is_none());
+        assert_eq!(queue[0].delivery_state, QueueDeliveryState::CommitUnknown);
+        assert!(!queue[0].can_remove);
+    }
+
+    #[test]
+    fn repeated_committed_occurrences_advance_on_a_near_end_progress_wrap() {
+        let mut previous = now_playing(true);
+        previous.progress_ms = 115_000;
+        let mut current = previous.clone();
+        current.progress_ms = 2_000;
+        let next_observation = SpotifyQueueObservation {
+            current_uri: current.spotify_uri.clone(),
+            next_uri: Some("spotify:track:next".to_string()),
+        };
+        let same_next_observation = SpotifyQueueObservation {
+            current_uri: current.spotify_uri.clone(),
+            next_uri: Some(current.spotify_uri.clone()),
+        };
+        assert!(same_track_occurrence_restarted(Some(&previous), &current));
+        assert!(!repeated_occurrence_advance_confirmed(
+            Some(&previous),
+            &current,
+            "track",
+            Some(&next_observation),
+        ));
+        assert!(!repeated_occurrence_advance_confirmed(
+            Some(&previous),
+            &current,
+            "",
+            Some(&next_observation),
+        ));
+        assert!(!repeated_occurrence_advance_confirmed(
+            Some(&previous),
+            &current,
+            "off",
+            Some(&same_next_observation),
+        ));
+        assert!(!repeated_occurrence_advance_confirmed(
+            Some(&previous),
+            &current,
+            "off",
+            None,
+        ));
+        assert!(repeated_occurrence_advance_confirmed(
+            Some(&previous),
+            &current,
+            "off",
+            Some(&next_observation),
+        ));
+
+        let mut queue = vec![
+            committed_queue_entry(&previous.spotify_uri),
+            committed_queue_entry(&previous.spotify_uri),
+            pending_queue_entry_with_id("later", "qe_later_track"),
+        ];
+        let removed = advance_repeated_committed_occurrence(&mut queue, &current.spotify_uri)
+            .expect("the first duplicate occurrence should advance");
+        assert_eq!(removed.spotify_uri, current.spotify_uri);
+        assert_eq!(queue.len(), 2);
+        assert_eq!(queue[0].track.spotify_uri, current.spotify_uri);
+        assert_eq!(
+            queue_frontier_candidate(&queue)
+                .expect("the pending successor should enter the frontier")
+                .track
+                .queue_entry_id,
+            "qe_later_track"
+        );
+
+        let mut seek = previous;
+        seek.progress_ms = 60_000;
+        assert!(!same_track_occurrence_restarted(Some(&seek), &current));
+    }
+
+    #[test]
+    fn queued_next_same_uri_waits_for_a_real_occurrence_boundary() {
+        let uri = "spotify:track:same";
+        let mut first = committed_queue_entry(uri);
+        first.current_match_state = QueueCurrentMatchState::AwaitingTransition;
+        let mut second = committed_queue_entry(uri);
+        second.current_match_state = QueueCurrentMatchState::AwaitingTransition;
+        let mut queue = vec![first, second];
+
+        assert!(reconcile_queue_to_current(&mut queue, uri).is_empty());
+        assert!(!observe_queue_current_transition(&mut queue, uri, false));
+        assert_eq!(
+            queue[0].current_match_state,
+            QueueCurrentMatchState::AwaitingTransition
+        );
+        assert!(advance_repeated_committed_occurrence(&mut queue, uri).is_none());
+
+        assert!(observe_queue_current_transition(&mut queue, uri, true));
+        assert_eq!(
+            queue[0].current_match_state,
+            QueueCurrentMatchState::Eligible
+        );
+        assert_eq!(
+            queue[1].current_match_state,
+            QueueCurrentMatchState::AwaitingTransition
+        );
+
+        let removed = advance_repeated_committed_occurrence(&mut queue, uri)
+            .expect("the first observed Echo occurrence should advance");
+        assert_eq!(removed.spotify_uri, uri);
+        assert!(observe_queue_current_transition(&mut queue, uri, true));
+        assert_eq!(
+            queue[0].current_match_state,
+            QueueCurrentMatchState::Eligible
+        );
+    }
+
+    #[test]
+    fn confirmed_same_uri_restart_retires_a_finished_echo_frontier_occurrence() {
+        let uri = "spotify:track:same";
+        let mut queue = vec![committed_queue_entry(uri)];
+
+        let removed = advance_repeated_committed_occurrence(&mut queue, uri)
+            .expect("the prior Echo occurrence finished at the confirmed restart");
+        assert_eq!(removed.spotify_uri, uri);
+        assert!(queue.is_empty());
+    }
+
+    #[test]
+    fn sole_naturally_finished_frontier_is_retired_so_the_next_add_starts() {
+        let uri = "spotify:track:finished";
+        let mut finished = now_playing(false);
+        finished.spotify_uri = uri.to_string();
+        finished.progress_ms = finished.duration_ms;
+        let mut queue = vec![committed_queue_entry(uri)];
+
+        assert!(stopped_playback_reached_track_end(&finished));
+        let removed = retire_finished_queue_frontier(&mut queue, &finished.spotify_uri)
+            .expect("the terminal committed occurrence must not remain stale");
+        assert_eq!(removed.spotify_uri, uri);
+
+        queue.push(pending_queue_entry_with_id(
+            "spotify:track:new",
+            "qe_new_after_end",
+        ));
+        let candidate = queue_frontier_candidate(&queue).expect("the new add must be selectable");
+        let spotify_reports_active_playback = false;
+        let should_queue = has_existing_spotify_frontier(&queue, &candidate.track.queue_entry_id)
+            || spotify_reports_active_playback;
+        assert!(!should_queue);
+        assert_eq!(
+            spotify_track_placement(should_queue),
+            SpotifyTrackPlacement::StartedCurrent,
+        );
+    }
+
+    #[test]
+    fn unobserved_natural_end_is_retired_atomically_during_the_first_add() {
+        let finished_uri = "spotify:track:finished";
+        let mut previous = now_playing(true);
+        previous.spotify_uri = finished_uri.to_string();
+        previous.progress_ms = 117_000;
+        previous.fetched_at = Some(std::time::Instant::now() - Duration::from_secs(4));
+        let observation = SpotifyPlacementObservation {
+            playback_present: true,
+            bound_device: true,
+            is_playing: false,
+            current_uri: Some(finished_uri.to_string()),
+            progress_ms: 120_000,
+            duration_ms: 120_000,
+        };
+        let mut jam = JamState {
+            active: true,
+            generation: 9,
+            queue_revision: 4,
+            now_playing: Some(previous),
+            queue: vec![
+                committed_queue_entry(finished_uri),
+                pending_queue_entry_with_id("spotify:track:new", "qe_new_after_end"),
+            ],
+            ..JamState::default()
+        };
+
+        let removed = retire_stale_frontier_for_queue_placement(&mut jam, &observation)
+            .expect("the corroborated terminal front should retire during add preflight");
+        assert_eq!(removed.spotify_uri, finished_uri);
+        assert_eq!(jam.queue_revision, 5);
+        assert!(jam.now_playing.is_none());
+        let candidate = queue_frontier_candidate(&jam.queue).unwrap();
+        assert!(!has_existing_spotify_frontier(
+            &jam.queue,
+            &candidate.track.queue_entry_id,
+        ));
+        assert_eq!(
+            spotify_track_placement(observation.should_queue()),
+            SpotifyTrackPlacement::StartedCurrent,
+        );
+    }
+
+    #[test]
+    fn paused_near_end_frontier_is_preserved_for_resume_then_queue() {
+        let paused_uri = "spotify:track:paused";
+        let mut previous = now_playing(true);
+        previous.spotify_uri = paused_uri.to_string();
+        previous.progress_ms = 117_000;
+        previous.fetched_at = Some(std::time::Instant::now() - Duration::from_secs(4));
+        let observation = SpotifyPlacementObservation {
+            playback_present: true,
+            bound_device: true,
+            is_playing: false,
+            current_uri: Some(paused_uri.to_string()),
+            progress_ms: 119_000,
+            duration_ms: 120_000,
+        };
+        let mut jam = JamState {
+            active: true,
+            generation: 9,
+            queue_revision: 4,
+            now_playing: Some(previous),
+            queue: vec![
+                committed_queue_entry(paused_uri),
+                pending_queue_entry_with_id("spotify:track:new", "qe_new_after_pause"),
+            ],
+            ..JamState::default()
+        };
+
+        assert!(retire_stale_frontier_for_queue_placement(&mut jam, &observation).is_none());
+        assert_eq!(jam.queue_revision, 4);
+        assert_eq!(jam.queue[0].track.spotify_uri, paused_uri);
+        assert_eq!(
+            jam.queue[0].current_match_state,
+            QueueCurrentMatchState::Eligible,
+        );
+        assert!(has_existing_spotify_frontier(
+            &jam.queue,
+            "qe_new_after_pause",
+        ));
+        // The explicit add path resumes this preserved occurrence, then uses
+        // Add to Queue for the new item; it never replaces the paused track.
+        assert_eq!(
+            spotify_track_placement(true),
+            SpotifyTrackPlacement::QueuedNext,
+        );
+    }
+
+    #[test]
+    fn intentional_stop_blocks_stale_retirement_and_automatic_resume() {
+        let stopped_uri = "spotify:track:stopped";
+        let mut previous = now_playing(true);
+        previous.spotify_uri = stopped_uri.to_string();
+        previous.progress_ms = 117_000;
+        previous.fetched_at = Some(std::time::Instant::now() - Duration::from_secs(4));
+        let observation = SpotifyPlacementObservation {
+            playback_present: true,
+            bound_device: true,
+            is_playing: false,
+            current_uri: Some(stopped_uri.to_string()),
+            progress_ms: 120_000,
+            duration_ms: 120_000,
+        };
+        let mut jam = JamState {
+            active: true,
+            generation: 9,
+            queue_revision: 4,
+            queue_control_stopped: true,
+            now_playing: Some(previous),
+            queue: vec![committed_queue_entry(stopped_uri)],
+            ..JamState::default()
+        };
+
+        assert!(retire_stale_frontier_for_queue_placement(&mut jam, &observation).is_none());
+        assert_eq!(jam.queue_revision, 4);
+        assert_eq!(jam.queue[0].track.spotify_uri, stopped_uri);
+        assert!(!stopped_frontier_should_resume(&jam.queue, true, false));
+        assert!(stopped_frontier_should_resume(&jam.queue, true, true));
+    }
+
+    #[test]
+    fn no_content_only_retires_a_prior_track_when_elapsed_time_reaches_its_end() {
+        let mut previous = now_playing(true);
+        previous.progress_ms = 117_000;
+        assert!(!prior_playback_finished_before_no_content(
+            &previous,
+            Duration::from_secs(1),
+        ));
+        assert!(prior_playback_finished_before_no_content(
+            &previous,
+            Duration::from_secs(3),
+        ));
+    }
+
+    #[test]
+    fn queued_next_with_a_different_predecessor_can_become_current() {
+        let first = committed_queue_entry("spotify:track:first");
+        let mut second = committed_queue_entry("spotify:track:second");
+        second.current_match_state = QueueCurrentMatchState::AwaitingTransition;
+        let mut queue = vec![first, second];
+
+        assert!(observe_queue_current_transition(
+            &mut queue,
+            "spotify:track:second",
+            false,
+        ));
+        let removed = reconcile_queue_to_current(&mut queue, "spotify:track:second");
+        assert_eq!(removed.len(), 1);
+        assert_eq!(queue.len(), 1);
+        assert_eq!(
+            queue[0].current_match_state,
+            QueueCurrentMatchState::Eligible
+        );
+    }
+
+    #[test]
+    fn rapid_skips_retire_each_observed_front_and_expose_the_next_refill() {
+        let mut queue = vec![
+            committed_queue_entry("a"),
+            committed_queue_entry("b"),
+            pending_queue_entry_with_id("c", "qe_c"),
+            pending_queue_entry_with_id("d", "qe_d"),
+        ];
+
+        assert_eq!(
+            retire_skipped_queue_frontier(&mut queue, Some("a"))
+                .expect("A should retire")
+                .spotify_uri,
+            "a"
+        );
+        let c_id = queue_frontier_candidate(&queue)
+            .expect("C should immediately enter the frontier")
+            .track
+            .queue_entry_id;
+        let c = queue
+            .iter_mut()
+            .find(|entry| entry.track.queue_entry_id == c_id)
+            .unwrap();
+        c.delivery_state = QueueDeliveryState::SpotifyCommitted;
+        c.can_remove = false;
+        c.current_match_state = QueueCurrentMatchState::AwaitingTransition;
+
+        assert_eq!(
+            retire_skipped_queue_frontier(&mut queue, Some("b"))
+                .expect("B should retire")
+                .spotify_uri,
+            "b"
+        );
+        assert_eq!(
+            queue_frontier_candidate(&queue)
+                .expect("D should be available for the second refill")
+                .track
+                .queue_entry_id,
+            "qe_d"
+        );
+    }
+
+    #[test]
+    fn skip_unlocks_same_uri_successor_without_duplicating_echo_history() {
+        let id = "AAAAAAAAAAAAAAAAAAAAAA";
+        let uri = format!("spotify:track:{id}");
+        let mut first = committed_queue_entry(&uri);
+        first.track.spotify_id = id.to_string();
+        let mut second = committed_queue_entry(&uri);
+        second.track.spotify_id = id.to_string();
+        second.current_match_state = QueueCurrentMatchState::AwaitingTransition;
+        let mut queue = vec![first, second];
+
+        let transition = apply_successful_skip_to_queue(
+            &mut queue,
+            Some(&uri),
+            Some(&uri),
+            PreSkipSameUriResolution::AwaitingStillNext,
+        );
+        assert!(transition.removed.is_some());
+        assert!(transition.unlocked_successor);
+        assert_eq!(queue.len(), 1);
+        assert_eq!(
+            queue[0].current_match_state,
+            QueueCurrentMatchState::Eligible,
+        );
+        assert!(new_history_observation(
+            Some(id),
+            true,
+            Some(id),
+            Some(&queue[0].track),
+            true,
+            false,
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn skip_unlocks_different_uri_successor_for_immediate_history() {
+        let first_id = "AAAAAAAAAAAAAAAAAAAAAA";
+        let second_id = "BBBBBBBBBBBBBBBBBBBBBB";
+        let first_uri = format!("spotify:track:{first_id}");
+        let second_uri = format!("spotify:track:{second_id}");
+        let mut first = committed_queue_entry(&first_uri);
+        first.track.spotify_id = first_id.to_string();
+        let mut second = committed_queue_entry(&second_uri);
+        second.track.spotify_id = second_id.to_string();
+        second.current_match_state = QueueCurrentMatchState::AwaitingTransition;
+        let mut queue = vec![first, second];
+
+        let transition = apply_successful_skip_to_queue(
+            &mut queue,
+            Some(&first_uri),
+            Some(&first_uri),
+            PreSkipSameUriResolution::NotNeeded,
+        );
+        assert!(transition.removed.is_some());
+        assert!(transition.unlocked_successor);
+        let observation = new_history_observation(
+            Some(first_id),
+            true,
+            Some(second_id),
+            Some(&queue[0].track),
+            true,
+            false,
+        )
+        .expect("the different successor should be immediately attributable");
+        assert_eq!(
+            observation
+                .queued_track
+                .as_ref()
+                .map(|track| track.spotify_id.as_str()),
+            Some(second_id),
+        );
+    }
+
+    #[test]
+    fn skip_reconciles_a_missed_different_uri_transition_before_retiring_current() {
+        let mut second = committed_queue_entry("b");
+        second.current_match_state = QueueCurrentMatchState::AwaitingTransition;
+        let mut queue = vec![
+            committed_queue_entry("a"),
+            second,
+            pending_queue_entry_with_id("c", "qe_c_after_missed_transition"),
+        ];
+
+        assert!(!same_uri_skip_observation_required(
+            &queue,
+            Some("b"),
+            Some("a"),
+        ));
+        let transition = apply_successful_skip_to_queue(
+            &mut queue,
+            Some("b"),
+            Some("a"),
+            PreSkipSameUriResolution::NotNeeded,
+        );
+        let mut queue_revision = 41_u64;
+        if transition.changed() {
+            queue_revision = queue_revision.wrapping_add(1);
+        }
+
+        assert_eq!(
+            queue_revision, 42,
+            "the compound transition is one revision"
+        );
+        assert_eq!(transition.removed_before_current.len(), 1);
+        assert_eq!(transition.removed_before_current[0].spotify_uri, "a");
+        assert_eq!(
+            transition
+                .removed
+                .as_ref()
+                .map(|track| track.spotify_uri.as_str()),
+            Some("b"),
+        );
+        assert_eq!(queue.len(), 1);
+        assert_eq!(
+            queue[0].track.queue_entry_id,
+            "qe_c_after_missed_transition"
+        );
+        assert_eq!(queue[0].delivery_state, QueueDeliveryState::Pending);
+    }
+
+    #[test]
+    fn pre_skip_observation_attributes_a_missed_transition_to_history() {
+        let first_id = "AAAAAAAAAAAAAAAAAAAAAA";
+        let second_id = "BBBBBBBBBBBBBBBBBBBBBB";
+        let first_uri = format!("spotify:track:{first_id}");
+        let second_uri = format!("spotify:track:{second_id}");
+        let mut first = committed_queue_entry(&first_uri);
+        first.track.spotify_id = first_id.to_string();
+        let mut second = committed_queue_entry(&second_uri);
+        second.track.spotify_id = second_id.to_string();
+        second.current_match_state = QueueCurrentMatchState::AwaitingTransition;
+        let queue = vec![first, second];
+
+        let observed = authoritative_pre_skip_echo_track(
+            &queue,
+            Some(&second_uri),
+            Some(&first_uri),
+            PreSkipSameUriResolution::NotNeeded,
+        )
+        .expect("the authoritative pre-skip current should align to the queued successor");
+        let history = new_history_observation(
+            Some(first_id),
+            true,
+            Some(second_id),
+            Some(&observed),
+            true,
+            false,
+        )
+        .expect("the newly observed Echo occurrence should start a history run");
+        assert_eq!(
+            history
+                .queued_track
+                .as_ref()
+                .map(|track| track.spotify_id.as_str()),
+            Some(second_id),
+        );
+    }
+
+    #[test]
+    fn skip_reconciles_external_to_echo_transition_observed_only_by_preflight() {
+        let mut queued_echo = committed_queue_entry("b");
+        queued_echo.current_match_state = QueueCurrentMatchState::AwaitingTransition;
+        let mut queue = vec![queued_echo];
+
+        assert!(!same_uri_skip_observation_required(
+            &queue,
+            Some("b"),
+            Some("external-a"),
+        ));
+        let transition = apply_successful_skip_to_queue(
+            &mut queue,
+            Some("b"),
+            Some("external-a"),
+            PreSkipSameUriResolution::NotNeeded,
+        );
+
+        assert!(transition.removed_before_current.is_empty());
+        assert_eq!(
+            transition
+                .removed
+                .as_ref()
+                .map(|track| track.spotify_uri.as_str()),
+            Some("b"),
+        );
+        assert!(queue.is_empty());
+    }
+
+    #[test]
+    fn same_uri_skip_uses_spotify_next_item_to_select_the_exact_occurrence() {
+        let uri = "spotify:track:AAAAAAAAAAAAAAAAAAAAAA";
+        let mut second = committed_queue_entry(uri);
+        second.track.queue_entry_id = "qe_same_second".to_string();
+        second.current_match_state = QueueCurrentMatchState::AwaitingTransition;
+        let first = committed_queue_entry(uri);
+        let first_id = first.track.queue_entry_id.clone();
+        let queue = vec![first, second];
+
+        assert!(same_uri_skip_observation_required(
+            &queue,
+            Some(uri),
+            Some(uri),
+        ));
+        let still_next = resolve_same_uri_skip_observation(
+            &queue,
+            &SpotifyQueueObservation {
+                current_uri: uri.to_string(),
+                next_uri: Some(uri.to_string()),
+            },
+            uri,
+            Some(uri),
+        )
+        .expect("the exact current/next observation should resolve the occurrence");
+        assert_eq!(still_next, PreSkipSameUriResolution::AwaitingStillNext,);
+        let mut first_is_current = queue.clone();
+        let transition =
+            apply_successful_skip_to_queue(&mut first_is_current, Some(uri), Some(uri), still_next);
+        assert!(transition.removed_before_current.is_empty());
+        assert_eq!(
+            transition
+                .removed
+                .as_ref()
+                .map(|track| track.queue_entry_id.as_str()),
+            Some(first_id.as_str()),
+        );
+        assert_eq!(first_is_current.len(), 1);
+        assert_eq!(first_is_current[0].track.queue_entry_id, "qe_same_second");
+        assert_eq!(
+            first_is_current[0].current_match_state,
+            QueueCurrentMatchState::Eligible,
+        );
+
+        let already_current = resolve_same_uri_skip_observation(
+            &queue,
+            &SpotifyQueueObservation {
+                current_uri: uri.to_string(),
+                next_uri: Some("spotify:track:BBBBBBBBBBBBBBBBBBBBBB".to_string()),
+            },
+            uri,
+            Some(uri),
+        )
+        .expect("a different next URI proves the queued duplicate is current");
+        assert_eq!(already_current, PreSkipSameUriResolution::AwaitingIsCurrent,);
+        let mut second_is_current = queue;
+        let transition = apply_successful_skip_to_queue(
+            &mut second_is_current,
+            Some(uri),
+            Some(uri),
+            already_current,
+        );
+        assert_eq!(transition.removed_before_current.len(), 1);
+        assert_eq!(
+            transition.removed_before_current[0].queue_entry_id,
+            first_id,
+        );
+        assert_eq!(
+            transition
+                .removed
+                .as_ref()
+                .map(|track| track.queue_entry_id.as_str()),
+            Some("qe_same_second"),
+        );
+        assert!(second_is_current.is_empty());
+    }
+
+    #[test]
+    fn same_uri_skip_fails_closed_when_spotify_current_does_not_match() {
+        let queue = Vec::new();
+        let observation = SpotifyQueueObservation {
+            current_uri: "spotify:track:BBBBBBBBBBBBBBBBBBBBBB".to_string(),
+            next_uri: None,
+        };
+        assert_eq!(
+            resolve_same_uri_skip_observation(
+                &queue,
+                &observation,
+                "spotify:track:AAAAAAAAAAAAAAAAAAAAAA",
+                None,
+            ),
+            Err(SameUriSkipObservationError::PlaybackChanged),
+        );
+    }
+
+    #[test]
+    fn commit_unknown_same_uri_skip_fails_closed_for_different_or_missing_next() {
+        let uri = "spotify:track:AAAAAAAAAAAAAAAAAAAAAA";
+        let mut unknown = committed_queue_entry(uri);
+        unknown.delivery_state = QueueDeliveryState::CommitUnknown;
+        unknown.current_match_state = QueueCurrentMatchState::AwaitingTransition;
+        let queue = vec![unknown];
+
+        for next_uri in [
+            Some("spotify:track:BBBBBBBBBBBBBBBBBBBBBB".to_string()),
+            None,
+        ] {
+            let observation = SpotifyQueueObservation {
+                current_uri: uri.to_string(),
+                next_uri,
+            };
+            assert_eq!(
+                resolve_same_uri_skip_observation(&queue, &observation, uri, Some(uri),),
+                Err(SameUriSkipObservationError::CommitUnknown),
+            );
+        }
+
+        assert!(authoritative_pre_skip_echo_track(
+            &queue,
+            Some(uri),
+            Some(uri),
+            PreSkipSameUriResolution::AwaitingIsCurrent,
+        )
+        .is_none());
+        let mut attempted = queue.clone();
+        let transition = apply_successful_skip_to_queue(
+            &mut attempted,
+            Some(uri),
+            Some(uri),
+            PreSkipSameUriResolution::AwaitingIsCurrent,
+        );
+        assert!(!transition.changed());
+        assert_eq!(attempted.len(), 1);
+        assert_eq!(
+            attempted[0].delivery_state,
+            QueueDeliveryState::CommitUnknown,
+        );
+        assert_eq!(
+            attempted[0].current_match_state,
+            QueueCurrentMatchState::AwaitingTransition,
+        );
+    }
+
+    #[test]
+    fn commit_unknown_skip_fails_closed_with_a_stale_different_predecessor() {
+        let mut unknown = committed_queue_entry("a");
+        unknown.delivery_state = QueueDeliveryState::CommitUnknown;
+        unknown.current_match_state = QueueCurrentMatchState::AwaitingTransition;
+        let queue = vec![committed_queue_entry("b"), unknown];
+
+        assert!(!same_uri_skip_observation_required(
+            &queue,
+            Some("a"),
+            Some("b"),
+        ));
+        assert_eq!(
+            reject_commit_unknown_pre_skip_target(
+                &queue,
+                "a",
+                Some("b"),
+                PreSkipSameUriResolution::NotNeeded,
+            ),
+            Err(SameUriSkipObservationError::CommitUnknown),
+        );
+        assert!(authoritative_pre_skip_echo_track(
+            &queue,
+            Some("a"),
+            Some("b"),
+            PreSkipSameUriResolution::NotNeeded,
+        )
+        .is_none());
+        let mut attempted = queue.clone();
+        let transition = apply_successful_skip_to_queue(
+            &mut attempted,
+            Some("a"),
+            Some("b"),
+            PreSkipSameUriResolution::NotNeeded,
+        );
+        assert!(!transition.changed());
+        assert_eq!(attempted.len(), 2);
+        assert_eq!(attempted[0].track.spotify_uri, "b");
+        assert_eq!(attempted[1].track.spotify_uri, "a");
+        assert_eq!(
+            attempted[1].delivery_state,
+            QueueDeliveryState::CommitUnknown,
+        );
+        assert_eq!(
+            attempted[1].current_match_state,
+            QueueCurrentMatchState::AwaitingTransition,
+        );
+    }
+
+    #[test]
+    fn uncertain_skip_reconciles_accepted_and_rejected_different_uri_results() {
+        let make_jam = || {
+            let mut successor = committed_queue_entry("b");
+            successor.current_match_state = QueueCurrentMatchState::AwaitingTransition;
+            JamState {
+                active: true,
+                generation: 9,
+                queue: vec![committed_queue_entry("a"), successor],
+                queue_revision: 12,
+                queue_control_stopped: true,
+                uncertain_skip: Some(UncertainSkipBoundary {
+                    pre_skip_current_uri: "a".to_string(),
+                    previous_uri: Some("a".to_string()),
+                    same_uri_resolution: PreSkipSameUriResolution::NotNeeded,
+                }),
+                ..JamState::default()
+            }
+        };
+
+        let mut accepted = make_jam();
+        assert_eq!(
+            reconcile_uncertain_skip_boundary(&mut accepted, Some("b"), None),
+            Some(UncertainSkipObservationResult::Accepted),
+        );
+        assert!(accepted.uncertain_skip.is_none());
+        assert!(accepted.queue_control_stopped);
+        assert_eq!(accepted.queue_revision, 13);
+        assert_eq!(accepted.queue.len(), 1);
+        assert_eq!(accepted.queue[0].track.spotify_uri, "b");
+        assert_eq!(
+            accepted.queue[0].current_match_state,
+            QueueCurrentMatchState::Eligible,
+        );
+
+        let mut rejected = make_jam();
+        assert_eq!(
+            reconcile_uncertain_skip_boundary(&mut rejected, Some("a"), None),
+            Some(UncertainSkipObservationResult::Rejected),
+        );
+        assert!(rejected.uncertain_skip.is_none());
+        assert!(rejected.queue_control_stopped);
+        assert_eq!(rejected.queue_revision, 12);
+        assert_eq!(rejected.queue.len(), 2);
+        assert_eq!(rejected.queue[0].track.spotify_uri, "a");
+        assert_eq!(
+            rejected.queue[1].current_match_state,
+            QueueCurrentMatchState::AwaitingTransition,
+        );
+    }
+
+    #[test]
+    fn uncertain_same_uri_skip_waits_for_queue_evidence_then_recovers_exactly_once() {
+        let uri = "spotify:track:AAAAAAAAAAAAAAAAAAAAAA";
+        let make_jam = || {
+            let mut successor = committed_queue_entry(uri);
+            successor.track.queue_entry_id = "qe_same_successor".to_string();
+            successor.current_match_state = QueueCurrentMatchState::AwaitingTransition;
+            JamState {
+                active: true,
+                generation: 9,
+                queue: vec![committed_queue_entry(uri), successor],
+                queue_revision: 20,
+                queue_control_stopped: true,
+                uncertain_skip: Some(UncertainSkipBoundary {
+                    pre_skip_current_uri: uri.to_string(),
+                    previous_uri: Some(uri.to_string()),
+                    same_uri_resolution: PreSkipSameUriResolution::AwaitingStillNext,
+                }),
+                ..JamState::default()
+            }
+        };
+
+        let mut pending = make_jam();
+        assert_eq!(
+            reconcile_uncertain_skip_boundary(&mut pending, Some(uri), None),
+            Some(UncertainSkipObservationResult::Pending),
+        );
+        assert!(pending.uncertain_skip.is_some());
+        assert_eq!(pending.queue_revision, 20);
+        assert_eq!(pending.queue.len(), 2);
+
+        let mut rejected = make_jam();
+        assert_eq!(
+            reconcile_uncertain_skip_boundary(
+                &mut rejected,
+                Some(uri),
+                Some(&SpotifyQueueObservation {
+                    current_uri: uri.to_string(),
+                    next_uri: Some(uri.to_string()),
+                }),
+            ),
+            Some(UncertainSkipObservationResult::Rejected),
+        );
+        assert!(rejected.uncertain_skip.is_none());
+        assert_eq!(rejected.queue_revision, 20);
+        assert_eq!(rejected.queue.len(), 2);
+
+        let mut accepted = make_jam();
+        let result = reconcile_uncertain_skip_boundary(
+            &mut accepted,
+            Some(uri),
+            Some(&SpotifyQueueObservation {
+                current_uri: uri.to_string(),
+                next_uri: Some("spotify:track:BBBBBBBBBBBBBBBBBBBBBB".to_string()),
+            }),
+        );
+        assert_eq!(result, Some(UncertainSkipObservationResult::Accepted));
+        if !uncertain_skip_blocks_ordinary_queue_update(result) {
+            let _ = advance_repeated_committed_occurrence(&mut accepted.queue, uri);
+        }
+        assert!(accepted.uncertain_skip.is_none());
+        assert!(accepted.queue_control_stopped);
+        assert_eq!(accepted.queue_revision, 21);
+        assert_eq!(accepted.queue.len(), 1);
+        assert_eq!(accepted.queue[0].track.queue_entry_id, "qe_same_successor");
+        assert_eq!(
+            accepted.queue[0].current_match_state,
+            QueueCurrentMatchState::Eligible,
+        );
+    }
+
+    #[test]
+    fn uncertain_skip_no_content_keeps_the_queue_fenced_without_retirement() {
+        let uri = "spotify:track:AAAAAAAAAAAAAAAAAAAAAA";
+        let mut successor = committed_queue_entry(uri);
+        successor.current_match_state = QueueCurrentMatchState::AwaitingTransition;
+        let mut previous = now_playing(true);
+        previous.spotify_uri = uri.to_string();
+        previous.progress_ms = previous.duration_ms;
+        previous.fetched_at = Some(std::time::Instant::now() - Duration::from_secs(2));
+        let mut jam = JamState {
+            active: true,
+            generation: 9,
+            queue: vec![committed_queue_entry(uri), successor],
+            queue_revision: 30,
+            queue_control_stopped: true,
+            uncertain_skip: Some(UncertainSkipBoundary {
+                pre_skip_current_uri: uri.to_string(),
+                previous_uri: Some(uri.to_string()),
+                same_uri_resolution: PreSkipSameUriResolution::AwaitingStillNext,
+            }),
+            now_playing: Some(previous),
+            ..JamState::default()
+        };
+
+        let reconciliation = reconcile_queue_after_no_content(&mut jam);
+        assert_eq!(
+            reconciliation.uncertain_skip,
+            Some(UncertainSkipObservationResult::Pending),
+        );
+        assert!(reconciliation.naturally_finished.is_none());
+        assert!(jam.uncertain_skip.is_some());
+        assert_eq!(jam.queue_revision, 30);
+        assert_eq!(jam.queue.len(), 2);
+        assert_eq!(
+            jam.queue[1].current_match_state,
+            QueueCurrentMatchState::AwaitingTransition,
+        );
+    }
+
+    #[test]
+    fn ambiguous_skip_error_fences_without_mutating_the_queue() {
+        let mut successor = committed_queue_entry("b");
+        successor.current_match_state = QueueCurrentMatchState::AwaitingTransition;
+        let queue = vec![committed_queue_entry("a"), successor];
+        let mut jam = JamState {
+            active: true,
+            generation: 5,
+            queue: queue.clone(),
+            queue_revision: 7,
+            queue_control_stopped: true,
+            uncertain_skip: Some(UncertainSkipBoundary {
+                pre_skip_current_uri: "a".to_string(),
+                previous_uri: Some("a".to_string()),
+                same_uri_resolution: PreSkipSameUriResolution::NotNeeded,
+            }),
+            ..JamState::default()
+        };
+
+        assert_eq!(jam.queue_revision, 7);
+        assert_eq!(jam.queue.len(), queue.len());
+        assert_eq!(
+            jam.queue[0].track.queue_entry_id,
+            queue[0].track.queue_entry_id
+        );
+        assert_eq!(
+            jam.queue[1].track.queue_entry_id,
+            queue[1].track.queue_entry_id
+        );
+        assert!(jam.uncertain_skip.is_some());
+        assert!(jam.queue_control_stopped);
+
+        clear_active_jam_state(&mut jam);
+        assert!(jam.uncertain_skip.is_none());
+    }
+
+    #[test]
+    fn skip_from_external_same_uri_unlocks_echo_provenance() {
+        let id = "AAAAAAAAAAAAAAAAAAAAAA";
+        let uri = format!("spotify:track:{id}");
+        let mut queued_echo = committed_queue_entry(&uri);
+        queued_echo.track.spotify_id = id.to_string();
+        queued_echo.current_match_state = QueueCurrentMatchState::AwaitingTransition;
+        let mut queue = vec![queued_echo];
+
+        assert!(same_uri_skip_observation_required(
+            &queue,
+            Some(&uri),
+            Some(&uri),
+        ));
+        let transition = apply_successful_skip_to_queue(
+            &mut queue,
+            Some(&uri),
+            Some(&uri),
+            PreSkipSameUriResolution::AwaitingStillNext,
+        );
+        assert!(transition.removed.is_none());
+        assert!(transition.unlocked_successor);
+        let observation = new_history_observation(
+            Some(id),
+            false,
+            Some(id),
+            Some(&queue[0].track),
+            true,
+            false,
+        )
+        .expect("external-to-Echo same-track skip should become attributable");
+        assert!(observation.queued_track.is_some());
+    }
+
+    #[test]
+    fn unknown_successor_remains_locked_after_observation_and_skip_boundary() {
+        let uri = "spotify:track:AAAAAAAAAAAAAAAAAAAAAA";
+        let mut unknown = committed_queue_entry(uri);
+        unknown.delivery_state = QueueDeliveryState::CommitUnknown;
+        unknown.current_match_state = QueueCurrentMatchState::AwaitingTransition;
+        let mut queue = vec![unknown];
+
+        assert!(!observe_queue_current_transition(&mut queue, uri, true));
+        let transition = apply_successful_skip_to_queue(
+            &mut queue,
+            Some("external"),
+            Some("external"),
+            PreSkipSameUriResolution::NotNeeded,
+        );
+        assert!(transition.removed.is_none());
+        assert!(!transition.unlocked_successor);
+        assert_eq!(queue[0].delivery_state, QueueDeliveryState::CommitUnknown,);
+        assert_eq!(
+            queue[0].current_match_state,
+            QueueCurrentMatchState::AwaitingTransition,
+        );
+        assert!(!queue[0].can_remove);
+        assert!(committed_queue_track_matching_current(&queue, uri).is_none());
+    }
+
+    #[test]
+    fn stopped_skip_unlocks_successor_but_keeps_playback_stopped() {
+        let mut successor = committed_queue_entry("b");
+        successor.current_match_state = QueueCurrentMatchState::AwaitingTransition;
+        let mut queue = vec![committed_queue_entry("a"), successor];
+
+        let transition = apply_successful_skip_to_queue(
+            &mut queue,
+            Some("a"),
+            Some("a"),
+            PreSkipSameUriResolution::NotNeeded,
+        );
+        assert!(transition.changed());
+        assert_eq!(
+            queue[0].current_match_state,
+            QueueCurrentMatchState::Eligible,
+        );
+        assert!(queue_control_stopped_after_skip(false));
+    }
+
+    #[test]
+    fn queue_mutation_errors_distinguish_definite_rejections_from_ambiguity() {
+        assert!(!spotify_mutation_response_is_ambiguous(
+            reqwest::StatusCode::BAD_REQUEST
+        ));
+        assert!(!spotify_mutation_response_is_ambiguous(
+            reqwest::StatusCode::UNAUTHORIZED
+        ));
+        assert!(!spotify_mutation_response_is_ambiguous(
+            reqwest::StatusCode::TOO_MANY_REQUESTS
+        ));
+        assert!(spotify_mutation_response_is_ambiguous(
+            reqwest::StatusCode::INTERNAL_SERVER_ERROR
+        ));
+
+        let transport = queue_mutation_request_error(
+            StatusCode::BAD_GATEWAY,
+            "transport lost".to_string(),
+            SpotifyTrackPlacement::QueuedNext,
+        );
+        assert!(transport.acceptance_ambiguous);
+        let pre_send_gate = queue_mutation_request_error(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "gate unavailable".to_string(),
+            SpotifyTrackPlacement::QueuedNext,
+        );
+        assert!(!pre_send_gate.acceptance_ambiguous);
+
+        let skip_transport =
+            skip_mutation_request_error(StatusCode::BAD_GATEWAY, "response lost".to_string());
+        assert!(skip_transport.acceptance_ambiguous);
+        let skip_rate_limit = skip_mutation_request_error(
+            StatusCode::TOO_MANY_REQUESTS,
+            "pre-send rate limit".to_string(),
+        );
+        assert!(!skip_rate_limit.acceptance_ambiguous);
+    }
+
+    #[tokio::test]
+    async fn required_queue_preflight_preserves_spotify_rate_limit_status() {
+        let response = reqwest::Response::from(
+            axum::http::Response::builder()
+                .status(reqwest::StatusCode::TOO_MANY_REQUESTS)
+                .header(reqwest::header::RETRY_AFTER, "17")
+                .body("{\"error\":{\"message\":\"slow down\"}}")
+                .unwrap(),
+        );
+
+        let (status, message) = spotify_response_error(response, "Read Spotify queue").await;
+        assert_eq!(status, StatusCode::TOO_MANY_REQUESTS);
+        assert!(message.contains("Spotify 429 Too Many Requests"));
+        assert!(message.contains("slow down"));
+    }
+
+    #[tokio::test]
+    async fn skip_response_classifies_server_failure_as_ambiguous_and_4xx_as_definite() {
+        let server_error = reqwest::Response::from(
+            axum::http::Response::builder()
+                .status(reqwest::StatusCode::INTERNAL_SERVER_ERROR)
+                .body("{\"error\":{\"message\":\"uncertain\"}}")
+                .unwrap(),
+        );
+        assert!(
+            spotify_skip_mutation_response_error(server_error)
+                .await
+                .acceptance_ambiguous
+        );
+
+        let forbidden = reqwest::Response::from(
+            axum::http::Response::builder()
+                .status(reqwest::StatusCode::FORBIDDEN)
+                .body("{\"error\":{\"message\":\"definite\"}}")
+                .unwrap(),
+        );
+        let forbidden = spotify_skip_mutation_response_error(forbidden).await;
+        assert_eq!(forbidden.status, StatusCode::FORBIDDEN);
+        assert!(!forbidden.acceptance_ambiguous);
+    }
+
+    #[test]
+    fn stopped_frontier_resumes_only_for_an_explicit_add() {
+        let queue = vec![committed_queue_entry("one"), committed_queue_entry("two")];
+        assert!(queue_frontier_candidate(&queue).is_none());
+        assert!(stopped_frontier_should_resume(&queue, true, true));
+        assert!(!stopped_frontier_should_resume(&queue, true, false));
+        assert!(!stopped_frontier_should_resume(&queue, false, true));
+        assert!(!stopped_frontier_should_resume(&[], true, true));
+    }
+
+    #[test]
+    fn queue_entries_serialize_flat_delivery_state_and_removability() {
+        let entry = pending_queue_entry_with_id("spotify:track:one", "qe_pending_one");
+        let json = serde_json::to_value(entry).unwrap();
+
+        assert_eq!(json["spotify_uri"], "spotify:track:one");
+        assert_eq!(json["queue_entry_id"], "qe_pending_one");
+        assert_eq!(json["delivery_state"], "pending");
+        assert_eq!(json["can_remove"], true);
+    }
+
+    #[test]
+    fn spotify_queue_frontier_never_selects_more_than_two_or_passes_unknown() {
+        let first = committed_queue_entry("one");
+        let second = pending_queue_entry_with_id("two", "qe_pending_two");
+        let third = pending_queue_entry_with_id("three", "qe_pending_three");
+        let queue = vec![first.clone(), second.clone(), third.clone()];
+        assert_eq!(
+            queue_frontier_candidate(&queue).map(|entry| entry.track.queue_entry_id),
+            Some("qe_pending_two".to_string())
+        );
+
+        let mut two_committed = queue;
+        two_committed[1].delivery_state = QueueDeliveryState::SpotifyCommitted;
+        two_committed[1].can_remove = false;
+        assert!(queue_frontier_candidate(&two_committed).is_none());
+
+        let mut unknown = vec![first, second, third];
+        unknown[0].delivery_state = QueueDeliveryState::CommitUnknown;
+        assert!(queue_frontier_candidate(&unknown).is_none());
+    }
+
+    #[test]
+    fn commit_unknown_blocks_new_admission_but_pending_tail_stays_removable() {
+        let mut unknown = committed_queue_entry("one");
+        unknown.delivery_state = QueueDeliveryState::CommitUnknown;
+        let pending = pending_queue_entry_with_id("two", "qe_pending_behind_unknown");
+        let mut jam = JamState {
+            queue_revision: 8,
+            queue: vec![unknown, pending],
+            ..JamState::default()
+        };
+
+        assert!(queue_has_commit_unknown(&jam.queue));
+        assert!(queue_frontier_candidate(&jam.queue).is_none());
+        remove_pending_queue_entries(&mut jam, &["qe_pending_behind_unknown".to_string()])
+            .expect("pending tail removal remains available behind the unknown frontier");
+        assert_eq!(jam.queue_revision, 9);
+        assert_eq!(jam.queue.len(), 1);
+        assert_eq!(
+            jam.queue[0].delivery_state,
+            QueueDeliveryState::CommitUnknown,
+        );
+    }
+
+    #[test]
+    fn bulk_queue_removal_uses_entry_ids_and_preserves_duplicate_occurrences() {
+        let mut jam = JamState {
+            active: true,
+            generation: 7,
+            queue_revision: 9,
+            queue: vec![
+                pending_queue_entry_with_id("same", "qe_duplicate_one"),
+                pending_queue_entry_with_id("same", "qe_duplicate_two"),
+                pending_queue_entry_with_id("later", "qe_later_three"),
+            ],
+            ..JamState::default()
+        };
+
+        remove_pending_queue_entries(&mut jam, &["qe_duplicate_two".to_string()]).unwrap();
+
+        assert_eq!(jam.queue_revision, 10);
+        assert_eq!(jam.queue.len(), 2);
+        assert_eq!(jam.queue[0].track.queue_entry_id, "qe_duplicate_one");
+        assert_eq!(jam.queue[1].track.queue_entry_id, "qe_later_three");
+    }
+
+    #[test]
+    fn bulk_queue_removal_is_atomic_when_any_entry_is_committed_or_missing() {
+        let pending = pending_queue_entry_with_id("one", "qe_pending_one");
+        let mut committed = committed_queue_entry("two");
+        committed.track.queue_entry_id = "qe_committed_two".to_string();
+        let mut jam = JamState {
+            queue_revision: 4,
+            queue: vec![pending, committed],
+            ..JamState::default()
+        };
+
+        assert_eq!(
+            remove_pending_queue_entries(
+                &mut jam,
+                &["qe_pending_one".to_string(), "qe_committed_two".to_string(),],
+            ),
+            Err(QueueRemovalMutationError::NotRemovable)
+        );
+        assert_eq!(jam.queue.len(), 2);
+        assert_eq!(jam.queue_revision, 4);
+
+        assert_eq!(
+            remove_pending_queue_entries(&mut jam, &["qe_missing_three".to_string()]),
+            Err(QueueRemovalMutationError::QueueChanged)
+        );
+        assert_eq!(jam.queue.len(), 2);
+        assert_eq!(jam.queue_revision, 4);
     }
 
     #[test]
@@ -3803,6 +7714,97 @@ mod tests {
         );
         assert!(spotify_track_id_from_uri("spotify:track:short").is_none());
         assert!(spotify_track_id_from_uri("https://example.invalid").is_none());
+    }
+
+    #[test]
+    fn track_queue_request_id_is_optional_for_legacy_viewers() {
+        let legacy: JamQueueRequest = serde_json::from_value(serde_json::json!({
+            "generation": 7,
+            "spotify_uri": "spotify:track:0VjIjW4GlUZAMYd2vXMi3b",
+            "name": "Legacy",
+            "artist": "Viewer",
+            "album_art_url": "",
+            "duration_ms": 123,
+        }))
+        .unwrap();
+        assert_eq!(legacy.request_id, None);
+
+        let modern: JamQueueRequest = serde_json::from_value(serde_json::json!({
+            "generation": 7,
+            "request_id": "track_request_123",
+            "spotify_uri": "spotify:track:0VjIjW4GlUZAMYd2vXMi3b",
+            "name": "Modern",
+            "artist": "Viewer",
+            "album_art_url": "",
+            "duration_ms": 123,
+        }))
+        .unwrap();
+        assert_eq!(modern.request_id.as_deref(), Some("track_request_123"));
+    }
+
+    #[test]
+    fn playlist_queue_selection_is_optional_and_canonical() {
+        let all: PlaylistQueueRequest = serde_json::from_value(serde_json::json!({
+            "generation": 7,
+            "playlist_id": "3n3Ppam7vgaVa1iaRUc9Lp",
+            "request_id": "request_123",
+        }))
+        .unwrap();
+        let all_fingerprint = playlist_queue_selection_fingerprint(&all).unwrap();
+        assert_eq!(all_fingerprint.selected_positions, None);
+        assert_eq!(all_fingerprint.snapshot_id, None);
+
+        let selected: PlaylistQueueRequest = serde_json::from_value(serde_json::json!({
+            "generation": 7,
+            "playlist_id": "3n3Ppam7vgaVa1iaRUc9Lp",
+            "request_id": "request_456",
+            "selected_positions": [9, 2, 5],
+            "snapshot_id": "snapshot",
+        }))
+        .unwrap();
+        let selected_fingerprint = playlist_queue_selection_fingerprint(&selected).unwrap();
+        assert_eq!(selected_fingerprint.selected_positions, Some(vec![2, 5, 9]));
+        assert_eq!(
+            selected_fingerprint.snapshot_id.as_deref(),
+            Some("snapshot")
+        );
+
+        let missing_snapshot: PlaylistQueueRequest = serde_json::from_value(serde_json::json!({
+            "generation": 7,
+            "playlist_id": "3n3Ppam7vgaVa1iaRUc9Lp",
+            "request_id": "request_missing_snapshot",
+            "selected_positions": [2],
+        }))
+        .unwrap();
+        assert!(playlist_queue_selection_fingerprint(&missing_snapshot).is_err());
+
+        let blank_snapshot: PlaylistQueueRequest = serde_json::from_value(serde_json::json!({
+            "generation": 7,
+            "playlist_id": "3n3Ppam7vgaVa1iaRUc9Lp",
+            "request_id": "request_blank_snapshot",
+            "selected_positions": [2],
+            "snapshot_id": "   ",
+        }))
+        .unwrap();
+        assert!(playlist_queue_selection_fingerprint(&blank_snapshot).is_err());
+
+        let empty: PlaylistQueueRequest = serde_json::from_value(serde_json::json!({
+            "generation": 7,
+            "playlist_id": "3n3Ppam7vgaVa1iaRUc9Lp",
+            "request_id": "request_789",
+            "selected_positions": [],
+        }))
+        .unwrap();
+        assert!(playlist_queue_selection_fingerprint(&empty).is_err());
+
+        let duplicate: PlaylistQueueRequest = serde_json::from_value(serde_json::json!({
+            "generation": 7,
+            "playlist_id": "3n3Ppam7vgaVa1iaRUc9Lp",
+            "request_id": "request_dup",
+            "selected_positions": [2, 2],
+        }))
+        .unwrap();
+        assert!(playlist_queue_selection_fingerprint(&duplicate).is_err());
     }
 
     #[test]
@@ -3827,14 +7829,21 @@ mod tests {
             spotify_url: "https://open.spotify.com/playlist/3n3Ppam7vgaVa1iaRUc9Lp".to_string(),
             name: "Mix".to_string(),
         };
-        let queued =
-            queued_track_from_summary(&summary, &actor, Some("batch"), Some(&playlist), 99);
+        let queued = queued_track_from_summary(
+            &summary,
+            &actor,
+            Some("batch"),
+            Some(&playlist),
+            Some(12),
+            99,
+        );
         assert_eq!(queued.name, "Server name");
         assert_eq!(queued.artist, "Server artist");
         assert_eq!(queued.added_by_actor_id, "ea1_actor");
         assert_eq!(queued.added_at_ms, 99);
         assert_eq!(queued.queue_batch_id.as_deref(), Some("batch"));
         assert_eq!(queued.playlist, Some(playlist));
+        assert_eq!(queued.playlist_position, Some(12));
     }
 
     #[test]
@@ -3844,9 +7853,46 @@ mod tests {
         assert!(enqueue_interrupted_by_stop(4, 5, true));
         assert!(!enqueue_interrupted_by_stop(4, 5, false));
         assert!(!enqueue_interrupted_by_stop(5, 5, true));
-        assert_eq!(playlist_batch_flags(false, 0), (false, true));
-        assert_eq!(playlist_batch_flags(false, 1), (true, false));
-        assert_eq!(playlist_batch_flags(true, 0), (true, false));
+        assert!(!queue_control_stopped_after_skip(true));
+        assert!(queue_control_stopped_after_skip(false));
+    }
+
+    #[test]
+    fn stop_admission_fence_survives_a_later_queue_resume() {
+        let mut jam = JamState {
+            active: true,
+            generation: 42,
+            spotify_device_id: Some("device-a".to_string()),
+            spotify_is_playing: true,
+            queue_control_epoch: 7,
+            queue_stop_epoch: 11,
+            ..JamState::default()
+        };
+        let slow_add_admission = jam.queue_stop_epoch;
+
+        assert!(apply_spotify_pause_result(
+            &mut jam,
+            42,
+            &spotify_device("device-a", "Echo PC")
+        ));
+        let post_stop_add_admission = jam.queue_stop_epoch;
+        assert!(enqueue_admission_cancelled_by_stop(
+            slow_add_admission,
+            jam.queue_stop_epoch
+        ));
+
+        // A newer explicit add may resume playback, but that must not erase the
+        // Stop boundary seen by an older, still-loading playlist expansion.
+        jam.queue_control_stopped = false;
+        jam.spotify_is_playing = true;
+        assert!(enqueue_admission_cancelled_by_stop(
+            slow_add_admission,
+            jam.queue_stop_epoch
+        ));
+        assert!(!enqueue_admission_cancelled_by_stop(
+            post_stop_add_admission,
+            jam.queue_stop_epoch
+        ));
     }
 
     #[test]
@@ -3857,35 +7903,6 @@ mod tests {
             spotify_url: "https://open.spotify.com/playlist/3n3Ppam7vgaVa1iaRUc9Lp".to_string(),
             name: "Server playlist".to_string(),
         };
-        let actor = JamActor {
-            actor_id: "ea1_actor".to_string(),
-            display_name: "Sam".to_string(),
-        };
-        let summary = |spotify_id: &str, name: &str| FavoriteSummary {
-            spotify_id: spotify_id.to_string(),
-            spotify_uri: format!("spotify:track:{spotify_id}"),
-            spotify_url: format!("https://open.spotify.com/track/{spotify_id}"),
-            name: name.to_string(),
-            artist: Some("Server artist".to_string()),
-            duration_ms: Some(321),
-            ..FavoriteSummary::default()
-        };
-        let queued = vec![
-            queued_track_from_summary(
-                &summary("0VjIjW4GlUZAMYd2vXMi3b", "First"),
-                &actor,
-                Some("batch-1"),
-                Some(&playlist),
-                99,
-            ),
-            queued_track_from_summary(
-                &summary("3n3Ppam7vgaVa1iaRUc9Lp", "Second"),
-                &actor,
-                Some("batch-1"),
-                Some(&playlist),
-                99,
-            ),
-        ];
         let response = PlaylistQueueResponse {
             schema_version: 1,
             ok: false,
@@ -3895,7 +7912,8 @@ mod tests {
             batch_id: "batch-1".to_string(),
             generation: 7,
             playlist,
-            queued,
+            queued_positions: vec![4, 9],
+            remaining_positions: vec![12, 15],
             queued_count: 2,
             skipped: vec![SkippedPlaylistItem {
                 position: 2,
@@ -3919,12 +7937,10 @@ mod tests {
         assert_eq!(json["queue_batch_id"], "batch-1");
         assert_eq!(json["batch_id"], "batch-1");
         assert_eq!(json["queued_count"], 2);
+        assert_eq!(json["queued_positions"], serde_json::json!([4, 9]));
+        assert_eq!(json["remaining_positions"], serde_json::json!([12, 15]));
         assert_eq!(json["skipped_count"], 1);
-        assert_eq!(json["queued"][0]["name"], "First");
-        assert_eq!(json["queued"][1]["name"], "Second");
-        assert_eq!(json["queued"][0]["added_by_actor_id"], "ea1_actor");
-        assert_eq!(json["queued"][0]["added_by"], "Sam");
-        assert_eq!(json["queued"][0]["playlist"]["name"], "Server playlist");
+        assert!(json.get("queued").is_none());
         assert_eq!(json["skipped"][0]["position"], 2);
         assert_eq!(json["skipped"][0]["reason"], "local_track");
         assert_eq!(json["failure"]["status"], 429);
@@ -3970,7 +7986,8 @@ mod tests {
                 batch_id: "batch".to_string(),
                 generation: 1,
                 playlist: QueuedPlaylistProvenance::default(),
-                queued: Vec::new(),
+                queued_positions: Vec::new(),
+                remaining_positions: Vec::new(),
                 queued_count: 0,
                 skipped: Vec::new(),
                 skipped_count: 0,
@@ -3979,6 +7996,10 @@ mod tests {
             }
         }
         let mut jam = JamState::default();
+        let selection = PlaylistQueueSelectionFingerprint {
+            selected_positions: Some(vec![2, 8]),
+            snapshot_id: Some("snapshot".to_string()),
+        };
         for index in 0..129u64 {
             let request_id = format!("request_{index:03}");
             insert_playlist_queue_receipt(
@@ -3987,6 +8008,7 @@ mod tests {
                 PlaylistQueueReceipt {
                     actor_id: "actor".to_string(),
                     playlist_id: "3n3Ppam7vgaVa1iaRUc9Lp".to_string(),
+                    selection: selection.clone(),
                     generation: 1,
                     created_at_ms: index,
                     response: response(request_id),
@@ -4001,6 +8023,7 @@ mod tests {
             "request_128",
             "actor",
             "3n3Ppam7vgaVa1iaRUc9Lp",
+            &selection,
             1,
         )
         .unwrap()
@@ -4011,7 +8034,133 @@ mod tests {
             "request_128",
             "other-actor",
             "3n3Ppam7vgaVa1iaRUc9Lp",
+            &selection,
             1,
+        )
+        .is_err());
+        let different_selection = PlaylistQueueSelectionFingerprint {
+            selected_positions: Some(vec![2, 9]),
+            snapshot_id: Some("snapshot".to_string()),
+        };
+        assert!(playlist_queue_receipt_response(
+            &jam,
+            "request_128",
+            "actor",
+            "3n3Ppam7vgaVa1iaRUc9Lp",
+            &different_selection,
+            1,
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn track_receipt_replays_only_the_same_actor_generation_and_track() {
+        let mut jam = JamState::default();
+        let track =
+            pending_queue_entry_with_id("spotify:track:0VjIjW4GlUZAMYd2vXMi3b", "qe_track_receipt");
+        insert_track_queue_receipt(
+            &mut jam,
+            "track_request_123".to_string(),
+            TrackQueueReceipt {
+                actor_id: "actor".to_string(),
+                spotify_id: "0VjIjW4GlUZAMYd2vXMi3b".to_string(),
+                generation: 7,
+                created_at_ms: 1,
+                track: track.clone(),
+            },
+        );
+
+        assert_eq!(
+            track_queue_receipt_response(
+                &jam,
+                "track_request_123",
+                "actor",
+                "0VjIjW4GlUZAMYd2vXMi3b",
+                7,
+            )
+            .unwrap()
+            .unwrap()
+            .track
+            .queue_entry_id,
+            track.track.queue_entry_id
+        );
+        assert!(track_queue_receipt_response(
+            &jam,
+            "track_request_123",
+            "other-actor",
+            "0VjIjW4GlUZAMYd2vXMi3b",
+            7,
+        )
+        .is_err());
+        assert!(track_queue_receipt_response(
+            &jam,
+            "track_request_123",
+            "actor",
+            "different-track",
+            7,
+        )
+        .is_err());
+        assert!(track_queue_receipt_response(
+            &jam,
+            "track_request_123",
+            "actor",
+            "0VjIjW4GlUZAMYd2vXMi3b",
+            8,
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn queue_removal_receipt_replays_only_the_same_actor_and_fingerprint() {
+        let fingerprint = QueueRemovalFingerprint {
+            expected_queue_revision: 11,
+            queue_entry_ids: vec!["qe_pending_one".to_string(), "qe_pending_two".to_string()],
+        };
+        let response = JamQueueRemoveResponse {
+            ok: true,
+            generation: 3,
+            queue_revision: 12,
+            removed_entry_ids: fingerprint.queue_entry_ids.clone(),
+            removed_count: 2,
+        };
+        let mut jam = JamState::default();
+        insert_queue_removal_receipt(
+            &mut jam,
+            "remove_request_1".to_string(),
+            QueueRemovalReceipt {
+                actor_id: "actor".to_string(),
+                generation: 3,
+                fingerprint: fingerprint.clone(),
+                created_at_ms: 1,
+                response: response.clone(),
+            },
+        );
+
+        assert_eq!(
+            queue_removal_receipt_response(&jam, "remove_request_1", "actor", 3, &fingerprint,)
+                .unwrap()
+                .unwrap()
+                .removed_entry_ids,
+            response.removed_entry_ids
+        );
+        assert!(queue_removal_receipt_response(
+            &jam,
+            "remove_request_1",
+            "other-actor",
+            3,
+            &fingerprint,
+        )
+        .is_err());
+        let different_revision = QueueRemovalFingerprint {
+            expected_queue_revision: 12,
+            queue_entry_ids: fingerprint.queue_entry_ids,
+        };
+        assert!(queue_removal_receipt_response(
+            &jam,
+            "remove_request_1",
+            "actor",
+            3,
+            &different_revision,
         )
         .is_err());
     }

--- a/core/control/src/main.rs
+++ b/core/control/src/main.rs
@@ -9,11 +9,13 @@ pub mod file_serving;
 mod jam_bot;
 mod jam_history;
 mod jam_library;
+mod jam_playlist_cache;
 mod jam_session;
 mod jam_source;
 mod rooms;
 pub mod sfu_proxy;
 mod soundboard;
+mod spotify_public_catalog;
 
 use admin::*;
 use auth::*;
@@ -83,6 +85,8 @@ pub(crate) struct AppState {
     pub(crate) spotify_token_storage_enabled: bool,
     pub(crate) jam_actor_secret: Arc<Option<Vec<u8>>>,
     pub(crate) jam_favorites: Arc<jam_library::FavoriteStore>,
+    pub(crate) jam_playlist_cache: Arc<jam_playlist_cache::PlaylistItemsCache>,
+    pub(crate) jam_playlist_cache_refresh: Arc<tokio::sync::Mutex<()>>,
     pub(crate) jam_history: Arc<jam_history::JamHistoryStore>,
     pub(crate) spotify_request_limit: Arc<tokio::sync::Semaphore>,
     pub(crate) spotify_refresh_lock: Arc<tokio::sync::Mutex<()>>,
@@ -379,6 +383,7 @@ async fn main() {
         .join("spotify-token.json");
     let jam_library_dir = session_log_dir.join("jam-library");
     let jam_favorites_file = jam_library_dir.join("favorites-v1.json");
+    let jam_playlist_cache_file = jam_library_dir.join("playlist-items-cache-v2.json");
     let jam_history_dir = session_log_dir.join("jam-history");
     let static_roots = [
         viewer_dir.as_path(),
@@ -497,6 +502,20 @@ async fn main() {
             }
         }
     };
+    let jam_playlist_cache = if !jam_storage_isolated {
+        jam_playlist_cache::PlaylistItemsCache::disabled(jam_playlist_cache_file.clone())
+    } else {
+        match jam_playlist_cache::PlaylistItemsCache::open(jam_playlist_cache_file.clone()) {
+            Ok(store) => store,
+            Err(error) => {
+                warn!(
+                    "Jam playlist-items cache primary store could not be loaded; preserving it and disabling writes: {}",
+                    error
+                );
+                jam_playlist_cache::PlaylistItemsCache::recover_read_only(jam_playlist_cache_file)
+            }
+        }
+    };
 
     // Viewer cache-busting stamp — unique per server start
     let viewer_stamp = format!(
@@ -544,6 +563,8 @@ async fn main() {
         spotify_token_storage_enabled,
         jam_actor_secret: Arc::new(jam_actor_secret),
         jam_favorites: Arc::new(jam_favorites),
+        jam_playlist_cache: Arc::new(jam_playlist_cache),
+        jam_playlist_cache_refresh: Arc::new(tokio::sync::Mutex::new(())),
         jam_history: Arc::new(jam_history),
         spotify_request_limit: Arc::new(tokio::sync::Semaphore::new(4)),
         spotify_refresh_lock: Arc::new(tokio::sync::Mutex::new(())),
@@ -908,7 +929,12 @@ async fn main() {
             put(jam_favorite_put).delete(jam_favorite_delete),
         )
         .route("/api/jam/queue", post(jam_queue_add))
+        .route("/api/jam/queue/remove", post(jam_queue_remove))
         .route("/api/jam/queue/playlist", post(jam_queue_playlist))
+        .route(
+            "/api/jam/queue/playlist/selection",
+            post(jam_queue_playlist_selection),
+        )
         .route("/api/jam/playback/stop", post(jam_stop_playback))
         .route("/api/jam/skip", post(jam_skip))
         .route("/api/jam/join", post(jam_join))

--- a/core/control/src/spotify_public_catalog.rs
+++ b/core/control/src/spotify_public_catalog.rs
@@ -1,0 +1,772 @@
+use crate::jam_library::{valid_spotify_id, FavoriteSummary};
+
+use hmac::{Hmac, Mac};
+use reqwest::header::{ACCEPT, ORIGIN, REFERER, RETRY_AFTER, USER_AGENT};
+use serde::{Deserialize, Serialize};
+use sha1::Sha1;
+use std::fmt;
+use std::sync::OnceLock;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use tokio::sync::Mutex;
+
+pub(crate) const PUBLIC_PLAYLIST_CHUNK_SIZE: usize = 50;
+pub(crate) const MAX_PUBLIC_PLAYLIST_POSITIONS: usize = 1_000;
+
+const SERVER_TIME_URL: &str = "https://open.spotify.com/api/server-time";
+const TOKEN_URL: &str = "https://open.spotify.com/api/token";
+const PARTNER_QUERY_URL: &str = "https://api-partner.spotify.com/pathfinder/v2/query";
+const TOKEN_PRODUCT_TYPE: &str = "web-player";
+const TOKEN_REASON: &str = "init";
+const TOTP_VERSION: &str = "61";
+const TOTP_SOURCE_SECRET: &str = ",7/*F(\"rLJ2oxaKL^f+E1xvP@N";
+const PLAYLIST_QUERY_OPERATION: &str = "queryPlaylist";
+const PLAYLIST_QUERY_HASH: &str =
+    "908a5597b4d0af0489a9ad6a2d41bc3b416ff47c0884016d92bbd6822d0eb6d8";
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(12);
+const TOKEN_EXPIRY_MARGIN_MS: u64 = 60_000;
+const USER_AGENT_VALUE: &str = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 \
+    (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36";
+
+type HmacSha1 = Hmac<Sha1>;
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub(crate) struct PublicPlaylistChunk {
+    pub(crate) playlist_id: String,
+    pub(crate) offset: usize,
+    pub(crate) limit: usize,
+    pub(crate) total_count: u64,
+    pub(crate) next_offset: Option<usize>,
+    pub(crate) truncated_at_position_limit: bool,
+    pub(crate) positions: Vec<PublicPlaylistPosition>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub(crate) struct PublicPlaylistPosition {
+    pub(crate) position: usize,
+    pub(crate) outcome: PublicPlaylistPositionOutcome,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub(crate) enum PublicPlaylistPositionOutcome {
+    Track { summary: FavoriteSummary },
+    Skipped { reason: String },
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct PublicCatalogError {
+    pub(crate) code: &'static str,
+    pub(crate) message: String,
+    pub(crate) retry_after_seconds: Option<u64>,
+}
+
+impl PublicCatalogError {
+    fn new(code: &'static str, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            message: message.into(),
+            retry_after_seconds: None,
+        }
+    }
+
+    fn rate_limited(retry_after_seconds: Option<u64>) -> Self {
+        Self {
+            code: "spotify_rate_limited",
+            message: "Spotify temporarily rate-limited the public playlist request".to_string(),
+            retry_after_seconds,
+        }
+    }
+
+    fn contract_outdated() -> Self {
+        Self::new(
+            "spotify_public_contract_outdated",
+            "Spotify changed its public playlist response; Echo needs an update before retrying",
+        )
+    }
+}
+
+impl fmt::Display for PublicCatalogError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for PublicCatalogError {}
+
+struct AnonymousToken {
+    access_token: String,
+    expires_at_ms: u64,
+}
+
+static ANONYMOUS_TOKEN: OnceLock<Mutex<Option<AnonymousToken>>> = OnceLock::new();
+
+fn anonymous_token_cache() -> &'static Mutex<Option<AnonymousToken>> {
+    ANONYMOUS_TOKEN.get_or_init(|| Mutex::new(None))
+}
+
+/// Fetch exactly one user-requested, ordered 50-position public-playlist chunk.
+///
+/// The anonymous access token is retained only in process memory. This function
+/// never persists it, includes it in an error, or logs it.
+pub(crate) async fn fetch_public_playlist_chunk(
+    client: &reqwest::Client,
+    playlist_id: &str,
+    offset: usize,
+) -> Result<PublicPlaylistChunk, PublicCatalogError> {
+    validate_chunk_request(playlist_id, offset)?;
+    let access_token = anonymous_access_token(client).await?;
+    let request_body = PlaylistQueryRequest {
+        variables: PlaylistQueryVariables {
+            uri: format!("spotify:playlist:{playlist_id}"),
+            limit: PUBLIC_PLAYLIST_CHUNK_SIZE,
+            offset,
+        },
+        operation_name: PLAYLIST_QUERY_OPERATION,
+        extensions: PlaylistQueryExtensions {
+            persisted_query: PersistedQuery {
+                version: 1,
+                sha256_hash: PLAYLIST_QUERY_HASH,
+            },
+        },
+    };
+
+    let response = client
+        .post(PARTNER_QUERY_URL)
+        .timeout(REQUEST_TIMEOUT)
+        .header(ACCEPT, "application/json")
+        .header(USER_AGENT, USER_AGENT_VALUE)
+        .header(ORIGIN, "https://open.spotify.com")
+        .header(REFERER, "https://open.spotify.com/")
+        .bearer_auth(&access_token)
+        .json(&request_body)
+        .send()
+        .await
+        .map_err(|_| {
+            PublicCatalogError::new(
+                "spotify_public_transport",
+                "Spotify's public playlist service could not be reached",
+            )
+        })?;
+
+    let status = response.status();
+    if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+        return Err(PublicCatalogError::rate_limited(retry_after_seconds(
+            &response,
+        )));
+    }
+    if status == reqwest::StatusCode::BAD_REQUEST || status == reqwest::StatusCode::UNAUTHORIZED {
+        if status == reqwest::StatusCode::UNAUTHORIZED {
+            invalidate_anonymous_token(&access_token).await;
+        }
+        return Err(PublicCatalogError::contract_outdated());
+    }
+    if status == reqwest::StatusCode::NOT_FOUND {
+        return Err(PublicCatalogError::new(
+            "spotify_public_playlist_not_found",
+            "Spotify could not find that public playlist",
+        ));
+    }
+    if status == reqwest::StatusCode::FORBIDDEN {
+        return Err(PublicCatalogError::new(
+            "spotify_public_playlist_unavailable",
+            "Spotify is not sharing that playlist publicly",
+        ));
+    }
+    if !status.is_success() {
+        return Err(PublicCatalogError::new(
+            "spotify_public_upstream",
+            "Spotify's public playlist service returned an error",
+        ));
+    }
+
+    let body = response
+        .json::<serde_json::Value>()
+        .await
+        .map_err(|_| PublicCatalogError::contract_outdated())?;
+    normalize_playlist_query_response(playlist_id, offset, &body)
+}
+
+fn validate_chunk_request(playlist_id: &str, offset: usize) -> Result<(), PublicCatalogError> {
+    if !valid_spotify_id(playlist_id) {
+        return Err(PublicCatalogError::new(
+            "invalid_spotify_playlist_id",
+            "invalid Spotify playlist ID",
+        ));
+    }
+    if offset % PUBLIC_PLAYLIST_CHUNK_SIZE != 0 || offset >= MAX_PUBLIC_PLAYLIST_POSITIONS {
+        return Err(PublicCatalogError::new(
+            "invalid_spotify_playlist_offset",
+            format!(
+                "playlist offset must be a 50-position boundary below {MAX_PUBLIC_PLAYLIST_POSITIONS}"
+            ),
+        ));
+    }
+    Ok(())
+}
+
+async fn anonymous_access_token(client: &reqwest::Client) -> Result<String, PublicCatalogError> {
+    let mut cached = anonymous_token_cache().lock().await;
+    let now_ms = unix_time_ms()?;
+    if let Some(token) = cached.as_ref() {
+        if token.expires_at_ms.saturating_sub(now_ms) > TOKEN_EXPIRY_MARGIN_MS {
+            return Ok(token.access_token.clone());
+        }
+    }
+
+    let token = request_anonymous_token(client, now_ms).await?;
+    let access_token = token.access_token.clone();
+    *cached = Some(token);
+    Ok(access_token)
+}
+
+async fn request_anonymous_token(
+    client: &reqwest::Client,
+    local_time_ms: u64,
+) -> Result<AnonymousToken, PublicCatalogError> {
+    let server_time_response = client
+        .get(SERVER_TIME_URL)
+        .timeout(REQUEST_TIMEOUT)
+        .header(ACCEPT, "application/json")
+        .header(USER_AGENT, USER_AGENT_VALUE)
+        .send()
+        .await
+        .map_err(|_| {
+            PublicCatalogError::new(
+                "spotify_public_transport",
+                "Spotify's public time service could not be reached",
+            )
+        })?;
+    let server_status = server_time_response.status();
+    if server_status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+        return Err(PublicCatalogError::rate_limited(retry_after_seconds(
+            &server_time_response,
+        )));
+    }
+    if !server_status.is_success() {
+        return Err(PublicCatalogError::new(
+            "spotify_public_upstream",
+            "Spotify's public time service returned an error",
+        ));
+    }
+    let server_time = server_time_response
+        .json::<ServerTimeResponse>()
+        .await
+        .map_err(|_| PublicCatalogError::contract_outdated())?
+        .server_time;
+    let server_time_ms = server_time
+        .checked_mul(1_000)
+        .ok_or_else(PublicCatalogError::contract_outdated)?;
+    let local_totp = totp_at_ms(local_time_ms);
+    let server_totp = totp_at_ms(server_time_ms);
+
+    let token_response = client
+        .get(TOKEN_URL)
+        .timeout(REQUEST_TIMEOUT)
+        .header(ACCEPT, "application/json")
+        .header(USER_AGENT, USER_AGENT_VALUE)
+        .query(&[
+            ("reason", TOKEN_REASON),
+            ("productType", TOKEN_PRODUCT_TYPE),
+            ("totp", local_totp.as_str()),
+            ("totpServer", server_totp.as_str()),
+            ("totpVer", TOTP_VERSION),
+        ])
+        .send()
+        .await
+        .map_err(|_| {
+            PublicCatalogError::new(
+                "spotify_public_transport",
+                "Spotify's anonymous token service could not be reached",
+            )
+        })?;
+    let token_status = token_response.status();
+    if token_status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+        return Err(PublicCatalogError::rate_limited(retry_after_seconds(
+            &token_response,
+        )));
+    }
+    if token_status == reqwest::StatusCode::BAD_REQUEST
+        || token_status == reqwest::StatusCode::UNAUTHORIZED
+    {
+        return Err(PublicCatalogError::contract_outdated());
+    }
+    if !token_status.is_success() {
+        return Err(PublicCatalogError::new(
+            "spotify_public_upstream",
+            "Spotify's anonymous token service returned an error",
+        ));
+    }
+
+    let body = token_response
+        .json::<TokenResponse>()
+        .await
+        .map_err(|_| PublicCatalogError::contract_outdated())?;
+    if !body.is_anonymous
+        || body.access_token.trim().is_empty()
+        || body.access_token_expiration_timestamp_ms <= local_time_ms
+    {
+        return Err(PublicCatalogError::contract_outdated());
+    }
+    Ok(AnonymousToken {
+        access_token: body.access_token,
+        expires_at_ms: body.access_token_expiration_timestamp_ms,
+    })
+}
+
+async fn invalidate_anonymous_token(rejected_token: &str) {
+    let mut cached = anonymous_token_cache().lock().await;
+    if cached
+        .as_ref()
+        .is_some_and(|token| token.access_token == rejected_token)
+    {
+        *cached = None;
+    }
+}
+
+fn retry_after_seconds(response: &reqwest::Response) -> Option<u64> {
+    response
+        .headers()
+        .get(RETRY_AFTER)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.trim().parse::<u64>().ok())
+}
+
+fn unix_time_ms() -> Result<u64, PublicCatalogError> {
+    let milliseconds = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|_| {
+            PublicCatalogError::new(
+                "system_clock_invalid",
+                "the system clock is earlier than the Unix epoch",
+            )
+        })?
+        .as_millis();
+    u64::try_from(milliseconds).map_err(|_| {
+        PublicCatalogError::new("system_clock_invalid", "the system clock is out of range")
+    })
+}
+
+fn totp_secret() -> Vec<u8> {
+    TOTP_SOURCE_SECRET
+        .encode_utf16()
+        .enumerate()
+        .map(|(index, code_unit)| u32::from(code_unit) ^ u32::try_from(index % 33 + 9).unwrap())
+        .map(|value| value.to_string())
+        .collect::<String>()
+        .into_bytes()
+}
+
+fn totp_at_ms(timestamp_ms: u64) -> String {
+    let counter = timestamp_ms / 1_000 / 30;
+    let mut mac = HmacSha1::new_from_slice(&totp_secret())
+        .expect("Spotify's public TOTP secret has a valid HMAC key length");
+    mac.update(&counter.to_be_bytes());
+    let digest = mac.finalize().into_bytes();
+    let offset = usize::from(digest[digest.len() - 1] & 0x0f);
+    let binary = (u32::from(digest[offset]) << 24)
+        | (u32::from(digest[offset + 1]) << 16)
+        | (u32::from(digest[offset + 2]) << 8)
+        | u32::from(digest[offset + 3]);
+    format!("{:06}", (binary & 0x7fff_ffff) % 1_000_000)
+}
+
+fn normalize_playlist_query_response(
+    playlist_id: &str,
+    offset: usize,
+    body: &serde_json::Value,
+) -> Result<PublicPlaylistChunk, PublicCatalogError> {
+    if graphql_reports_persisted_query_failure(body) {
+        return Err(PublicCatalogError::contract_outdated());
+    }
+    let playlist = body
+        .get("data")
+        .and_then(|value| value.get("playlistV2"))
+        .ok_or_else(|| graphql_response_error(body))?;
+    match playlist
+        .get("__typename")
+        .and_then(serde_json::Value::as_str)
+    {
+        Some("NotFound") => {
+            return Err(PublicCatalogError::new(
+                "spotify_public_playlist_not_found",
+                "Spotify could not find that public playlist",
+            ));
+        }
+        Some("GenericError") => {
+            return Err(PublicCatalogError::new(
+                "spotify_public_playlist_unavailable",
+                "Spotify could not load that public playlist",
+            ));
+        }
+        _ => {}
+    }
+    let content = playlist
+        .get("content")
+        .and_then(serde_json::Value::as_object)
+        .ok_or_else(PublicCatalogError::contract_outdated)?;
+    let total_count = content
+        .get("totalCount")
+        .and_then(serde_json::Value::as_u64)
+        .ok_or_else(PublicCatalogError::contract_outdated)?;
+    let items = content
+        .get("items")
+        .and_then(serde_json::Value::as_array)
+        .ok_or_else(PublicCatalogError::contract_outdated)?;
+    if items.len() > PUBLIC_PLAYLIST_CHUNK_SIZE {
+        return Err(PublicCatalogError::contract_outdated());
+    }
+
+    let raw_next_offset = content
+        .get("pagingInfo")
+        .and_then(|value| value.get("nextOffset"))
+        .map(|value| {
+            if value.is_null() {
+                Ok(None)
+            } else {
+                value
+                    .as_u64()
+                    .and_then(|value| usize::try_from(value).ok())
+                    .map(Some)
+                    .ok_or_else(PublicCatalogError::contract_outdated)
+            }
+        })
+        .transpose()?
+        .flatten();
+    if let Some(next_offset) = raw_next_offset {
+        if next_offset != offset + PUBLIC_PLAYLIST_CHUNK_SIZE
+            || items.len() != PUBLIC_PLAYLIST_CHUNK_SIZE
+        {
+            return Err(PublicCatalogError::contract_outdated());
+        }
+    }
+
+    let positions = items
+        .iter()
+        .enumerate()
+        .map(|(index, wrapper)| PublicPlaylistPosition {
+            position: offset + index,
+            outcome: normalize_public_track(wrapper),
+        })
+        .collect();
+    let next_offset = raw_next_offset.filter(|value| *value < MAX_PUBLIC_PLAYLIST_POSITIONS);
+    Ok(PublicPlaylistChunk {
+        playlist_id: playlist_id.to_string(),
+        offset,
+        limit: PUBLIC_PLAYLIST_CHUNK_SIZE,
+        total_count,
+        next_offset,
+        truncated_at_position_limit: total_count > MAX_PUBLIC_PLAYLIST_POSITIONS as u64,
+        positions,
+    })
+}
+
+fn graphql_reports_persisted_query_failure(body: &serde_json::Value) -> bool {
+    body.get("errors")
+        .and_then(serde_json::Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(|error| error.get("message"))
+        .filter_map(serde_json::Value::as_str)
+        .any(|message| {
+            let normalized = message.to_ascii_lowercase();
+            normalized.contains("persistedquery") || normalized.contains("persisted query")
+        })
+}
+
+fn graphql_response_error(body: &serde_json::Value) -> PublicCatalogError {
+    if body
+        .get("errors")
+        .and_then(serde_json::Value::as_array)
+        .is_some_and(|errors| !errors.is_empty())
+    {
+        PublicCatalogError::new(
+            "spotify_public_upstream",
+            "Spotify's public playlist query returned an error",
+        )
+    } else {
+        PublicCatalogError::contract_outdated()
+    }
+}
+
+fn normalize_public_track(wrapper: &serde_json::Value) -> PublicPlaylistPositionOutcome {
+    let item = match wrapper.get("itemV2") {
+        Some(item) => item,
+        None => return skipped("malformed"),
+    };
+    if item
+        .get("__typename")
+        .and_then(serde_json::Value::as_str)
+        .is_some_and(|kind| kind != "TrackResponseWrapper")
+    {
+        return skipped("non_track");
+    }
+    let track = match item.get("data") {
+        Some(track) if !track.is_null() => track,
+        _ => return skipped("malformed"),
+    };
+    if track
+        .get("__typename")
+        .and_then(serde_json::Value::as_str)
+        .is_some_and(|kind| kind != "Track")
+    {
+        return skipped("non_track");
+    }
+    if track
+        .get("playability")
+        .and_then(|value| value.get("playable"))
+        .and_then(serde_json::Value::as_bool)
+        == Some(false)
+    {
+        return skipped("unplayable");
+    }
+    let spotify_uri = match trimmed_string(track.get("uri")) {
+        Some(uri) if uri.starts_with("spotify:local:") => return skipped("local_track"),
+        Some(uri) => uri,
+        None => return skipped("malformed"),
+    };
+    let spotify_id = match spotify_uri.strip_prefix("spotify:track:") {
+        Some(id) if valid_spotify_id(id) => id.to_string(),
+        _ => return skipped("malformed"),
+    };
+    let name = match trimmed_string(track.get("name")) {
+        Some(name) => name,
+        None => return skipped("malformed"),
+    };
+    let artist_names = track
+        .get("artists")
+        .and_then(|value| value.get("items"))
+        .and_then(serde_json::Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(|artist| artist.get("profile"))
+        .filter_map(|profile| trimmed_string(profile.get("name")))
+        .collect::<Vec<_>>();
+    if artist_names.is_empty() {
+        return skipped("malformed");
+    }
+    let artwork_url = track
+        .get("albumOfTrack")
+        .and_then(|album| album.get("coverArt"))
+        .and_then(|cover_art| cover_art.get("sources"))
+        .and_then(serde_json::Value::as_array)
+        .and_then(|sources| {
+            sources
+                .iter()
+                .find_map(|source| trimmed_string(source.get("url")))
+        });
+    let duration_ms = track
+        .get("duration")
+        .and_then(|duration| duration.get("totalMilliseconds"))
+        .and_then(serde_json::Value::as_u64);
+    let explicit = track
+        .get("contentRating")
+        .and_then(|rating| trimmed_string(rating.get("label")))
+        .and_then(|label| match label.as_str() {
+            "EXPLICIT" => Some(true),
+            "NONE" => Some(false),
+            _ => None,
+        });
+
+    PublicPlaylistPositionOutcome::Track {
+        summary: FavoriteSummary {
+            spotify_uri,
+            spotify_url: format!("https://open.spotify.com/track/{spotify_id}"),
+            spotify_id,
+            name,
+            artist: Some(artist_names.join(", ")),
+            owner: None,
+            description: None,
+            artwork_url,
+            duration_ms,
+            track_count: None,
+            snapshot_id: None,
+            explicit,
+        },
+    }
+}
+
+fn trimmed_string(value: Option<&serde_json::Value>) -> Option<String> {
+    value
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
+fn skipped(reason: &str) -> PublicPlaylistPositionOutcome {
+    PublicPlaylistPositionOutcome::Skipped {
+        reason: reason.to_string(),
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ServerTimeResponse {
+    server_time: u64,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct TokenResponse {
+    access_token: String,
+    access_token_expiration_timestamp_ms: u64,
+    is_anonymous: bool,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct PlaylistQueryRequest<'a> {
+    variables: PlaylistQueryVariables,
+    operation_name: &'a str,
+    extensions: PlaylistQueryExtensions<'a>,
+}
+
+#[derive(Serialize)]
+struct PlaylistQueryVariables {
+    uri: String,
+    limit: usize,
+    offset: usize,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct PlaylistQueryExtensions<'a> {
+    persisted_query: PersistedQuery<'a>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct PersistedQuery<'a> {
+    version: u8,
+    sha256_hash: &'a str,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn track(id: &str, name: &str) -> serde_json::Value {
+        json!({
+            "itemV2": {
+                "__typename": "TrackResponseWrapper",
+                "data": {
+                    "__typename": "Track",
+                    "uri": format!("spotify:track:{id}"),
+                    "name": name,
+                    "artists": {"items": [
+                        {"profile": {"name": "Artist One"}},
+                        {"profile": {"name": "Artist Two"}}
+                    ]},
+                    "albumOfTrack": {"coverArt": {"sources": [
+                        {"url": "https://i.scdn.co/image/test"}
+                    ]}},
+                    "duration": {"totalMilliseconds": 123456},
+                    "playability": {"playable": true},
+                    "contentRating": {"label": "EXPLICIT"}
+                }
+            }
+        })
+    }
+
+    #[test]
+    fn spotify_totp_v61_is_deterministic() {
+        assert_eq!(totp_at_ms(0), "204513");
+        assert_eq!(totp_at_ms(30_000), "332823");
+        assert_eq!(totp_at_ms(1_700_000_000_000), "371599");
+        assert_eq!(totp_at_ms(1_753_891_200_000), "659962");
+    }
+
+    #[test]
+    fn graphql_normalization_preserves_positions_duplicates_and_skips() {
+        let duplicate_id = "0123456789ABCDEFGHIJKL";
+        let mut unplayable = track("ABCDEFGHIJKLMNOPQRSTUV", "Unavailable");
+        unplayable["itemV2"]["data"]["playability"]["playable"] = json!(false);
+        let body = json!({
+            "data": {"playlistV2": {
+                "__typename": "Playlist",
+                "content": {
+                    "totalCount": 204,
+                    "pagingInfo": {"nextOffset": null},
+                    "items": [
+                        track(duplicate_id, "First Copy"),
+                        {"itemV2": {"__typename": "EpisodeResponseWrapper", "data": {}}},
+                        track(duplicate_id, "Second Copy"),
+                        unplayable
+                    ]
+                }
+            }}
+        });
+
+        let chunk =
+            normalize_playlist_query_response("2a514BsnnFkgMBxVrCAOEj", 200, &body).unwrap();
+        assert_eq!(chunk.total_count, 204);
+        assert_eq!(chunk.next_offset, None);
+        assert_eq!(chunk.positions.len(), 4);
+        assert_eq!(chunk.positions[0].position, 200);
+        assert_eq!(chunk.positions[1].position, 201);
+        assert_eq!(chunk.positions[2].position, 202);
+        assert_eq!(chunk.positions[3].position, 203);
+
+        let ids = chunk
+            .positions
+            .iter()
+            .filter_map(|position| match &position.outcome {
+                PublicPlaylistPositionOutcome::Track { summary } => {
+                    Some(summary.spotify_id.as_str())
+                }
+                PublicPlaylistPositionOutcome::Skipped { .. } => None,
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(ids, vec![duplicate_id, duplicate_id]);
+        assert!(matches!(
+            &chunk.positions[1].outcome,
+            PublicPlaylistPositionOutcome::Skipped { reason } if reason == "non_track"
+        ));
+        assert!(matches!(
+            &chunk.positions[3].outcome,
+            PublicPlaylistPositionOutcome::Skipped { reason } if reason == "unplayable"
+        ));
+
+        let PublicPlaylistPositionOutcome::Track { summary } = &chunk.positions[0].outcome else {
+            panic!("expected normalized track")
+        };
+        assert_eq!(summary.artist.as_deref(), Some("Artist One, Artist Two"));
+        assert_eq!(summary.duration_ms, Some(123456));
+        assert_eq!(summary.explicit, Some(true));
+        assert_eq!(
+            summary.artwork_url.as_deref(),
+            Some("https://i.scdn.co/image/test")
+        );
+    }
+
+    #[test]
+    fn graphql_contract_failures_are_stable() {
+        let persisted_query_error = json!({
+            "errors": [{"message": "PersistedQueryNotFound"}]
+        });
+        let error =
+            normalize_playlist_query_response("2a514BsnnFkgMBxVrCAOEj", 0, &persisted_query_error)
+                .unwrap_err();
+        assert_eq!(error.code, "spotify_public_contract_outdated");
+
+        let oversized_page = json!({
+            "data": {"playlistV2": {"content": {
+                "totalCount": 51,
+                "pagingInfo": {"nextOffset": 50},
+                "items": (0..51).map(|_| track("0123456789ABCDEFGHIJKL", "Track")).collect::<Vec<_>>()
+            }}}
+        });
+        let error = normalize_playlist_query_response("2a514BsnnFkgMBxVrCAOEj", 0, &oversized_page)
+            .unwrap_err();
+        assert_eq!(error.code, "spotify_public_contract_outdated");
+    }
+
+    #[test]
+    fn public_playlist_requests_use_fifty_position_boundaries() {
+        assert!(validate_chunk_request("2a514BsnnFkgMBxVrCAOEj", 0).is_ok());
+        assert!(validate_chunk_request("2a514BsnnFkgMBxVrCAOEj", 50).is_ok());
+        assert!(validate_chunk_request("2a514BsnnFkgMBxVrCAOEj", 25).is_err());
+        assert!(validate_chunk_request("2a514BsnnFkgMBxVrCAOEj", 1_000).is_err());
+    }
+}

--- a/core/viewer-tests/README.md
+++ b/core/viewer-tests/README.md
@@ -36,6 +36,18 @@ npm test
 
 From the repository root, use `npm run verify:viewer:layout` after setup.
 
+For a clearly labeled, disconnected Jam workspace preview on Windows:
+
+```powershell
+$env:ECHO_JAM_PREVIEW = "1"
+node .\scripts\serve-viewer.mjs
+```
+
+Then open `http://127.0.0.1:4175/?echo-ui-shell-v2=1`. The fixture uses mock
+Jam state and never connects to production or Spotify. Echo Pulse therefore
+shows its truthful static **Join Jam to activate** state in this preview; the
+reactive spectrum requires a joined Jam audio stream.
+
 Known legacy failures at `960x540`, `640x480`, and narrow Chat execute on every
 run under the explicit `?echo-ui-shell-v2=0` override. They retain the legacy
 rollback baseline while separate V2 tests assert a usable participant region

--- a/core/viewer-tests/scripts/serve-viewer.mjs
+++ b/core/viewer-tests/scripts/serve-viewer.mjs
@@ -9,6 +9,8 @@ const adminRoot = path.resolve(scriptDirectory, "..", "..", "admin");
 const previewFixture = path.resolve(scriptDirectory, "..", "fixtures", "install-scenario.js");
 const port = Number.parseInt(process.env.PORT || "4175", 10);
 const isolatedThemePreview = process.env.ECHO_THEME_PREVIEW === "1";
+const isolatedJamPreview = process.env.ECHO_JAM_PREVIEW === "1";
+const isolatedPreview = isolatedThemePreview || isolatedJamPreview;
 const transparentPng = Buffer.from(
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=",
   "base64",
@@ -39,7 +41,7 @@ function send(response, statusCode, body, contentType) {
 function resolveStaticFile(requestUrl) {
   const url = new URL(requestUrl, `http://127.0.0.1:${port}`);
   const pathname = decodeURIComponent(url.pathname);
-  if (isolatedThemePreview && pathname === "/__echo-theme-preview-fixture.js") {
+  if (isolatedPreview && pathname === "/__echo-preview-fixture.js") {
     return previewFixture;
   }
   const isAdminRequest = pathname === "/admin" || pathname.startsWith("/admin/");
@@ -60,7 +62,8 @@ function resolveStaticFile(requestUrl) {
   return candidate;
 }
 
-function injectIsolatedThemePreview(html) {
+function injectIsolatedPreview(html) {
+  const previewName = isolatedJamPreview ? "Isolated Jam Preview" : "Isolated Theme Preview";
   const earlyBootstrap = `
     <script>
       (function () {
@@ -146,14 +149,27 @@ function injectIsolatedThemePreview(html) {
     </style>
   `;
   const banner = `
-    <div id="echo-isolated-preview-banner" role="status" aria-label="Isolated theme preview. Not live Echo.">
-      <span>Isolated Theme Preview</span>
+    <div id="echo-isolated-preview-banner" role="status" aria-label="${previewName}. Not live Echo.">
+      <span>${previewName}</span>
       <strong>Not Live Echo</strong>
       <small>localhost fixture · no production connection</small>
     </div>
   `;
+  const openPreview = isolatedJamPreview
+    ? `
+          if (typeof setThemeStudioOpen === "function") setThemeStudioOpen(false);
+          if (typeof adminToken !== "undefined") adminToken = "isolated-jam-preview-admin";
+          if (typeof currentAccessToken !== "undefined") currentAccessToken = "isolated-jam-preview-participant";
+          var jamButton = document.getElementById("open-jam");
+          if (jamButton) jamButton.disabled = false;
+          if (typeof openJamPanel === "function") openJamPanel(jamButton);
+          if (typeof setJamView === "function") setJamView("library", false);
+      `
+    : `
+          if (typeof setThemeStudioOpen === "function") setThemeStudioOpen(true);
+      `;
   const scenario = `
-    <script src="/__echo-theme-preview-fixture.js"></script>
+    <script src="/__echo-preview-fixture.js"></script>
     <script>
       window.addEventListener("load", function () {
         var fixture = window.EchoLayoutTestScenario;
@@ -164,12 +180,13 @@ function injectIsolatedThemePreview(html) {
           screenShares: 1,
           shareAspects: [16 / 9],
           chatOpen: false,
-          localCamera: true
+          localCamera: true,
+          screenOwners: [0]
         }).then(function () {
           document.documentElement.dataset.echoIsolatedPreviewReady = "true";
-          if (typeof setThemeStudioOpen === "function") setThemeStudioOpen(true);
+          ${openPreview}
         }).catch(function (error) {
-          console.error("[isolated-theme-preview] fixture failed", error);
+          console.error("[isolated-preview] fixture failed", error);
         });
       });
     </script>
@@ -193,7 +210,7 @@ const server = http.createServer(async (request, response) => {
     return;
   }
 
-  if (isolatedThemePreview) {
+  if (isolatedPreview) {
     const requestUrl = new URL(request.url || "/", `http://127.0.0.1:${port}`);
     if (requestUrl.pathname === "/api/online") {
       send(response, 200, "[]", "application/json; charset=utf-8");
@@ -205,6 +222,52 @@ const server = http.createServer(async (request, response) => {
     }
     if (requestUrl.pathname.startsWith("/api/avatar/")) {
       send(response, 200, transparentPng, "image/png");
+      return;
+    }
+    if (isolatedJamPreview && requestUrl.pathname === "/api/jam/state") {
+      send(response, 200, JSON.stringify({
+        jam_protocol_version: 3,
+        active: true,
+        generation: 7,
+        spotify_connected: true,
+        spotify_library_authorized: false,
+        spotify_is_playing: true,
+        playback_stop_supported: true,
+        playlist_selection_supported: true,
+        source_enabled: true,
+        source_availability_known: true,
+        source_status: "live",
+        source_ready: true,
+        source_last_frame_ms: 18,
+        source_peak: 0.42,
+        host_identity: "layout-fixture-1",
+        listener_count: 1,
+        listeners: ["layout-fixture-1"],
+        now_playing: {
+          spotify_id: "0VjIjW4GlUZAMYd2vXMi3b",
+          spotify_uri: "spotify:track:0VjIjW4GlUZAMYd2vXMi3b",
+          spotify_url: "https://open.spotify.com/track/0VjIjW4GlUZAMYd2vXMi3b",
+          name: "Blinding Lights",
+          artist: "The Weeknd",
+          duration_ms: 200040,
+          progress_ms: 86000,
+          is_playing: true,
+        },
+        queue: [],
+      }), "application/json; charset=utf-8");
+      return;
+    }
+    if (isolatedJamPreview && requestUrl.pathname === "/api/jam/favorites") {
+      send(response, 200, JSON.stringify({
+        schema_version: 1,
+        items: [],
+        contributors: [],
+        counts: { tracks: 0, playlists: 0, contributors: 0 },
+        offset: 0,
+        limit: 20,
+        total: 0,
+        next_offset: null,
+      }), "application/json; charset=utf-8");
       return;
     }
   }
@@ -226,10 +289,10 @@ const server = http.createServer(async (request, response) => {
     if (!fileStat.isFile()) throw new Error("not a file");
     let body = await readFile(filePath);
     if (
-      isolatedThemePreview &&
+      isolatedPreview &&
       filePath === path.join(viewerRoot, "index.html")
     ) {
-      body = injectIsolatedThemePreview(body.toString("utf8"));
+      body = injectIsolatedPreview(body.toString("utf8"));
     }
     const contentType = contentTypes.get(path.extname(filePath).toLowerCase()) || "application/octet-stream";
     response.writeHead(200, {
@@ -247,7 +310,7 @@ const server = http.createServer(async (request, response) => {
 server.listen(port, "127.0.0.1", () => {
   console.log(
     `[viewer-tests] serving ${viewerRoot} and ${adminRoot} at http://127.0.0.1:${port}` +
-      (isolatedThemePreview ? " [ISOLATED THEME PREVIEW]" : ""),
+      (isolatedJamPreview ? " [ISOLATED JAM PREVIEW]" : isolatedThemePreview ? " [ISOLATED THEME PREVIEW]" : ""),
   );
 });
 

--- a/core/viewer-tests/tests/shell.phase2.utility.spec.js
+++ b/core/viewer-tests/tests/shell.phase2.utility.spec.js
@@ -26,6 +26,9 @@ function createJamState() {
     spotify_connected: true,
     spotify_is_playing: true,
     playback_stop_supported: true,
+    playlist_selection_supported: true,
+    skip_reconciliation_pending: false,
+    last_error: null,
     source_enabled: true,
     source_availability_known: true,
     source_status: "live",
@@ -46,7 +49,13 @@ function createJamState() {
       progress_ms: 91_000,
       is_playing: true,
     },
+    spotify_library_authorized: true,
+    queue_revision: 11,
+    history_revision: 0,
     queue: Array.from({ length: 8 }, (_, index) => ({
+      queue_entry_id: `queue-entry-${index + 1}`,
+      delivery_state: index === 0 ? "spotify_committed" : index === 1 ? "commit_unknown" : "pending",
+      can_remove: index >= 2,
       spotify_uri: `spotify:track:queue-${index + 1}`,
       name: longText(`Queued Song ${index + 1}`),
       artist: longText(`Queued Artist ${index + 1}`),
@@ -77,14 +86,46 @@ test.beforeEach(async ({ page }) => {
   const errors = [];
   const model = {
     counts: Object.create(null),
+    ambiguousPlaylistQueue: false,
+    ambiguousResponseSent: false,
+    committedPlaylistRequestIds: new Set(),
+    committedTrackRequestIds: new Set(),
+    duplicatePlaylistTracks: false,
+    entirePlaylistPartial: false,
+    entirePlaylistPartialSent: false,
     errors,
     expectedConfirmationConflict: false,
+    expectedArtworkFailure: false,
     expectedPlaylistForbidden: false,
+    expectedQueueRemovalConflict: false,
+    expectedQueueRemovalNetworkError: false,
+    expectedTrackQueueNetworkError: false,
     favoriteItems: null,
     favoriteQueries: [],
     forceConfirmation: false,
     forbidPlaylistItems: false,
+    importError: null,
+    importTracksOnly: false,
+    importRuns: 0,
+    historyItems: null,
+    queueTrackBodies: [],
+    queueTrackAbortAfterCommitOnce: false,
+    queueTrackDelayOnceMs: 0,
+    queueTrackMutations: 0,
+    queueRemovalBodies: [],
+    queueRemovalAbortAfterCommitOnce: false,
+    queueRemovalConflictOnce: false,
     queuePlaylistBodies: [],
+    queuePlaylistMutations: 0,
+    selectedPlaylistPartial: false,
+    playlistItemOffsets: [],
+    playlistItemsSource: "spotify",
+    playlistSnapshot: "snapshot-fixture-1",
+    playlistSnapshotChangesOnAppend: false,
+    playlistQueueDelayOnceMs: 0,
+    playlistQueueDelays: [],
+    playlistQueueResponses: 0,
+    playlistTotal: 30,
     searchTracks: createSearchTracks(),
     state: createJamState(),
     playlist: {
@@ -95,6 +136,8 @@ test.beforeEach(async ({ page }) => {
       name: "Fixture Road Trip",
       owner: "Fixture Owner",
       description: "A playlist used to verify the real Jam browser.",
+      artwork_url: "https://i.scdn.co/image/playlist-fixture",
+      snapshot_id: "snapshot-fixture-1",
       track_count: 30,
       favorited_by_me: false,
       favorite_contributor_count: 1,
@@ -107,9 +150,23 @@ test.beforeEach(async ({ page }) => {
   page.on("console", (message) => {
     if (message.type() === "error") {
       if (model.expectedConfirmationConflict && message.text().includes("409 (Conflict)")) return;
-      if (model.expectedPlaylistForbidden && message.text().includes("403 (Forbidden)")) return;
+      if (model.expectedQueueRemovalConflict && message.text().includes("409 (Conflict)")) return;
+      if (model.expectedQueueRemovalNetworkError && message.text().includes("Failed to load resource")) return;
+      if (model.expectedTrackQueueNetworkError && message.text().includes("Failed to load resource")) return;
+      if (model.expectedArtworkFailure && message.text().includes("Failed to load resource")) return;
+      if (model.expectedPlaylistForbidden &&
+          (message.text().includes("403 (Forbidden)") || message.text().includes("502 (Bad Gateway)"))) return;
+      if (model.importError && message.text().includes(`${model.importError.status || 403} (Forbidden)`)) return;
+      if (model.ambiguousPlaylistQueue && message.text().includes("Failed to load resource")) return;
       errors.push(`console.error: ${message.text()}`);
     }
+  });
+
+  await page.route("https://i.scdn.co/image/history-fixture", async (route) => {
+    await route.fulfill({ status: 200, contentType: "image/png", body: transparentPng });
+  });
+  await page.route("https://i.scdn.co/image/playlist-fixture", async (route) => {
+    await route.fulfill({ status: 200, contentType: "image/png", body: transparentPng });
   });
 
   await page.route("**/api/**", async (route) => {
@@ -187,7 +244,10 @@ test.beforeEach(async ({ page }) => {
           current.count += 1;
           contributors.set(attribution.actor_id, current);
         }
-        const items = facetItems.filter((item) => !actorId || (item.attributions || []).some((entry) => entry.actor_id === actorId));
+        const filteredItems = facetItems.filter((item) => !actorId || (item.attributions || []).some((entry) => entry.actor_id === actorId));
+        const offset = Number(url.searchParams.get("offset") || 0);
+        const limit = Number(url.searchParams.get("limit") || 20);
+        const items = filteredItems.slice(offset, offset + limit);
         await route.fulfill({
           status: 200,
           contentType: "application/json",
@@ -196,14 +256,14 @@ test.beforeEach(async ({ page }) => {
             items,
             contributors: Array.from(contributors.values()),
             counts: {
-              tracks: items.filter((item) => item.kind === "track").length,
-              playlists: items.filter((item) => item.kind === "playlist").length,
+              tracks: filteredItems.filter((item) => item.kind === "track").length,
+              playlists: filteredItems.filter((item) => item.kind === "playlist").length,
               contributors: contributors.size,
             },
-            offset: Number(url.searchParams.get("offset") || 0),
-            limit: 20,
-            total: items.length,
-            next_offset: null,
+            offset,
+            limit,
+            total: filteredItems.length,
+            next_offset: offset + items.length < filteredItems.length ? offset + items.length : null,
           }),
         });
         return;
@@ -234,45 +294,236 @@ test.beforeEach(async ({ page }) => {
       });
       return;
     }
-    if (url.pathname === `/api/jam/playlists/${playlistId}/items` && request.method() === "GET") {
+    if (url.pathname === "/api/jam/favorites/import-spotify" && request.method() === "POST") {
       increment(model, key);
-      if (model.forbidPlaylistItems) {
+      if (model.importError) {
         await route.fulfill({
-          status: 403,
+          status: model.importError.status || 403,
           contentType: "application/json",
           body: JSON.stringify({
-            error: "playlist_items_forbidden",
-            message: "Spotify only allows this Echo app to expand playlists the connected account owns or collaborates on; other public playlists require Spotify Extended Quota",
+            error: model.importError.error,
+            message: model.importError.message,
           }),
         });
         return;
       }
-      const items = Array.from({ length: 20 }, (_, index) => ({
-        ...model.searchTracks[index % model.searchTracks.length],
-        spotify_id: `1${String(index + 1).padStart(21, "0")}`,
-        spotify_uri: `spotify:track:1${String(index + 1).padStart(21, "0")}`,
-        name: `Playlist Song ${index + 1}`,
-        playlist_position: index,
-      }));
+      if (model.state.spotify_library_authorized === false) {
+        await route.fulfill({
+          status: 403,
+          contentType: "application/json",
+          body: JSON.stringify({
+            error: "spotify_library_scope_required",
+            message: "Spotify Library access is missing. Use Refresh Spotify Access, then try again.",
+          }),
+        });
+        return;
+      }
+      model.importRuns += 1;
+      if (!model.favoriteItems || model.favoriteItems.length === 0) {
+        model.favoriteItems = [{
+          kind: "track",
+          spotify_id: trackId,
+          spotify_uri: `spotify:track:${trackId}`,
+          spotify_url: `https://open.spotify.com/track/${trackId}`,
+          name: "Imported Liked Song",
+          artist: "Fixture Artist",
+          attributions: [{ actor_id: "sam", display_name: "Sam", added_at_ms: 300, source: "spotify_saved_tracks" }],
+          contributor_count: 1,
+          favorited_by_me: true,
+        }];
+        if (!model.importTracksOnly) {
+          model.favoriteItems.push({
+            ...model.playlist,
+            name: "Imported Saved Playlist",
+            attributions: [{ actor_id: "sam", display_name: "Sam", added_at_ms: 300, source: "spotify_playlists" }],
+            contributor_count: 1,
+            favorited_by_me: true,
+          });
+        }
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          ok: true,
+          tracks_seen: 1,
+          playlists_seen: 1,
+          items_created: model.importRuns === 1 ? 2 : 0,
+          attributions_added: model.importRuns === 1 ? 2 : 0,
+          skipped: 0,
+        }),
+      });
+      return;
+    }
+    if (url.pathname === `/api/jam/playlists/${playlistId}/items` && request.method() === "GET") {
+      increment(model, key);
+      if (model.forbidPlaylistItems) {
+        await route.fulfill({
+          status: 502,
+          contentType: "application/json",
+          body: JSON.stringify({
+            error: "playlist_catalog_unavailable",
+            message: "Spotify changed its public playlist response; Echo needs an update before retrying",
+          }),
+        });
+        return;
+      }
+      const offset = Number(url.searchParams.get("offset") || 0);
+      const limit = Number(url.searchParams.get("limit") || 50);
+      model.playlistItemOffsets.push(offset);
+      if (model.playlistSnapshotChangesOnAppend && offset > 0) {
+        model.playlistSnapshot = "snapshot-fixture-2";
+      }
+      const total = model.playlistTotal;
+      const accessibleTotal = model.playlistItemsSource === "local_cache"
+        ? Math.min(total, 1000)
+        : total;
+      const returned = Math.max(0, Math.min(limit, accessibleTotal - offset));
+      const items = Array.from({ length: returned }, (_, index) => {
+        const position = offset + index;
+        return {
+          ...model.searchTracks[position % model.searchTracks.length],
+          spotify_id: `1${String(position + 1).padStart(21, "0")}`,
+          spotify_uri: `spotify:track:1${String(position + 1).padStart(21, "0")}`,
+          name: model.duplicatePlaylistTracks && position < 2 ? "Duplicate Song" : `Playlist Song ${position + 1}`,
+          artist: model.duplicatePlaylistTracks && position < 2 ? "Same Artist" : model.searchTracks[position % model.searchTracks.length].artist,
+          playlist_position: position,
+        };
+      });
       await route.fulfill({
         status: 200,
         contentType: "application/json",
         body: JSON.stringify({
           schema_version: 1,
-          playlist: model.playlist,
+          playlist: {
+            ...model.playlist,
+            snapshot_id: model.playlistSnapshot,
+            track_count: total,
+          },
           items,
           skipped: [],
-          offset: 0,
-          limit: 20,
-          total: 30,
-          next_offset: 20,
+          offset,
+          limit,
+          total,
+          next_offset: offset + returned < accessibleTotal ? offset + returned : null,
+          items_source: model.playlistItemsSource,
+          local_cache: model.playlistItemsSource === "local_cache" ? {
+            chunk_size: 50,
+            cached_count: Math.min(total, offset + returned),
+            cached_chunk_offsets: Array.from({ length: Math.ceil((offset + returned) / 50) }, (_, index) => index * 50),
+            next_missing_chunk_offset: offset + returned < accessibleTotal ? offset + returned : null,
+            total,
+            complete: total <= 1000 && offset + returned >= total,
+            position_limit: 1000,
+            truncated: total > 1000,
+            updated_at_ms: 123456,
+          } : undefined,
         }),
       });
       return;
     }
-    if (url.pathname === "/api/jam/queue/playlist" && request.method() === "POST") {
+    if (url.pathname === "/api/jam/queue" && request.method() === "POST") {
       increment(model, key);
-      model.queuePlaylistBodies.push(request.postDataJSON());
+      const requestBody = request.postDataJSON();
+      model.queueTrackBodies.push(requestBody);
+      if (!model.committedTrackRequestIds.has(requestBody.request_id)) {
+        model.committedTrackRequestIds.add(requestBody.request_id);
+        model.queueTrackMutations += 1;
+      }
+      const responseDelay = Number(model.queueTrackDelayOnceMs || 0);
+      model.queueTrackDelayOnceMs = 0;
+      if (responseDelay > 0) await new Promise((resolve) => setTimeout(resolve, responseDelay));
+      if (model.queueTrackAbortAfterCommitOnce) {
+        model.queueTrackAbortAfterCommitOnce = false;
+        await route.abort("connectionreset");
+        return;
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ ok: true }),
+      });
+      return;
+    }
+    if (url.pathname === "/api/jam/queue/remove" && request.method() === "POST") {
+      increment(model, key);
+      const requestBody = request.postDataJSON();
+      model.queueRemovalBodies.push(requestBody);
+      if (model.queueRemovalConflictOnce) {
+        model.queueRemovalConflictOnce = false;
+        const lockedEntry = model.state.queue.find((track) => track.queue_entry_id === requestBody.queue_entry_ids[0]);
+        if (lockedEntry) {
+          lockedEntry.delivery_state = "spotify_committed";
+          lockedEntry.can_remove = false;
+        }
+        model.state.queue_revision += 1;
+        await route.fulfill({
+          status: 409,
+          contentType: "application/json",
+          body: JSON.stringify({
+            error: "queue_changed",
+            message: "The Jam queue changed; refresh it before removing songs",
+            queue_revision: model.state.queue_revision,
+          }),
+        });
+        return;
+      }
+      const requestedIds = new Set(requestBody.queue_entry_ids || []);
+      const removableIds = model.state.queue
+        .filter((track) => requestedIds.has(track.queue_entry_id) && track.delivery_state === "pending" && track.can_remove)
+        .map((track) => track.queue_entry_id);
+      if (requestBody.expected_queue_revision !== model.state.queue_revision || removableIds.length !== requestedIds.size) {
+        await route.fulfill({
+          status: 409,
+          contentType: "application/json",
+          body: JSON.stringify({ error: "queue_changed", message: "The Jam queue changed", queue_revision: model.state.queue_revision }),
+        });
+        return;
+      }
+      const removedIds = new Set(removableIds);
+      model.state.queue = model.state.queue.filter((track) => !removedIds.has(track.queue_entry_id));
+      model.state.queue_revision += 1;
+      if (model.queueRemovalAbortAfterCommitOnce) {
+        model.queueRemovalAbortAfterCommitOnce = false;
+        await route.abort("connectionreset");
+        return;
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          ok: true,
+          generation: model.state.generation,
+          queue_revision: model.state.queue_revision,
+          removed_entry_ids: removableIds,
+          removed_count: removableIds.length,
+        }),
+      });
+      return;
+    }
+    if (["/api/jam/queue/playlist", "/api/jam/queue/playlist/selection"].includes(url.pathname) && request.method() === "POST") {
+      increment(model, key);
+      const requestBody = request.postDataJSON();
+      model.queuePlaylistBodies.push(requestBody);
+      if (model.trackPlaylistQueueMutations && !model.committedPlaylistRequestIds.has(requestBody.request_id)) {
+        model.committedPlaylistRequestIds.add(requestBody.request_id);
+        model.queuePlaylistMutations += 1;
+      }
+      const responseDelay = model.playlistQueueDelays.length
+        ? Number(model.playlistQueueDelays.shift() || 0)
+        : Number(model.playlistQueueDelayOnceMs || 0);
+      model.playlistQueueDelayOnceMs = 0;
+      if (responseDelay > 0) await new Promise((resolve) => setTimeout(resolve, responseDelay));
+      const selectedEndpoint = url.pathname.endsWith("/selection");
+      const selectedRequest = Array.isArray(requestBody.selected_positions);
+      if (selectedEndpoint !== selectedRequest) {
+        await route.fulfill({
+          status: 400,
+          contentType: "application/json",
+          body: JSON.stringify({ error: "wrong_playlist_queue_endpoint" }),
+        });
+        return;
+      }
       if (model.forbidPlaylistItems) {
         await route.fulfill({
           status: 403,
@@ -292,36 +543,106 @@ test.beforeEach(async ({ page }) => {
         });
         return;
       }
+      if (selectedRequest) {
+        if (model.ambiguousPlaylistQueue) {
+          if (!model.committedPlaylistRequestIds.has(requestBody.request_id)) {
+            model.committedPlaylistRequestIds.add(requestBody.request_id);
+            model.queuePlaylistMutations += 1;
+          }
+          if (!model.ambiguousResponseSent) {
+            model.ambiguousResponseSent = true;
+            await route.abort("connectionreset");
+            return;
+          }
+        }
+        if (model.selectedPlaylistPartial) {
+          await route.fulfill({
+            status: 200,
+            contentType: "application/json",
+            body: JSON.stringify({
+              ok: false,
+              partial: true,
+              complete: false,
+              request_id: requestBody.request_id,
+              queue_batch_id: "selected-batch-1",
+              queued_count: 1,
+              queued_positions: [requestBody.selected_positions[1]],
+              skipped: [{ position: requestBody.selected_positions[0], reason: "unavailable" }],
+              failure: { status: 429, error: "spotify_rate_limited", message: "Spotify rate limit interrupted the batch.", retry_after: "12" },
+            }),
+          });
+          return;
+        }
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            ok: true,
+            partial: false,
+            complete: true,
+            request_id: requestBody.request_id,
+            queue_batch_id: "selected-batch-1",
+            queued_count: requestBody.selected_positions.length,
+            queued_positions: requestBody.selected_positions,
+            skipped: [],
+          }),
+        });
+        model.playlistQueueResponses += 1;
+        return;
+      }
+      if (model.entirePlaylistPartial && !model.entirePlaylistPartialSent) {
+        model.entirePlaylistPartialSent = true;
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            ok: false,
+            partial: true,
+            complete: false,
+            request_id: requestBody.request_id,
+            queue_batch_id: "entire-batch-1",
+            queued_count: 2,
+            queued_positions: [0, 1],
+            remaining_positions: Array.from({ length: model.playlistTotal - 2 }, (_, index) => index + 2),
+            skipped: [],
+            failure: { status: 429, error: "spotify_rate_limited", message: "Spotify rate limit interrupted the batch.", retry_after: "12" },
+          }),
+        });
+        return;
+      }
       await route.fulfill({
         status: 200,
         contentType: "application/json",
-        body: JSON.stringify({ ok: true, request_id: request.postDataJSON().request_id, queue_batch_id: "batch-1", queued_count: 29, skipped: [{ position: 4, reason: "unavailable" }], partial: true, complete: false, failure: { status: 429, error: "spotify_rate_limited", message: "Spotify rate limit interrupted the batch.", retry_after: "12" } }),
+        body: JSON.stringify({ ok: true, request_id: request.postDataJSON().request_id, queue_batch_id: "batch-1", queued_count: model.playlistTotal - 1, queued_positions: Array.from({ length: model.playlistTotal }, (_, index) => index).filter((position) => position !== 4), remaining_positions: [], skipped: [{ position: 4, reason: "unavailable" }], partial: false, complete: true }),
       });
       return;
     }
     if (url.pathname === "/api/jam/history" && request.method() === "GET") {
       increment(model, key);
+      const historyItems = model.historyItems === null ? [{
+        history_entry_id: "history-1",
+        spotify_id: trackId,
+        spotify_uri: `spotify:track:${trackId}`,
+        spotify_url: `https://open.spotify.com/track/${trackId}`,
+         name: "Played While Inactive",
+         artist: "Fixture Artist",
+         album_art_url: "https://i.scdn.co/image/history-fixture",
+         duration_ms: 222_000,
+         added_at_ms: 1_700_000_000_000,
+        played_at_ms: 1_700_000_100_000,
+        added_by_actor_id: "sam",
+        added_by_name: "Sam",
+        playlist: model.playlist,
+      }] : model.historyItems;
       await route.fulfill({
         status: 200,
         contentType: "application/json",
         body: JSON.stringify({
           schema_version: 1,
-          items: [{
-            history_entry_id: "history-1",
-            spotify_id: trackId,
-            spotify_uri: `spotify:track:${trackId}`,
-            spotify_url: `https://open.spotify.com/track/${trackId}`,
-            name: "Played While Inactive",
-            artist: "Fixture Artist",
-            added_at_ms: 1_700_000_000_000,
-            played_at_ms: 1_700_000_100_000,
-            added_by_actor_id: "sam",
-            added_by_name: "Sam",
-            playlist: model.playlist,
-          }],
+          items: historyItems,
           offset: 0,
           limit: 20,
-          total: 1,
+          total: historyItems.length,
           next_offset: null,
         }),
       });
@@ -510,8 +831,8 @@ test("one logical utility owns stable People, Chat, and portaled Jam tools witho
     input.dispatchEvent(new Event("input", { bubbles: true }));
   });
   await expect(page.locator("#jam-volume-value")).toHaveText("73%");
-  await page.locator(".jam-body").evaluate((body) => { body.scrollTop = body.scrollHeight; });
-  const jamScrollTop = await page.locator(".jam-body").evaluate((body) => body.scrollTop);
+  await page.locator("#jam-browser").evaluate((browser) => { browser.scrollTop = browser.scrollHeight; });
+  const jamScrollTop = await page.locator("#jam-browser").evaluate((browser) => browser.scrollTop);
   expect(jamScrollTop).toBeGreaterThan(0);
 
   await page.locator("#shell-toggle-utility").click();
@@ -534,7 +855,7 @@ test("one logical utility owns stable People, Chat, and portaled Jam tools witho
   await expect(page.locator("#jam-search-input")).toHaveValue("clubhouse");
   await expect(page.locator(".jam-result-item")).toHaveCount(6);
   await expect(page.locator("#jam-volume-slider")).toHaveValue("73");
-  expect(await page.locator(".jam-body").evaluate((body) => body.scrollTop)).toBe(jamScrollTop);
+  expect(await page.locator("#jam-browser").evaluate((browser) => browser.scrollTop)).toBe(jamScrollTop);
   expect(await page.evaluate(() => window.__phase2JamNode === document.getElementById("jam-panel"))).toBe(true);
 });
 
@@ -866,8 +1187,12 @@ test("source-PC settings stay collapsed while playback controls remain reachable
     [{ width: 360, height: 640 }, "mini"],
   ]) {
     await resizeTo(page, viewport, expectedMode);
-    const body = page.locator("#jam-panel .jam-body");
-    await body.evaluate((element) => { element.scrollTop = 0; });
+    await page.evaluate(() => {
+      const body = document.querySelector("#jam-panel .jam-body");
+      const overview = document.querySelector("#jam-panel .jam-session-overview");
+      const scrollOwner = getComputedStyle(body).display === "grid" ? overview : body;
+      scrollOwner.scrollTop = 0;
+    });
     await nextPaint(page);
 
     const initial = await page.evaluate(() => {
@@ -878,8 +1203,11 @@ test("source-PC settings stay collapsed while playback controls remain reachable
       const buttonTops = Array.from(document.querySelectorAll("#jam-host-controls button"))
         .filter((button) => getComputedStyle(button).display !== "none")
         .map((button) => Math.round(button.getBoundingClientRect().top));
+      const body = document.querySelector("#jam-panel .jam-body");
+      const overview = document.querySelector("#jam-panel .jam-session-overview");
+      const scrollOwner = getComputedStyle(body).display === "grid" ? overview : body;
       return {
-        bodyRect: verticalBounds(document.querySelector("#jam-panel .jam-body")),
+        bodyRect: verticalBounds(scrollOwner),
         buttonTops,
         toolbarRect: verticalBounds(document.getElementById("jam-host-controls")),
       };
@@ -888,15 +1216,23 @@ test("source-PC settings stay collapsed while playback controls remain reachable
     expect(initial.toolbarRect.bottom).toBeLessThanOrEqual(initial.bodyRect.bottom + 1);
     expect(new Set(initial.buttonTops).size, `one playback row at ${viewport.width}x${viewport.height}`).toBe(1);
 
-    await body.evaluate((element) => { element.scrollTop = element.scrollHeight; });
+    await page.evaluate(() => {
+      const body = document.querySelector("#jam-panel .jam-body");
+      const overview = document.querySelector("#jam-panel .jam-session-overview");
+      const scrollOwner = getComputedStyle(body).display === "grid" ? overview : body;
+      scrollOwner.scrollTop = scrollOwner.scrollHeight;
+    });
     await nextPaint(page);
     const sticky = await page.evaluate(() => {
       function verticalBounds(element) {
         const rect = element.getBoundingClientRect();
         return { bottom: rect.bottom, top: rect.top };
       }
+      const body = document.querySelector("#jam-panel .jam-body");
+      const overview = document.querySelector("#jam-panel .jam-session-overview");
+      const scrollOwner = getComputedStyle(body).display === "grid" ? overview : body;
       return {
-        bodyRect: verticalBounds(document.querySelector("#jam-panel .jam-body")),
+        bodyRect: verticalBounds(scrollOwner),
         toolbarRect: verticalBounds(document.getElementById("jam-host-controls")),
       };
     });
@@ -906,7 +1242,12 @@ test("source-PC settings stay collapsed while playback controls remain reachable
       .toBeLessThanOrEqual(sticky.bodyRect.bottom + 1);
   }
 
-  await page.locator("#jam-panel .jam-body").evaluate((element) => { element.scrollTop = 0; });
+  await page.evaluate(() => {
+    const body = document.querySelector("#jam-panel .jam-body");
+    const overview = document.querySelector("#jam-panel .jam-session-overview");
+    const scrollOwner = getComputedStyle(body).display === "grid" ? overview : body;
+    scrollOwner.scrollTop = 0;
+  });
   await summary.click();
   await expect(disclosure).toHaveAttribute("open", "");
   await expect(switches.first()).toBeVisible();
@@ -937,6 +1278,8 @@ test("populated Jam remains inside the workspace and above the dock at represent
   await searchJam(page, "responsive");
 
   for (const [viewport, expectedMode] of [
+    [{ width: 1920, height: 1080 }, "theater"],
+    [{ width: 1366, height: 768 }, "theater"],
     [{ width: 1280, height: 720 }, "theater"],
     [{ width: 900, height: 700 }, "lounge"],
     [{ width: 600, height: 900 }, "compact"],
@@ -965,14 +1308,25 @@ test("populated Jam remains inside the workspace and above the dock at represent
         "#jam-panel .jam-result-info, #jam-panel .jam-now-playing-info, #jam-panel .jam-result-name, #jam-panel .jam-result-artist",
       )).some((element) => element.scrollWidth > element.clientWidth + 1 && getComputedStyle(element).overflowX === "visible");
       return {
+        bodyDisplay: getComputedStyle(document.querySelector("#jam-panel .jam-body")).display,
         bodyOverflowX: document.body.scrollWidth - window.innerWidth,
+        browser: rect("#jam-browser"),
+        dockInert: document.getElementById("call-controls").inert,
         documentOverflowX: document.documentElement.scrollWidth - window.innerWidth,
         dock: rect("#call-controls"),
         header: rect('.room-top[data-ui-region="shell-header"]'),
         jam: rect("#jam-panel"),
+        overview: rect("#jam-panel .jam-session-overview"),
+        overviewEnd: rect("#jam-status"),
         search: rect("#jam-search-input"),
+        scrimVisible: !document.getElementById("utility-scrim").classList.contains("hidden"),
+        stageInert: document.querySelector('[data-ui-region="primary-stage"]').inert,
         targetSizes,
         textOverflow,
+        visualizer: rect("#jam-audio-visualizer"),
+        visualizerBackingPixels: Number(document.getElementById("jam-audio-visualizer-canvas").dataset.backingPixels || 0),
+        visualizerCanvasCount: document.querySelectorAll("#jam-audio-visualizer canvas").length,
+        visualizerOverflow: document.getElementById("jam-audio-visualizer").scrollWidth - document.getElementById("jam-audio-visualizer").clientWidth,
         viewport: { height: window.innerHeight, width: window.innerWidth },
         workspace: rect('.room-layout[data-ui-region="workspace"]'),
       };
@@ -989,12 +1343,325 @@ test("populated Jam remains inside the workspace and above the dock at represent
     expect(geometry.documentOverflowX).toBeLessThanOrEqual(1);
     expect(geometry.bodyOverflowX).toBeLessThanOrEqual(1);
     expect(geometry.textOverflow).toBe(false);
+    expect(geometry.visualizerCanvasCount).toBe(1);
+    expect(geometry.visualizerOverflow).toBeLessThanOrEqual(1);
+    expect(geometry.visualizerBackingPixels).toBeGreaterThan(0);
+    expect(geometry.visualizerBackingPixels).toBeLessThanOrEqual(180000);
+    expect(geometry.visualizer.left).toBeGreaterThanOrEqual(geometry.jam.left - 1);
+    expect(geometry.visualizer.right).toBeLessThanOrEqual(geometry.jam.right + 1);
+    if (geometry.bodyDisplay === "grid") {
+      expect(geometry.visualizer.left).toBeGreaterThanOrEqual(geometry.overview.left - 1);
+      expect(geometry.visualizer.right).toBeLessThanOrEqual(geometry.overview.right + 1);
+    }
+    expect(geometry.scrimVisible).toBe(true);
+    expect(geometry.stageInert).toBe(true);
+    expect(geometry.dockInert).toBe(false);
+    if (expectedMode === "theater" || expectedMode === "lounge") {
+      expect(geometry.jam.width).toBeGreaterThanOrEqual(839.5);
+      expect(geometry.jam.width).toBeLessThanOrEqual(1120.5);
+      expect(geometry.jam.height).toBeLessThanOrEqual(840.5);
+      expect(geometry.bodyDisplay).toBe("grid");
+      expect(geometry.overview.right).toBeLessThanOrEqual(geometry.browser.left + 1);
+      expect(geometry.browser.width).toBeGreaterThanOrEqual(459.5);
+    } else {
+      expect(geometry.bodyDisplay).toBe("flex");
+      expect(geometry.overviewEnd.bottom).toBeLessThanOrEqual(geometry.browser.top + 1);
+    }
     expect(geometry.targetSizes.length).toBeGreaterThan(4);
     for (const target of geometry.targetSizes) {
       expect(target.height, `${target.id} height at ${viewport.width}x${viewport.height}`).toBeGreaterThanOrEqual(39.5);
       expect(target.width, `${target.id} width at ${viewport.width}x${viewport.height}`).toBeGreaterThanOrEqual(39.5);
     }
   }
+});
+
+test("Echo Pulse uses real Jam analyser data, survives state polls, and honors reduced motion", async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 720 });
+  await page.emulateMedia({ reducedMotion: "no-preference" });
+  await openPhaseTwoViewer(page);
+  await openJam(page);
+
+  const visualizer = page.locator("#jam-audio-visualizer");
+  const canvas = visualizer.locator("canvas");
+  await expect(visualizer).toBeVisible();
+  await expect(visualizer).toHaveAttribute("data-state", "waiting");
+  await expect(visualizer).toHaveAttribute("data-reactive", "false");
+  await expect(page.locator("#jam-audio-visualizer-status")).toHaveText("JOIN JAM TO ACTIVATE");
+  await expect(visualizer).toHaveAttribute("aria-hidden", "true");
+  await expect(canvas).toHaveAttribute("aria-hidden", "true");
+  await expect(canvas).not.toHaveAttribute("tabindex", /.+/);
+
+  await page.evaluate(() => {
+    const visualizerNode = document.getElementById("jam-audio-visualizer");
+    window.__echoPulseStableNode = visualizerNode;
+    const analyser = {
+      frequencyBinCount: 256,
+      fftSize: 512,
+      getByteFrequencyData(target) {
+        for (let index = 0; index < target.length; index += 1) {
+          target[index] = 42 + ((index * 31) % 190);
+        }
+      },
+      getByteTimeDomainData(target) {
+        for (let index = 0; index < target.length; index += 1) {
+          target[index] = 128 + Math.round(Math.sin(index / 7) * 54);
+        }
+      },
+    };
+    _jamAudioAnalysisGraph = { available: true, analyser, destroy() {} };
+    _jamAudioCtx = { state: "running" };
+    _jamAudioStreamReady = true;
+    _jamAudioWs = { readyState: 1 };
+    syncJamAudioVisualizer(_jamState.now_playing);
+  });
+  await nextPaint(page);
+
+  await expect(visualizer).toHaveAttribute("data-state", "live");
+  await expect(visualizer).toHaveAttribute("data-reactive", "true");
+  await expect(page.locator("#jam-audio-visualizer-status")).toHaveText("LIVE");
+  const active = await page.evaluate(() => {
+    const canvasElement = document.getElementById("jam-audio-visualizer-canvas");
+    const context = canvasElement.getContext("2d");
+    const pixels = context.getImageData(0, 0, canvasElement.width, canvasElement.height).data;
+    let energy = 0;
+    for (let index = 3; index < pixels.length; index += 4) energy += pixels[index];
+    return {
+      energy,
+      nodeStable: window.__echoPulseStableNode === document.getElementById("jam-audio-visualizer"),
+      snapshot: _jamAudioVisualizerController.snapshot(),
+    };
+  });
+  expect(active.energy).toBeGreaterThan(0);
+  expect(active.nodeStable).toBe(true);
+  expect(active.snapshot.drawCount).toBeGreaterThan(0);
+  expect(active.snapshot.backingPixels).toBeGreaterThan(0);
+  expect(active.snapshot.backingPixels).toBeLessThanOrEqual(180000);
+
+  await page.evaluate(() => { document.getElementById("jam-panel").inert = true; });
+  await expect.poll(() => page.evaluate(() => _jamAudioVisualizerController.snapshot().frameScheduled)).toBe(false);
+  const drawCountWhileInert = await page.evaluate(() => _jamAudioVisualizerController.snapshot().drawCount);
+  await page.evaluate(() => { document.getElementById("jam-panel").inert = false; });
+  await expect.poll(() => page.evaluate(() => _jamAudioVisualizerController.snapshot().frameScheduled)).toBe(true);
+  await expect.poll(() => page.evaluate(() => _jamAudioVisualizerController.snapshot().drawCount)).toBeGreaterThan(drawCountWhileInert);
+
+  await page.evaluate(async () => {
+    await fetchJamState();
+    await fetchJamState();
+  });
+  expect(await page.evaluate(() => window.__echoPulseStableNode === document.getElementById("jam-audio-visualizer"))).toBe(true);
+  await expect(page.locator("#jam-audio-visualizer canvas")).toHaveCount(1);
+
+  await page.emulateMedia({ reducedMotion: "reduce" });
+  await expect(page.locator("html")).toHaveAttribute("data-theme-motion-effective", "still");
+  await expect(visualizer).toHaveAttribute("data-motion", "still");
+  await expect(visualizer).toHaveAttribute("data-state", "still");
+  await expect(visualizer).toHaveAttribute("data-reactive", "false");
+  await expect(page.locator("#jam-audio-visualizer-status")).toHaveText("MOTION OFF");
+  expect(await page.evaluate(() => _jamAudioVisualizerController.snapshot().frameScheduled)).toBe(false);
+
+  const model = apiModels.get(page);
+  model.state.spotify_is_playing = false;
+  model.state.now_playing.is_playing = false;
+  await page.evaluate(() => fetchJamState());
+  await expect(visualizer).toBeHidden();
+  await expect(visualizer).toHaveAttribute("data-state", "idle");
+});
+
+test("Echo Pulse observes scheduled PCM on a muted branch without replacing playback", async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 720 });
+  await page.emulateMedia({ reducedMotion: "no-preference" });
+  await openPhaseTwoViewer(page);
+  await openJam(page);
+
+  const graph = await page.evaluate(async () => {
+    const NativeAudioContext = window.AudioContext;
+    const NativeWebkitAudioContext = window.webkitAudioContext;
+    const NativeWebSocket = window.WebSocket;
+    let contextInstance = null;
+    let socketInstance = null;
+
+    class FakeNode {
+      constructor(kind) {
+        this.kind = kind;
+        this.connections = [];
+        this.disconnectCount = 0;
+      }
+      connect(target) {
+        this.connections.push(target && target.kind ? target.kind : "unknown");
+        return target;
+      }
+      disconnect() { this.disconnectCount += 1; }
+    }
+
+    class FakeAudioContext {
+      constructor() {
+        contextInstance = this;
+        this.state = "running";
+        this.currentTime = 1;
+        this.destination = new FakeNode("destination");
+        this.sources = [];
+        this.gains = [];
+        this.analyser = null;
+      }
+      createGain() {
+        const gain = new FakeNode(this.gains.length ? "analysis-sink" : "playback-gain");
+        gain.gain = { value: 1 };
+        this.gains.push(gain);
+        return gain;
+      }
+      createAnalyser() {
+        const analyser = new FakeNode("analyser");
+        analyser.frequencyBinCount = 256;
+        analyser.getByteFrequencyData = (target) => target.fill(120);
+        analyser.getByteTimeDomainData = (target) => target.fill(128);
+        this.analyser = analyser;
+        return analyser;
+      }
+      createBuffer(channels, length, sampleRate) {
+        const channelData = Array.from({ length: channels }, () => new Float32Array(length));
+        return {
+          duration: length / sampleRate,
+          getChannelData(index) { return channelData[index]; },
+        };
+      }
+      createBufferSource() {
+        const source = new FakeNode("buffer-source");
+        source.startedAt = null;
+        source.start = (time) => { source.startedAt = time; };
+        this.sources.push(source);
+        return source;
+      }
+      resume() { return Promise.resolve(); }
+      close() { this.state = "closed"; return Promise.resolve(); }
+    }
+
+    class FakeWebSocket {
+      constructor(url) {
+        socketInstance = this;
+        this.url = url;
+        this.binaryType = "";
+        this.sent = [];
+        this.closed = false;
+      }
+      send(value) { this.sent.push(value); }
+      close() { this.closed = true; }
+    }
+
+    try {
+      window.AudioContext = FakeAudioContext;
+      window.webkitAudioContext = undefined;
+      window.WebSocket = FakeWebSocket;
+      _jamAudioCtx = null;
+      _jamGainNode = null;
+      _jamAudioWs = null;
+      _jamAudioStreamReady = false;
+      destroyJamAudioAnalysisGraph();
+      _jamListeningGeneration = _jamState.generation;
+      _jamContract = { canJoin: true, compatible: true };
+
+      startJamAudioStream();
+      socketInstance.onopen();
+      socketInstance.onmessage({ data: JSON.stringify({ type: "ready" }) });
+      socketInstance.onmessage({ data: new Float32Array([0.1, -0.1, 0.2, -0.2, 0.3, -0.3, 0.4, -0.4]).buffer });
+
+      const source = contextInstance.sources[0];
+      return {
+        analyserConnections: contextInstance.analyser.connections.slice(),
+        analysisSinkConnections: contextInstance.gains[1].connections.slice(),
+        analysisSinkGain: contextInstance.gains[1].gain.value,
+        authFrames: socketInstance.sent.length,
+        playbackConnections: contextInstance.gains[0].connections.slice(),
+        sourceConnections: source.connections.slice(),
+        sourceStarted: Number.isFinite(source.startedAt),
+        visualizerState: document.getElementById("jam-audio-visualizer").dataset.state,
+      };
+    } finally {
+      stopJamAudioStream();
+      window.AudioContext = NativeAudioContext;
+      window.webkitAudioContext = NativeWebkitAudioContext;
+      window.WebSocket = NativeWebSocket;
+    }
+  });
+
+  expect(graph.playbackConnections).toEqual(["destination"]);
+  expect(graph.sourceConnections).toEqual(["playback-gain", "analyser"]);
+  expect(graph.analyserConnections).toEqual(["analysis-sink"]);
+  expect(graph.analysisSinkConnections).toEqual(["destination"]);
+  expect(graph.analysisSinkGain).toBe(0);
+  expect(graph.authFrames).toBe(1);
+  expect(graph.sourceStarted).toBe(true);
+  expect(graph.visualizerState).toBe("live");
+});
+
+test("an Echo Pulse failure cannot block Jam audio startup", async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 720 });
+  await openPhaseTwoViewer(page);
+  await openJam(page);
+
+  const result = await page.evaluate(() => {
+    const NativeAudioContext = window.AudioContext;
+    const NativeWebkitAudioContext = window.webkitAudioContext;
+    const NativeWebSocket = window.WebSocket;
+    const NativeVisualizer = window.EchoJamVisualizer;
+    let socketCreated = false;
+
+    class FakeGain {
+      constructor() { this.gain = { value: 1 }; }
+      connect() {}
+      disconnect() {}
+    }
+    class FakeAudioContext {
+      constructor() {
+        this.state = "running";
+        this.destination = {};
+      }
+      createGain() { return new FakeGain(); }
+      createAnalyser() { throw new Error("analysis unavailable"); }
+      close() { return Promise.resolve(); }
+    }
+    class FakeWebSocket {
+      constructor() { socketCreated = true; }
+      close() {}
+    }
+
+    try {
+      destroyJamAudioVisualizer();
+      _jamAudioVisualizerDisabled = false;
+      _jamAudioCtx = null;
+      _jamGainNode = null;
+      _jamAudioWs = null;
+      _jamAudioStreamReady = false;
+      _jamListeningGeneration = _jamState.generation;
+      _jamContract = { canJoin: true, compatible: true };
+      window.AudioContext = FakeAudioContext;
+      window.webkitAudioContext = undefined;
+      window.WebSocket = FakeWebSocket;
+      window.EchoJamVisualizer = Object.assign({}, NativeVisualizer, {
+        createJamVisualizerController() { throw new Error("canvas failed"); },
+      });
+
+      startJamAudioStream();
+      return {
+        socketCreated,
+        socketInstalled: _jamAudioWs instanceof FakeWebSocket,
+        audioContextInstalled: _jamAudioCtx instanceof FakeAudioContext,
+        visualizerDisabled: _jamAudioVisualizerDisabled,
+      };
+    } finally {
+      stopJamAudioStream();
+      window.AudioContext = NativeAudioContext;
+      window.webkitAudioContext = NativeWebkitAudioContext;
+      window.WebSocket = NativeWebSocket;
+      window.EchoJamVisualizer = NativeVisualizer;
+    }
+  });
+
+  expect(result).toEqual({
+    socketCreated: true,
+    socketInstalled: true,
+    audioContextInstalled: true,
+    visualizerDisabled: true,
+  });
 });
 
 test("Jam browser tabs are keyboard navigable and history remains available while inactive", async ({ page }) => {
@@ -1036,6 +1703,680 @@ test("Jam browser tabs are keyboard navigable and history remains available whil
   }));
   expect(overflow.browser).toBeLessThanOrEqual(1);
   expect(overflow.document).toBeLessThanOrEqual(1);
+});
+
+test("visible History refreshes once when the server history revision advances", async ({ page }) => {
+  await page.setViewportSize({ width: 900, height: 700 });
+  const model = apiModels.get(page);
+  await openPhaseTwoViewer(page);
+  await openJam(page);
+  await page.evaluate(() => {
+    if (_jamPollTimer) clearInterval(_jamPollTimer);
+    _jamPollTimer = null;
+  });
+
+  await page.locator("#jam-view-history-tab").click();
+  await expect(page.locator("#jam-history-list")).toContainText("Played While Inactive");
+  await expect.poll(() => model.counts["GET /api/jam/history"] || 0).toBe(1);
+
+  model.state.history_revision = 1;
+  model.historyItems = [{
+    history_entry_id: "history-2",
+    spotify_id: "1234567890ABCDEFGHIJKL",
+    spotify_uri: "spotify:track:1234567890ABCDEFGHIJKL",
+    spotify_url: "https://open.spotify.com/track/1234567890ABCDEFGHIJKL",
+    name: "Advanced Without Tab Switching",
+    artist: "Fixture Artist Two",
+    added_at_ms: 1_700_000_200_000,
+    played_at_ms: 1_700_000_300_000,
+    added_by_actor_id: "friend",
+    added_by_name: "Friend",
+  }];
+
+  await page.evaluate(async () => { await fetchJamState(); });
+  await expect.poll(() => model.counts["GET /api/jam/history"] || 0).toBe(2);
+  await expect(page.locator("#jam-history-section")).toBeVisible();
+  await expect(page.locator("#jam-view-history-tab")).toHaveAttribute("aria-selected", "true");
+  await expect(page.locator("#jam-history-list")).toContainText("Advanced Without Tab Switching");
+  await page.evaluate(() => { window.__phase2HistoryRow = document.querySelector("#jam-history-list > li"); });
+
+  await page.evaluate(async () => { await fetchJamState(); });
+  expect(model.counts["GET /api/jam/history"] || 0).toBe(2);
+  expect(await page.evaluate(() => window.__phase2HistoryRow === document.querySelector("#jam-history-list > li"))).toBe(true);
+});
+
+test("History adds a playable song through the existing queue path without leaving the current view", async ({ page }) => {
+  await page.setViewportSize({ width: 360, height: 700 });
+  const model = apiModels.get(page);
+  model.queueTrackDelayOnceMs = 300;
+  await openPhaseTwoViewer(page);
+  await openJam(page);
+  await page.evaluate(() => {
+    if (_jamPollTimer) clearInterval(_jamPollTimer);
+    _jamPollTimer = null;
+  });
+
+  await page.locator("#jam-view-history-tab").click();
+  await page.locator("#jam-history-sort").selectOption("added_at");
+  await page.locator("#jam-history-direction").selectOption("asc");
+  const add = page.getByRole("button", {
+    name: "Add Played While Inactive by Fixture Artist to queue",
+    exact: true,
+  });
+  await expect(add).toBeEnabled();
+  await expect(add).toHaveAttribute("title", "Add this song to the active Jam queue");
+
+  const geometry = await add.evaluate((button) => {
+    const buttonRect = button.getBoundingClientRect();
+    const rowRect = button.closest(".jam-history-item").getBoundingClientRect();
+    const panelRect = document.getElementById("jam-panel").getBoundingClientRect();
+    return {
+      buttonLeft: buttonRect.left,
+      buttonRight: buttonRect.right,
+      rowLeft: rowRect.left,
+      rowRight: rowRect.right,
+      panelLeft: panelRect.left,
+      panelRight: panelRect.right,
+      documentOverflow: document.documentElement.scrollWidth - window.innerWidth,
+    };
+  });
+  expect(geometry.buttonLeft).toBeGreaterThanOrEqual(geometry.rowLeft - 1);
+  expect(geometry.buttonRight).toBeLessThanOrEqual(geometry.rowRight + 1);
+  expect(geometry.rowLeft).toBeGreaterThanOrEqual(geometry.panelLeft - 1);
+  expect(geometry.rowRight).toBeLessThanOrEqual(geometry.panelRight + 1);
+  expect(geometry.documentOverflow).toBeLessThanOrEqual(1);
+
+  await add.click();
+  await expect.poll(() => model.counts["POST /api/jam/queue"] || 0).toBe(1);
+  await expect(add).toBeDisabled();
+  await expect(add).toHaveAttribute("title", "Wait for the current song to finish adding");
+  await expect(add).toHaveAttribute("aria-description", "Wait for the current song to finish adding");
+  expect(model.queueTrackBodies[0]).toMatchObject({
+    spotify_uri: `spotify:track:${trackId}`,
+    name: "Played While Inactive",
+    artist: "Fixture Artist",
+    album_art_url: "https://i.scdn.co/image/history-fixture",
+    duration_ms: 222_000,
+    generation: 7,
+  });
+  expect(model.queueTrackBodies[0].request_id).toMatch(/^[A-Za-z0-9_-]{8,128}$/);
+
+  await expect(add).toBeEnabled({ timeout: 2_000 });
+  await expect(page.locator("#jam-history-status")).toHaveText("Added Played While Inactive to the queue.");
+  await expect(page.locator("#jam-history-section")).toBeVisible();
+  await expect(page.locator("#jam-view-history-tab")).toHaveAttribute("aria-selected", "true");
+  await expect(page.locator("#jam-history-sort")).toHaveValue("added_at");
+  await expect(page.locator("#jam-history-direction")).toHaveValue("asc");
+});
+
+test("History explains why queue actions are disabled before Start Jam and sends no request", async ({ page }) => {
+  await page.setViewportSize({ width: 360, height: 700 });
+  const model = apiModels.get(page);
+  model.state.active = false;
+  model.state.spotify_is_playing = false;
+  model.state.now_playing = null;
+  await openPhaseTwoViewer(page);
+  await openJam(page);
+  await page.locator("#jam-view-history-tab").click();
+
+  const add = page.getByRole("button", {
+    name: "Add Played While Inactive by Fixture Artist to queue",
+    exact: true,
+  });
+  const guidance = "Start a Jam to add this song to the queue";
+  await expect(add).toBeDisabled();
+  await expect(add).toHaveAttribute("title", guidance);
+  await expect(add).toHaveAttribute("aria-description", guidance);
+  await add.evaluate((button) => button.click());
+  expect(model.counts["POST /api/jam/queue"] || 0).toBe(0);
+  await expect(page.locator("#jam-history-section")).toBeVisible();
+  await expect(page.locator("#jam-view-history-tab")).toHaveAttribute("aria-selected", "true");
+});
+
+test("empty History explains why songs played directly in Spotify are not recorded", async ({ page }) => {
+  await page.setViewportSize({ width: 900, height: 700 });
+  const model = apiModels.get(page);
+  model.historyItems = [];
+  await openPhaseTwoViewer(page);
+  await openJam(page);
+  await expect(page.locator("#jam-results")).not.toHaveAttribute("role", "list");
+  await page.locator("#jam-view-history-tab").click();
+
+  const explanation = "History records only songs added through Echo and then observed playing";
+  await expect(page.locator("#jam-history-list .jam-history-empty")).toContainText(explanation);
+  await expect(page.locator("#jam-history-list .jam-history-empty")).toContainText("played directly in Spotify are not recorded");
+  await expect(page.locator("#jam-history-list .jam-history-empty")).toContainText("no Jam adder attribution");
+  await expect(page.locator("#jam-history-status")).toContainText(explanation);
+  await expect(page.locator("#jam-history-list > li")).toHaveCount(1);
+});
+
+test("Queue removes one or multiple pending songs while truthfully locking Spotify-committed entries", async ({ page }) => {
+  await page.setViewportSize({ width: 360, height: 640 });
+  const model = apiModels.get(page);
+  model.state.now_playing.spotify_uri = model.state.queue[0].spotify_uri;
+  model.state.queue[1].spotify_uri = model.state.queue[0].spotify_uri;
+  await openPhaseTwoViewer(page);
+  await openJam(page);
+  await page.locator("#jam-view-queue-tab").click();
+
+  await expect(page.locator("#jam-queue-list .jam-queue-select")).toHaveCount(6);
+  await expect(page.locator('[data-queue-entry-id="queue-entry-1"] .jam-queue-lock-reason'))
+    .toContainText("Currently playing in Spotify");
+  await expect(page.locator('[data-queue-entry-id="queue-entry-2"] .jam-queue-lock-reason'))
+    .toContainText("Spotify delivery could not be verified. End Jam and start a new one to recover.");
+  await expect(page.locator('[data-queue-entry-id="queue-entry-1"] .jam-queue-remove-one')).toHaveCount(0);
+
+  const narrowGeometry = await page.locator("#jam-queue-section").evaluate((section) => {
+    const sectionRect = section.getBoundingClientRect();
+    const itemRects = Array.from(section.querySelectorAll(".jam-queue-item")).map((item) => {
+      const rect = item.getBoundingClientRect();
+      return { left: rect.left, right: rect.right };
+    });
+    return {
+      internalOverflow: section.scrollWidth - section.clientWidth,
+      viewportOverflow: document.documentElement.scrollWidth - window.innerWidth,
+      itemsContained: itemRects.every((rect) => rect.left >= sectionRect.left - 1 && rect.right <= sectionRect.right + 1),
+    };
+  });
+  expect(narrowGeometry.internalOverflow).toBeLessThanOrEqual(1);
+  expect(narrowGeometry.viewportOverflow).toBeLessThanOrEqual(1);
+  expect(narrowGeometry.itemsContained).toBe(true);
+
+  const thirdRow = page.locator('[data-queue-entry-id="queue-entry-3"]');
+  const fourthRow = page.locator('[data-queue-entry-id="queue-entry-4"]');
+  const thirdChoice = thirdRow.locator(".jam-queue-select");
+  const fourthChoice = fourthRow.locator(".jam-queue-select");
+  await expect(thirdChoice).toHaveAttribute("aria-label", /queue position 3 for removal$/);
+  await thirdChoice.check();
+  await fourthChoice.check();
+  await expect(page.locator("#jam-queue-selection-count")).toHaveText("2 songs selected");
+
+  await page.evaluate(async () => { await fetchJamState(); });
+  await expect(thirdChoice).toBeChecked();
+  await expect(fourthChoice).toBeChecked();
+
+  await page.locator("#jam-queue-remove-selected").click();
+  await expect.poll(() => model.counts["POST /api/jam/queue/remove"] || 0).toBe(1);
+  expect(model.queueRemovalBodies[0]).toMatchObject({
+    generation: 7,
+    expected_queue_revision: 11,
+    queue_entry_ids: ["queue-entry-3", "queue-entry-4"],
+  });
+  expect(model.queueRemovalBodies[0].request_id).toMatch(/^[A-Za-z0-9_-]{8,128}$/);
+  await expect(page.locator('[data-queue-entry-id="queue-entry-3"]')).toHaveCount(0);
+  await expect(page.locator('[data-queue-entry-id="queue-entry-4"]')).toHaveCount(0);
+  await expect(page.locator("#jam-queue-status")).toHaveText("Removed 2 songs from the queue.");
+
+  const fifthRow = page.locator('[data-queue-entry-id="queue-entry-5"]');
+  const removeFifth = fifthRow.getByRole("button", { name: /Remove Queued Song 5 .* queue position 3 from queue$/ });
+  await expect(removeFifth).toHaveText("Remove");
+  await removeFifth.click();
+  await expect.poll(() => model.counts["POST /api/jam/queue/remove"] || 0).toBe(2);
+  expect(model.queueRemovalBodies[1]).toMatchObject({
+    generation: 7,
+    expected_queue_revision: 12,
+    queue_entry_ids: ["queue-entry-5"],
+  });
+  await expect(page.locator('[data-queue-entry-id="queue-entry-5"]')).toHaveCount(0);
+  await expect(page.locator("#jam-queue-status")).toHaveText("Removed 1 song from the queue.");
+});
+
+test("commit-unknown queue recovery guidance overrides the now-playing explanation", async ({ page }) => {
+  await page.setViewportSize({ width: 900, height: 700 });
+  const model = apiModels.get(page);
+  model.state.queue[0].delivery_state = "commit_unknown";
+  model.state.queue[0].can_remove = false;
+  model.state.now_playing.spotify_uri = model.state.queue[0].spotify_uri;
+  await openPhaseTwoViewer(page);
+  await openJam(page);
+  await page.locator("#jam-view-queue-tab").click();
+
+  const reason = page.locator('[data-queue-entry-id="queue-entry-1"] .jam-queue-lock-reason');
+  await expect(reason).toHaveText(
+    "Spotify delivery could not be verified. End Jam and start a new one to recover.",
+  );
+  await expect(reason).not.toContainText("Currently playing");
+});
+
+test("stale queue removal refreshes for review and preserves only still-removable selections", async ({ page }) => {
+  await page.setViewportSize({ width: 900, height: 700 });
+  const model = apiModels.get(page);
+  model.queueRemovalConflictOnce = true;
+  model.expectedQueueRemovalConflict = true;
+  await openPhaseTwoViewer(page);
+  await openJam(page);
+  await page.locator("#jam-view-queue-tab").click();
+
+  await page.locator('[data-queue-entry-id="queue-entry-3"] .jam-queue-select').check();
+  await page.locator('[data-queue-entry-id="queue-entry-4"] .jam-queue-select').check();
+  await page.locator("#jam-queue-remove-selected").click();
+
+  await expect.poll(() => model.counts["POST /api/jam/queue/remove"] || 0).toBe(1);
+  await expect(page.locator("#jam-queue-status")).toContainText("queue changed");
+  await expect(page.locator("#jam-queue-status")).toContainText("review your selections");
+  await expect(page.locator('[data-queue-entry-id="queue-entry-3"] .jam-queue-select')).toHaveCount(0);
+  await expect(page.locator('[data-queue-entry-id="queue-entry-3"] .jam-queue-lock-reason'))
+    .toContainText("Already sent to Spotify");
+  await expect(page.locator('[data-queue-entry-id="queue-entry-4"] .jam-queue-select')).toBeChecked();
+  await expect(page.locator("#jam-queue-selection-count")).toHaveText("1 song selected");
+  await expect(page.locator("#jam-queue-remove-selected")).toBeEnabled();
+  await page.waitForTimeout(50);
+  expect(model.counts["POST /api/jam/queue/remove"]).toBe(1);
+});
+
+test("an interrupted queue-removal response refreshes and confirms the server result", async ({ page }) => {
+  await page.setViewportSize({ width: 900, height: 700 });
+  const model = apiModels.get(page);
+  model.queueRemovalAbortAfterCommitOnce = true;
+  model.expectedQueueRemovalNetworkError = true;
+  await openPhaseTwoViewer(page);
+  await openJam(page);
+  await page.locator("#jam-view-queue-tab").click();
+
+  await page.locator('[data-queue-entry-id="queue-entry-3"] .jam-queue-select').check();
+  await page.locator("#jam-queue-remove-selected").click();
+
+  await expect.poll(() => model.counts["POST /api/jam/queue/remove"] || 0).toBe(1);
+  await expect.poll(() => model.counts["GET /api/jam/state"] || 0).toBeGreaterThanOrEqual(2);
+  await expect(page.locator('[data-queue-entry-id="queue-entry-3"]')).toHaveCount(0);
+  await expect(page.locator("#jam-queue-selection-count")).toHaveText("0 songs selected");
+  await expect(page.locator("#jam-queue-status")).toContainText("response was interrupted");
+  await expect(page.locator("#jam-queue-status")).toContainText("confirmed 1 selected song is no longer queued");
+});
+
+test("large Queue stays unbuilt while hidden, preserves DOM on unchanged polls, and restores focus after revisions", async ({ page }) => {
+  await page.setViewportSize({ width: 900, height: 700 });
+  const model = apiModels.get(page);
+  model.state.queue = Array.from({ length: 220 }, (_, index) => ({
+    queue_entry_id: `large-queue-entry-${index + 1}`,
+    delivery_state: "pending",
+    can_remove: true,
+    spotify_uri: `spotify:track:large-${index + 1}`,
+    name: `Large Queue Song ${index + 1}`,
+    artist: `Large Queue Artist ${index + 1}`,
+    album_art_url: "",
+    duration_ms: 180_000,
+    added_by: `Friend ${index + 1}`,
+  }));
+  model.state.queue_revision = 42;
+  await openPhaseTwoViewer(page);
+  await openJam(page);
+
+  await expect(page.locator("#jam-queue-list .jam-queue-item")).toHaveCount(0);
+  await page.evaluate(async () => { await fetchJamState(); });
+  await expect(page.locator("#jam-queue-list .jam-queue-item")).toHaveCount(0);
+
+  await page.locator("#jam-view-queue-tab").click();
+  await expect(page.locator("#jam-queue-list .jam-queue-item")).toHaveCount(220);
+  const focusedChoice = page.locator('[data-queue-entry-id="large-queue-entry-150"] .jam-queue-select');
+  await focusedChoice.focus();
+  await focusedChoice.check();
+  await page.locator('[data-queue-entry-id="large-queue-entry-1"]').evaluate((row) => { row.dataset.pollIdentity = "preserved"; });
+
+  await page.evaluate(async () => { await fetchJamState(); });
+  await expect(page.locator('[data-queue-entry-id="large-queue-entry-1"]')).toHaveAttribute("data-poll-identity", "preserved");
+  await expect(focusedChoice).toBeFocused();
+  await expect(focusedChoice).toBeChecked();
+
+  model.state.queue_revision += 1;
+  model.state.queue[219].name = "Large Queue Song 220 revised";
+  await page.evaluate(async () => { await fetchJamState(); });
+  await expect(page.locator('[data-queue-entry-id="large-queue-entry-1"]')).not.toHaveAttribute("data-poll-identity", "preserved");
+  await expect(page.locator('[data-queue-entry-id="large-queue-entry-150"] .jam-queue-select')).toBeFocused();
+  await expect(page.locator('[data-queue-entry-id="large-queue-entry-150"] .jam-queue-select')).toBeChecked();
+  await expect(page.locator("#jam-queue-list")).toContainText("Large Queue Song 220 revised");
+});
+
+test.describe("coarse pointer Queue controls", () => {
+  test.use({ hasTouch: true });
+
+  test("queue selection choices expose a computed 44 by 44 hit target", async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 700 });
+    await openPhaseTwoViewer(page);
+    await openJam(page);
+    await page.locator("#jam-view-queue-tab").click();
+    expect(await page.evaluate(() => matchMedia("(pointer: coarse)").matches)).toBe(true);
+    const size = await page.locator('[data-queue-entry-id="queue-entry-3"] .jam-queue-choice').evaluate((choice) => {
+      const rect = choice.getBoundingClientRect();
+      return { height: rect.height, width: rect.width };
+    });
+    expect(size.width).toBeGreaterThanOrEqual(44);
+    expect(size.height).toBeGreaterThanOrEqual(44);
+  });
+});
+
+test("single-song queue actions serialize double-clicks and send an idempotency key", async ({ page }) => {
+  await page.setViewportSize({ width: 900, height: 700 });
+  const model = apiModels.get(page);
+  model.queueTrackDelayOnceMs = 300;
+  await openPhaseTwoViewer(page);
+  await openJam(page);
+  await page.locator("#jam-search-input").fill("single track");
+  const firstAdd = page.locator("#jam-results .jam-result-add").first();
+  await expect(firstAdd).toBeEnabled();
+  await firstAdd.dblclick();
+
+  await expect.poll(() => model.counts["POST /api/jam/queue"] || 0).toBe(1);
+  await expect(firstAdd).toBeDisabled();
+  for (const button of await page.locator("#jam-results .jam-result-add").all()) await expect(button).toBeDisabled();
+  await page.waitForTimeout(100);
+  expect(model.counts["POST /api/jam/queue"]).toBe(1);
+  expect(model.queueTrackBodies[0]).toMatchObject({
+    generation: 7,
+    spotify_uri: model.searchTracks[0].spotify_uri,
+  });
+  expect(model.queueTrackBodies[0].request_id).toMatch(/^[A-Za-z0-9_-]{8,128}$/);
+  await expect(firstAdd).toBeEnabled({ timeout: 2_000 });
+  expect(model.queueTrackMutations).toBe(1);
+});
+
+test("interrupted single-song adds retry with the same request id without a second mutation", async ({ page }) => {
+  await page.setViewportSize({ width: 900, height: 700 });
+  const model = apiModels.get(page);
+  model.queueTrackAbortAfterCommitOnce = true;
+  model.expectedTrackQueueNetworkError = true;
+  await openPhaseTwoViewer(page);
+  await openJam(page);
+  await page.locator("#jam-search-input").fill("retry track");
+  const firstAdd = page.locator("#jam-results .jam-result-add").first();
+
+  await firstAdd.click();
+  await expect(page.locator("#jam-status")).toContainText("response was interrupted");
+  await expect(firstAdd).toBeEnabled();
+  await firstAdd.click();
+
+  await expect.poll(() => model.counts["POST /api/jam/queue"] || 0).toBe(2);
+  await expect(firstAdd).toBeEnabled();
+  expect(model.queueTrackBodies[1].request_id).toBe(model.queueTrackBodies[0].request_id);
+  expect(model.queueTrackMutations).toBe(1);
+  await expect.poll(() => page.evaluate(() => {
+    const entries = JSON.parse(sessionStorage.getItem("echo-jam-track-ambiguous-v1") || "[]");
+    return entries.length;
+  })).toBe(0);
+});
+
+test("Library cards expose explicit Spotify and queue or song-selection actions", async ({ page }) => {
+  await page.setViewportSize({ width: 900, height: 700 });
+  const model = apiModels.get(page);
+  await openPhaseTwoViewer(page);
+  await openJam(page);
+  await page.locator("#jam-view-library-tab").click();
+
+  const trackCard = page.locator("#jam-library-list .jam-catalog-track").filter({ hasText: "Shared Favorite" });
+  await expect(trackCard).toHaveCount(1);
+  const trackSpotify = trackCard.getByRole("link", { name: "Open Shared Favorite in Spotify", exact: true });
+  await expect(trackSpotify).toHaveText("Open in Spotify");
+  await expect(trackSpotify).toHaveAttribute("href", `https://open.spotify.com/track/${trackId}`);
+  const addTrack = trackCard.getByRole("button", { name: "Add Shared Favorite by Fixture Artist to queue", exact: true });
+  await expect(addTrack).toHaveText("Add to queue");
+  await addTrack.click();
+  await expect.poll(() => model.counts["POST /api/jam/queue"] || 0).toBe(1);
+  expect(model.queueTrackBodies).toHaveLength(1);
+  expect(model.queueTrackBodies[0]).toMatchObject({
+    spotify_uri: `spotify:track:${trackId}`,
+    name: "Shared Favorite",
+    artist: "Fixture Artist",
+    generation: 7,
+  });
+
+  const libraryPlaylist = page.locator("#jam-library-list .jam-catalog-playlist").filter({ hasText: "Fixture Road Trip" });
+  await expect(libraryPlaylist).toHaveCount(1);
+  const playlistArtwork = libraryPlaylist.locator("img.jam-result-art");
+  await expect(playlistArtwork).toHaveAttribute("src", "https://i.scdn.co/image/playlist-fixture");
+  await expect.poll(() => playlistArtwork.evaluate((image) => image.naturalWidth)).toBeGreaterThan(0);
+  await expect(libraryPlaylist.getByRole("link", { name: "Open Fixture Road Trip in Spotify", exact: true }))
+    .toHaveText("Open in Spotify");
+  const chooseLibrarySongs = libraryPlaylist.getByRole("button", { name: "Choose songs from Fixture Road Trip", exact: true });
+  await expect(chooseLibrarySongs).toHaveText("Choose songs");
+  await chooseLibrarySongs.click();
+  await expect(page.locator("#jam-playlist-detail")).toBeVisible();
+  await expect(page.locator("#jam-playlist-back")).toHaveText("Back to Library");
+  await expect(page.locator("#jam-playlist-items .jam-catalog-item")).toHaveCount(30);
+
+  await page.locator("#jam-playlist-back").click();
+  await page.locator("#jam-view-search-tab").click();
+  await page.locator("#jam-search-playlist-tab").click();
+  await page.locator("#jam-search-input").fill("road trip");
+  const searchPlaylist = page.locator("#jam-results .jam-catalog-playlist").filter({ hasText: "Fixture Road Trip" });
+  await expect(searchPlaylist).toHaveCount(1);
+  await expect(searchPlaylist.getByRole("link", { name: "Open Fixture Road Trip in Spotify", exact: true }))
+    .toHaveText("Open in Spotify");
+  const chooseSearchSongs = searchPlaylist.getByRole("button", { name: "Choose songs from Fixture Road Trip", exact: true });
+  await expect(chooseSearchSongs).toHaveText("Choose songs");
+  await chooseSearchSongs.click();
+  await expect(page.locator("#jam-playlist-back")).toHaveText("Back to search results");
+  await page.locator("#jam-playlist-back").click();
+  await expect(searchPlaylist).toBeVisible();
+
+  await page.setViewportSize({ width: 360, height: 640 });
+  await searchPlaylist.scrollIntoViewIfNeeded();
+  const narrowActions = await searchPlaylist.evaluate((card) => ({
+    cardOverflow: card.scrollWidth - card.clientWidth,
+    documentOverflow: document.documentElement.scrollWidth - window.innerWidth,
+    actionWidths: Array.from(card.querySelectorAll(".jam-card-actions > *"), (action) => action.getBoundingClientRect().width),
+  }));
+  expect(narrowActions.cardOverflow).toBeLessThanOrEqual(1);
+  expect(narrowActions.documentOverflow).toBeLessThanOrEqual(1);
+  expect(narrowActions.actionWidths.every((width) => width >= 39.5)).toBe(true);
+});
+
+test("expired playlist artwork falls back to the clean Library placeholder", async ({ page }) => {
+  await page.setViewportSize({ width: 900, height: 700 });
+  const model = apiModels.get(page);
+  model.expectedArtworkFailure = true;
+  model.favoriteItems = [{
+    ...model.playlist,
+    artwork_url: "https://i.scdn.co/image/expired-playlist-fixture",
+    attributions: [{ actor_id: "sam", display_name: "Sam", added_at_ms: 100, source: "echo" }],
+    contributor_count: 1,
+    favorited_by_me: true,
+  }];
+  await page.route("https://i.scdn.co/image/expired-playlist-fixture", async (route) => {
+    await route.abort("failed");
+  });
+  await openPhaseTwoViewer(page);
+  await openJam(page);
+  await page.locator("#jam-view-library-tab").click();
+
+  const playlistCard = page.locator("#jam-library-list .jam-catalog-playlist");
+  await expect(playlistCard.locator("img.jam-result-art")).toHaveCount(0);
+  await expect(playlistCard.locator(".jam-result-art.jam-art-placeholder")).toHaveCount(1);
+});
+
+test("playlist detail returns to the preserved Library page and restores its opener focus", async ({ page }) => {
+  await page.setViewportSize({ width: 900, height: 700 });
+  const model = apiModels.get(page);
+  model.favoriteItems = Array.from({ length: 20 }, (_, index) => ({
+    ...model.searchTracks[index % model.searchTracks.length],
+    kind: "track",
+    spotify_id: `2${String(index + 1).padStart(21, "0")}`,
+    spotify_uri: `spotify:track:2${String(index + 1).padStart(21, "0")}`,
+    name: `Paged Favorite ${index + 1}`,
+    attributions: [{ actor_id: "sam", display_name: "Sam", added_at_ms: 100 + index, source: "manual" }],
+    favorited_by_me: true,
+  }));
+  model.favoriteItems.push({
+    ...model.playlist,
+    attributions: [{ actor_id: "sam", display_name: "Sam", added_at_ms: 500, source: "manual" }],
+    favorited_by_me: true,
+  });
+  await openPhaseTwoViewer(page);
+  await openJam(page);
+  await page.locator("#jam-view-library-tab").click();
+  await page.locator("#jam-library-next").click();
+
+  await expect(page.locator("#jam-library-page")).toHaveText("21 favorites \u00b7 2 of 2");
+  const playlistCard = page.locator("#jam-library-list .jam-catalog-playlist");
+  const opener = playlistCard.getByRole("button", { name: "Choose songs from Fixture Road Trip", exact: true });
+  await playlistCard.evaluate((card) => { card.dataset.preservedPage = "yes"; });
+  await opener.click();
+  await expect(page.locator("#jam-playlist-back")).toHaveText("Back to Library");
+  await expect(page.locator("#jam-playlist-items .jam-catalog-item")).toHaveCount(30);
+  await page.locator("#jam-playlist-back").click();
+
+  await expect(page.locator("#jam-library-page")).toHaveText("21 favorites \u00b7 2 of 2");
+  await expect(page.locator("#jam-library-list .jam-catalog-playlist")).toHaveAttribute("data-preserved-page", "yes");
+  await expect(opener).toBeFocused();
+  expect(model.favoriteQueries.map((query) => query.offset)).toEqual(["0", "20"]);
+});
+
+test("empty Echo Favorites explains first use and copies Spotify saves idempotently", async ({ page }) => {
+  await page.setViewportSize({ width: 1366, height: 768 });
+  const model = apiModels.get(page);
+  model.favoriteItems = [];
+  await openPhaseTwoViewer(page);
+  await openJam(page);
+  await page.locator("#jam-view-library-tab").click();
+
+  await expect(page.locator("#jam-library-import-card strong")).toHaveText("Bring in your Spotify saves");
+  await expect(page.locator("#jam-library-import-card")).toContainText("not the songs inside playlists");
+  await expect(page.locator("#jam-library-import-card")).toContainText("nothing is added to the Jam queue");
+  await expect(page.locator("#jam-library-refresh-spotify")).toBeHidden();
+  await expect(page.locator("#jam-import-spotify")).toHaveText("Copy Spotify saves");
+  await expect(page.locator("#jam-import-spotify")).toHaveClass(/jam-primary-btn/);
+  await expect(page.locator("#jam-import-spotify")).toBeEnabled();
+  await expect(page.locator("#jam-library-status")).toHaveText(
+    "No Echo Favorites yet. Copy your Spotify saves above, or use Search and press ☆.",
+  );
+  await expect(page.locator("#jam-library-list .jam-library-empty")).toHaveText(
+    "Your shared Echo Favorites library is empty.",
+  );
+  await expect(page.locator("#jam-library-list .jam-library-empty")).not.toHaveAttribute("role", "listitem");
+  await expect(page.locator("#jam-library-list")).not.toHaveAttribute("role", "list");
+
+  await page.locator("#jam-import-spotify").click();
+  await expect.poll(() => model.counts["POST /api/jam/favorites/import-spotify"] || 0).toBe(1);
+  await expect(page.locator("#jam-library-list .jam-catalog-item")).toHaveCount(2);
+  await expect(page.locator("#jam-library-status")).toHaveText(
+    "Checked 1 Liked Song and 1 saved playlist; added 2 new Echo Favorites.",
+  );
+  await expect(page.locator("#jam-library-list")).toContainText("Imported Saved Playlist");
+  await expect(page.locator("#jam-library-import-card")).toHaveClass(/compact/);
+  await expect(page.locator("#jam-library-import-card strong")).toHaveText("Spotify saves");
+  await expect(page.locator("#jam-import-spotify")).toHaveText("Check for new Spotify saves");
+  await expect(page.locator("#jam-import-spotify")).toHaveClass(/jam-secondary-btn/);
+
+  await page.setViewportSize({ width: 360, height: 640 });
+  await page.locator("#jam-library-import-card").scrollIntoViewIfNeeded();
+  const compactLayout = await page.locator("#jam-library-import-card").evaluate((card) => ({
+    cardOverflow: card.scrollWidth - card.clientWidth,
+    documentOverflow: document.documentElement.scrollWidth - window.innerWidth,
+    actionWidth: card.querySelector("#jam-import-spotify").getBoundingClientRect().width,
+  }));
+  expect(compactLayout.cardOverflow).toBeLessThanOrEqual(1);
+  expect(compactLayout.documentOverflow).toBeLessThanOrEqual(1);
+  expect(compactLayout.actionWidth).toBeGreaterThanOrEqual(120);
+  await page.setViewportSize({ width: 1366, height: 768 });
+
+  await page.locator("#jam-library-kind").selectOption("playlist");
+  await expect(page.locator("#jam-library-list .jam-catalog-item")).toHaveCount(1);
+  await expect(page.locator("#jam-library-list")).toContainText("Imported Saved Playlist");
+
+  await page.locator("#jam-import-spotify").click();
+  await expect.poll(() => model.counts["POST /api/jam/favorites/import-spotify"] || 0).toBe(2);
+  await expect(page.locator("#jam-library-status")).toContainText("added 0 new Echo Favorites");
+  await expect(page.locator("#jam-library-list .jam-catalog-item")).toHaveCount(1);
+});
+
+test("filtered import does not leave the global-empty message stale", async ({ page }) => {
+  await page.setViewportSize({ width: 1366, height: 768 });
+  const model = apiModels.get(page);
+  model.favoriteItems = [];
+  model.importTracksOnly = true;
+  await openPhaseTwoViewer(page);
+  await openJam(page);
+  await page.locator("#jam-view-library-tab").click();
+  await expect(page.locator("#jam-library-list .jam-library-empty")).toHaveText(
+    "Your shared Echo Favorites library is empty.",
+  );
+
+  await page.locator("#jam-library-kind").selectOption("playlist");
+  await page.locator("#jam-import-spotify").click();
+  await expect.poll(() => model.counts["POST /api/jam/favorites/import-spotify"] || 0).toBe(1);
+  await expect(page.locator("#jam-library-list .jam-library-empty")).toHaveText(
+    "Nothing matches the current Library filters.",
+  );
+
+  await page.locator("#jam-library-kind").selectOption("all");
+  await expect(page.locator("#jam-library-list .jam-catalog-item")).toHaveCount(1);
+  await expect(page.locator("#jam-library-list")).toContainText("Imported Liked Song");
+});
+
+test("disconnected Spotify Library presents only the connect action", async ({ page }) => {
+  await page.setViewportSize({ width: 900, height: 700 });
+  const model = apiModels.get(page);
+  model.favoriteItems = [];
+  await openPhaseTwoViewer(page);
+  await openJam(page);
+  model.state.spotify_connected = false;
+  model.state.spotify_library_authorized = false;
+  await page.evaluate(async () => { await fetchJamState(); });
+  await page.locator("#jam-view-library-tab").click();
+
+  await expect(page.locator("#jam-library-import-card strong")).toHaveText("Connect your Spotify Library");
+  await expect(page.locator("#jam-library-refresh-spotify")).toHaveText("Connect Spotify");
+  await expect(page.locator("#jam-library-refresh-spotify")).toBeVisible();
+  await expect(page.locator("#jam-import-spotify")).toBeHidden();
+});
+
+test("stale Spotify authorization presents only the library-access action", async ({ page }) => {
+  await page.setViewportSize({ width: 1366, height: 768 });
+  const model = apiModels.get(page);
+  model.favoriteItems = [];
+  model.state.spotify_library_authorized = false;
+  await openPhaseTwoViewer(page);
+  await openJam(page);
+  await page.locator("#jam-view-library-tab").click();
+
+  await expect(page.locator("#jam-library-import-card")).toHaveClass(/needs-access/);
+  await expect(page.locator("#jam-library-import-card strong")).toHaveText("Spotify Library access required");
+  await expect(page.locator("#jam-library-import-card")).toContainText(
+    "Grant read access to copy your Liked Songs and saved playlists into shared Echo Favorites.",
+  );
+  await expect(page.locator("#jam-library-refresh-spotify")).toHaveText("Grant Spotify Library Access");
+  await expect(page.locator("#jam-library-refresh-spotify")).toBeEnabled();
+  await expect(page.locator("#jam-import-spotify")).toBeHidden();
+  expect(await page.locator("#jam-library-refresh-spotify").evaluate((button) => typeof button.onclick)).toBe("function");
+});
+
+test("Spotify account allowlist failures stay distinct from missing Library scopes", async ({ page }) => {
+  await page.setViewportSize({ width: 1366, height: 768 });
+  const model = apiModels.get(page);
+  model.favoriteItems = [];
+  model.importError = {
+    status: 403,
+    error: "spotify_account_forbidden",
+    message: "Spotify rejected this account: User is not registered for this application.",
+  };
+  await openPhaseTwoViewer(page);
+  await openJam(page);
+  await page.locator("#jam-view-library-tab").click();
+
+  await page.locator("#jam-import-spotify").click();
+  await expect(page.locator("#jam-library-status")).toHaveText(model.importError.message);
+  await expect(page.locator("#jam-library-import-card strong")).toHaveText("Bring in your Spotify saves");
+  await expect(page.locator("#jam-library-refresh-spotify")).toBeHidden();
+  await expect(page.locator("#jam-import-spotify")).toBeEnabled();
+});
+
+test("backend Library-scope errors switch Import to reauthorization guidance", async ({ page }) => {
+  await page.setViewportSize({ width: 1366, height: 768 });
+  const model = apiModels.get(page);
+  model.favoriteItems = [];
+  model.importError = {
+    status: 403,
+    error: "spotify_library_scope_required",
+    message: "Spotify Library access is missing. Use Refresh Spotify Access, then try again.",
+  };
+  await openPhaseTwoViewer(page);
+  await openJam(page);
+  await page.locator("#jam-view-library-tab").click();
+
+  await page.locator("#jam-import-spotify").click();
+  await expect(page.locator("#jam-library-status")).toHaveText(model.importError.message);
+  await expect(page.locator("#jam-library-import-card strong")).toHaveText("Spotify Library access required");
+  await expect(page.locator("#jam-library-refresh-spotify")).toHaveText("Grant Spotify Library Access");
+  await expect(page.locator("#jam-import-spotify")).toBeHidden();
 });
 
 test("zero-match kind keeps the selected favorite contributor and truthful empty results", async ({ page }) => {
@@ -1106,29 +2447,330 @@ test("catalog search aborts and rejects stale results", async ({ page }) => {
   await expect(page.locator("#jam-results")).not.toContainText("Stale Result");
 });
 
-test("playlist detail confirms over 25 once and enqueues one locked server batch", async ({ page }) => {
+test("playlist detail preserves cross-page selections and clears only processed positions after a partial batch", async ({ page }) => {
   await page.setViewportSize({ width: 900, height: 700 });
   await openPhaseTwoViewer(page);
   await openJam(page);
   const model = apiModels.get(page);
+  model.selectedPlaylistPartial = true;
+  model.playlistTotal = 130;
+  model.playlist.track_count = 130;
+  await page.locator("#jam-search-playlist-tab").click();
+  await page.locator("#jam-search-input").fill("road trip");
+  await page.locator("#jam-results .jam-inspect-btn").click();
+
+  const first = page.getByRole("checkbox", { name: /Select Playlist Song 1 by Search Artist 1/ });
+  const third = page.getByRole("checkbox", { name: /Select Playlist Song 3 by Search Artist 3/ });
+  await expect(page.locator("#jam-playlist-items .jam-playlist-track-select")).toHaveCount(50);
+  await expect(page.locator("#jam-playlist-selection-count")).toHaveText("0 songs selected");
+  await expect(page.locator("#jam-playlist-add-selected")).toBeDisabled();
+  await first.check();
+  await third.check();
+  await expect(page.locator("#jam-playlist-selection-count")).toHaveText("2 songs selected");
+  await page.locator("#jam-playlist-clear-selection").click();
+  await expect(page.locator("#jam-playlist-selection-count")).toHaveText("0 songs selected");
+  await expect(page.locator("#jam-playlist-clear-selection")).toBeDisabled();
+  await expect(first).not.toBeChecked();
+  await expect(third).not.toBeChecked();
+  await first.check();
+  await third.check();
+
+  await page.locator("#jam-playlist-load-more").click();
+  await expect(page.locator("#jam-playlist-items .jam-playlist-track-select")).toHaveCount(100);
+  await expect(first).toBeChecked();
+  await expect(third).toBeChecked();
+  const fiftyFirst = page.getByRole("checkbox", { name: /Select Playlist Song 51 by/ });
+  await fiftyFirst.check();
+  await expect(page.locator("#jam-playlist-selection-count")).toHaveText("3 songs selected");
+
+  await page.locator("#jam-playlist-add-selected").dblclick();
+  await expect.poll(() => model.counts["POST /api/jam/queue/playlist/selection"] || 0).toBe(1);
+  expect(model.queuePlaylistBodies).toHaveLength(1);
+  expect(model.queuePlaylistBodies[0]).toMatchObject({
+    playlist_id: playlistId,
+    selected_positions: [0, 2, 50],
+    snapshot_id: "snapshot-fixture-1",
+    confirmed: false,
+    generation: 7,
+  });
+  expect(model.queuePlaylistBodies[0].request_id).toBeTruthy();
+  await expect(page.locator("#jam-playlist-status")).toContainText("1 song remains selected");
+  await expect(page.locator("#jam-playlist-selection-count")).toHaveText("1 song selected");
+  await expect(first).not.toBeChecked();
+  await expect(third).not.toBeChecked();
+  await expect(fiftyFirst).toBeChecked();
+
+  await resizeTo(page, { width: 360, height: 640 }, "mini");
+  await page.locator(".jam-playlist-selection").scrollIntoViewIfNeeded();
+  const narrowGeometry = await page.locator(".jam-playlist-selection").evaluate((selection) => {
+    const rect = selection.getBoundingClientRect();
+    const panel = document.getElementById("jam-panel").getBoundingClientRect();
+    return {
+      insidePanel: rect.left >= panel.left - 1 && rect.right <= panel.right + 1,
+      internalOverflow: selection.scrollWidth - selection.clientWidth,
+      viewportOverflow: document.documentElement.scrollWidth - window.innerWidth,
+      actionWidths: Array.from(selection.querySelectorAll("button"), (button) => button.getBoundingClientRect().width),
+    };
+  });
+  expect(narrowGeometry.insidePanel).toBe(true);
+  expect(narrowGeometry.internalOverflow).toBeLessThanOrEqual(1);
+  expect(narrowGeometry.viewportOverflow).toBeLessThanOrEqual(1);
+  expect(narrowGeometry.actionWidths.every((width) => width >= 39.5)).toBe(true);
+});
+
+test("playlist selection stays hidden when the server does not advertise the safe selection endpoint", async ({ page }) => {
+  await page.setViewportSize({ width: 900, height: 700 });
+  await openPhaseTwoViewer(page);
+  const model = apiModels.get(page);
+  model.state.playlist_selection_supported = false;
+  await openJam(page);
+  await page.locator("#jam-search-playlist-tab").click();
+  await page.locator("#jam-search-input").fill("road trip");
+  await page.locator("#jam-results .jam-inspect-btn").click();
+
+  await expect(page.locator(".jam-playlist-selection")).toBeHidden();
+  await expect(page.locator("#jam-playlist-items .jam-playlist-track-choice")).toHaveCount(30);
+  await expect(page.locator("#jam-playlist-items .jam-playlist-track-choice").first()).toBeHidden();
+  await expect(page.locator("#jam-playlist-add-all")).toBeVisible();
+});
+
+test("playlist page snapshot changes discard mixed rows and selections before reloading page one", async ({ page }) => {
+  await page.setViewportSize({ width: 900, height: 700 });
+  await openPhaseTwoViewer(page);
+  await openJam(page);
+  const model = apiModels.get(page);
+  model.playlistSnapshotChangesOnAppend = true;
+  model.playlistTotal = 130;
+  model.playlist.track_count = 130;
+  await page.locator("#jam-search-playlist-tab").click();
+  await page.locator("#jam-search-input").fill("road trip");
+  await page.locator("#jam-results .jam-inspect-btn").click();
+
+  const first = page.getByRole("checkbox", { name: /Select Playlist Song 1 by/ });
+  await first.check();
+  await expect(page.locator("#jam-playlist-selection-count")).toHaveText("1 song selected");
+  await page.locator("#jam-playlist-load-more").click();
+  await expect.poll(() => model.playlistItemOffsets.join(",")).toBe("0,50,0");
+  await expect(page.locator("#jam-playlist-items .jam-catalog-item")).toHaveCount(50);
+  await expect(page.locator("#jam-playlist-selection-count")).toHaveText("0 songs selected");
+  await expect(page.getByRole("checkbox", { name: /Select Playlist Song 1 by/ })).not.toBeChecked();
+  await expect.poll(() => page.evaluate(() => _jamPlaylist && _jamPlaylist.snapshot_id)).toBe("snapshot-fixture-2");
+  expect(model.queuePlaylistBodies).toHaveLength(0);
+});
+
+test("ambiguous selected-playlist retries reuse the request id and do not commit twice", async ({ page }) => {
+  await page.setViewportSize({ width: 900, height: 700 });
+  await openPhaseTwoViewer(page);
+  await openJam(page);
+  const model = apiModels.get(page);
+  model.ambiguousPlaylistQueue = true;
+  await page.locator("#jam-search-playlist-tab").click();
+  await page.locator("#jam-search-input").fill("road trip");
+  await page.locator("#jam-results .jam-inspect-btn").click();
+  await page.getByRole("checkbox", { name: /Select Playlist Song 1 by/ }).check();
+
+  await page.locator("#jam-playlist-add-selected").click();
+  await expect(page.locator("#jam-playlist-status")).toContainText("Could not add the selected songs");
+  await page.locator("#jam-playlist-add-selected").click();
+  await expect.poll(() => model.counts["POST /api/jam/queue/playlist/selection"] || 0).toBe(2);
+  await expect(page.locator("#jam-playlist-selection-count")).toHaveText("0 songs selected");
+  expect(model.queuePlaylistBodies).toHaveLength(2);
+  expect(model.queuePlaylistBodies[1].request_id).toBe(model.queuePlaylistBodies[0].request_id);
+  expect(model.queuePlaylistMutations).toBe(1);
+});
+
+test("playlist request id survives teardown before an in-flight success can be applied", async ({ page }) => {
+  await page.setViewportSize({ width: 900, height: 700 });
+  await openPhaseTwoViewer(page);
+  await openJam(page);
+  const model = apiModels.get(page);
+  model.trackPlaylistQueueMutations = true;
+  model.playlistQueueDelayOnceMs = 300;
+  await page.locator("#jam-search-playlist-tab").click();
+  await page.locator("#jam-search-input").fill("road trip");
+  await page.locator("#jam-results .jam-inspect-btn").click();
+  await page.getByRole("checkbox", { name: /Select Playlist Song 1 by/ }).check();
+
+  await page.locator("#jam-playlist-add-selected").click();
+  await expect.poll(() => model.queuePlaylistBodies.length).toBe(1);
+  const firstRequestId = model.queuePlaylistBodies[0].request_id;
+  await expect.poll(() => page.evaluate((requestId) => {
+    const entries = JSON.parse(sessionStorage.getItem("echo-jam-playlist-ambiguous-v1") || "[]");
+    return entries.some((entry) => Array.isArray(entry) && entry[1] === requestId);
+  }, firstRequestId)).toBe(true);
+
+  // Model the state invalidation caused by a reload/disconnect while keeping
+  // same-origin sessionStorage. The late success must not discard the key.
+  await page.evaluate(() => {
+    _jamPlaylistRequestSeq += 1;
+    invalidateJamPlaylistQueueLifecycle();
+    _jamPlaylistAmbiguousRequests = null;
+  });
+  await page.waitForTimeout(350);
+  await expect.poll(() => page.evaluate((requestId) => {
+    const entries = JSON.parse(sessionStorage.getItem("echo-jam-playlist-ambiguous-v1") || "[]");
+    return entries.some((entry) => Array.isArray(entry) && entry[1] === requestId);
+  }, firstRequestId)).toBe(true);
+
+  await page.locator("#jam-playlist-add-selected").click();
+  await expect.poll(() => model.queuePlaylistBodies.length).toBe(2);
+  await expect(page.locator("#jam-playlist-selection-count")).toHaveText("0 songs selected");
+  expect(model.queuePlaylistBodies[1].request_id).toBe(firstRequestId);
+  expect(model.queuePlaylistMutations).toBe(1);
+});
+
+test("cleanup invalidates an old playlist operation without letting its late finally unlock a new one", async ({ page }) => {
+  await page.setViewportSize({ width: 900, height: 700 });
+  const model = apiModels.get(page);
+  model.playlistTotal = 2;
+  model.playlist.track_count = 2;
+  model.playlistQueueDelays = [1_200, 2_200];
+  await openPhaseTwoViewer(page);
+  await openJam(page);
+  await page.locator("#jam-search-playlist-tab").click();
+  await page.locator("#jam-search-input").fill("road trip");
+  await page.locator("#jam-results .jam-inspect-btn").click();
+  await expect(page.locator("#jam-playlist-items .jam-catalog-item")).toHaveCount(2);
+  await page.getByRole("checkbox", { name: /Select Playlist Song 1 by/ }).check();
+  await page.locator("#jam-playlist-add-selected").click();
+  await expect.poll(() => model.queuePlaylistBodies.length).toBe(1);
+
+  const cleanupControls = await page.evaluate(() => {
+    cleanupJam();
+    return {
+      backDisabled: document.getElementById("jam-playlist-back").disabled,
+      tabsDisabled: Array.from(document.querySelectorAll(".jam-browser-tab"), (tab) => tab.disabled),
+    };
+  });
+  expect(cleanupControls.backDisabled).toBe(false);
+  expect(cleanupControls.tabsDisabled.every((disabled) => disabled === false)).toBe(true);
+
+  await openJam(page);
+  await page.locator("#jam-search-playlist-tab").click();
+  await page.locator("#jam-search-input").fill("");
+  await page.locator("#jam-search-input").fill("road trip");
+  await page.locator("#jam-results .jam-inspect-btn").click();
+  await expect(page.locator("#jam-playlist-items .jam-catalog-item")).toHaveCount(2);
+  await page.getByRole("checkbox", { name: /Select Playlist Song 1 by/ }).check();
+  await page.locator("#jam-playlist-add-selected").click();
+  await expect.poll(() => model.queuePlaylistBodies.length).toBe(2);
+  await expect(page.locator("#jam-playlist-back")).toBeDisabled();
+
+  await expect.poll(() => model.playlistQueueResponses).toBe(1);
+  await page.waitForTimeout(50);
+  await expect(page.locator("#jam-playlist-back")).toBeDisabled();
+  for (const tab of await page.locator(".jam-browser-tab").all()) await expect(tab).toBeDisabled();
+  await expect.poll(() => page.evaluate(() => jamPlaylistQueuePending())).toBe(true);
+
+  await expect.poll(() => model.playlistQueueResponses, { timeout: 3_500 }).toBe(2);
+  await expect(page.locator("#jam-playlist-back")).toBeEnabled();
+  for (const tab of await page.locator(".jam-browser-tab").all()) await expect(tab).toBeEnabled();
+  await expect.poll(() => page.evaluate(() => jamPlaylistQueuePending())).toBe(false);
+});
+
+test("playlist navigation stays locked until a partial batch receipt is applied", async ({ page }) => {
+  await page.setViewportSize({ width: 900, height: 700 });
+  await openPhaseTwoViewer(page);
+  await openJam(page);
+  const model = apiModels.get(page);
+  model.entirePlaylistPartial = true;
+  model.playlistQueueDelayOnceMs = 300;
+  await page.locator("#jam-search-playlist-tab").click();
+  await page.locator("#jam-search-input").fill("road trip");
+  await page.locator("#jam-results .jam-inspect-btn").click();
+
+  page.once("dialog", async (dialog) => { await dialog.accept(); });
+  await page.locator("#jam-playlist-add-all").click();
+  await expect.poll(() => model.queuePlaylistBodies.length).toBe(1);
+  await expect(page.locator("#jam-playlist-back")).toBeDisabled();
+  await expect(page.locator(".jam-browser-tab")).toHaveCount(4);
+  for (const tab of await page.locator(".jam-browser-tab").all()) await expect(tab).toBeDisabled();
+  await page.evaluate(() => closeJamPlaylistDetail());
+  await expect(page.locator("#jam-playlist-detail")).toBeVisible();
+  await expect(page.locator("#jam-playlist-status")).toContainText("Wait for the playlist queue operation");
+
+  await expect(page.locator("#jam-playlist-status")).toContainText("28 songs remain selected");
+  await expect(page.locator("#jam-playlist-back")).toBeEnabled();
+  for (const tab of await page.locator(".jam-browser-tab").all()) await expect(tab).toBeEnabled();
+});
+
+test("interrupted entire-playlist batches resume only the remaining positions", async ({ page }) => {
+  await page.setViewportSize({ width: 900, height: 700 });
+  await openPhaseTwoViewer(page);
+  await openJam(page);
+  const model = apiModels.get(page);
+  model.entirePlaylistPartial = true;
+  await page.locator("#jam-search-playlist-tab").click();
+  await page.locator("#jam-search-input").fill("road trip");
+  await page.locator("#jam-results .jam-inspect-btn").click();
+
+  page.once("dialog", async (dialog) => { await dialog.accept(); });
+  await page.locator("#jam-playlist-add-all").click();
+  await expect(page.locator("#jam-playlist-status")).toContainText("28 songs remain selected");
+  await expect(page.locator("#jam-playlist-add-all")).toHaveText("Add remaining songs");
+  await expect(page.locator("#jam-playlist-selection-count")).toHaveText("28 songs selected");
+
+  page.once("dialog", async (dialog) => {
+    expect(dialog.message()).toContain("28 selected songs");
+    await dialog.accept();
+  });
+  await page.locator("#jam-playlist-add-all").click();
+  await expect.poll(() => model.counts["POST /api/jam/queue/playlist/selection"] || 0).toBe(1);
+  await expect(page.locator("#jam-playlist-selection-count")).toHaveText("0 songs selected");
+  await expect(page.locator("#jam-playlist-add-all")).toHaveText("Add entire playlist");
+  expect(model.queuePlaylistBodies).toHaveLength(2);
+  expect(model.queuePlaylistBodies[0]).not.toHaveProperty("selected_positions");
+  expect(model.queuePlaylistBodies[1].selected_positions).toEqual(Array.from({ length: 28 }, (_, index) => index + 2));
+  expect(model.queuePlaylistBodies[1].request_id).not.toBe(model.queuePlaylistBodies[0].request_id);
+});
+
+test("duplicate playlist occurrences have distinct position-aware checkbox names", async ({ page }) => {
+  await page.setViewportSize({ width: 900, height: 700 });
+  await openPhaseTwoViewer(page);
+  await openJam(page);
+  const model = apiModels.get(page);
+  model.duplicatePlaylistTracks = true;
+  await page.locator("#jam-search-playlist-tab").click();
+  await page.locator("#jam-search-input").fill("road trip");
+  await page.locator("#jam-results .jam-inspect-btn").click();
+
+  await expect(page.getByRole("checkbox", { name: "Select Duplicate Song by Same Artist, playlist position 1", exact: true })).toHaveCount(1);
+  await expect(page.getByRole("checkbox", { name: "Select Duplicate Song by Same Artist, playlist position 2", exact: true })).toHaveCount(1);
+});
+
+test("playlist detail confirms over 25 once and enqueues the entire playlist as one locked server batch", async ({ page }) => {
+  await page.setViewportSize({ width: 900, height: 700 });
+  await openPhaseTwoViewer(page);
+  await openJam(page);
+  const model = apiModels.get(page);
+  model.playlistTotal = 120;
+  model.playlist.track_count = 120;
   await page.locator("#jam-search-playlist-tab").click();
   await page.locator("#jam-search-input").fill("road trip");
   await expect(page.locator("#jam-results .jam-inspect-btn")).toHaveCount(1);
   await page.locator("#jam-results .jam-inspect-btn").click();
-  await expect(page.locator("#jam-playlist-items .jam-catalog-item")).toHaveCount(20);
+  await expect(page.locator("#jam-playlist-items .jam-catalog-item")).toHaveCount(50);
   await expect(page.locator("#jam-playlist-load-more")).toBeVisible();
+  await expect(page.locator("#jam-playlist-add-all")).toHaveText("Add entire playlist");
 
   page.once("dialog", async (dialog) => {
-    expect(dialog.message()).toContain("30 songs");
+    expect(dialog.message()).toContain("120 songs");
     await dialog.accept();
   });
   await page.locator("#jam-playlist-add-all").dblclick();
   await expect.poll(() => model.counts["POST /api/jam/queue/playlist"] || 0).toBe(1);
   expect(model.queuePlaylistBodies).toHaveLength(1);
-  expect(model.queuePlaylistBodies[0]).toMatchObject({ playlist_id: playlistId, confirmed: true, generation: 7 });
+  expect(model.queuePlaylistBodies[0]).toMatchObject({
+    playlist_id: playlistId,
+    snapshot_id: "snapshot-fixture-1",
+    confirmed: true,
+    generation: 7,
+  });
+  expect(model.queuePlaylistBodies[0]).not.toHaveProperty("selected_positions");
   expect(model.queuePlaylistBodies[0].request_id).toBeTruthy();
-  await expect(page.locator("#jam-playlist-status")).toContainText("partially added");
-  await expect(page.locator("#jam-playlist-status")).toContainText("Try again in 12 seconds");
+  await expect(page.locator("#jam-playlist-status")).toContainText("Added 119 songs");
+  await expect(page.locator("#jam-playlist-status")).toContainText("skipped 1 unavailable");
+  await expect(page.locator("#jam-playlist-status")).not.toContainText("partially added");
 });
 
 test("unknown playlist count honors the server confirmation_required contract", async ({ page }) => {
@@ -1157,7 +2799,69 @@ test("unknown playlist count honors the server confirmation_required contract", 
   expect(model.queuePlaylistBodies[1].request_id).toBe(model.queuePlaylistBodies[0].request_id);
 });
 
-test("Spotify development-mode playlist restrictions remain actionable in detail and add-all", async ({ page }) => {
+test("restricted playlists load and document their private cache in 50-song chunks", async ({ page }) => {
+  await page.setViewportSize({ width: 1100, height: 760 });
+  await openPhaseTwoViewer(page);
+  await openJam(page);
+  const model = apiModels.get(page);
+  model.playlistTotal = 268;
+  model.playlist.track_count = 268;
+  model.playlistItemsSource = "local_cache";
+
+  await page.locator("#jam-search-playlist-tab").click();
+  await page.locator("#jam-search-input").fill("hardwave");
+  await page.locator("#jam-results .jam-inspect-btn").click();
+
+  await expect(page.locator("#jam-playlist-items .jam-catalog-item")).toHaveCount(50);
+  await expect(page.locator("#jam-playlist-status")).toContainText("50 of 268 songs are cached privately on Echo in 50-song chunks");
+  await expect(page.locator("#jam-playlist-load-more")).toHaveText("Load next 50 songs");
+
+  await page.locator("#jam-playlist-load-more").click();
+  await expect(page.locator("#jam-playlist-items .jam-catalog-item")).toHaveCount(100);
+  await expect(page.locator("#jam-playlist-status")).toContainText("100 of 268 songs are cached privately on Echo in 50-song chunks");
+
+  for (let pageIndex = 2; pageIndex < 6; pageIndex += 1) {
+    await page.locator("#jam-playlist-load-more").click();
+  }
+  await expect(page.locator("#jam-playlist-items .jam-catalog-item")).toHaveCount(268);
+  await expect(page.locator("#jam-playlist-status")).toContainText("268 of 268 songs are cached privately on Echo in 50-song chunks");
+  await expect(page.locator("#jam-playlist-load-more")).toBeHidden();
+  expect(model.playlistItemOffsets).toEqual([0, 50, 100, 150, 200, 250]);
+});
+
+test("restricted playlists over 1,000 songs stay selectable but cannot bulk queue", async ({ page }) => {
+  await page.setViewportSize({ width: 1100, height: 760 });
+  await openPhaseTwoViewer(page);
+  await openJam(page);
+  const model = apiModels.get(page);
+  model.playlistTotal = 1200;
+  model.playlist.track_count = 1200;
+  model.playlistItemsSource = "local_cache";
+
+  await page.locator("#jam-search-playlist-tab").click();
+  await page.locator("#jam-search-input").fill("large restricted playlist");
+  await page.locator("#jam-results .jam-inspect-btn").click();
+
+  await expect(page.locator("#jam-playlist-items .jam-catalog-item")).toHaveCount(50);
+  await expect(page.locator("#jam-playlist-status")).toContainText(
+    "Echo exposes the first 1000 positions; select a smaller group to queue",
+  );
+  await expect(page.locator("#jam-playlist-add-all")).toBeDisabled();
+  await expect(page.locator("#jam-playlist-add-all")).toHaveAttribute(
+    "title",
+    "Echo can queue at most 1,000 songs at once; select a smaller group",
+  );
+  await expect(page.locator("#jam-playlist-items .jam-playlist-track-select").first()).toBeEnabled();
+
+  for (let pageIndex = 1; pageIndex < 20; pageIndex += 1) {
+    await page.locator("#jam-playlist-load-more").click();
+    await expect(page.locator("#jam-playlist-items .jam-catalog-item")).toHaveCount((pageIndex + 1) * 50);
+  }
+  await expect(page.locator("#jam-playlist-load-more")).toBeHidden();
+  expect(model.playlistItemOffsets).toEqual(Array.from({ length: 20 }, (_, index) => index * 50));
+});
+
+test("a failed bounded public-catalog fallback renders retry guidance without queueing", async ({ page }) => {
   await page.setViewportSize({ width: 900, height: 700 });
   await openPhaseTwoViewer(page);
   await openJam(page);
@@ -1167,14 +2871,87 @@ test("Spotify development-mode playlist restrictions remain actionable in detail
   await page.locator("#jam-search-playlist-tab").click();
   await page.locator("#jam-search-input").fill("restricted playlist");
   await page.locator("#jam-results .jam-inspect-btn").click();
-  const expectedMessage = "only allows this Echo app to expand playlists the connected account owns or collaborates on";
+  const expectedMessage = "Spotify changed its public playlist response";
   await expect(page.locator("#jam-playlist-status")).toContainText(expectedMessage);
   await expect(page.locator("#jam-playlist-status")).not.toContainText("unavailable right now");
+  const blocked = page.locator("#jam-playlist-items .jam-playlist-access-blocked");
+  await expect(blocked).toBeVisible();
+  await expect(page.locator("#jam-playlist-items")).not.toHaveAttribute("role", "list");
+  await expect(blocked).toContainText("Echo couldn't load this playlist's next 50 songs");
+  await expect(blocked).toContainText("bounded public-catalog fallback did not complete");
+  await expect(blocked.getByRole("link", { name: "Open Fixture Road Trip in Spotify", exact: true }))
+    .toHaveAttribute("href", `https://open.spotify.com/playlist/${playlistId}`);
+  await expect(page.locator("#jam-playlist-items .jam-catalog-item")).toHaveCount(0);
+  await expect(page.locator("#jam-playlist-add-all")).toBeDisabled();
+  await expect(page.locator(".jam-playlist-selection")).toBeHidden();
+  await expect(page.locator("#jam-playlist-load-more")).toBeHidden();
 
-  page.once("dialog", async (dialog) => { await dialog.accept(); });
-  await page.locator("#jam-playlist-add-all").click();
-  await expect.poll(() => model.counts["POST /api/jam/queue/playlist"] || 0).toBe(1);
+  await blocked.getByRole("button", { name: "Retry 50-song chunk", exact: true }).click();
+  await expect.poll(() => model.counts[`GET /api/jam/playlists/${playlistId}/items`] || 0).toBe(2);
+  await expect(blocked).toBeVisible();
+
+  await page.evaluate(() => addPlaylistToQueue());
+  await page.waitForTimeout(25);
+  expect(model.counts["POST /api/jam/queue/playlist"] || 0).toBe(0);
   await expect(page.locator("#jam-playlist-status")).toContainText(expectedMessage);
+});
+
+test("pending Skip reconciliation pauses queue mutations while Stop Music and End Jam stay available", async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 720 });
+  const model = apiModels.get(page);
+  model.state.skip_reconciliation_pending = true;
+  model.state.last_error = "PRIVATE RAW SPOTIFY ERROR <script>must not render</script>";
+  await openPhaseTwoViewer(page);
+  await openJam(page);
+
+  const warning = page.locator("#jam-skip-reconciliation-warning");
+  await expect(warning).toBeVisible();
+  await expect(warning).toHaveText(
+    "Echo is confirming the last Skip with Spotify. Skip and queue changes are paused until that check finishes.",
+  );
+  await expect(page.locator("#jam-panel")).not.toContainText("PRIVATE RAW SPOTIFY ERROR");
+  await expect(page.locator("#jam-skip-btn")).toBeDisabled();
+  await expect(page.locator("#jam-stop-music-btn")).toBeEnabled();
+  await expect(page.locator("#jam-end-btn")).toBeEnabled();
+
+  await page.locator("#jam-search-input").fill("reconciliation track");
+  const searchAdd = page.locator("#jam-results .jam-result-add").first();
+  await expect(searchAdd).toBeDisabled();
+  await page.evaluate(async () => { await addToQueue(_jamSearchItems[0]); });
+  expect(model.counts["POST /api/jam/queue"] || 0).toBe(0);
+
+  await page.locator("#jam-view-library-tab").click();
+  await expect(page.locator("#jam-library-list .jam-library-queue-btn").first()).toBeDisabled();
+
+  await page.locator("#jam-view-queue-tab").click();
+  await expect(page.locator('[data-queue-entry-id="queue-entry-3"] .jam-queue-select')).toBeDisabled();
+  await expect(page.locator('[data-queue-entry-id="queue-entry-3"] .jam-queue-remove-one')).toBeDisabled();
+  await expect(page.locator("#jam-queue-remove-selected")).toBeDisabled();
+
+  await page.locator("#jam-view-search-tab").click();
+  await page.locator("#jam-search-playlist-tab").click();
+  await page.locator("#jam-search-input").fill("reconciliation playlist");
+  await page.locator("#jam-results .jam-inspect-btn").click();
+  await expect(page.locator("#jam-playlist-items .jam-playlist-track-select").first()).toBeDisabled();
+  await expect(page.locator("#jam-playlist-add-selected")).toBeDisabled();
+  await expect(page.locator("#jam-playlist-add-all")).toBeDisabled();
+
+  await page.evaluate(async () => { await fetchJamState(); });
+  await expect(warning).toBeVisible();
+
+  model.state.skip_reconciliation_pending = false;
+  await page.evaluate(async () => { await fetchJamState(); });
+
+  await expect(warning).toBeHidden();
+  await expect(warning).toHaveText("");
+  await expect(page.locator("#jam-skip-btn")).toBeEnabled();
+  await expect(page.locator("#jam-stop-music-btn")).toBeEnabled();
+  await expect(page.locator("#jam-end-btn")).toBeEnabled();
+  await expect(page.locator("#jam-playlist-add-all")).toBeEnabled();
+  const firstPlaylistChoice = page.locator("#jam-playlist-items .jam-playlist-track-select").first();
+  await expect(firstPlaylistChoice).toBeEnabled();
+  await firstPlaylistChoice.check();
+  await expect(page.locator("#jam-playlist-add-selected")).toBeEnabled();
 });
 
 test("Stop Music preserves the Jam while exact-host End Jam remains a distinct destructive action", async ({ page }) => {

--- a/core/viewer/app.js
+++ b/core/viewer/app.js
@@ -257,7 +257,6 @@ function syncClubhouseUtilityPresentation() {
     var isV2 = document.documentElement.dataset.uiShell === "v2";
     var mode = document.documentElement.dataset.uiMode;
     var collapsed = shellLayout.classList.contains("utility-collapsed");
-    var overlaysStage = mode === "lounge" || mode === "compact" || mode === "mini";
 
     if (!isV2) {
       if (!collapsed) activeUtilityTool = inferVisibleUtilityTool();
@@ -302,6 +301,8 @@ function syncClubhouseUtilityPresentation() {
       activeUtilityTool = "people";
     }
     activeUtilityTool = normalizeUtilityTool(activeUtilityTool);
+    var overlaysStage = activeUtilityTool === "jam" ||
+      mode === "lounge" || mode === "compact" || mode === "mini";
     shellUtilityHost.dataset.activeTool = activeUtilityTool;
     shellLayout.dataset.activeUtility = activeUtilityTool;
     document.documentElement.dataset.uiUtility = activeUtilityTool;

--- a/core/viewer/clubhouse-shell.css
+++ b/core/viewer/clubhouse-shell.css
@@ -1746,21 +1746,21 @@
   border-radius: var(--club-radius-panel);
 }
 
-/* Portaled Jam follows the same rail / drawer / full-workspace geometry. */
+/* Jam is a feature-dense workspace; People and Chat keep the utility rail. */
 :root[data-ui-shell="v2"] .jam-panel.clubhouse-utility-tool {
   position: fixed;
-  top: var(--club-workspace-top);
-  right: var(--club-safe-right);
-  bottom: var(--club-workspace-bottom);
-  left: auto;
+  top: max(var(--club-workspace-top), calc(50vh - 420px));
+  right: auto;
+  bottom: max(var(--club-workspace-bottom), calc(50vh - 420px));
+  left: 50%;
   z-index: var(--club-layer-utility);
-  width: clamp(320px, 24vw, 360px);
+  width: min(1120px, calc(100vw - var(--club-safe-left) - var(--club-safe-right)));
   height: auto;
   max-height: none;
   margin: 0;
-  padding: 12px;
-  gap: 10px;
-  transform: none;
+  padding: 16px;
+  gap: 12px;
+  transform: translateX(-50%);
   container-type: inline-size;
   overflow: hidden;
   border: 1px solid var(--club-border-strong);
@@ -1772,14 +1772,18 @@
 }
 
 :root[data-ui-shell="v2"][data-ui-mode="lounge"] .jam-panel.clubhouse-utility-tool {
-  width: clamp(320px, 42vw, 380px);
+  width: min(1080px, calc(100vw - var(--club-safe-left) - var(--club-safe-right)));
 }
 
 :root[data-ui-shell="v2"][data-ui-mode="compact"] .jam-panel.clubhouse-utility-tool,
 :root[data-ui-shell="v2"][data-ui-mode="mini"] .jam-panel.clubhouse-utility-tool {
+  top: var(--club-workspace-top);
   right: var(--club-safe-right);
+  bottom: var(--club-workspace-bottom);
   left: var(--club-safe-left);
   width: auto;
+  max-width: none;
+  transform: none;
 }
 
 :root[data-ui-shell="v2"] .jam-panel.clubhouse-utility-tool .jam-header {
@@ -1817,6 +1821,12 @@
   overflow-y: auto;
   overscroll-behavior: contain;
   scroll-padding-top: 58px;
+}
+
+:root[data-ui-shell="v2"] .jam-panel.clubhouse-utility-tool .jam-session-overview {
+  display: contents;
+  min-width: 0;
+  min-height: 0;
 }
 
 :root[data-ui-shell="v2"] .utility-host :where(button, input, textarea, select),
@@ -2017,9 +2027,63 @@
   gap: 8px;
 }
 
+:root[data-ui-shell="v2"][data-ui-very-short] .jam-panel.clubhouse-utility-tool .jam-audio-visualizer {
+  height: 44px;
+  flex-basis: 44px;
+}
+
+:root[data-ui-shell="v2"][data-ui-very-short] .jam-panel.clubhouse-utility-tool .jam-audio-visualizer-chrome {
+  top: 5px;
+}
+
 @container (min-width: 620px) {
   :root[data-ui-shell="v2"] .jam-panel.clubhouse-utility-tool .jam-search-queue-row {
     flex-direction: row;
+  }
+}
+
+@container (min-width: 820px) {
+  :root[data-ui-shell="v2"] .jam-panel.clubhouse-utility-tool .jam-body {
+    display: grid;
+    grid-template-columns: minmax(280px, 340px) minmax(0, 1fr);
+    align-items: stretch;
+    gap: 18px;
+    padding-right: 1px;
+    overflow: hidden;
+  }
+
+  :root[data-ui-shell="v2"] .jam-panel.clubhouse-utility-tool .jam-session-overview,
+  :root[data-ui-shell="v2"] .jam-panel.clubhouse-utility-tool .jam-browser {
+    min-height: 0;
+    overflow-x: hidden;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    scrollbar-gutter: stable;
+  }
+
+  :root[data-ui-shell="v2"] .jam-panel.clubhouse-utility-tool .jam-session-overview {
+    display: flex;
+    padding-right: 6px;
+  }
+
+  :root[data-ui-shell="v2"] .jam-panel.clubhouse-utility-tool .jam-browser {
+    padding: 0 6px 8px 2px;
+    border-top: 0;
+  }
+
+  :root[data-ui-shell="v2"] .jam-panel.clubhouse-utility-tool .jam-browser-tabs {
+    position: sticky;
+    top: 0;
+  }
+}
+
+@container (min-width: 1040px) {
+  :root[data-ui-shell="v2"] .jam-panel.clubhouse-utility-tool .jam-library-section > .jam-filter-grid {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+
+  :root[data-ui-shell="v2"] .jam-panel.clubhouse-utility-tool .jam-history-filters {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 

--- a/core/viewer/index.html
+++ b/core/viewer/index.html
@@ -39,7 +39,7 @@
       })();
     </script>
     <link rel="stylesheet" href="style.css?v=0.6.11.1777930912" />
-    <link rel="stylesheet" href="jam.css?v=0.6.11.1777930912" />
+    <link rel="stylesheet" href="jam.css?v=0.6.34.1785384000" />
     <link rel="stylesheet" href="capture-picker.css?v=0.6.11.1777930912" />
     <link rel="stylesheet" href="clubhouse-shell.css?v=0.6.11.1777930912" />
     <link rel="stylesheet" href="themes.css?v=0.6.11.1777930912" />
@@ -497,6 +497,7 @@
           <button id="close-jam" type="button">Close</button>
         </div>
         <div class="jam-body">
+          <div class="jam-session-overview">
           <div class="jam-spotify-row">
             <span id="jam-spotify-status" class="jam-spotify-status">Not Connected</span>
             <button id="jam-connect-spotify" type="button" class="jam-connect-btn">Connect Spotify</button>
@@ -547,6 +548,13 @@
           <div id="jam-now-playing" class="jam-now-playing">
             <div class="jam-now-playing-empty">No music playing</div>
           </div>
+          <div id="jam-audio-visualizer" class="jam-audio-visualizer" data-state="idle" data-motion="full" data-reactive="false" aria-hidden="true" hidden>
+            <canvas id="jam-audio-visualizer-canvas" aria-hidden="true"></canvas>
+            <div class="jam-audio-visualizer-chrome" aria-hidden="true">
+              <span class="jam-audio-visualizer-title"><span class="jam-audio-visualizer-dot"></span>Echo Pulse</span>
+              <span id="jam-audio-visualizer-status" class="jam-audio-visualizer-status">Join Jam to activate</span>
+            </div>
+          </div>
           <div id="jam-actions-section" class="jam-actions" style="display:none">
             <button id="jam-join-btn" type="button" class="jam-join-btn">Join Jam</button>
             <button id="jam-leave-btn" type="button" class="jam-leave-btn" style="display:none">Leave Jam</button>
@@ -558,6 +566,9 @@
               <input id="jam-volume-slider" type="range" min="0" max="100" value="50" />
               <span id="jam-volume-value" class="jam-volume-value">50%</span>
             </div>
+          </div>
+            <div id="jam-status" class="jam-status" role="status" aria-live="polite"></div>
+            <div id="jam-skip-reconciliation-warning" class="jam-reconciliation-warning" role="status" aria-live="polite" hidden></div>
           </div>
           <section id="jam-browser" class="jam-browser" aria-label="Jam library, search, queue, and history">
             <div class="jam-browser-tabs" role="tablist" aria-label="Jam views">
@@ -572,6 +583,17 @@
             </a>
 
             <div id="jam-library-section" class="jam-browser-panel jam-library-section" role="tabpanel" aria-labelledby="jam-view-library-tab" hidden>
+              <div id="jam-library-import-card" class="jam-library-import-card">
+                <div class="jam-library-import-copy">
+                  <strong>Bring in your Spotify saves</strong>
+                  <p>Copy your Liked Songs and saved playlists into shared Echo Favorites.</p>
+                </div>
+                <div class="jam-library-import-actions">
+                  <button id="jam-library-refresh-spotify" type="button" class="jam-secondary-btn">Refresh Spotify Access</button>
+                  <button id="jam-import-spotify" type="button" class="jam-primary-btn">Copy Spotify saves</button>
+                </div>
+                <small>Copies Liked Songs and saved playlists, not the songs inside playlists. Spotify is unchanged, and nothing is added to the Jam queue.</small>
+              </div>
               <div class="jam-filter-grid">
                 <label class="jam-filter-field">Show
                   <select id="jam-library-kind">
@@ -600,9 +622,8 @@
                   </select>
                 </label>
               </div>
-              <button id="jam-import-spotify" type="button" class="jam-secondary-btn">Import to Echo Favorites</button>
               <div id="jam-library-status" class="jam-view-status" role="status" aria-live="polite"></div>
-              <div id="jam-library-list" class="jam-catalog-list" role="list" aria-label="Echo favorite Spotify items"></div>
+              <div id="jam-library-list" class="jam-catalog-list" aria-label="Echo favorite Spotify items"></div>
               <nav class="jam-pager" aria-label="Echo Favorites pages">
                 <button id="jam-library-prev" type="button" class="jam-secondary-btn">Previous</button>
                 <span id="jam-library-page" class="jam-page-summary">0 items</span>
@@ -618,7 +639,7 @@
               <label class="jam-visually-hidden" for="jam-search-input">Search Spotify</label>
               <input id="jam-search-input" type="search" class="jam-search-input" placeholder="Search for a song..." autocomplete="off" />
               <div id="jam-search-status" class="jam-view-status" role="status" aria-live="polite"></div>
-              <div id="jam-results" class="jam-results" role="list" aria-label="Spotify search results"></div>
+              <div id="jam-results" class="jam-results" aria-label="Spotify search results"></div>
               <nav class="jam-pager" aria-label="Spotify search result pages">
                 <button id="jam-search-prev" type="button" class="jam-secondary-btn">Previous</button>
                 <span id="jam-search-page" class="jam-page-summary">0 results</span>
@@ -631,17 +652,29 @@
               <div id="jam-playlist-summary"></div>
               <div class="jam-detail-actions">
                 <button id="jam-playlist-favorite" type="button" class="jam-secondary-btn" aria-pressed="false">Save to Echo</button>
-                <button id="jam-playlist-add-all" type="button" class="jam-primary-btn">Add all to queue</button>
+                <button id="jam-playlist-add-all" type="button" class="jam-primary-btn">Add entire playlist</button>
+              </div>
+              <div class="jam-playlist-selection" role="group" aria-label="Selected playlist songs">
+                <span id="jam-playlist-selection-count" role="status" aria-live="polite">0 songs selected</span>
+                <button id="jam-playlist-clear-selection" type="button" class="jam-secondary-btn" disabled>Clear selection</button>
+                <button id="jam-playlist-add-selected" type="button" class="jam-primary-btn" aria-describedby="jam-playlist-selection-count" disabled>Add selected to queue</button>
               </div>
               <div id="jam-playlist-status" class="jam-view-status" role="status" aria-live="polite"></div>
-              <div id="jam-playlist-items" class="jam-catalog-list" role="list" aria-label="Playlist songs"></div>
-              <button id="jam-playlist-load-more" type="button" class="jam-secondary-btn jam-load-more" hidden>Load more</button>
+              <div id="jam-playlist-items" class="jam-catalog-list" aria-label="Playlist songs"></div>
+              <button id="jam-playlist-load-more" type="button" class="jam-secondary-btn jam-load-more" hidden>Load next 50 songs</button>
             </div>
 
             <div id="jam-queue-section" class="jam-browser-panel jam-queue-section" role="tabpanel" aria-labelledby="jam-view-queue-tab" hidden>
-              <div class="jam-queue-title">Queue</div>
+              <div class="jam-queue-header">
+                <div class="jam-queue-heading">
+                  <div class="jam-queue-title">Queue</div>
+                  <div id="jam-queue-selection-count" class="jam-queue-selection-count" role="status" aria-live="polite">0 songs selected</div>
+                </div>
+                <button id="jam-queue-remove-selected" type="button" class="jam-secondary-btn jam-queue-remove-selected" aria-describedby="jam-queue-selection-count" disabled>Remove selected</button>
+              </div>
+              <div id="jam-queue-status" class="jam-view-status" role="status" aria-live="polite"></div>
               <div id="jam-queue-list" class="jam-queue-list" role="list" aria-label="Jam queue">
-                <div class="jam-queue-empty">Queue is empty</div>
+                <div class="jam-queue-empty" role="listitem">Queue is empty</div>
               </div>
             </div>
 
@@ -673,7 +706,6 @@
               </nav>
             </div>
           </section>
-          <div id="jam-status" class="jam-status" role="status" aria-live="polite"></div>
         </div>
       </div>
       <!-- Dashboard Panel (visible to all connected users) -->
@@ -761,7 +793,8 @@
     <script src="connect.js?v=0.6.11.1777930912"></script>
     <script src="app.js?v=0.6.11.1777930912"></script>
     <script src="capture-picker.js?v=0.6.11.1777930912"></script>
-    <script src="jam.js?v=0.6.11.1777930912"></script>
+    <script src="jam-visualizer.js?v=0.6.34.1785384000"></script>
+    <script src="jam.js?v=0.6.34.1785384000"></script>
     <script src="changelog.js?v=0.6.11.1777930912"></script>
 
     <!-- Admin login modal (hidden by default; toggled by adminLoginBtn) -->

--- a/core/viewer/jam-catalog.test.js
+++ b/core/viewer/jam-catalog.test.js
@@ -29,6 +29,19 @@ function normalize(raw, expectedKind) {
   return context.result;
 }
 
+function normalizeHistory(raw) {
+  const helpers = section("function jamSafeString(", "function jamNormalizeCatalogItems(");
+  const history = section("function jamDateValue(", "function jamAppendHistoryTime(");
+  const context = {
+    URL,
+    window: { location: { href: "https://echo.test/" } },
+    raw,
+    result: null,
+  };
+  vm.runInNewContext(`${helpers}\n${history}\nresult = jamHistoryEntry(raw);`, context);
+  return context.result;
+}
+
 test("catalog normalization accepts only canonical 22-character Spotify identities", () => {
   const id = "0123456789ABCDEFGHIJKL";
   const item = normalize({
@@ -45,6 +58,13 @@ test("catalog normalization accepts only canonical 22-character Spotify identiti
   assert.equal(item.url, `https://open.spotify.com/playlist/${id}`);
   assert.equal(item.item_count, 37);
   assert.equal(item.favorite_contributor_count, 2);
+  const occurrence = normalize({
+    kind: "track",
+    spotify_id: "1234567890ABCDEFGHIJKL",
+    name: "Repeated Song",
+    playlist_position: 0,
+  }, "track");
+  assert.equal(occurrence.playlist_position, 0, "position zero remains selectable");
   assert.equal(normalize({ kind: "track", spotify_id: "too-short" }, "track"), null);
   assert.equal(normalize({ kind: "track", spotify_url: `https://evil.test/track/${id}` }, "track"), null);
 });
@@ -71,6 +91,25 @@ test("favorite views normalize exact attribution fields defensively", () => {
   assert.doesNotMatch(jamSource, /\\u2665|\\u2661/);
 });
 
+test("history rows normalize every field required by the idempotent track queue path", () => {
+  const item = normalizeHistory({
+    track: {
+      spotify_id: "1234567890ABCDEFGHIJKL",
+      name: "Play It Again",
+    },
+    artist: "Fixture Artist",
+    album_art_url: "https://i.scdn.co/image/history-fixture",
+    duration_ms: 222000,
+    added_by_name: "Sam",
+  });
+
+  assert.equal(item.track.spotify_uri, "spotify:track:1234567890ABCDEFGHIJKL");
+  assert.equal(item.track.name, "Play It Again");
+  assert.equal(item.track.artist, "Fixture Artist");
+  assert.equal(item.track.artwork_url, "https://i.scdn.co/image/history-fixture");
+  assert.equal(item.track.duration_ms, 222000);
+});
+
 test("search uses typed paging with abort and a monotonic stale-response gate", () => {
   const search = section("function onSearchInput(", "function jamFavoriteSummary(");
   assert.match(search, /setTimeout\(function\(\) \{ searchSpotify\(value, 0\); \}, 300\)/);
@@ -91,19 +130,45 @@ test("library omits a blank actor filter and supports import upgrade guidance", 
   assert.match(jamSource, /tracks_seen/);
   assert.match(jamSource, /playlists_seen/);
   assert.match(jamSource, /Refresh Spotify Access/);
+  assert.match(jamSource, /spotify_library_authorized/);
+  assert.match(jamSource, /playlistSelectionSupported/);
+  assert.match(jamSource, /No Echo Favorites yet\. Copy your Spotify saves above/);
+  assert.match(indexSource, /id="jam-library-refresh-spotify"/);
+  assert.match(indexSource, /id="jam-import-spotify"[^>]*>Copy Spotify saves</);
+  assert.match(indexSource, /not the songs inside playlists/);
+  assert.match(indexSource, /Spotify is unchanged, and nothing is added to the Jam queue/);
   assert.match(jamSource, /payload\.retry_after/);
 });
 
-test("playlist enqueue is one batch operation with confirmation and hard-limit guards", () => {
-  const enqueue = section("async function addPlaylistToQueue(", "function jamDateValue(");
-  assert.equal((enqueue.match(/\/api\/jam\/queue\/playlist/g) || []).length, 2, "initial and server-requested confirmation paths use the same batch endpoint");
-  assert.match(enqueue, /trackCount > 50/);
+test("Jam markup separates playback controls from the music browser workspace", () => {
+  const overviewStart = indexSource.indexOf('class="jam-session-overview"');
+  const overviewEnd = indexSource.indexOf("</div>", indexSource.indexOf('id="jam-status"', overviewStart));
+  const browserStart = indexSource.indexOf('id="jam-browser"');
+  assert.notEqual(overviewStart, -1);
+  assert.notEqual(browserStart, -1);
+  assert.ok(overviewEnd < browserStart, "overview and browser are sibling workspace columns");
+});
+
+test("entire and selected playlist enqueue share one provenance-preserving batch operation", () => {
+  const enqueue = section("function jamPlaylistQueueActionContext(", "function jamDateValue(");
+  assert.match(enqueue, /"\/api\/jam\/queue\/playlist\/selection"/);
+  assert.match(enqueue, /"\/api\/jam\/queue\/playlist"/);
   assert.match(enqueue, /trackCount > 25/);
-  assert.match(enqueue, /_jamPlaylistQueuePending/);
+  assert.match(enqueue, /jamBeginPlaylistQueueOperation/);
+  assert.match(enqueue, /jamFinishPlaylistQueueOperation/);
   assert.match(enqueue, /request_id: requestId/);
+  assert.match(enqueue, /snapshot_id: context\.snapshot_id/);
+  assert.match(enqueue, /payload\.selected_positions = context\.selected_positions\.slice\(\)/);
   assert.match(enqueue, /rejection\.error === "confirmation_required"/);
   assert.match(enqueue, /rejection\.playable_count/);
+  assert.match(enqueue, /jamRememberAmbiguousPlaylistRequest/);
+  assert.match(enqueue, /remaining_positions/);
   assert.doesNotMatch(enqueue, /forEach[\s\S]*addToQueue/);
+  assert.doesNotMatch(enqueue, /trackCount > 50/);
+  assert.match(indexSource, /id="jam-playlist-add-all"[^>]*>Add entire playlist</);
+  assert.match(indexSource, /id="jam-playlist-selection-count"[^>]*aria-live="polite"/);
+  assert.match(indexSource, /id="jam-playlist-clear-selection"/);
+  assert.match(indexSource, /id="jam-playlist-add-selected"/);
 });
 
 test("Jam browser markup exposes keyboard tabs and inactive-accessible history", () => {

--- a/core/viewer/jam-session-state.js
+++ b/core/viewer/jam-session-state.js
@@ -172,6 +172,8 @@
     const spotifyConnected = input.spotify_connected === true;
     const spotifyIsPlaying = input.spotify_is_playing === true;
     const playbackStopSupported = input.playback_stop_supported === true;
+    const playlistSelectionSupported = input.playlist_selection_supported === true;
+    const skipReconciliationPending = input.skip_reconciliation_pending === true;
     const sourceError = typeof input.source_error === "string" ? input.source_error.trim() : "";
 
     let sourceTone = "waiting";
@@ -231,6 +233,8 @@
       spotifyConnected,
       spotifyIsPlaying,
       playbackStopSupported,
+      playlistSelectionSupported,
+      skipReconciliationPending,
       sourceEnabled,
       sourceAvailabilityKnown,
       sourceStatus,
@@ -245,7 +249,10 @@
       // New listeners fail closed on stalled PCM. Queue/skip intentionally stay
       // available against the current source so they can recover Spotify playback.
       canJoin: compatible && active && sourceReady,
-      canControl: compatible && active && sourceControlReady,
+      // Spotify may have accepted a Skip even when its response was interrupted.
+      // Freeze all queue-shaping controls until the server reconciles that result,
+      // preventing a second mutation from racing the unknown playback state.
+      canControl: compatible && active && sourceControlReady && !skipReconciliationPending,
       // Stopping Spotify playback does not depend on capture health or a fresh
       // playback observation. Pause is idempotent and exact-device fenced, so
       // keep this emergency control available for the whole active Jam.

--- a/core/viewer/jam-session-state.test.js
+++ b/core/viewer/jam-session-state.test.js
@@ -114,6 +114,21 @@ test("Jam protocol v3 rejects missing and mismatched server contracts", () => {
   assert.match(mismatched.compatibilityMessage, /viewer v3, server v1/);
 });
 
+test("playlist selection requires an explicit server capability", () => {
+  const base = {
+    jam_protocol_version: 3,
+    active: true,
+    source_enabled: true,
+    source_availability_known: true,
+    source_status: "live",
+  };
+  assert.equal(evaluateJamContract(base).playlistSelectionSupported, false);
+  assert.equal(evaluateJamContract({
+    ...base,
+    playlist_selection_supported: true,
+  }).playlistSelectionSupported, true);
+});
+
 test("ready, live, and silent sources are capture-ready for a new Jam", () => {
   for (const source_status of ["ready", "live", "silent"]) {
     const contract = evaluateJamContract({
@@ -260,6 +275,34 @@ test("Stop Music remains available when capture fails but Spotify is playing", (
     });
     assert.equal(contract.canStopPlayback, true, source_status);
   }
+});
+
+test("skip reconciliation pauses queue controls without hiding emergency Jam controls", () => {
+  const base = {
+    jam_protocol_version: 3,
+    spotify_connected: true,
+    playback_stop_supported: true,
+    active: true,
+    source_enabled: true,
+    source_availability_known: true,
+    source_status: "live",
+  };
+
+  const pending = evaluateJamContract({
+    ...base,
+    skip_reconciliation_pending: true,
+  });
+  assert.equal(pending.skipReconciliationPending, true);
+  assert.equal(pending.canControl, false);
+  assert.equal(pending.canStopPlayback, true);
+
+  const resolved = evaluateJamContract({
+    ...base,
+    skip_reconciliation_pending: false,
+  });
+  assert.equal(resolved.skipReconciliationPending, false);
+  assert.equal(resolved.canControl, true);
+  assert.equal(resolved.canStopPlayback, true);
 });
 
 test("Stop Music is capability and generation-state gated, not observation gated", () => {

--- a/core/viewer/jam-visualizer.js
+++ b/core/viewer/jam-visualizer.js
@@ -1,0 +1,560 @@
+(function (root, factory) {
+  if (typeof module === "object" && module.exports) {
+    module.exports = factory();
+  } else {
+    root.EchoJamVisualizer = factory();
+  }
+})(typeof globalThis !== "undefined" ? globalThis : this, function () {
+  "use strict";
+
+  var DEFAULT_BAR_COUNT = 32;
+  var DEFAULT_DPR_CAP = 1.25;
+  var DEFAULT_PIXEL_BUDGET = 180000;
+
+  function clamp(value, minimum, maximum) {
+    return Math.max(minimum, Math.min(maximum, value));
+  }
+
+  function finiteOr(value, fallback) {
+    var number = Number(value);
+    return Number.isFinite(number) ? number : fallback;
+  }
+
+  function normalizeMotionLevel(value) {
+    var motion = String(value || "full").trim().toLowerCase();
+    if (motion === "still" || motion === "reduce" || motion === "reduced") return "still";
+    if (motion === "ambient") return "ambient";
+    return "full";
+  }
+
+  function frameIntervalForMotion(value) {
+    var motion = normalizeMotionLevel(value);
+    if (motion === "still") return Number.POSITIVE_INFINITY;
+    return 1000 / (motion === "ambient" ? 12 : 24);
+  }
+
+  function computeCanvasSize(cssWidth, cssHeight, devicePixelRatio, options) {
+    var config = options || {};
+    var width = Math.max(0, finiteOr(cssWidth, 0));
+    var height = Math.max(0, finiteOr(cssHeight, 0));
+    var dprCap = Math.max(1, finiteOr(config.dprCap, DEFAULT_DPR_CAP));
+    var pixelBudget = Math.max(1, finiteOr(config.pixelBudget, DEFAULT_PIXEL_BUDGET));
+    var scale = clamp(finiteOr(devicePixelRatio, 1), 1, dprCap);
+    var backingWidth = Math.max(0, Math.round(width * scale));
+    var backingHeight = Math.max(0, Math.round(height * scale));
+    var pixels = backingWidth * backingHeight;
+
+    if (pixels > pixelBudget && backingWidth > 0 && backingHeight > 0) {
+      var reduction = Math.sqrt(pixelBudget / pixels);
+      backingWidth = Math.max(1, Math.floor(backingWidth * reduction));
+      backingHeight = Math.max(1, Math.floor(backingHeight * reduction));
+      scale = Math.min(backingWidth / width, backingHeight / height);
+      pixels = backingWidth * backingHeight;
+    }
+
+    return {
+      cssWidth: width,
+      cssHeight: height,
+      width: backingWidth,
+      height: backingHeight,
+      scale: Number.isFinite(scale) && scale > 0 ? scale : 1,
+      pixels: pixels,
+    };
+  }
+
+  function computeLogBandRanges(binCount, barCount) {
+    var bins = Math.max(1, Math.floor(finiteOr(binCount, 1)));
+    var count = clamp(Math.floor(finiteOr(barCount, DEFAULT_BAR_COUNT)), 1, bins);
+    var ranges = [];
+    var highestBin = Math.max(1, bins - 1);
+
+    for (var index = 0; index < count; index += 1) {
+      var startRatio = index / count;
+      var endRatio = (index + 1) / count;
+      var start = Math.floor(1 + Math.pow(startRatio, 2.15) * (highestBin - 1));
+      var end = Math.floor(1 + Math.pow(endRatio, 2.15) * (highestBin - 1));
+      start = clamp(start, 0, bins - 1);
+      end = clamp(Math.max(start + 1, end), 1, bins);
+      ranges.push({ start: start, end: end });
+    }
+    return ranges;
+  }
+
+  function sampleSpectrumBands(frequencyData, ranges, previousLevels, decay) {
+    var data = frequencyData || [];
+    var prior = Array.isArray(previousLevels) ? previousLevels : [];
+    var release = clamp(finiteOr(decay, 0.84), 0, 0.99);
+    return (Array.isArray(ranges) ? ranges : []).map(function (range, index) {
+      var start = clamp(Math.floor(finiteOr(range && range.start, 0)), 0, data.length);
+      var end = clamp(Math.floor(finiteOr(range && range.end, start + 1)), start + 1, data.length);
+      var energy = 0;
+      var samples = 0;
+      for (var bin = start; bin < end; bin += 1) {
+        var normalized = clamp(finiteOr(data[bin], 0) / 255, 0, 1);
+        energy += normalized * normalized;
+        samples += 1;
+      }
+      var level = samples ? Math.sqrt(energy / samples) : 0;
+      level = clamp(Math.pow(level, 0.82) * 1.08, 0, 1);
+      var previous = clamp(finiteOr(prior[index], 0), 0, 1);
+      return Math.max(level, previous * release);
+    });
+  }
+
+  function computeSpectrumBars(levels, cssWidth, cssHeight) {
+    var values = Array.isArray(levels) && levels.length ? levels : [0];
+    var width = Math.max(0, finiteOr(cssWidth, 0));
+    var height = Math.max(0, finiteOr(cssHeight, 0));
+    var cellWidth = values.length ? width / values.length : width;
+    var barWidth = Math.max(1, cellWidth * 0.58);
+    var horizon = height * 0.66;
+    var maxHeight = Math.max(0, height * 0.48);
+
+    return values.map(function (value, index) {
+      var level = clamp(finiteOr(value, 0), 0, 1);
+      var barHeight = Math.max(height > 0 ? 1 : 0, Math.pow(level, 1.08) * maxHeight);
+      return {
+        x: index * cellWidth + (cellWidth - barWidth) / 2,
+        width: barWidth,
+        top: horizon - barHeight,
+        height: barHeight,
+        reflectionTop: horizon + 2,
+        reflectionHeight: Math.min(Math.max(0, height - horizon - 3), barHeight * 0.34),
+        level: level,
+      };
+    });
+  }
+
+  function resolveVisualizerState(input) {
+    var state = input && typeof input === "object" ? input : {};
+    if (state.playing !== true) return "idle";
+    if (state.streamReady !== true) return state.streamConnecting === true ? "connecting" : "waiting";
+    if (state.analyserAvailable !== true || state.analysisFailed === true) return "unavailable";
+    if (String(state.contextState || "") !== "running") return "connecting";
+    if (normalizeMotionLevel(state.motion) === "still") return "still";
+    return "live";
+  }
+
+  function createAnalysisGraph(audioContext) {
+    var analyser = null;
+    var sink = null;
+    var destroyed = false;
+
+    function disconnect(node) {
+      if (!node || typeof node.disconnect !== "function") return;
+      try { node.disconnect(); } catch (_error) {}
+    }
+
+    function destroy() {
+      if (destroyed) return;
+      destroyed = true;
+      disconnect(analyser);
+      disconnect(sink);
+    }
+
+    try {
+      if (!audioContext || typeof audioContext.createAnalyser !== "function" ||
+          typeof audioContext.createGain !== "function" || !audioContext.destination) {
+        return { available: false, analyser: null, sink: null, destroy: destroy };
+      }
+      analyser = audioContext.createAnalyser();
+      sink = audioContext.createGain();
+      analyser.fftSize = 512;
+      analyser.smoothingTimeConstant = 0.72;
+      analyser.minDecibels = -92;
+      analyser.maxDecibels = -20;
+      sink.gain.value = 0;
+      analyser.connect(sink);
+      sink.connect(audioContext.destination);
+      return { available: true, analyser: analyser, sink: sink, destroy: destroy };
+    } catch (_error) {
+      destroy();
+      analyser = null;
+      sink = null;
+      return { available: false, analyser: null, sink: null, destroy: function () {} };
+    }
+  }
+
+  function connectSource(source, playbackGain, analyser) {
+    if (!source || typeof source.connect !== "function") {
+      throw new Error("Jam audio source is unavailable");
+    }
+    source.connect(playbackGain);
+    if (!analyser) return false;
+    try {
+      source.connect(analyser);
+      return true;
+    } catch (_error) {
+      return false;
+    }
+  }
+
+  function createJamVisualizerController(options) {
+    var config = options || {};
+    var windowRef = config.window || (typeof window !== "undefined" ? window : null);
+    var documentRef = config.document || (windowRef && windowRef.document) || null;
+    var rootElement = config.root || (documentRef && documentRef.getElementById("jam-audio-visualizer"));
+    var canvas = config.canvas || (documentRef && documentRef.getElementById("jam-audio-visualizer-canvas"));
+    var statusElement = config.status || (documentRef && documentRef.getElementById("jam-audio-visualizer-status"));
+    var requestFrame = config.requestAnimationFrame || (windowRef && windowRef.requestAnimationFrame && windowRef.requestAnimationFrame.bind(windowRef));
+    var cancelFrame = config.cancelAnimationFrame || (windowRef && windowRef.cancelAnimationFrame && windowRef.cancelAnimationFrame.bind(windowRef));
+    var context = null;
+    if (canvas && typeof canvas.getContext === "function") {
+      try { context = canvas.getContext("2d"); } catch (_contextError) {}
+    }
+    var analyser = null;
+    var audioContext = null;
+    var failedAnalyser = null;
+    var playing = false;
+    var streamReady = false;
+    var streamConnecting = false;
+    var frameId = null;
+    var lastDrawAt = Number.NEGATIVE_INFINITY;
+    var frequencyData = null;
+    var timeData = null;
+    var bandRanges = null;
+    var levels = [];
+    var currentState = "idle";
+    var currentMotion = "full";
+    var destroyed = false;
+    var drawCount = 0;
+    var resizeObserver = null;
+    var motionObserver = null;
+
+    function readMotion() {
+      if (typeof config.getMotionLevel === "function") return normalizeMotionLevel(config.getMotionLevel());
+      var value = documentRef && documentRef.documentElement && documentRef.documentElement.dataset
+        ? documentRef.documentElement.dataset.themeMotionEffective
+        : "full";
+      return normalizeMotionLevel(value);
+    }
+
+    function surfaceVisible() {
+      if (!rootElement || !canvas || !context || destroyed) return false;
+      if (documentRef && documentRef.hidden) return false;
+      if (typeof config.isVisible === "function") return config.isVisible() === true;
+      var panel = documentRef && documentRef.getElementById("jam-panel");
+      if (panel && (panel.hidden || (panel.classList && panel.classList.contains("hidden")) || panel.inert)) return false;
+      var rect = typeof rootElement.getBoundingClientRect === "function"
+        ? rootElement.getBoundingClientRect()
+        : { width: rootElement.clientWidth, height: rootElement.clientHeight };
+      return finiteOr(rect && rect.width, 0) > 0 && finiteOr(rect && rect.height, 0) > 0;
+    }
+
+    function cancelScheduledFrame() {
+      if (frameId === null) return;
+      if (cancelFrame) cancelFrame(frameId);
+      frameId = null;
+    }
+
+    function ensureCanvasSize() {
+      if (!rootElement || !canvas || !context) return null;
+      var rect = typeof rootElement.getBoundingClientRect === "function"
+        ? rootElement.getBoundingClientRect()
+        : { width: rootElement.clientWidth, height: rootElement.clientHeight };
+      var size = computeCanvasSize(
+        rect && rect.width,
+        rect && rect.height,
+        windowRef && windowRef.devicePixelRatio,
+        { dprCap: config.dprCap, pixelBudget: config.pixelBudget }
+      );
+      if (!size.width || !size.height) return null;
+      if (canvas.width !== size.width) canvas.width = size.width;
+      if (canvas.height !== size.height) canvas.height = size.height;
+      canvas.dataset.backingPixels = String(size.pixels);
+      if (typeof context.setTransform === "function") context.setTransform(size.scale, 0, 0, size.scale, 0, 0);
+      return size;
+    }
+
+    function palette() {
+      var styles = windowRef && typeof windowRef.getComputedStyle === "function" && rootElement
+        ? windowRef.getComputedStyle(rootElement)
+        : null;
+      function color(name, fallback) {
+        var value = styles && styles.getPropertyValue ? styles.getPropertyValue(name).trim() : "";
+        return value || fallback;
+      }
+      return {
+        low: color("--jam-pulse-low", "#4cc38a"),
+        middle: color("--jam-pulse-mid", "#57b1ff"),
+        high: color("--jam-pulse-high", "#c0a7ff"),
+        trace: color("--jam-pulse-trace", "#d9fff0"),
+      };
+    }
+
+    function restingLevels() {
+      var pattern = [0.08, 0.13, 0.2, 0.12, 0.27, 0.18, 0.34, 0.23, 0.17, 0.3, 0.22, 0.15, 0.25, 0.19, 0.12, 0.08];
+      return Array.from({ length: DEFAULT_BAR_COUNT }, function (_unused, index) {
+        return pattern[index % pattern.length];
+      });
+    }
+
+    function drawSpectrum(values, waveform, reactive) {
+      var size = ensureCanvasSize();
+      if (!size || !context) return false;
+      var width = size.cssWidth;
+      var height = size.cssHeight;
+      var colors = palette();
+      var bars = computeSpectrumBars(values, width, height);
+      context.clearRect(0, 0, width, height);
+
+      context.save();
+      context.lineWidth = 1;
+      context.strokeStyle = "rgba(190, 230, 218, 0.075)";
+      for (var grid = 1; grid < 4; grid += 1) {
+        var gridY = Math.round((height / 4) * grid) + 0.5;
+        context.beginPath();
+        context.moveTo(0, gridY);
+        context.lineTo(width, gridY);
+        context.stroke();
+      }
+
+      var gradient = context.createLinearGradient(0, height, 0, 0);
+      gradient.addColorStop(0, colors.low);
+      gradient.addColorStop(0.58, colors.middle);
+      gradient.addColorStop(1, colors.high);
+      context.fillStyle = gradient;
+      context.shadowColor = colors.middle;
+      context.shadowBlur = reactive ? 7 : 0;
+
+      bars.forEach(function (bar) {
+        context.globalAlpha = reactive ? 0.3 + bar.level * 0.7 : 0.22;
+        context.fillRect(bar.x, bar.top, bar.width, bar.height);
+        context.globalAlpha = reactive ? 0.08 + bar.level * 0.22 : 0.06;
+        context.fillRect(bar.x, bar.reflectionTop, bar.width, bar.reflectionHeight);
+      });
+
+      if (waveform && waveform.length) {
+        context.globalAlpha = reactive ? 0.5 : 0.2;
+        context.shadowBlur = reactive ? 5 : 0;
+        context.shadowColor = colors.trace;
+        context.strokeStyle = colors.trace;
+        context.lineWidth = 1.1;
+        context.beginPath();
+        var center = height * 0.66;
+        var amplitude = height * 0.13;
+        for (var point = 0; point < waveform.length; point += 1) {
+          var x = waveform.length <= 1 ? 0 : (point / (waveform.length - 1)) * width;
+          var y = center + ((finiteOr(waveform[point], 128) - 128) / 128) * amplitude;
+          if (point === 0) context.moveTo(x, y);
+          else context.lineTo(x, y);
+        }
+        context.stroke();
+      }
+      context.restore();
+      drawCount += 1;
+      return true;
+    }
+
+    function drawRestingFrame() {
+      if (!surfaceVisible()) return false;
+      var values = restingLevels();
+      var waveform = null;
+      if (currentState === "still" && analyser && failedAnalyser !== analyser) {
+        try {
+          var bins = Math.max(1, analyser.frequencyBinCount || 256);
+          var sampled = new Uint8Array(bins);
+          analyser.getByteFrequencyData(sampled);
+          values = sampleSpectrumBands(sampled, computeLogBandRanges(bins, DEFAULT_BAR_COUNT), [], 0);
+        } catch (_error) {
+          failedAnalyser = analyser;
+        }
+      }
+      return drawSpectrum(values, waveform, false);
+    }
+
+    function sampleAnalyser() {
+      if (!analyser || failedAnalyser === analyser) return false;
+      try {
+        var bins = Math.max(1, analyser.frequencyBinCount || 256);
+        if (!frequencyData || frequencyData.length !== bins) {
+          frequencyData = new Uint8Array(bins);
+          bandRanges = computeLogBandRanges(bins, DEFAULT_BAR_COUNT);
+          levels = [];
+        }
+        var timeBins = Math.max(2, analyser.fftSize || bins * 2);
+        if (!timeData || timeData.length !== timeBins) timeData = new Uint8Array(timeBins);
+        analyser.getByteFrequencyData(frequencyData);
+        if (typeof analyser.getByteTimeDomainData === "function") analyser.getByteTimeDomainData(timeData);
+        levels = sampleSpectrumBands(frequencyData, bandRanges, levels, currentMotion === "ambient" ? 0.78 : 0.84);
+        return drawSpectrum(levels, timeData, true);
+      } catch (_error) {
+        failedAnalyser = analyser;
+        return false;
+      }
+    }
+
+    function scheduleFrame() {
+      if (frameId !== null || destroyed || !requestFrame || currentState === "idle" || !surfaceVisible()) return;
+      frameId = requestFrame(drawFrame);
+    }
+
+    function drawFrame(timestamp) {
+      frameId = null;
+      if (destroyed || currentState === "idle" || !surfaceVisible()) return;
+      if (currentState !== "live") {
+        drawRestingFrame();
+        return;
+      }
+      currentMotion = readMotion();
+      if (currentMotion === "still") {
+        applyState();
+        return;
+      }
+      var interval = frameIntervalForMotion(currentMotion);
+      if (!Number.isFinite(lastDrawAt) || timestamp - lastDrawAt >= interval - 0.5) {
+        if (!sampleAnalyser()) {
+          applyState();
+          return;
+        }
+        lastDrawAt = timestamp;
+      }
+      scheduleFrame();
+    }
+
+    function stateCopy(state) {
+      if (state === "live") return currentMotion === "ambient" ? "LIVE \u00b7 LOW MOTION" : "LIVE";
+      if (state === "still") return "MOTION OFF";
+      if (state === "connecting") return "SYNCING AUDIO";
+      if (state === "unavailable") return "STATIC MODE";
+      return "JOIN JAM TO ACTIVATE";
+    }
+
+    function applyState() {
+      if (destroyed) return;
+      currentMotion = readMotion();
+      currentState = resolveVisualizerState({
+        playing: playing,
+        streamReady: streamReady,
+        streamConnecting: streamConnecting,
+        analyserAvailable: !!analyser,
+        analysisFailed: failedAnalyser === analyser && !!analyser,
+        contextState: audioContext && audioContext.state,
+        motion: currentMotion,
+      });
+      if (rootElement) {
+        rootElement.hidden = currentState === "idle";
+        rootElement.dataset.state = currentState;
+        rootElement.dataset.motion = currentMotion;
+        rootElement.dataset.reactive = String(currentState === "live");
+      }
+      if (statusElement) statusElement.textContent = stateCopy(currentState);
+      cancelScheduledFrame();
+      lastDrawAt = Number.NEGATIVE_INFINITY;
+      if (currentState === "live") scheduleFrame();
+      else if (currentState !== "idle") drawRestingFrame();
+      else if (canvas && context) context.clearRect(0, 0, canvas.width || 0, canvas.height || 0);
+    }
+
+    function update(next) {
+      if (destroyed) return;
+      var input = next && typeof next === "object" ? next : {};
+      if (Object.prototype.hasOwnProperty.call(input, "playing")) playing = input.playing === true;
+      if (Object.prototype.hasOwnProperty.call(input, "streamReady")) streamReady = input.streamReady === true;
+      if (Object.prototype.hasOwnProperty.call(input, "streamConnecting")) streamConnecting = input.streamConnecting === true;
+      if (Object.prototype.hasOwnProperty.call(input, "analyser") && input.analyser !== analyser) {
+        analyser = input.analyser || null;
+        failedAnalyser = null;
+        frequencyData = null;
+        timeData = null;
+        bandRanges = null;
+        levels = [];
+      }
+      if (Object.prototype.hasOwnProperty.call(input, "audioContext")) audioContext = input.audioContext || null;
+      applyState();
+    }
+
+    function pause() {
+      cancelScheduledFrame();
+      lastDrawAt = Number.NEGATIVE_INFINITY;
+    }
+
+    function handleVisibilityChange() {
+      if (documentRef && documentRef.hidden) pause();
+      else applyState();
+    }
+
+    function handleResize() {
+      scheduleFrame();
+    }
+
+    function installObservers() {
+      if (documentRef && typeof documentRef.addEventListener === "function") {
+        documentRef.addEventListener("visibilitychange", handleVisibilityChange);
+      }
+      var ResizeObserverCtor = config.ResizeObserver || (windowRef && windowRef.ResizeObserver);
+      if (ResizeObserverCtor && rootElement) {
+        resizeObserver = new ResizeObserverCtor(handleResize);
+        resizeObserver.observe(rootElement);
+      }
+      var MutationObserverCtor = config.MutationObserver || (windowRef && windowRef.MutationObserver);
+      if (MutationObserverCtor && documentRef && documentRef.documentElement) {
+        motionObserver = new MutationObserverCtor(applyState);
+        motionObserver.observe(documentRef.documentElement, {
+          attributes: true,
+          attributeFilter: ["data-theme-motion-effective"],
+        });
+        var panel = documentRef.getElementById && documentRef.getElementById("jam-panel");
+        if (panel) {
+          motionObserver.observe(panel, {
+            attributes: true,
+            attributeFilter: ["hidden", "class", "inert", "aria-hidden"],
+          });
+        }
+      }
+    }
+
+    function destroy() {
+      if (destroyed) return;
+      destroyed = true;
+      cancelScheduledFrame();
+      if (resizeObserver) resizeObserver.disconnect();
+      if (motionObserver) motionObserver.disconnect();
+      if (documentRef && typeof documentRef.removeEventListener === "function") {
+        documentRef.removeEventListener("visibilitychange", handleVisibilityChange);
+      }
+      resizeObserver = null;
+      motionObserver = null;
+      analyser = null;
+      audioContext = null;
+      frequencyData = null;
+      timeData = null;
+      bandRanges = null;
+      levels = [];
+    }
+
+    function snapshot() {
+      return {
+        state: currentState,
+        motion: currentMotion,
+        frameScheduled: frameId !== null,
+        drawCount: drawCount,
+        backingPixels: canvas && canvas.dataset ? Number(canvas.dataset.backingPixels || 0) : 0,
+        destroyed: destroyed,
+      };
+    }
+
+    installObservers();
+    applyState();
+    return Object.freeze({
+      update: update,
+      refresh: applyState,
+      pause: pause,
+      destroy: destroy,
+      snapshot: snapshot,
+    });
+  }
+
+  return Object.freeze({
+    DEFAULT_BAR_COUNT: DEFAULT_BAR_COUNT,
+    computeCanvasSize: computeCanvasSize,
+    computeLogBandRanges: computeLogBandRanges,
+    sampleSpectrumBands: sampleSpectrumBands,
+    computeSpectrumBars: computeSpectrumBars,
+    resolveVisualizerState: resolveVisualizerState,
+    frameIntervalForMotion: frameIntervalForMotion,
+    createAnalysisGraph: createAnalysisGraph,
+    connectSource: connectSource,
+    createJamVisualizerController: createJamVisualizerController,
+  });
+});

--- a/core/viewer/jam-visualizer.test.js
+++ b/core/viewer/jam-visualizer.test.js
@@ -1,0 +1,292 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const {
+  computeCanvasSize,
+  computeLogBandRanges,
+  sampleSpectrumBands,
+  computeSpectrumBars,
+  resolveVisualizerState,
+  frameIntervalForMotion,
+  createAnalysisGraph,
+  connectSource,
+  createJamVisualizerController,
+} = require("./jam-visualizer.js");
+
+test("canvas and spectrum geometry stay finite and inside their budgets", () => {
+  const ordinary = computeCanvasSize(340, 64, 2, { dprCap: 1.25, pixelBudget: 180000 });
+  assert.equal(ordinary.width, 425);
+  assert.equal(ordinary.height, 80);
+  assert.equal(ordinary.pixels, 34000);
+
+  const extreme = computeCanvasSize(7680, 4320, 4, { dprCap: 1.25, pixelBudget: 180000 });
+  assert.ok(extreme.width > 0);
+  assert.ok(extreme.height > 0);
+  assert.ok(extreme.pixels <= 180000);
+
+  const ranges = computeLogBandRanges(256, 32);
+  assert.equal(ranges.length, 32);
+  for (const range of ranges) {
+    assert.ok(Number.isInteger(range.start));
+    assert.ok(Number.isInteger(range.end));
+    assert.ok(range.start >= 0);
+    assert.ok(range.end > range.start);
+    assert.ok(range.end <= 256);
+  }
+
+  const silence = new Uint8Array(256);
+  const energy = new Uint8Array(256).fill(220);
+  const silentLevels = sampleSpectrumBands(silence, ranges, [], 0.84);
+  const energeticLevels = sampleSpectrumBands(energy, ranges, [], 0.84);
+  assert.ok(energeticLevels.every((level, index) => level > silentLevels[index]));
+
+  const bars = computeSpectrumBars(energeticLevels, 340, 64);
+  assert.equal(bars.length, 32);
+  for (const bar of bars) {
+    for (const value of [bar.x, bar.width, bar.top, bar.height, bar.reflectionTop, bar.reflectionHeight]) {
+      assert.ok(Number.isFinite(value));
+      assert.ok(value >= 0);
+    }
+    assert.ok(bar.x + bar.width <= 340.001);
+    assert.ok(bar.top + bar.height <= 64.001);
+    assert.ok(bar.reflectionTop + bar.reflectionHeight <= 64.001);
+  }
+});
+
+test("visualizer state distinguishes real audio, connection, fallback, and reduced motion", () => {
+  const base = {
+    playing: true,
+    streamReady: true,
+    analyserAvailable: true,
+    contextState: "running",
+    motion: "full",
+  };
+  assert.equal(resolveVisualizerState(base), "live");
+  assert.equal(resolveVisualizerState({ ...base, motion: "ambient" }), "live");
+  assert.equal(resolveVisualizerState({ ...base, motion: "still" }), "still");
+  assert.equal(resolveVisualizerState({ ...base, streamReady: false, streamConnecting: true }), "connecting");
+  assert.equal(resolveVisualizerState({ ...base, streamReady: false, streamConnecting: false }), "waiting");
+  assert.equal(resolveVisualizerState({ ...base, analyserAvailable: false }), "unavailable");
+  assert.equal(resolveVisualizerState({ ...base, contextState: "suspended" }), "connecting");
+  assert.equal(resolveVisualizerState({ ...base, playing: false }), "idle");
+  assert.equal(frameIntervalForMotion("full"), 1000 / 24);
+  assert.equal(frameIntervalForMotion("ambient"), 1000 / 12);
+  assert.equal(frameIntervalForMotion("still"), Number.POSITIVE_INFINITY);
+});
+
+test("analysis is a muted optional branch and cannot replace Jam playback", () => {
+  const destination = { name: "destination" };
+  const connections = [];
+  let analyserDisconnected = 0;
+  let sinkDisconnected = 0;
+  const analyser = {
+    connect(target) { connections.push(["analyser", target]); },
+    disconnect() { analyserDisconnected += 1; },
+  };
+  const sink = {
+    gain: { value: 1 },
+    connect(target) { connections.push(["sink", target]); },
+    disconnect() { sinkDisconnected += 1; },
+  };
+  const graph = createAnalysisGraph({
+    destination,
+    createAnalyser() { return analyser; },
+    createGain() { return sink; },
+  });
+
+  assert.equal(graph.available, true);
+  assert.equal(sink.gain.value, 0);
+  assert.equal(analyser.fftSize, 512);
+  assert.deepEqual(connections, [["analyser", sink], ["sink", destination]]);
+
+  const playbackGain = { name: "playback" };
+  const sourceConnections = [];
+  const source = { connect(target) { sourceConnections.push(target); } };
+  assert.equal(connectSource(source, playbackGain, analyser), true);
+  assert.deepEqual(sourceConnections, [playbackGain, analyser]);
+
+  graph.destroy();
+  graph.destroy();
+  assert.equal(analyserDisconnected, 1);
+  assert.equal(sinkDisconnected, 1);
+
+  const fallback = createAnalysisGraph({
+    destination,
+    createAnalyser() { throw new Error("unsupported"); },
+    createGain() { throw new Error("must not matter"); },
+  });
+  assert.equal(fallback.available, false);
+
+  const failingSourceConnections = [];
+  const failingSource = {
+    connect(target) {
+      failingSourceConnections.push(target);
+      if (target === analyser) throw new Error("analysis branch failed");
+    },
+  };
+  assert.equal(connectSource(failingSource, playbackGain, analyser), false);
+  assert.equal(failingSourceConnections[0], playbackGain);
+});
+
+function createControllerHarness() {
+  const callbacks = new Map();
+  let nextFrameId = 1;
+  let resizeCallback = null;
+  let mutationCallback = null;
+  const listeners = new Map();
+  const root = {
+    hidden: false,
+    dataset: {},
+    clientWidth: 340,
+    clientHeight: 64,
+    getBoundingClientRect() { return { width: 340, height: 64 }; },
+  };
+  const canvasContext = {
+    setTransform() {},
+    clearRect() {},
+    save() {},
+    restore() {},
+    beginPath() {},
+    moveTo() {},
+    lineTo() {},
+    stroke() {},
+    fillRect() {},
+    createLinearGradient() { return { addColorStop() {} }; },
+  };
+  const canvas = {
+    width: 0,
+    height: 0,
+    dataset: {},
+    style: {},
+    getContext() { return canvasContext; },
+  };
+  const status = { textContent: "" };
+  const panel = {
+    hidden: false,
+    inert: false,
+    classList: { contains() { return false; } },
+  };
+  const documentElement = { dataset: { themeMotionEffective: "full" } };
+  const document = {
+    hidden: false,
+    documentElement,
+    getElementById(id) {
+      return {
+        "jam-audio-visualizer": root,
+        "jam-audio-visualizer-canvas": canvas,
+        "jam-audio-visualizer-status": status,
+        "jam-panel": panel,
+      }[id] || null;
+    },
+    addEventListener(name, listener) { listeners.set(name, listener); },
+    removeEventListener(name) { listeners.delete(name); },
+  };
+  const window = {
+    document,
+    devicePixelRatio: 2,
+    requestAnimationFrame(callback) {
+      const id = nextFrameId++;
+      callbacks.set(id, callback);
+      return id;
+    },
+    cancelAnimationFrame(id) { callbacks.delete(id); },
+    getComputedStyle() { return { getPropertyValue() { return ""; } }; },
+    ResizeObserver: class {
+      constructor(callback) { resizeCallback = callback; }
+      observe() {}
+      disconnect() { resizeCallback = null; }
+    },
+    MutationObserver: class {
+      constructor(callback) { mutationCallback = callback; }
+      observe() {}
+      disconnect() { mutationCallback = null; }
+    },
+  };
+  const controller = createJamVisualizerController({ window, document, root, canvas, status });
+  return {
+    controller,
+    root,
+    canvas,
+    status,
+    panel,
+    document,
+    documentElement,
+    callbacks,
+    triggerResize() { if (resizeCallback) resizeCallback([]); },
+    triggerMutation() { if (mutationCallback) mutationCallback([]); },
+    step(timestamp) {
+      const pending = Array.from(callbacks.entries());
+      callbacks.clear();
+      for (const [, callback] of pending) callback(timestamp);
+    },
+  };
+}
+
+test("controller owns one capped loop and stops for still, hidden, idle, and destroy", () => {
+  const harness = createControllerHarness();
+  const analyser = {
+    frequencyBinCount: 256,
+    fftSize: 512,
+    getByteFrequencyData(target) {
+      for (let index = 0; index < target.length; index += 1) target[index] = (index * 17) % 255;
+    },
+    getByteTimeDomainData(target) {
+      for (let index = 0; index < target.length; index += 1) target[index] = 128 + Math.round(Math.sin(index / 8) * 48);
+    },
+  };
+  const audioContext = { state: "running" };
+
+  harness.controller.update({
+    playing: true,
+    streamReady: true,
+    streamConnecting: false,
+    analyser,
+    audioContext,
+  });
+  harness.controller.update({ playing: true, analyser, audioContext });
+  assert.equal(harness.controller.snapshot().state, "live");
+  assert.equal(harness.callbacks.size, 1);
+  assert.equal(harness.root.hidden, false);
+  assert.equal(harness.root.dataset.reactive, "true");
+
+  for (let frame = 0; frame <= 120; frame += 1) harness.step((frame * 1000) / 120);
+  const active = harness.controller.snapshot();
+  assert.ok(active.drawCount >= 23 && active.drawCount <= 25, `draw count was ${active.drawCount}`);
+  assert.equal(harness.callbacks.size, 1);
+  assert.ok(active.backingPixels > 0 && active.backingPixels <= 180000);
+
+  harness.panel.inert = true;
+  harness.triggerMutation();
+  assert.equal(harness.callbacks.size, 0);
+  harness.panel.inert = false;
+  harness.triggerMutation();
+  assert.equal(harness.callbacks.size, 1);
+
+  harness.documentElement.dataset.themeMotionEffective = "still";
+  harness.controller.refresh();
+  const still = harness.controller.snapshot();
+  assert.equal(still.state, "still");
+  assert.equal(still.frameScheduled, false);
+  assert.equal(harness.root.dataset.reactive, "false");
+  assert.equal(harness.callbacks.size, 0);
+  for (let resize = 0; resize < 20; resize += 1) harness.triggerResize();
+  assert.equal(harness.callbacks.size, 1);
+  harness.step(1100);
+  assert.equal(harness.callbacks.size, 0);
+
+  harness.document.hidden = true;
+  harness.controller.refresh();
+  assert.equal(harness.callbacks.size, 0);
+  harness.document.hidden = false;
+  harness.documentElement.dataset.themeMotionEffective = "full";
+  harness.controller.refresh();
+  assert.equal(harness.callbacks.size, 1);
+
+  harness.controller.update({ playing: false });
+  assert.equal(harness.controller.snapshot().state, "idle");
+  assert.equal(harness.root.hidden, true);
+  assert.equal(harness.callbacks.size, 0);
+
+  harness.controller.destroy();
+  assert.equal(harness.controller.snapshot().destroyed, true);
+  assert.equal(harness.callbacks.size, 0);
+});

--- a/core/viewer/jam.css
+++ b/core/viewer/jam.css
@@ -56,6 +56,13 @@
   padding-right: 4px;
 }
 
+.jam-session-overview {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 14px;
+}
+
 .jam-body::-webkit-scrollbar {
   width: 5px;
 }
@@ -458,6 +465,121 @@
   padding: 8px 0;
 }
 
+/* --- Echo Pulse audio visualizer --- */
+.jam-audio-visualizer {
+  --jam-pulse-low: #4cc38a;
+  --jam-pulse-mid: #57b1ff;
+  --jam-pulse-high: #c0a7ff;
+  --jam-pulse-trace: #d9fff0;
+  position: relative;
+  width: 100%;
+  min-width: 0;
+  height: 64px;
+  flex: 0 0 64px;
+  overflow: hidden;
+  border: 1px solid rgba(76, 195, 138, 0.24);
+  border-radius: var(--radius);
+  background:
+    radial-gradient(circle at 18% 115%, rgba(76, 195, 138, 0.17), transparent 46%),
+    radial-gradient(circle at 84% -25%, rgba(87, 177, 255, 0.14), transparent 48%),
+    linear-gradient(180deg, rgba(5, 12, 18, 0.9), rgba(8, 15, 23, 0.72));
+  box-shadow: inset 0 1px rgba(255, 255, 255, 0.025);
+  isolation: isolate;
+}
+
+.jam-audio-visualizer[hidden] {
+  display: none !important;
+}
+
+.jam-audio-visualizer::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  pointer-events: none;
+  background:
+    linear-gradient(90deg, rgba(4, 9, 14, 0.38), transparent 13%, transparent 87%, rgba(4, 9, 14, 0.38)),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.025), transparent 36%, rgba(0, 0, 0, 0.14));
+}
+
+.jam-audio-visualizer canvas {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+.jam-audio-visualizer-chrome {
+  position: absolute;
+  top: 7px;
+  right: 9px;
+  left: 9px;
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  color: rgba(218, 234, 228, 0.66);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.11em;
+  line-height: 1;
+  text-transform: uppercase;
+  pointer-events: none;
+}
+
+.jam-audio-visualizer-title,
+.jam-audio-visualizer-status {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.jam-audio-visualizer-title {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  color: rgba(232, 255, 246, 0.82);
+}
+
+.jam-audio-visualizer-status {
+  color: rgba(169, 197, 187, 0.58);
+  text-align: right;
+}
+
+.jam-audio-visualizer-dot {
+  width: 5px;
+  height: 5px;
+  flex: 0 0 5px;
+  border-radius: 50%;
+  background: rgba(148, 163, 184, 0.52);
+  box-shadow: 0 0 0 2px rgba(148, 163, 184, 0.08);
+}
+
+.jam-audio-visualizer[data-state="live"] {
+  border-color: rgba(76, 195, 138, 0.38);
+  box-shadow: inset 0 1px rgba(255, 255, 255, 0.035), 0 0 22px rgba(76, 195, 138, 0.055);
+}
+
+.jam-audio-visualizer[data-state="live"] .jam-audio-visualizer-dot {
+  background: var(--jam-pulse-low);
+  box-shadow: 0 0 8px rgba(76, 195, 138, 0.72), 0 0 0 2px rgba(76, 195, 138, 0.12);
+}
+
+.jam-audio-visualizer[data-state="connecting"] .jam-audio-visualizer-dot {
+  background: var(--jam-pulse-mid);
+  box-shadow: 0 0 7px rgba(87, 177, 255, 0.52), 0 0 0 2px rgba(87, 177, 255, 0.1);
+}
+
+.jam-audio-visualizer[data-state="still"] .jam-audio-visualizer-dot,
+.jam-audio-visualizer[data-state="unavailable"] .jam-audio-visualizer-dot {
+  background: var(--jam-pulse-high);
+  box-shadow: 0 0 6px rgba(192, 167, 255, 0.4), 0 0 0 2px rgba(192, 167, 255, 0.09);
+}
+
 /* --- Progress Bar --- */
 .jam-progress {
   width: 100%;
@@ -700,11 +822,45 @@
   color: var(--text);
 }
 
+.jam-queue-header,
+.jam-queue-heading {
+  display: flex;
+  min-width: 0;
+}
+
+.jam-queue-header {
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.jam-queue-heading {
+  flex-direction: column;
+  gap: 2px;
+}
+
+.jam-queue-selection-count {
+  color: var(--muted);
+  font-size: 11px;
+}
+
+.jam-queue-remove-selected,
+.jam-queue-remove-one {
+  border-color: rgba(251, 113, 133, 0.45);
+  color: #fda4af;
+}
+
+.jam-queue-remove-selected:not(:disabled):hover,
+.jam-queue-remove-one:not(:disabled):hover {
+  border-color: rgba(251, 113, 133, 0.85);
+  background: rgba(244, 63, 94, 0.12);
+}
+
 .jam-queue-list {
   display: flex;
   flex-direction: column;
   gap: 4px;
-  max-height: 160px;
+  max-height: min(52vh, 520px);
   overflow-y: auto;
 }
 
@@ -719,11 +875,52 @@
 
 .jam-queue-item {
   display: flex;
+  min-width: 0;
   align-items: center;
   gap: 10px;
   padding: 8px;
   border-radius: var(--radius-sm);
   background: rgba(148, 163, 184, 0.04);
+}
+
+.jam-queue-item-locked {
+  background: rgba(148, 163, 184, 0.025);
+}
+
+.jam-queue-choice {
+  display: grid;
+  place-items: center;
+  flex: 0 0 22px;
+  width: 22px;
+  height: 32px;
+}
+
+.jam-queue-select {
+  width: 18px;
+  height: 18px;
+  min-height: 18px;
+  margin: 0;
+  accent-color: var(--accent);
+  cursor: pointer;
+}
+
+.jam-queue-lock-icon {
+  color: rgba(148, 163, 184, 0.55);
+  font-size: 22px;
+  line-height: 1;
+}
+
+.jam-queue-lock-reason {
+  margin-top: 3px;
+  color: var(--muted);
+  font-size: 11px;
+  line-height: 1.35;
+  white-space: normal;
+}
+
+.jam-queue-remove-one {
+  flex: 0 0 auto;
+  padding-inline: 10px;
 }
 
 .jam-queue-empty {
@@ -858,6 +1055,67 @@
   gap: 9px;
 }
 
+.jam-library-import-card {
+  display: grid;
+  gap: 9px;
+  padding: 12px;
+  border: 1px solid rgba(29, 185, 84, 0.28);
+  border-radius: var(--radius);
+  background: rgba(29, 185, 84, 0.055);
+}
+
+.jam-library-import-card.compact {
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 4px 12px;
+  padding: 9px 10px;
+  background: rgba(29, 185, 84, 0.035);
+}
+
+.jam-library-import-card.compact .jam-library-import-copy,
+.jam-library-import-card.compact > small {
+  grid-column: 1;
+}
+
+.jam-library-import-card.compact .jam-library-import-actions {
+  grid-column: 2;
+  grid-row: 1 / span 2;
+  min-width: 188px;
+}
+
+.jam-library-import-card.compact .jam-library-import-actions button {
+  white-space: nowrap;
+}
+
+.jam-library-import-card.needs-access {
+  border-color: rgba(245, 158, 11, 0.55);
+  background: rgba(245, 158, 11, 0.08);
+}
+
+.jam-library-import-copy {
+  display: grid;
+  gap: 4px;
+}
+
+.jam-library-import-copy strong {
+  color: var(--text);
+  font-size: 13px;
+}
+
+.jam-library-import-copy p,
+.jam-library-import-card > small {
+  margin: 0;
+  color: var(--muted);
+  font-size: 11px;
+  line-height: 1.45;
+}
+
+.jam-library-import-actions {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 7px;
+}
+
 .jam-filter-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -917,6 +1175,16 @@
   overscroll-behavior: contain;
 }
 
+.jam-library-empty {
+  padding: 24px 16px;
+  color: var(--muted);
+  border: 1px dashed rgba(148, 163, 184, 0.2);
+  border-radius: var(--radius-sm);
+  font-size: 12px;
+  line-height: 1.45;
+  text-align: center;
+}
+
 .jam-catalog-item,
 .jam-history-item {
   border: 1px solid transparent;
@@ -932,7 +1200,15 @@
   display: flex;
   flex: 0 0 auto;
   align-items: center;
+  justify-content: flex-end;
   gap: 5px;
+}
+
+.jam-card-actions .jam-spotify-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  white-space: nowrap;
 }
 
 .jam-favorite-btn {
@@ -947,6 +1223,10 @@
 .jam-inspect-btn {
   min-width: 52px;
   padding-inline: 8px;
+}
+
+.jam-library-queue-btn {
+  white-space: nowrap;
 }
 
 .jam-favorite-summary,
@@ -1063,12 +1343,102 @@
   gap: 7px;
 }
 
+.jam-playlist-selection {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: 7px;
+  padding: 7px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: rgba(148, 163, 184, 0.035);
+}
+
+.jam-playlist-selection[hidden],
+.jam-playlist-track-choice[hidden] {
+  display: none;
+}
+
+.jam-playlist-access-blocked {
+  display: grid;
+  gap: 8px;
+  padding: 16px;
+  color: var(--text);
+  border: 1px solid rgba(245, 158, 11, 0.42);
+  border-radius: var(--radius-sm);
+  background: rgba(245, 158, 11, 0.08);
+}
+
+.jam-playlist-access-blocked strong {
+  font-size: 13px;
+  line-height: 1.35;
+}
+
+.jam-playlist-access-blocked p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 11px;
+  line-height: 1.5;
+}
+
+.jam-playlist-access-blocked .jam-spotify-action,
+.jam-playlist-access-blocked .jam-secondary-btn {
+  justify-self: start;
+}
+
+#jam-playlist-selection-count {
+  min-width: 0;
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1.35;
+}
+
+.jam-playlist-track-choice {
+  display: inline-flex;
+  width: 40px;
+  height: 40px;
+  flex: 0 0 40px;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+}
+
+.jam-playlist-track-choice:hover {
+  background: rgba(56, 189, 248, 0.09);
+}
+
+.jam-playlist-track-choice:has(input:disabled) {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.jam-playlist-track-select {
+  width: 18px;
+  height: 18px;
+  min-height: 18px;
+  margin: 0;
+  accent-color: var(--accent);
+  cursor: pointer;
+}
+
 .jam-load-more {
   width: 100%;
 }
 
 .jam-history-list {
   list-style: none;
+}
+
+.jam-history-empty {
+  padding: 18px 14px;
+  color: var(--muted);
+  border: 1px dashed rgba(148, 163, 184, 0.2);
+  border-radius: var(--radius-sm);
+  font-size: 12px;
+  line-height: 1.5;
+  text-align: center;
 }
 
 .jam-history-item {
@@ -1082,6 +1452,12 @@
 .jam-history-content {
   min-width: 0;
   flex: 1;
+}
+
+.jam-history-queue-btn {
+  align-self: center;
+  flex: 0 0 auto;
+  white-space: nowrap;
 }
 
 .jam-history-playlist .jam-spotify-link,
@@ -1102,6 +1478,20 @@
 }
 
 @media (max-width: 580px) {
+  .jam-library-import-card.compact {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .jam-library-import-card.compact .jam-library-import-actions {
+    grid-column: 1;
+    grid-row: auto;
+    min-width: 0;
+  }
+
+  .jam-library-import-card.compact .jam-library-import-actions button {
+    white-space: normal;
+  }
+
   .jam-browser-tab {
     padding-inline: 4px;
     font-size: 11px;
@@ -1110,6 +1500,60 @@
   .jam-catalog-item {
     gap: 7px;
     padding-inline: 5px;
+  }
+
+  .jam-catalog-item-with-explicit-actions {
+    flex-wrap: wrap;
+  }
+
+  .jam-catalog-item-with-explicit-actions .jam-card-actions {
+    width: 100%;
+  }
+
+  .jam-playlist-selection {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  #jam-playlist-selection-count {
+    grid-column: 1 / -1;
+  }
+
+  .jam-queue-header {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .jam-queue-remove-selected {
+    width: 100%;
+  }
+
+  .jam-queue-item {
+    align-items: flex-start;
+    flex-wrap: wrap;
+    padding-inline: 5px;
+  }
+
+  .jam-queue-item > .jam-result-info {
+    flex: 1 1 calc(100% - 82px);
+  }
+
+  .jam-queue-remove-one {
+    flex: 1 0 100%;
+    width: 100%;
+  }
+
+  .jam-history-item {
+    align-items: flex-start;
+    flex-wrap: wrap;
+  }
+
+  .jam-history-content {
+    flex: 1 1 calc(100% - 58px);
+  }
+
+  .jam-history-queue-btn {
+    width: 100%;
+    flex: 1 0 100%;
   }
 }
 
@@ -1120,6 +1564,26 @@
 
   .jam-favorite-btn {
     width: 44px;
+    flex-basis: 44px;
+  }
+
+  .jam-playlist-track-choice {
+    width: 44px;
+    height: 44px;
+    flex-basis: 44px;
+  }
+
+  .jam-browser .jam-playlist-track-select {
+    min-height: 18px;
+  }
+
+  .jam-browser .jam-queue-select {
+    min-height: 18px;
+  }
+
+  .jam-browser .jam-queue-choice {
+    width: 44px;
+    height: 44px;
     flex-basis: 44px;
   }
 }
@@ -1133,6 +1597,20 @@
 
 .jam-status.error {
   color: #ef4444;
+}
+
+.jam-reconciliation-warning {
+  padding: 9px 10px;
+  border: 1px solid rgba(251, 191, 36, 0.42);
+  border-radius: 8px;
+  background: rgba(120, 53, 15, 0.22);
+  color: #fbbf24;
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.jam-reconciliation-warning[hidden] {
+  display: none;
 }
 
 /* --- Toast Notification --- */

--- a/core/viewer/jam.js
+++ b/core/viewer/jam.js
@@ -17,6 +17,10 @@ var _bannerPollTimer = null;  // lightweight poll for now-playing banner (runs e
 var _jamAudioWs = null;        // WebSocket connection
 var _jamAudioCtx = null;       // AudioContext for playback
 var _jamGainNode = null;       // GainNode for volume control
+var _jamAudioAnalysisGraph = null; // Muted pre-gain branch for Echo Pulse
+var _jamAudioStreamReady = false;
+var _jamAudioVisualizerController = null;
+var _jamAudioVisualizerDisabled = false;
 var _jamNextPlayTime = 0;      // next scheduled buffer start time
 var _jamReconnectTimer = null;
 var _jamRejoinPromise = null;
@@ -43,6 +47,76 @@ var _jamStateRequestGate = (window.EchoJamSessionState && window.EchoJamSessionS
 var _jamSessionState = (window.EchoJamSessionState && window.EchoJamSessionState.createJamSessionState)
   ? window.EchoJamSessionState.createJamSessionState({ reconnectBaseMs: 500, reconnectMaxMs: 8000 })
   : null;
+
+function ensureJamAudioVisualizer() {
+  if (_jamAudioVisualizerDisabled) return null;
+  if (_jamAudioVisualizerController) return _jamAudioVisualizerController;
+  if (!window.EchoJamVisualizer || typeof window.EchoJamVisualizer.createJamVisualizerController !== "function") {
+    return null;
+  }
+  try {
+    _jamAudioVisualizerController = window.EchoJamVisualizer.createJamVisualizerController();
+  } catch (error) {
+    disableJamAudioVisualizer(error);
+  }
+  return _jamAudioVisualizerController;
+}
+
+function disableJamAudioVisualizer(error) {
+  _jamAudioVisualizerDisabled = true;
+  if (_jamAudioVisualizerController && typeof _jamAudioVisualizerController.destroy === "function") {
+    try { _jamAudioVisualizerController.destroy(); } catch (_destroyError) {}
+  }
+  _jamAudioVisualizerController = null;
+  var surface = document.getElementById("jam-audio-visualizer");
+  if (surface) surface.hidden = true;
+  if (typeof debugLog === "function") {
+    debugLog("[jam] Echo Pulse disabled: " + ((error && error.message) || "visualizer failure"));
+  }
+}
+
+function syncJamAudioVisualizer(nowPlaying) {
+  if (_jamAudioVisualizerDisabled) return;
+  if (!_jamInited && !_jamAudioVisualizerController) return;
+  try {
+    var controller = ensureJamAudioVisualizer();
+    if (!controller) return;
+    var current = nowPlaying === undefined
+      ? (_jamState && _jamState.now_playing)
+      : nowPlaying;
+    controller.update({
+      playing: !!(current && current.name && current.is_playing),
+      streamReady: _jamAudioStreamReady,
+      streamConnecting: !!_jamAudioWs || !!_jamReconnectTimer || !!_jamRejoinPromise,
+      analyser: _jamAudioAnalysisGraph && _jamAudioAnalysisGraph.available
+        ? _jamAudioAnalysisGraph.analyser
+        : null,
+      audioContext: _jamAudioCtx,
+    });
+  } catch (error) {
+    disableJamAudioVisualizer(error);
+  }
+}
+
+function pauseJamAudioVisualizer() {
+  if (_jamAudioVisualizerController && typeof _jamAudioVisualizerController.pause === "function") {
+    try { _jamAudioVisualizerController.pause(); } catch (error) { disableJamAudioVisualizer(error); }
+  }
+}
+
+function destroyJamAudioVisualizer() {
+  if (_jamAudioVisualizerController && typeof _jamAudioVisualizerController.destroy === "function") {
+    try { _jamAudioVisualizerController.destroy(); } catch (_error) {}
+  }
+  _jamAudioVisualizerController = null;
+}
+
+function destroyJamAudioAnalysisGraph() {
+  if (_jamAudioAnalysisGraph && typeof _jamAudioAnalysisGraph.destroy === "function") {
+    try { _jamAudioAnalysisGraph.destroy(); } catch (_error) {}
+  }
+  _jamAudioAnalysisGraph = null;
+}
 
 function jamActorHeaders(participantToken) {
   return {
@@ -304,6 +378,8 @@ function evaluateJamServerContract(state) {
     spotifyConnected: false,
     spotifyIsPlaying: false,
     playbackStopSupported: false,
+    playlistSelectionSupported: false,
+    skipReconciliationPending: false,
     sourceEnabled: false,
     sourceAvailabilityKnown: false,
     sourceStatus: "unknown",
@@ -346,6 +422,15 @@ function ensureJamSourceStatusElement() {
 
 function renderJamContractStatus() {
   var contract = _jamContract || evaluateJamServerContract(null);
+  var reconciliationWarning = document.getElementById("jam-skip-reconciliation-warning");
+  if (reconciliationWarning) {
+    var reconciliationPending = contract.skipReconciliationPending === true;
+    reconciliationWarning.hidden = !reconciliationPending;
+    reconciliationWarning.textContent = reconciliationPending
+      ? "Echo is confirming the last Skip with Spotify. Skip and queue changes are paused until that check finishes."
+      : "";
+  }
+
   var el = ensureJamSourceStatusElement();
   if (!el) return;
 
@@ -415,6 +500,7 @@ function jamActionAllowed(action) {
 function applyJamContractToControls() {
   var contract = _jamContract || evaluateJamServerContract(null);
   var connectBtn = document.getElementById("jam-connect-spotify");
+  var libraryRefreshBtn = document.getElementById("jam-library-refresh-spotify");
   var startBtn = document.getElementById("jam-start-btn");
   var stopBtn = document.getElementById("jam-stop-music-btn");
   var endBtn = document.getElementById("jam-end-btn");
@@ -422,8 +508,11 @@ function applyJamContractToControls() {
   var searchInput = document.getElementById("jam-search-input");
   var importBtn = document.getElementById("jam-import-spotify");
   var playlistAddBtn = document.getElementById("jam-playlist-add-all");
+  var playlistAddSelectedBtn = document.getElementById("jam-playlist-add-selected");
 
+  var libraryAccess = jamSpotifyLibraryAccessState();
   if (connectBtn) connectBtn.disabled = !contract.compatible;
+  if (libraryRefreshBtn) libraryRefreshBtn.disabled = _jamImportPending || !contract.compatible;
   if (startBtn) {
     startBtn.disabled = !contract.canStart;
     startBtn.title = contract.canStart
@@ -454,13 +543,86 @@ function applyJamContractToControls() {
   }
   if (skipBtn) skipBtn.disabled = !contract.canControl || !contract.active;
   if (searchInput) searchInput.disabled = !contract.compatible || !contract.spotifyConnected;
-  if (importBtn) importBtn.disabled = _jamImportPending || !contract.compatible || !contract.spotifyConnected;
-  if (playlistAddBtn) playlistAddBtn.disabled = _jamPlaylistQueuePending || !contract.canControl;
-  document.querySelectorAll(".jam-result-add").forEach(function(button) {
-    button.disabled = !contract.canControl;
+  if (importBtn) {
+    importBtn.disabled = _jamImportPending || !contract.compatible ||
+      !contract.spotifyConnected || libraryAccess === "required";
+    importBtn.title = libraryAccess === "required"
+      ? "Grant Spotify Library access before copying your saves"
+      : _jamLibraryKnownEmpty === true
+        ? "Copy your Spotify Liked Songs and saved playlists into Echo Favorites"
+        : "Check Spotify for newly liked songs and saved playlists";
+  }
+  if (playlistAddBtn) playlistAddBtn.disabled = jamPlaylistQueuePending() || _jamPlaylistLoading ||
+    !!_jamPlaylistAccessError || !contract.canControl;
+  if (playlistAddSelectedBtn) playlistAddSelectedBtn.disabled = true;
+  document.querySelectorAll(".jam-result-add, .jam-library-queue-btn, .jam-history-queue-btn").forEach(function(button) {
+    button.disabled = jamTrackQueuePending() || !contract.canControl;
+  });
+  document.querySelectorAll(".jam-history-queue-btn").forEach(function(button) {
+    var description = jamHistoryQueueActionTitle(contract);
+    button.title = description;
+    button.setAttribute("aria-description", description);
   });
 
+  renderJamLibrarySetup();
+  renderJamPlaylistSelectionControls();
+  renderJamQueueRemovalControls((_jamState && _jamState.queue) || []);
+  syncJamQueueInteractiveState();
+
   syncJamButtonsFromState();
+}
+
+function jamSpotifyLibraryAccessState() {
+  if (!_jamState || _jamState.spotify_connected !== true) return "disconnected";
+  if (_jamState.spotify_library_authorized === true) return "authorized";
+  if (_jamState.spotify_library_authorized === false) return "required";
+  return "unknown";
+}
+
+function renderJamLibrarySetup() {
+  var card = document.getElementById("jam-library-import-card");
+  var refresh = document.getElementById("jam-library-refresh-spotify");
+  var importButton = document.getElementById("jam-import-spotify");
+  var copy = card && card.querySelector(".jam-library-import-copy");
+  var title = copy && copy.querySelector("strong");
+  var description = copy && copy.querySelector("p");
+  var access = jamSpotifyLibraryAccessState();
+  if (!card || !refresh || !importButton || !title || !description) return;
+
+  var firstUse = access === "authorized" && _jamLibraryKnownEmpty === true;
+  var compact = access === "authorized" && !firstUse;
+
+  card.classList.toggle("needs-access", access === "required");
+  card.classList.toggle("first-use", firstUse);
+  card.classList.toggle("compact", compact);
+  refresh.hidden = access === "authorized";
+  importButton.hidden = access !== "authorized";
+  importButton.classList.toggle("jam-primary-btn", firstUse);
+  importButton.classList.toggle("jam-secondary-btn", !firstUse);
+  refresh.textContent = access === "disconnected"
+    ? "Connect Spotify"
+    : access === "required"
+      ? "Grant Spotify Library Access"
+      : "Refresh Spotify Access";
+
+  if (access === "required") {
+    title.textContent = "Spotify Library access required";
+    description.textContent = "Grant read access to copy your Liked Songs and saved playlists into shared Echo Favorites.";
+  } else if (access === "disconnected") {
+    title.textContent = "Connect your Spotify Library";
+    description.textContent = "Connect Spotify to copy your Liked Songs and saved playlists into shared Echo Favorites.";
+  } else if (firstUse) {
+    title.textContent = "Bring in your Spotify saves";
+    description.textContent = "Copy your Liked Songs and saved playlists into shared Echo Favorites.";
+    importButton.textContent = "Copy Spotify saves";
+  } else if (access === "authorized") {
+    title.textContent = "Spotify saves";
+    description.textContent = "Already saved more music in Spotify? Copy the new items into Echo Favorites.";
+    importButton.textContent = "Check for new Spotify saves";
+  } else {
+    title.textContent = "Refresh Spotify Library access";
+    description.textContent = "Refresh Spotify access before copying your Liked Songs and saved playlists into shared Echo Favorites.";
+  }
 }
 
 function stopJamForCompatibilityFailure() {
@@ -625,6 +787,7 @@ function openJamPanel(opener) {
       window.EchoClubhouseUtility.open("jam", opener || document.activeElement);
     if (!handledByClubhouse) panel.classList.remove("hidden");
     initJam();
+    syncJamAudioVisualizer();
   }
 }
 
@@ -634,6 +797,7 @@ function closeJamPanel(options) {
   var handledByClubhouse = window.EchoClubhouseUtility &&
     window.EchoClubhouseUtility.close("jam", options);
   if (!handledByClubhouse) panel.classList.add("hidden");
+  pauseJamAudioVisualizer();
 }
 
 // ──────────────────────────────────────────
@@ -735,8 +899,7 @@ async function connectSpotify() {
           setTimeout(function() { showJamStatus(""); }, 3000);
           fetchJamState();
         } else {
-          var tokenErr = await tokenResp.text();
-          showJamError("Token exchange failed: " + tokenErr);
+          showJamError(await jamApiErrorMessage(tokenResp, "connect Spotify"));
         }
       } catch (e) {
         debugLog("[jam] spotify poll error: " + e);
@@ -923,8 +1086,11 @@ async function skipTrack() {
 
 var JAM_CATALOG_PAGE_SIZE = 10;
 var JAM_LIBRARY_PAGE_SIZE = 20;
-var JAM_PLAYLIST_PAGE_SIZE = 20;
+var JAM_PLAYLIST_PAGE_SIZE = 50;
+var JAM_PLAYLIST_MAX_QUEUE_TRACKS = 1000;
 var JAM_HISTORY_PAGE_SIZE = 20;
+var JAM_PLAYLIST_AMBIGUOUS_STORAGE_KEY = "echo-jam-playlist-ambiguous-v1";
+var JAM_TRACK_AMBIGUOUS_STORAGE_KEY = "echo-jam-track-ambiguous-v1";
 var _searchTimer = null;
 var _jamActiveView = "search";
 var _jamSearchKind = "track";
@@ -940,12 +1106,14 @@ var _jamLibraryTotal = 0;
 var _jamLibraryNextOffset = null;
 var _jamLibraryItems = [];
 var _jamLibraryLoaded = false;
+var _jamLibraryKnownEmpty = null;
 var _jamLibraryController = null;
 var _jamLibraryRequestSeq = 0;
 var _jamHistoryOffset = 0;
 var _jamHistoryTotal = 0;
 var _jamHistoryNextOffset = null;
 var _jamHistoryLoaded = false;
+var _jamHistoryLoadedRevision = null;
 var _jamHistoryController = null;
 var _jamHistoryRequestSeq = 0;
 var _jamPlaylist = null;
@@ -955,11 +1123,25 @@ var _jamPlaylistTotal = 0;
 var _jamPlaylistController = null;
 var _jamPlaylistRequestSeq = 0;
 var _jamPlaylistLoading = false;
-var _jamPlaylistQueuePending = false;
+var _jamPlaylistQueueEpoch = 0;
+var _jamPlaylistQueueOperation = null;
+var _jamPlaylistAccessError = null;
+var _jamPlaylistFailedOffset = 0;
+var _jamPlaylistCacheTruncated = false;
+var _jamPlaylistCachePositionLimit = JAM_PLAYLIST_MAX_QUEUE_TRACKS;
+var _jamPlaylistSelectedPositions = new Set();
+var _jamPlaylistResumeRequired = false;
+var _jamPlaylistAmbiguousRequests = null;
 var _jamPlaylistReturnView = "search";
 var _jamPlaylistOpener = null;
 var _jamFavoritePending = Object.create(null);
 var _jamImportPending = false;
+var _jamTrackQueueEpoch = 0;
+var _jamTrackQueueOperation = null;
+var _jamTrackAmbiguousRequests = null;
+var _jamQueueSelectedEntryIds = new Set();
+var _jamQueueRemovalPending = false;
+var _jamQueueRenderKey = null;
 
 function jamSafeString(value) {
   return typeof value === "string" ? value.trim() : "";
@@ -1083,6 +1265,7 @@ function normalizeSpotifyCatalogItem(raw, expectedKind) {
     album_art_url: jamSafeArtworkUrl(artwork),
     duration_ms: jamSafeInteger(raw.duration_ms, 0),
     item_count: jamSafeOptionalInteger(raw.item_count !== undefined ? raw.item_count : (raw.track_count !== undefined ? raw.track_count : raw.total_tracks)),
+    playlist_position: jamSafeOptionalInteger(raw.playlist_position),
     snapshot_id: jamSafeString(raw.snapshot_id),
     attributions: attributions,
     contributor_count: contributorCount,
@@ -1123,7 +1306,9 @@ async function jamApiErrorMessage(response, action) {
   var serverMessage = jamSafeString(payload.message || (payload.error && payload.error.message)).slice(0, 240);
   if (response.status === 401) return "Your Echo session expired. Sign in again.";
   if (response.status === 403) {
-    if (action === "import Spotify favorites") return "Spotify access needs refreshing. Use Refresh Spotify Access, then import again.";
+    if (payload.error === "spotify_library_scope_required") {
+      return serverMessage || "Spotify access needs refreshing. Grant Spotify Library access, then copy your saves again.";
+    }
     if (payload.error === "playlist_items_forbidden" && serverMessage) return serverMessage;
     return serverMessage || "You don't have permission to " + action + ".";
   }
@@ -1153,19 +1338,27 @@ function jamSetPager(prefix, offset, limit, total, nextOffset, noun, busy) {
   if (summary) summary.textContent = total + " " + noun + (total === 1 ? "" : "s") + (total ? " \u00b7 " + page + " of " + pages : "");
 }
 
+function jamCreateArtworkPlaceholder(className) {
+  var placeholder = document.createElement("span");
+  placeholder.className = (className || "jam-result-art") + " jam-art-placeholder";
+  placeholder.setAttribute("aria-hidden", "true");
+  return placeholder;
+}
+
 function jamCreateArtwork(item, className) {
-  if (!item.artwork_url) {
-    var placeholder = document.createElement("span");
-    placeholder.className = (className || "jam-result-art") + " jam-art-placeholder";
-    placeholder.setAttribute("aria-hidden", "true");
-    return placeholder;
-  }
+  if (!item.artwork_url) return jamCreateArtworkPlaceholder(className);
   var image = document.createElement("img");
   image.className = className || "jam-result-art";
   image.src = item.artwork_url;
   image.alt = "";
   image.loading = "lazy";
   image.decoding = "async";
+  image.referrerPolicy = "no-referrer";
+  image.addEventListener("error", function() {
+    if (image.parentNode) {
+      image.parentNode.replaceChild(jamCreateArtworkPlaceholder(className), image);
+    }
+  }, { once: true });
   return image;
 }
 
@@ -1178,6 +1371,16 @@ function jamCreateSpotifyLink(item, label, className) {
   link.textContent = label;
   link.title = "Open in Spotify";
   link.onclick = function(event) { openSpotifyItem(item, event); };
+  return link;
+}
+
+function jamCreateSpotifyAction(item) {
+  var link = jamCreateSpotifyLink(
+    item,
+    "Open in Spotify",
+    "jam-secondary-btn jam-spotify-link jam-spotify-action"
+  );
+  link.setAttribute("aria-label", "Open " + item.name + " in Spotify");
   return link;
 }
 
@@ -1224,10 +1427,15 @@ function jamTabKeydown(event, selector, activate) {
   activate(tabs[index]);
 }
 
-function setJamView(view, focusTab) {
+function setJamView(view, focusTab, options) {
   if (["library", "search", "queue", "history"].indexOf(view) === -1) return;
-  _jamActiveView = view;
+  options = options || {};
   var detail = document.getElementById("jam-playlist-detail");
+  if (jamPlaylistQueuePending() && detail && !detail.hidden) {
+    jamSetViewStatus("jam-playlist-status", "Wait for the playlist queue operation to finish before leaving this playlist.", "warning");
+    return;
+  }
+  _jamActiveView = view;
   if (detail) detail.hidden = true;
   document.querySelectorAll(".jam-browser-tab").forEach(function(tab) {
     var active = tab.getAttribute("data-jam-view") === view;
@@ -1240,7 +1448,8 @@ function setJamView(view, focusTab) {
     var panel = document.getElementById("jam-" + name + "-section");
     if (panel) panel.hidden = name !== view;
   });
-  if (view === "library") loadJamLibrary(0);
+  if (view === "library" && !(options.preserveContent && _jamLibraryLoaded)) loadJamLibrary(0);
+  if (view === "queue") renderQueue((_jamState && _jamState.queue) || []);
   if (view === "history") loadJamHistory(0);
 }
 
@@ -1365,8 +1574,35 @@ function jamFavoriteSummary(item) {
 function jamCreateCatalogCard(item, context) {
   var card = document.createElement("div");
   card.className = "jam-result-item jam-catalog-item jam-catalog-" + item.kind;
+  var explicitActions = context === "library" || (context === "search" && item.kind === "playlist");
+  if (explicitActions) card.classList.add("jam-catalog-item-with-explicit-actions");
   card.setAttribute("role", "listitem");
   card.setAttribute("data-jam-item-key", jamItemKey(item));
+  if (item.kind === "track" && context === "playlist-detail") {
+    var position = jamSafeOptionalInteger(item.playlist_position);
+    var choice = document.createElement("label");
+    choice.className = "jam-playlist-track-choice";
+    choice.hidden = !jamPlaylistSelectionAvailable();
+    var checkbox = document.createElement("input");
+    checkbox.type = "checkbox";
+    checkbox.className = "jam-playlist-track-select";
+    checkbox.setAttribute("data-jam-playlist-position", position === null ? "" : String(position));
+    checkbox.setAttribute(
+      "aria-label",
+      "Select " + item.name + " by " + (item.artist || "unknown artist") +
+        (position === null ? "" : ", playlist position " + (position + 1))
+    );
+    checkbox.checked = position !== null && _jamPlaylistSelectedPositions.has(position);
+    checkbox.disabled = position === null || jamPlaylistQueuePending() || !_jamContract || !_jamContract.canControl;
+    checkbox.onchange = function() {
+      if (position === null) return;
+      if (checkbox.checked) _jamPlaylistSelectedPositions.add(position);
+      else _jamPlaylistSelectedPositions.delete(position);
+      renderJamPlaylistSelectionControls();
+    };
+    choice.appendChild(checkbox);
+    card.appendChild(choice);
+  }
   card.appendChild(jamCreateArtwork(item, "jam-result-art"));
 
   var info = document.createElement("div");
@@ -1413,22 +1649,33 @@ function jamCreateCatalogCard(item, context) {
   favorite.onclick = function() { toggleJamFavorite(item); };
   actions.appendChild(favorite);
 
-  if (item.kind === "track" && context === "search") {
+  if (explicitActions) actions.appendChild(jamCreateSpotifyAction(item));
+
+  if (item.kind === "track" && context === "library") {
+    var libraryAdd = document.createElement("button");
+    libraryAdd.type = "button";
+    libraryAdd.className = "jam-primary-btn jam-library-queue-btn";
+    libraryAdd.textContent = "Add to queue";
+    libraryAdd.setAttribute("aria-label", "Add " + item.name + " by " + (item.artist || "unknown artist") + " to queue");
+    libraryAdd.disabled = jamTrackQueuePending() || !_jamContract || !_jamContract.canControl;
+    libraryAdd.onclick = function() { addToQueue(item); };
+    actions.appendChild(libraryAdd);
+  } else if (item.kind === "track" && context === "search") {
     var add = document.createElement("button");
     add.type = "button";
     add.className = "jam-result-add";
     add.textContent = "+";
     add.title = "Add to queue";
     add.setAttribute("aria-label", "Add " + item.name + " by " + (item.artist || "unknown artist") + " to queue");
-    add.disabled = !_jamContract || !_jamContract.canControl;
+    add.disabled = jamTrackQueuePending() || !_jamContract || !_jamContract.canControl;
     add.onclick = function() { addToQueue(item); };
     actions.appendChild(add);
   } else if (item.kind === "playlist" && context !== "detail-summary") {
     var inspect = document.createElement("button");
     inspect.type = "button";
     inspect.className = "jam-secondary-btn jam-inspect-btn";
-    inspect.textContent = "Open";
-    inspect.setAttribute("aria-label", "View " + item.name + " playlist songs");
+    inspect.textContent = "Choose songs";
+    inspect.setAttribute("aria-label", "Choose songs from " + item.name);
     inspect.onclick = function(event) { openJamPlaylistDetail(item, event.currentTarget); };
     actions.appendChild(inspect);
   }
@@ -1441,6 +1688,8 @@ function renderSearchResults(items) {
   if (!container) return;
   container.innerHTML = "";
   _jamSearchItems = jamNormalizeCatalogItems(items, _jamSearchKind);
+  if (_jamSearchItems.length) container.setAttribute("role", "list");
+  else container.removeAttribute("role");
   _jamSearchItems.forEach(function(item) {
     container.appendChild(jamCreateCatalogCard(item, "search"));
   });
@@ -1521,6 +1770,10 @@ async function loadJamLibrary(offset) {
     });
     _jamLibraryOffset = jamSafeInteger(data.offset, requestedOffset);
     _jamLibraryTotal = jamSafeInteger(data.total, _jamLibraryItems.length);
+    if ((!kind || kind.value === "all") && (!contributor || !contributor.value)) {
+      _jamLibraryKnownEmpty = _jamLibraryTotal === 0;
+    }
+    renderJamLibrarySetup();
     var suppliedNext = data.next_offset;
     _jamLibraryNextOffset = suppliedNext === null || suppliedNext === undefined
       ? (_jamLibraryOffset + _jamLibraryItems.length < _jamLibraryTotal ? _jamLibraryOffset + JAM_LIBRARY_PAGE_SIZE : null)
@@ -1528,7 +1781,14 @@ async function loadJamLibrary(offset) {
     _jamLibraryLoaded = true;
     jamUpdateContributorOptions(data.contributors || (data.counts && data.counts.contributors), _jamLibraryItems);
     renderJamLibrary();
-    jamSetViewStatus("jam-library-status", _jamLibraryItems.length ? "Echo Favorites loaded." : "No Echo Favorites match these filters.");
+    jamSetViewStatus(
+      "jam-library-status",
+      _jamLibraryItems.length
+        ? "Echo Favorites loaded."
+        : _jamLibraryKnownEmpty === true
+          ? "No Echo Favorites yet. Copy your Spotify saves above, or use Search and press ☆."
+          : "No Echo Favorites match these filters."
+    );
   } catch (error) {
     if (requestId !== _jamLibraryRequestSeq || (error && error.name === "AbortError")) return;
     jamSetViewStatus("jam-library-status", "Echo Favorites are unavailable right now.", "error");
@@ -1545,7 +1805,17 @@ function renderJamLibrary() {
   var container = document.getElementById("jam-library-list");
   if (!container) return;
   container.innerHTML = "";
+  if (_jamLibraryItems.length) container.setAttribute("role", "list");
+  else container.removeAttribute("role");
   _jamLibraryItems.forEach(function(item) { container.appendChild(jamCreateCatalogCard(item, "library")); });
+  if (!_jamLibraryItems.length) {
+    var empty = document.createElement("div");
+    empty.className = "jam-library-empty";
+    empty.textContent = _jamLibraryKnownEmpty === true
+      ? "Your shared Echo Favorites library is empty."
+      : "Nothing matches the current Library filters.";
+    container.appendChild(empty);
+  }
 }
 
 function jamApplyFavoriteState(item, favorited, normalizedResponse) {
@@ -1612,8 +1882,11 @@ async function toggleJamFavorite(rawItem) {
     var data = await response.json().catch(function() { return {}; });
     var normalized = data.item ? normalizeSpotifyCatalogItem(data.item, item.kind) : null;
     jamApplyFavoriteState(rawItem, favorited, normalized);
-    _jamLibraryLoaded = false;
-    if (_jamActiveView === "library") loadJamLibrary(_jamLibraryOffset);
+    _jamLibraryKnownEmpty = favorited ? false : null;
+    var playlistDetail = document.getElementById("jam-playlist-detail");
+    var preservingLibraryDetail = _jamPlaylistReturnView === "library" && playlistDetail && !playlistDetail.hidden;
+    if (!preservingLibraryDetail) _jamLibraryLoaded = false;
+    if (_jamActiveView === "library" && !preservingLibraryDetail) loadJamLibrary(_jamLibraryOffset);
   } catch (error) {
     showJamError("Could not update Echo Favorites.");
     debugLog("[jam] favorite update error: " + error);
@@ -1629,7 +1902,7 @@ async function importSpotifyFavorites() {
   if (_jamImportPending) return;
   _jamImportPending = true;
   applyJamContractToControls();
-  jamSetViewStatus("jam-library-status", "Importing your Spotify saved songs and playlists...");
+  jamSetViewStatus("jam-library-status", "Checking Spotify for Liked Songs and saved playlists...");
   try {
     var response = await fetch(apiUrl("/api/jam/favorites/import-spotify"), {
       method: "POST",
@@ -1637,7 +1910,16 @@ async function importSpotifyFavorites() {
       body: JSON.stringify({})
     });
     if (!response.ok) {
-      jamSetViewStatus("jam-library-status", await jamApiErrorMessage(response, "import Spotify favorites"), "error");
+      var importPayload = {};
+      try { importPayload = await response.clone().json(); } catch (_) { importPayload = {}; }
+      var importError = await jamApiErrorMessage(response, "import Spotify favorites");
+      if (importPayload.error === "spotify_library_scope_required" && _jamState) {
+        _jamState.spotify_library_authorized = false;
+        renderJamLibrarySetup();
+      }
+      _jamLibraryLoaded = false;
+      await loadJamLibrary(0);
+      jamSetViewStatus("jam-library-status", importError, "error");
       return;
     }
     var data = await response.json();
@@ -1646,12 +1928,21 @@ async function importSpotifyFavorites() {
     var skipped = jamSafeInteger(data.skipped, 0);
     var created = jamSafeOptionalInteger(data.items_created);
     var attributionsAdded = jamSafeOptionalInteger(data.attributions_added);
-    var importMessage = "Scanned " + tracks + " songs and " + playlists + " playlists";
-    if (created !== null) importMessage += "; created " + created + " new favorites";
-    if (attributionsAdded !== null) importMessage += "; added " + attributionsAdded + " attributions";
-    if (skipped) importMessage += "; skipped " + skipped;
+    var importMessage = "Checked " + tracks + " Liked Song" + (tracks === 1 ? "" : "s") +
+      " and " + playlists + " saved playlist" + (playlists === 1 ? "" : "s");
+    if (created !== null) {
+      importMessage += "; added " + created + " new Echo Favorite" + (created === 1 ? "" : "s");
+    }
+    if (attributionsAdded !== null && created !== null && attributionsAdded > created) {
+      var existingAttributions = attributionsAdded - created;
+      importMessage += "; credited you on " + existingAttributions + " existing favorite" +
+        (existingAttributions === 1 ? "" : "s");
+    }
+    if (skipped) importMessage += "; skipped " + skipped + " unavailable item" + (skipped === 1 ? "" : "s");
     var truncated = data.partial === true || data.truncated === true;
     if (truncated) importMessage += "; import stopped at Spotify's safety limit";
+    if (_jamState) _jamState.spotify_library_authorized = true;
+    _jamLibraryKnownEmpty = null;
     _jamLibraryLoaded = false;
     await loadJamLibrary(0);
     jamSetViewStatus("jam-library-status", importMessage + ".", truncated ? "warning" : "success");
@@ -1667,6 +1958,93 @@ async function importSpotifyFavorites() {
 // ──────────────────────────────────────────
 // Queue
 // ──────────────────────────────────────────
+
+function jamSelectedPlaylistPositions() {
+  return Array.from(_jamPlaylistSelectedPositions).sort(function(a, b) { return a - b; });
+}
+
+function jamPlaylistQueuePending() {
+  return !!_jamPlaylistQueueOperation;
+}
+
+function jamBeginPlaylistQueueOperation(context) {
+  if (jamPlaylistQueuePending()) return null;
+  var operation = Object.freeze({
+    epoch: _jamPlaylistQueueEpoch,
+    context: context
+  });
+  _jamPlaylistQueueOperation = operation;
+  return operation;
+}
+
+function jamPlaylistQueueOperationIsCurrent(operation) {
+  return !!operation && operation.epoch === _jamPlaylistQueueEpoch &&
+    _jamPlaylistQueueOperation === operation;
+}
+
+function jamFinishPlaylistQueueOperation(operation) {
+  if (!jamPlaylistQueueOperationIsCurrent(operation)) return false;
+  _jamPlaylistQueueOperation = null;
+  renderJamPlaylistSummary();
+  return true;
+}
+
+function invalidateJamPlaylistQueueLifecycle() {
+  _jamPlaylistQueueEpoch += 1;
+  _jamPlaylistQueueOperation = null;
+  renderJamPlaylistSummary();
+  renderJamPlaylistSelectionControls();
+}
+
+function jamPlaylistSelectionAvailable() {
+  return !!_jamContract && _jamContract.playlistSelectionSupported === true &&
+    !!_jamPlaylist && !_jamPlaylistAccessError && !!jamSafeString(_jamPlaylist.snapshot_id);
+}
+
+function renderJamPlaylistSelectionControls() {
+  var selected = jamSelectedPlaylistPositions();
+  var count = selected.length;
+  var countLabel = document.getElementById("jam-playlist-selection-count");
+  var clear = document.getElementById("jam-playlist-clear-selection");
+  var addSelected = document.getElementById("jam-playlist-add-selected");
+  var loadMore = document.getElementById("jam-playlist-load-more");
+  var selectionGroup = document.querySelector(".jam-playlist-selection");
+  var canControl = !!_jamContract && _jamContract.canControl;
+  var selectionAvailable = jamPlaylistSelectionAvailable();
+  if (selectionGroup) selectionGroup.hidden = !selectionAvailable;
+  if (!selectionAvailable && _jamPlaylistSelectedPositions.size) {
+    _jamPlaylistSelectedPositions.clear();
+    _jamPlaylistResumeRequired = false;
+    selected = [];
+    count = 0;
+  }
+  if (countLabel) countLabel.textContent = count + (count === 1 ? " song selected" : " songs selected");
+  if (clear) clear.disabled = !selectionAvailable || jamPlaylistQueuePending() || count === 0;
+  if (addSelected) {
+    addSelected.disabled = !selectionAvailable || jamPlaylistQueuePending() || _jamPlaylistLoading || count === 0 || !canControl;
+    addSelected.title = count
+      ? "Add the selected playlist songs as one queue batch"
+      : "Select one or more playlist songs first";
+  }
+  if (loadMore) loadMore.disabled = jamPlaylistQueuePending() || _jamPlaylistLoading || !!_jamPlaylistAccessError;
+  document.querySelectorAll(".jam-playlist-track-select").forEach(function(input) {
+    var position = jamSafeOptionalInteger(input.getAttribute("data-jam-playlist-position"));
+    var choice = input.closest(".jam-playlist-track-choice");
+    if (choice) choice.hidden = !selectionAvailable;
+    input.checked = position !== null && _jamPlaylistSelectedPositions.has(position);
+    input.disabled = !selectionAvailable || position === null || jamPlaylistQueuePending() || !canControl;
+  });
+}
+
+function clearJamPlaylistSelection() {
+  if (jamPlaylistQueuePending() || !_jamPlaylistSelectedPositions.size) return;
+  _jamPlaylistSelectedPositions.clear();
+  if (_jamPlaylistResumeRequired) {
+    _jamPlaylistResumeRequired = false;
+    jamSetViewStatus("jam-playlist-status", "Remaining-song recovery was cleared. Adding the entire playlist again can duplicate songs already queued.", "warning");
+  }
+  renderJamPlaylistSelectionControls();
+}
 
 function renderJamPlaylistSummary() {
   var container = document.getElementById("jam-playlist-summary");
@@ -1707,11 +2085,29 @@ function renderJamPlaylistSummary() {
     favorite.disabled = !!_jamFavoritePending[jamItemKey(_jamPlaylist)];
   }
   if (addAll) {
-    var countKnown = knownCount !== null && knownCount !== undefined;
-    var overLimit = countKnown && knownCount > 50;
-    addAll.disabled = _jamPlaylistQueuePending || _jamPlaylistLoading || overLimit || !_jamContract || !_jamContract.canControl;
-    addAll.title = overLimit ? "Echo can add at most 50 playlist songs at once" : "Add this playlist as one queue batch";
+    var resumeReady = _jamPlaylistResumeRequired && _jamPlaylistSelectedPositions.size > 0;
+    var exceedsBulkLimit = jamSafeInteger(_jamPlaylistTotal, 0) > JAM_PLAYLIST_MAX_QUEUE_TRACKS;
+    addAll.textContent = resumeReady ? "Add remaining songs" : "Add entire playlist";
+    addAll.disabled = jamPlaylistQueuePending() || _jamPlaylistLoading || !!_jamPlaylistAccessError ||
+      !_jamContract || !_jamContract.canControl ||
+      (!resumeReady && exceedsBulkLimit) ||
+      (resumeReady && !jamPlaylistSelectionAvailable());
+    if (_jamPlaylistAccessError) {
+      addAll.title = "Spotify does not allow Echo to read this playlist's songs";
+    } else if (resumeReady) {
+      addAll.title = "Continue the interrupted batch without queueing its successful songs again";
+    } else if (exceedsBulkLimit) {
+      addAll.title = "Echo can queue at most 1,000 songs at once; select a smaller group";
+    } else {
+      addAll.title = "Add every playable song from this playlist as one queue batch";
+    }
   }
+  var back = document.getElementById("jam-playlist-back");
+  if (back) back.disabled = jamPlaylistQueuePending();
+  document.querySelectorAll(".jam-browser-tab").forEach(function(tab) {
+    tab.disabled = jamPlaylistQueuePending();
+  });
+  renderJamPlaylistSelectionControls();
 }
 
 function openJamPlaylistDetail(rawPlaylist, opener) {
@@ -1723,10 +2119,16 @@ function openJamPlaylistDetail(rawPlaylist, opener) {
   if (_jamPlaylistController) _jamPlaylistController.abort();
   _jamPlaylistRequestSeq += 1;
   _jamPlaylistLoading = false;
+  _jamPlaylistAccessError = null;
+  _jamPlaylistFailedOffset = 0;
+  _jamPlaylistCacheTruncated = false;
+  _jamPlaylistCachePositionLimit = JAM_PLAYLIST_MAX_QUEUE_TRACKS;
   _jamPlaylist = playlist;
   _jamPlaylistItems = [];
   _jamPlaylistTotal = playlist.item_count;
   _jamPlaylistNextOffset = 0;
+  _jamPlaylistSelectedPositions.clear();
+  _jamPlaylistResumeRequired = false;
   _jamPlaylistReturnView = _jamActiveView;
   _jamPlaylistOpener = opener || document.activeElement;
   ["library", "search", "queue", "history"].forEach(function(name) {
@@ -1740,15 +2142,27 @@ function openJamPlaylistDetail(rawPlaylist, opener) {
   jamSetViewStatus("jam-playlist-status", "Loading playlist songs...");
   fetchJamPlaylistItems(0, false);
   var back = document.getElementById("jam-playlist-back");
-  if (back) back.focus();
+  if (back) {
+    back.textContent = _jamPlaylistReturnView === "library"
+      ? "Back to Library"
+      : _jamPlaylistReturnView === "search"
+        ? "Back to search results"
+        : "Back to " + _jamPlaylistReturnView.charAt(0).toUpperCase() + _jamPlaylistReturnView.slice(1);
+    back.focus();
+  }
 }
 
 function closeJamPlaylistDetail() {
+  if (jamPlaylistQueuePending()) {
+    jamSetViewStatus("jam-playlist-status", "Wait for the playlist queue operation to finish before leaving this playlist.", "warning");
+    return;
+  }
   if (_jamPlaylistController) _jamPlaylistController.abort();
   _jamPlaylistRequestSeq += 1;
   _jamPlaylistLoading = false;
   var opener = _jamPlaylistOpener;
-  setJamView(_jamPlaylistReturnView || "search", false);
+  var returnView = _jamPlaylistReturnView || "search";
+  setJamView(returnView, false, { preserveContent: returnView === "library" });
   _jamPlaylistOpener = null;
   if (opener && document.contains(opener) && typeof opener.focus === "function") opener.focus();
 }
@@ -1758,12 +2172,14 @@ function jamSkippedCount(value) {
 }
 
 async function fetchJamPlaylistItems(offset, append) {
-  if (!_jamPlaylist || _jamPlaylistLoading) return;
+  if (!_jamPlaylist || _jamPlaylistLoading || _jamPlaylistAccessError) return;
   if (_jamPlaylistController) _jamPlaylistController.abort();
   var controller = typeof AbortController === "function" ? new AbortController() : null;
   _jamPlaylistController = controller;
   var requestId = ++_jamPlaylistRequestSeq;
   var requestedOffset = jamSafeInteger(offset, 0);
+  var expectedSnapshot = jamSafeString(_jamPlaylist.snapshot_id);
+  var reloadForSnapshotChange = false;
   _jamPlaylistLoading = true;
   renderJamPlaylistSummary();
   jamSetBusy("jam-playlist-items", true);
@@ -1775,13 +2191,50 @@ async function fetchJamPlaylistItems(offset, append) {
     var response = await fetch(apiUrl("/api/jam/playlists/" + encodeURIComponent(_jamPlaylist.spotify_id) + "/items?offset=" + requestedOffset + "&limit=" + JAM_PLAYLIST_PAGE_SIZE), options);
     if (requestId !== _jamPlaylistRequestSeq) return;
     if (!response.ok) {
-      jamSetViewStatus("jam-playlist-status", await jamApiErrorMessage(response, "load playlist songs"), "error");
+      var rejection = {};
+      try { rejection = await response.clone().json(); } catch (_) { rejection = {}; }
+      var errorMessage = await jamApiErrorMessage(response, "load playlist songs");
+      if ((response.status === 403 && rejection.error === "playlist_items_forbidden") ||
+          rejection.error === "playlist_catalog_unavailable") {
+        _jamPlaylistAccessError = {
+          code: rejection.error || "playlist_catalog_unavailable",
+          message: errorMessage
+        };
+        _jamPlaylistFailedOffset = requestedOffset;
+        if (!append) _jamPlaylistItems = [];
+        _jamPlaylistNextOffset = requestedOffset;
+        _jamPlaylistSelectedPositions.clear();
+        _jamPlaylistResumeRequired = false;
+        renderJamPlaylistSummary();
+        renderJamPlaylistItems();
+      }
+      jamSetViewStatus("jam-playlist-status", errorMessage, "error");
       return;
     }
     var data = await response.json();
     if (requestId !== _jamPlaylistRequestSeq) return;
+    _jamPlaylistAccessError = null;
+    _jamPlaylistFailedOffset = 0;
+    var returnedPlaylist = data.playlist
+      ? normalizeSpotifyCatalogItem(data.playlist, "playlist")
+      : null;
+    var returnedSnapshot = returnedPlaylist ? jamSafeString(returnedPlaylist.snapshot_id) : "";
+    if (append && (!returnedPlaylist || returnedSnapshot !== expectedSnapshot)) {
+      if (returnedPlaylist) _jamPlaylist = returnedPlaylist;
+      _jamPlaylistItems = [];
+      _jamPlaylistTotal = returnedPlaylist && returnedPlaylist.item_count !== null
+        ? returnedPlaylist.item_count
+        : jamSafeInteger(data.total, 0);
+      _jamPlaylistNextOffset = 0;
+      _jamPlaylistSelectedPositions.clear();
+      _jamPlaylistResumeRequired = false;
+      reloadForSnapshotChange = true;
+      renderJamPlaylistSummary();
+      renderJamPlaylistItems();
+      jamSetViewStatus("jam-playlist-status", "This playlist changed on Spotify. Reloading its songs before you select or queue anything...", "warning");
+      return;
+    }
     if (data.playlist) {
-      var returnedPlaylist = normalizeSpotifyCatalogItem(data.playlist, "playlist");
       if (returnedPlaylist) _jamPlaylist = returnedPlaylist;
     }
     var pageItems = jamNormalizeCatalogItems(data.items || [], "track");
@@ -1789,15 +2242,41 @@ async function fetchJamPlaylistItems(offset, append) {
     _jamPlaylistTotal = jamSafeInteger(data.total, _jamPlaylist.item_count || _jamPlaylistItems.length);
     _jamPlaylist.item_count = _jamPlaylistTotal;
     var suppliedNext = data.next_offset;
-    _jamPlaylistNextOffset = suppliedNext === null || suppliedNext === undefined
-      ? (requestedOffset + pageItems.length < _jamPlaylistTotal ? requestedOffset + pageItems.length : null)
-      : jamSafeInteger(suppliedNext, 0);
+    if (suppliedNext === null) {
+      _jamPlaylistNextOffset = null;
+    } else if (suppliedNext === undefined) {
+      _jamPlaylistNextOffset = requestedOffset + pageItems.length < _jamPlaylistTotal
+        ? requestedOffset + pageItems.length
+        : null;
+    } else {
+      _jamPlaylistNextOffset = jamSafeInteger(suppliedNext, 0);
+    }
     renderJamPlaylistSummary();
     renderJamPlaylistItems();
     var skipped = jamSkippedCount(data.skipped);
+    var localCacheNote = "";
+    if (data.items_source === "local_cache") {
+      var cacheInfo = data.local_cache || {};
+      var cachedCount = jamSafeInteger(cacheInfo.cached_count, _jamPlaylistItems.length);
+      var cacheTotal = jamSafeInteger(cacheInfo.total, _jamPlaylistTotal);
+      _jamPlaylistCacheTruncated = cacheInfo.truncated === true;
+      _jamPlaylistCachePositionLimit = jamSafeInteger(
+        cacheInfo.position_limit,
+        JAM_PLAYLIST_MAX_QUEUE_TRACKS
+      );
+      localCacheNote = " " + cachedCount + " of " + cacheTotal +
+        " songs are cached privately on Echo in 50-song chunks.";
+      if (_jamPlaylistCacheTruncated) {
+        localCacheNote += " Echo exposes the first " + _jamPlaylistCachePositionLimit +
+          " positions; select a smaller group to queue.";
+      }
+    } else {
+      _jamPlaylistCacheTruncated = false;
+      _jamPlaylistCachePositionLimit = JAM_PLAYLIST_MAX_QUEUE_TRACKS;
+    }
     jamSetViewStatus(
       "jam-playlist-status",
-      "Loaded " + _jamPlaylistItems.length + " of " + _jamPlaylistTotal + " songs" + (skipped ? "; " + skipped + " unavailable skipped" : "") + ".",
+      "Loaded " + _jamPlaylistItems.length + " of " + _jamPlaylistTotal + " songs" + (skipped ? "; " + skipped + " unavailable skipped" : "") + "." + localCacheNote,
       skipped ? "warning" : ""
     );
   } catch (error) {
@@ -1811,8 +2290,9 @@ async function fetchJamPlaylistItems(offset, append) {
       jamSetBusy("jam-playlist-items", false);
       if (loadMore) {
         loadMore.disabled = false;
-        loadMore.hidden = _jamPlaylistNextOffset === null;
+        loadMore.hidden = !!_jamPlaylistAccessError || _jamPlaylistNextOffset === null;
       }
+      if (reloadForSnapshotChange) fetchJamPlaylistItems(0, false);
     }
   }
 }
@@ -1821,9 +2301,46 @@ function renderJamPlaylistItems() {
   var container = document.getElementById("jam-playlist-items");
   if (!container) return;
   container.innerHTML = "";
+  if (_jamPlaylistAccessError && _jamPlaylist) {
+    container.removeAttribute("role");
+    var blocked = document.createElement("div");
+    blocked.className = "jam-playlist-access-blocked";
+    blocked.setAttribute("role", "alert");
+    var title = document.createElement("strong");
+    title.textContent = "Echo couldn't load this playlist's next 50 songs";
+    blocked.appendChild(title);
+    var explanation = document.createElement("p");
+    explanation.textContent = "Spotify's normal playlist endpoint blocked this playlist, and Echo's bounded public-catalog fallback did not complete. Retry this 50-song chunk or open the playlist in Spotify.";
+    blocked.appendChild(explanation);
+    var retry = document.createElement("button");
+    retry.type = "button";
+    retry.className = "jam-secondary-btn";
+    retry.textContent = "Retry 50-song chunk";
+    retry.addEventListener("click", function() {
+      var retryOffset = _jamPlaylistFailedOffset;
+      _jamPlaylistAccessError = null;
+      _jamPlaylistNextOffset = retryOffset;
+      renderJamPlaylistSummary();
+      renderJamPlaylistItems();
+      fetchJamPlaylistItems(retryOffset, retryOffset > 0);
+    });
+    blocked.appendChild(retry);
+    blocked.appendChild(jamCreateSpotifyAction(_jamPlaylist));
+    container.appendChild(blocked);
+    var blockedLoadMore = document.getElementById("jam-playlist-load-more");
+    if (blockedLoadMore) blockedLoadMore.hidden = true;
+    renderJamPlaylistSelectionControls();
+    return;
+  }
+  if (_jamPlaylistItems.length) container.setAttribute("role", "list");
+  else container.removeAttribute("role");
   _jamPlaylistItems.forEach(function(item) { container.appendChild(jamCreateCatalogCard(item, "playlist-detail")); });
   var loadMore = document.getElementById("jam-playlist-load-more");
-  if (loadMore) loadMore.hidden = _jamPlaylistNextOffset === null;
+  if (loadMore) {
+    loadMore.hidden = _jamPlaylistNextOffset === null;
+    loadMore.textContent = "Load next 50 songs";
+  }
+  renderJamPlaylistSelectionControls();
 }
 
 function jamRequestId() {
@@ -1831,41 +2348,302 @@ function jamRequestId() {
   return "jam-playlist-" + Date.now() + "-" + Math.random().toString(36).slice(2);
 }
 
-async function addPlaylistToQueue() {
-  if (!_jamPlaylist || _jamPlaylistQueuePending || !jamActionAllowed("control")) return;
-  if (_jamPlaylistLoading) {
-    jamSetViewStatus("jam-playlist-status", "Wait for the playlist details to finish loading.");
+function jamTrackQueuePending() {
+  return !!_jamTrackQueueOperation;
+}
+
+function jamTrackQueueFingerprint(track, generation) {
+  return JSON.stringify([generation, track.spotify_uri]);
+}
+
+function jamTrackAmbiguousRequestMap() {
+  if (_jamTrackAmbiguousRequests) return _jamTrackAmbiguousRequests;
+  _jamTrackAmbiguousRequests = new Map();
+  try {
+    var saved = JSON.parse(sessionStorage.getItem(JAM_TRACK_AMBIGUOUS_STORAGE_KEY) || "[]");
+    (Array.isArray(saved) ? saved.slice(-16) : []).forEach(function(entry) {
+      if (!Array.isArray(entry) || entry.length !== 2) return;
+      if (typeof entry[0] !== "string" || typeof entry[1] !== "string") return;
+      if (entry[0].length > 512 || !/^[A-Za-z0-9_-]{8,128}$/.test(entry[1])) return;
+      _jamTrackAmbiguousRequests.set(entry[0], entry[1]);
+    });
+  } catch (_) {}
+  return _jamTrackAmbiguousRequests;
+}
+
+function jamPersistAmbiguousTrackRequests() {
+  try {
+    var entries = Array.from(jamTrackAmbiguousRequestMap().entries()).slice(-16);
+    if (entries.length) sessionStorage.setItem(JAM_TRACK_AMBIGUOUS_STORAGE_KEY, JSON.stringify(entries));
+    else sessionStorage.removeItem(JAM_TRACK_AMBIGUOUS_STORAGE_KEY);
+  } catch (_) {}
+}
+
+function jamTrackQueueRequestRecord(track, generation) {
+  var fingerprint = jamTrackQueueFingerprint(track, generation);
+  var requests = jamTrackAmbiguousRequestMap();
+  return {
+    fingerprint: fingerprint,
+    request_id: requests.get(fingerprint) || jamRequestId()
+  };
+}
+
+function jamRememberAmbiguousTrackRequest(record) {
+  var requests = jamTrackAmbiguousRequestMap();
+  requests.delete(record.fingerprint);
+  requests.set(record.fingerprint, record.request_id);
+  while (requests.size > 16) requests.delete(requests.keys().next().value);
+  jamPersistAmbiguousTrackRequests();
+}
+
+function jamForgetAmbiguousTrackRequest(record) {
+  var requests = jamTrackAmbiguousRequestMap();
+  if (requests.get(record.fingerprint) !== record.request_id) return;
+  requests.delete(record.fingerprint);
+  jamPersistAmbiguousTrackRequests();
+}
+
+function jamBeginTrackQueueOperation(record) {
+  if (jamTrackQueuePending()) return null;
+  var operation = Object.freeze({
+    epoch: _jamTrackQueueEpoch,
+    record: record
+  });
+  _jamTrackQueueOperation = operation;
+  applyJamContractToControls();
+  return operation;
+}
+
+function jamTrackQueueOperationIsCurrent(operation) {
+  return !!operation && operation.epoch === _jamTrackQueueEpoch &&
+    _jamTrackQueueOperation === operation;
+}
+
+function jamFinishTrackQueueOperation(operation) {
+  if (!jamTrackQueueOperationIsCurrent(operation)) return false;
+  _jamTrackQueueOperation = null;
+  applyJamContractToControls();
+  return true;
+}
+
+function invalidateJamTrackQueueLifecycle() {
+  _jamTrackQueueEpoch += 1;
+  _jamTrackQueueOperation = null;
+  applyJamContractToControls();
+}
+
+function jamPlaylistQueueFingerprint(context) {
+  return JSON.stringify([
+    context.generation,
+    context.playlist_id,
+    context.snapshot_id || "",
+    context.selected_positions === null ? null : context.selected_positions
+  ]);
+}
+
+function jamPlaylistAmbiguousRequestMap() {
+  if (_jamPlaylistAmbiguousRequests) return _jamPlaylistAmbiguousRequests;
+  _jamPlaylistAmbiguousRequests = new Map();
+  try {
+    var saved = JSON.parse(sessionStorage.getItem(JAM_PLAYLIST_AMBIGUOUS_STORAGE_KEY) || "[]");
+    (Array.isArray(saved) ? saved.slice(-8) : []).forEach(function(entry) {
+      if (!Array.isArray(entry) || entry.length !== 2) return;
+      if (typeof entry[0] !== "string" || typeof entry[1] !== "string") return;
+      if (entry[0].length > 12000 || !/^[A-Za-z0-9_-]{8,128}$/.test(entry[1])) return;
+      _jamPlaylistAmbiguousRequests.set(entry[0], entry[1]);
+    });
+  } catch (_) {}
+  return _jamPlaylistAmbiguousRequests;
+}
+
+function jamPersistAmbiguousPlaylistRequests() {
+  try {
+    var entries = Array.from(jamPlaylistAmbiguousRequestMap().entries()).slice(-8);
+    if (entries.length) sessionStorage.setItem(JAM_PLAYLIST_AMBIGUOUS_STORAGE_KEY, JSON.stringify(entries));
+    else sessionStorage.removeItem(JAM_PLAYLIST_AMBIGUOUS_STORAGE_KEY);
+  } catch (_) {}
+}
+
+function jamPlaylistRequestRecord(context) {
+  var fingerprint = jamPlaylistQueueFingerprint(context);
+  var requests = jamPlaylistAmbiguousRequestMap();
+  return {
+    fingerprint: fingerprint,
+    request_id: requests.get(fingerprint) || jamRequestId()
+  };
+}
+
+function jamRememberAmbiguousPlaylistRequest(record) {
+  var requests = jamPlaylistAmbiguousRequestMap();
+  requests.delete(record.fingerprint);
+  requests.set(record.fingerprint, record.request_id);
+  while (requests.size > 8) requests.delete(requests.keys().next().value);
+  jamPersistAmbiguousPlaylistRequests();
+}
+
+function jamForgetAmbiguousPlaylistRequest(record) {
+  var requests = jamPlaylistAmbiguousRequestMap();
+  if (requests.get(record.fingerprint) !== record.request_id) return;
+  requests.delete(record.fingerprint);
+  jamPersistAmbiguousPlaylistRequests();
+}
+
+function jamClearAmbiguousPlaylistRequests() {
+  jamPlaylistAmbiguousRequestMap().clear();
+  jamPersistAmbiguousPlaylistRequests();
+}
+
+function jamPlaylistQueueActionContext(selectedPositions) {
+  if (!_jamPlaylist) return null;
+  if (selectedPositions !== null && !jamPlaylistSelectionAvailable()) return null;
+  var positions = selectedPositions === null
+    ? null
+    : Object.freeze(selectedPositions.slice().sort(function(a, b) { return a - b; }));
+  return Object.freeze({
+    generation: _jamState && _jamState.generation,
+    playlist_id: _jamPlaylist.spotify_id,
+    playlist_name: _jamPlaylist.name,
+    snapshot_id: _jamPlaylist.snapshot_id || null,
+    selected_positions: positions,
+    track_count: positions === null
+      ? (_jamPlaylistTotal !== null && _jamPlaylistTotal !== undefined ? _jamPlaylistTotal : (_jamPlaylist.item_count || 0))
+      : positions.length,
+    detail_request_seq: _jamPlaylistRequestSeq,
+    queue_epoch: _jamPlaylistQueueEpoch
+  });
+}
+
+function jamPlaylistQueuePayload(context, requestId, confirmed) {
+  var payload = {
+    generation: context.generation,
+    playlist_id: context.playlist_id,
+    request_id: requestId,
+    confirmed: confirmed,
+    snapshot_id: context.snapshot_id
+  };
+  if (context.selected_positions !== null) payload.selected_positions = context.selected_positions.slice();
+  return payload;
+}
+
+function jamPlaylistActionIsCurrent(context) {
+  return !!_jamPlaylist && _jamPlaylist.spotify_id === context.playlist_id &&
+    _jamPlaylistRequestSeq === context.detail_request_seq &&
+    _jamPlaylistQueueEpoch === context.queue_epoch;
+}
+
+function jamSetPlaylistActionStatus(context, message, tone) {
+  if (jamPlaylistActionIsCurrent(context)) jamSetViewStatus("jam-playlist-status", message, tone);
+}
+
+function jamPlaylistResponsePositions(value) {
+  if (!Array.isArray(value)) return [];
+  var seen = new Set();
+  return value.map(function(entry) {
+    if (!entry || typeof entry !== "object") return jamSafeOptionalInteger(entry);
+    return jamSafeOptionalInteger(entry.position !== undefined ? entry.position : entry.playlist_position);
+  }).filter(function(position) {
+    if (position === null || seen.has(position)) return false;
+    seen.add(position);
+    return true;
+  });
+}
+
+function applyJamPlaylistSelectionReceipt(context, data) {
+  if (context.selected_positions === null || !jamPlaylistActionIsCurrent(context)) return;
+  var submitted = context.selected_positions.slice();
+  var processed = new Set();
+  var skippedPositions = jamPlaylistResponsePositions(data && data.skipped);
+  skippedPositions.forEach(function(position) { processed.add(position); });
+
+  var exactQueued = jamPlaylistResponsePositions(data && data.queued_positions);
+  if (!exactQueued.length) exactQueued = jamPlaylistResponsePositions(data && data.queued);
+  var exactProcessed = jamPlaylistResponsePositions(data && data.processed_positions);
+  exactQueued.concat(exactProcessed).forEach(function(position) { processed.add(position); });
+
+  var complete = data && data.complete === true;
+  var partial = data && (data.partial === true || data.complete === false || data.ok === false);
+  if (complete || !partial) {
+    submitted.forEach(function(position) { processed.add(position); });
+  } else if (!exactQueued.length && !exactProcessed.length) {
+    var queuedRemaining = jamSafeInteger(data && data.queued_count, 0);
+    submitted.forEach(function(position) {
+      if (processed.has(position) || queuedRemaining <= 0) return;
+      processed.add(position);
+      queuedRemaining -= 1;
+    });
+  }
+
+  processed.forEach(function(position) { _jamPlaylistSelectedPositions.delete(position); });
+  if (_jamPlaylistResumeRequired && _jamPlaylistSelectedPositions.size === 0) {
+    _jamPlaylistResumeRequired = false;
+  }
+  renderJamPlaylistSelectionControls();
+}
+
+function applyJamPlaylistEntireReceipt(context, data) {
+  if (context.selected_positions !== null || !jamPlaylistActionIsCurrent(context)) return 0;
+  var remaining = jamPlaylistResponsePositions(data && data.remaining_positions).filter(function(position) {
+    return context.track_count <= 0 || position < context.track_count;
+  });
+  _jamPlaylistSelectedPositions.clear();
+  remaining.forEach(function(position) { _jamPlaylistSelectedPositions.add(position); });
+  _jamPlaylistResumeRequired = remaining.length > 0;
+  renderJamPlaylistSelectionControls();
+  return remaining.length;
+}
+
+function jamPlaylistConfirmationMessage(context, trackCount) {
+  return context.selected_positions === null
+    ? "Add all " + trackCount + " songs from " + context.playlist_name + " to the queue?"
+    : "Add " + trackCount + " selected songs from " + context.playlist_name + " to the queue?";
+}
+
+async function enqueueJamPlaylist(context) {
+  if (!context || jamPlaylistQueuePending() || !jamActionAllowed("control")) return;
+  if (_jamPlaylistAccessError) {
+    jamSetPlaylistActionStatus(context, _jamPlaylistAccessError.message, "error");
     return;
   }
-  var trackCount = _jamPlaylistTotal !== null && _jamPlaylistTotal !== undefined
-    ? _jamPlaylistTotal
-    : (_jamPlaylist.item_count || 0);
-  if (trackCount > 50) {
-    jamSetViewStatus("jam-playlist-status", "This playlist has " + trackCount + " songs. Echo can add at most 50 at once.", "error");
+  if (_jamPlaylistLoading) {
+    jamSetPlaylistActionStatus(context, "Wait for the playlist details to finish loading.");
+    return;
+  }
+  var selectedBatch = context.selected_positions !== null;
+  if (selectedBatch && !jamPlaylistSelectionAvailable()) {
+    jamSetPlaylistActionStatus(context, "Reopen this playlist after Echo finishes updating before adding selected songs.", "error");
+    return;
+  }
+  var trackCount = context.track_count;
+  if (selectedBatch && trackCount === 0) {
+    jamSetPlaylistActionStatus(context, "Select one or more playlist songs first.");
     return;
   }
   var confirmed = false;
   if (trackCount > 25) {
-    confirmed = window.confirm("Add all " + trackCount + " songs from " + _jamPlaylist.name + " to the queue?");
+    confirmed = window.confirm(jamPlaylistConfirmationMessage(context, trackCount));
     if (!confirmed) {
-      jamSetViewStatus("jam-playlist-status", "Playlist was not added.");
+      jamSetPlaylistActionStatus(context, selectedBatch ? "Selected songs were not added." : "Playlist was not added.");
       return;
     }
   }
-  _jamPlaylistQueuePending = true;
+  var operation = jamBeginPlaylistQueueOperation(context);
+  if (!operation) return;
   renderJamPlaylistSummary();
-  jamSetViewStatus("jam-playlist-status", "Adding playlist to the queue...");
+  jamSetPlaylistActionStatus(context, selectedBatch ? "Adding selected songs to the queue..." : "Adding playlist to the queue...");
+  var requestRecord = jamPlaylistRequestRecord(context);
+  var requestId = requestRecord.request_id;
+  // Persist before dispatch. A reload or renderer exit can happen after the
+  // server commits but before fetch rejects, so catch is too late to establish
+  // the idempotency key needed by the next attempt.
+  jamRememberAmbiguousPlaylistRequest(requestRecord);
+  var endpoint = selectedBatch
+    ? "/api/jam/queue/playlist/selection"
+    : "/api/jam/queue/playlist";
   try {
-    var requestId = jamRequestId();
-    var response = await fetch(apiUrl("/api/jam/queue/playlist"), {
+    var response = await fetch(apiUrl(endpoint), {
       method: "POST",
       headers: jamActorHeaders(),
-      body: JSON.stringify({
-        generation: _jamState && _jamState.generation,
-        playlist_id: _jamPlaylist.spotify_id,
-        request_id: requestId,
-        confirmed: confirmed
-      })
+      body: JSON.stringify(jamPlaylistQueuePayload(context, requestId, confirmed))
     });
     if (!response.ok) {
       var rejection = {};
@@ -1874,55 +2652,80 @@ async function addPlaylistToQueue() {
         var serverCount = jamSafeOptionalInteger(rejection.playable_count !== undefined
           ? rejection.playable_count
           : (rejection.track_count || rejection.item_count));
-        if (serverCount !== null && serverCount > 50) {
-          jamSetViewStatus("jam-playlist-status", "This playlist has " + serverCount + " songs. Echo can add at most 50 at once.", "error");
-          return;
-        }
-        confirmed = window.confirm("Add all " + (serverCount !== null ? serverCount + " " : "available ") + "songs from " + _jamPlaylist.name + " to the queue?");
+        confirmed = window.confirm(serverCount !== null
+          ? jamPlaylistConfirmationMessage(context, serverCount)
+          : "Add the available " + (selectedBatch ? "selected songs" : "songs") + " from " + context.playlist_name + " to the queue?");
         if (!confirmed) {
-          jamSetViewStatus("jam-playlist-status", "Playlist was not added.");
+          jamForgetAmbiguousPlaylistRequest(requestRecord);
+          jamSetPlaylistActionStatus(context, selectedBatch ? "Selected songs were not added." : "Playlist was not added.");
           return;
         }
-        response = await fetch(apiUrl("/api/jam/queue/playlist"), {
+        response = await fetch(apiUrl(endpoint), {
           method: "POST",
           headers: jamActorHeaders(),
-          body: JSON.stringify({
-            generation: _jamState && _jamState.generation,
-            playlist_id: _jamPlaylist.spotify_id,
-            request_id: requestId,
-            confirmed: true
-          })
+          body: JSON.stringify(jamPlaylistQueuePayload(context, requestId, true))
         });
       }
     }
     if (!response.ok) {
-      jamSetViewStatus("jam-playlist-status", await jamApiErrorMessage(response, "add playlist to the queue"), "error");
+      jamForgetAmbiguousPlaylistRequest(requestRecord);
+      jamSetPlaylistActionStatus(context, await jamApiErrorMessage(response, selectedBatch ? "add selected songs to the queue" : "add playlist to the queue"), "error");
       return;
     }
     var data = await response.json();
+    if (!jamPlaylistActionIsCurrent(context)) {
+      // Keep the request ID until this exact playlist/snapshot is reopened.
+      // Retrying then retrieves the server's cached receipt instead of
+      // duplicating a batch whose response arrived after disconnect/cleanup.
+      return;
+    }
+    jamForgetAmbiguousPlaylistRequest(requestRecord);
     var queued = jamSafeInteger(data.queued_count, 0);
     var skipped = jamSkippedCount(data.skipped);
-    var partial = data.partial === true || data.complete === false || data.ok === false || skipped > 0;
     var failureObject = data.failure && typeof data.failure === "object" ? data.failure : null;
+    var interrupted = !!failureObject;
     var failure = jamSafeString(failureObject ? failureObject.message : data.failure);
     var failureRetryAfter = failureObject && failureObject.retry_after !== null && failureObject.retry_after !== undefined
       ? String(failureObject.retry_after).trim()
       : "";
     var retryMessage = failureRetryAfter ? " Try again in " + failureRetryAfter + " seconds." : "";
-    jamSetViewStatus(
-      "jam-playlist-status",
-      "Added " + queued + (queued === 1 ? " song" : " songs") + " to the queue" + (skipped ? "; skipped " + skipped : "") + "." + (partial ? " The playlist was partially added." : "") + (failure ? " " + failure : "") + retryMessage,
-      partial ? "warning" : "success"
+    applyJamPlaylistSelectionReceipt(context, data);
+    var remaining = selectedBatch
+      ? _jamPlaylistSelectedPositions.size
+      : applyJamPlaylistEntireReceipt(context, data);
+    var recoveryMessage = interrupted && remaining
+      ? " " + remaining + (remaining === 1 ? " song remains" : " songs remain") +
+        (selectedBatch ? " selected." : " selected; use Add remaining songs to continue without duplicating the successful songs.")
+      : interrupted
+        ? " The batch stopped before Echo could confirm every remaining song."
+        : "";
+    var warning = interrupted || skipped > 0;
+    jamSetPlaylistActionStatus(
+      context,
+      "Added " + queued + (queued === 1 ? " song" : " songs") + " to the queue" + (skipped ? "; skipped " + skipped + " unavailable" : "") + "." + recoveryMessage + (failure ? " " + failure : "") + retryMessage,
+      warning ? "warning" : "success"
     );
-    showJamToast("Added " + queued + (queued === 1 ? " song" : " songs") + " from " + _jamPlaylist.name);
+    showJamToast("Added " + queued + (queued === 1 ? " song" : " songs") + " from " + context.playlist_name);
     fetchJamState();
   } catch (error) {
-    jamSetViewStatus("jam-playlist-status", "Could not add that playlist to the queue.", "error");
+    // This is normally already persisted before dispatch; remembering again
+    // refreshes its bounded recency without changing the request ID.
+    jamRememberAmbiguousPlaylistRequest(requestRecord);
+    jamSetPlaylistActionStatus(context, selectedBatch ? "Could not add the selected songs to the queue." : "Could not add that playlist to the queue.", "error");
     debugLog("[jam] playlist queue error: " + error);
   } finally {
-    _jamPlaylistQueuePending = false;
-    renderJamPlaylistSummary();
+    jamFinishPlaylistQueueOperation(operation);
   }
+}
+
+function addPlaylistToQueue() {
+  return enqueueJamPlaylist(jamPlaylistQueueActionContext(
+    _jamPlaylistResumeRequired ? jamSelectedPlaylistPositions() : null
+  ));
+}
+
+function addSelectedPlaylistTracksToQueue() {
+  return enqueueJamPlaylist(jamPlaylistQueueActionContext(jamSelectedPlaylistPositions()));
 }
 
 function jamDateValue(value) {
@@ -1940,17 +2743,17 @@ function jamDateValue(value) {
 
 function jamHistoryEntry(raw) {
   if (!raw || typeof raw !== "object") return null;
-  var trackSource = raw.track && typeof raw.track === "object" ? Object.assign({}, raw.track) : {
-    kind: "track",
-    spotify_id: raw.spotify_id || raw.track_id || raw.track_spotify_id,
-    spotify_uri: raw.spotify_uri || raw.track_uri,
-    spotify_url: raw.spotify_url || raw.track_url,
-    name: raw.name || raw.track_name,
-    artist: raw.artist || raw.track_artist,
-    artwork_url: raw.artwork_url || raw.album_art_url,
-    duration_ms: raw.duration_ms
-  };
+  var trackSource = raw.track && typeof raw.track === "object" ? Object.assign({}, raw.track) : {};
   trackSource.kind = "track";
+  trackSource.spotify_id = trackSource.spotify_id || raw.spotify_id || raw.track_id || raw.track_spotify_id;
+  trackSource.spotify_uri = trackSource.spotify_uri || trackSource.uri || raw.spotify_uri || raw.track_uri;
+  trackSource.spotify_url = trackSource.spotify_url || trackSource.url || raw.spotify_url || raw.track_url;
+  trackSource.name = trackSource.name || raw.name || raw.track_name;
+  trackSource.artist = trackSource.artist || trackSource.artist_name || raw.artist || raw.track_artist;
+  trackSource.artwork_url = trackSource.artwork_url || trackSource.album_art_url || raw.artwork_url || raw.album_art_url;
+  if (trackSource.duration_ms === undefined || trackSource.duration_ms === null) {
+    trackSource.duration_ms = raw.duration_ms;
+  }
   var track = normalizeSpotifyCatalogItem(trackSource, "track");
   var playlistSource = raw.playlist && typeof raw.playlist === "object" ? Object.assign({}, raw.playlist) : null;
   if (!playlistSource && (raw.playlist_id || raw.playlist_spotify_id)) {
@@ -1991,10 +2794,26 @@ function jamAppendHistoryTime(parent, label, date) {
   parent.appendChild(row);
 }
 
+function jamHistoryEmptyExplanation() {
+  return "Nothing has played through Echo yet. History records only songs added through Echo and then observed playing. Songs opened or played directly in Spotify are not recorded because Echo has no Jam adder attribution.";
+}
+
+function jamHistoryQueueActionTitle(contract) {
+  contract = contract || _jamContract || evaluateJamServerContract(null);
+  if (jamTrackQueuePending()) return "Wait for the current song to finish adding";
+  if (!contract.compatible) return contract.compatibilityMessage || "Queue controls are unavailable until Echo finishes updating";
+  if (!contract.active) return "Start a Jam to add this song to the queue";
+  if (contract.skipReconciliationPending) return "Wait for Echo to finish confirming the last Skip";
+  if (!contract.spotifyConnected) return "Connect Spotify before adding songs to the queue";
+  if (!contract.canControl) return "Queue controls are unavailable until the active Jam is ready";
+  return "Add this song to the active Jam queue";
+}
+
 function renderJamHistory(items) {
   var list = document.getElementById("jam-history-list");
-  if (!list) return;
+  if (!list) return 0;
   list.innerHTML = "";
+  var rendered = 0;
   (items || []).forEach(function(raw) {
     var entry = jamHistoryEntry(raw);
     if (!entry) return;
@@ -2028,8 +2847,36 @@ function renderJamHistory(items) {
       content.appendChild(provenance);
     }
     row.appendChild(content);
+    if (entry.track) {
+      var queueButton = document.createElement("button");
+      queueButton.type = "button";
+      queueButton.className = "jam-primary-btn jam-history-queue-btn";
+      queueButton.textContent = "Add to queue";
+      queueButton.setAttribute(
+        "aria-label",
+        "Add " + entry.track_name + " by " + (entry.artist || "unknown artist") + " to queue"
+      );
+      var contract = _jamContract || evaluateJamServerContract(null);
+      queueButton.disabled = jamTrackQueuePending() || !contract.canControl;
+      queueButton.title = jamHistoryQueueActionTitle(contract);
+      queueButton.setAttribute("aria-description", queueButton.title);
+      queueButton.onclick = async function() {
+        if (await addToQueue(entry.track)) {
+          jamSetViewStatus("jam-history-status", "Added " + entry.track_name + " to the queue.", "success");
+        }
+      };
+      row.appendChild(queueButton);
+    }
     list.appendChild(row);
+    rendered += 1;
   });
+  if (!rendered) {
+    var empty = document.createElement("li");
+    empty.className = "jam-history-empty";
+    empty.textContent = jamHistoryEmptyExplanation();
+    list.appendChild(empty);
+  }
+  return rendered;
 }
 
 async function loadJamHistory(offset) {
@@ -2037,6 +2884,7 @@ async function loadJamHistory(offset) {
   var controller = typeof AbortController === "function" ? new AbortController() : null;
   _jamHistoryController = controller;
   var requestId = ++_jamHistoryRequestSeq;
+  var requestedHistoryRevision = jamSafeOptionalInteger(_jamState && _jamState.history_revision);
   var requestedOffset = jamSafeInteger(offset, 0);
   var sort = document.getElementById("jam-history-sort");
   var direction = document.getElementById("jam-history-direction");
@@ -2065,8 +2913,9 @@ async function loadJamHistory(offset) {
       ? (_jamHistoryOffset + items.length < _jamHistoryTotal ? _jamHistoryOffset + JAM_HISTORY_PAGE_SIZE : null)
       : jamSafeInteger(suppliedNext, 0);
     _jamHistoryLoaded = true;
-    renderJamHistory(items);
-    jamSetViewStatus("jam-history-status", items.length ? "Play history loaded." : "Nothing has played yet.");
+    _jamHistoryLoadedRevision = requestedHistoryRevision;
+    var rendered = renderJamHistory(items);
+    jamSetViewStatus("jam-history-status", rendered ? "Play history loaded." : jamHistoryEmptyExplanation());
   } catch (error) {
     if (requestId !== _jamHistoryRequestSeq || (error && error.name === "AbortError")) return;
     jamSetViewStatus("jam-history-status", "Play history is unavailable right now.", "error");
@@ -2080,29 +2929,51 @@ async function loadJamHistory(offset) {
 }
 
 async function addToQueue(track) {
+  var normalizedTrack = normalizeSpotifyCatalogItem(Object.assign({}, track, { kind: "track" }), "track");
+  if (!normalizedTrack || jamTrackQueuePending() || !jamActionAllowed("control")) return false;
+  var generation = jamSafeOptionalInteger(_jamState && _jamState.generation);
+  if (generation === null) {
+    showJamError("Add to queue is unavailable until the Jam state refreshes.");
+    return false;
+  }
+  var requestRecord = jamTrackQueueRequestRecord(normalizedTrack, generation);
+  var operation = jamBeginTrackQueueOperation(requestRecord);
+  if (!operation) return false;
+  // Persist before dispatch so a renderer exit or interrupted response can
+  // safely retry the same logical add against the server's idempotency cache.
+  jamRememberAmbiguousTrackRequest(requestRecord);
   try {
-    if (!jamActionAllowed("control")) return;
     var resp = await fetch(apiUrl("/api/jam/queue"), {
       method: "POST",
       headers: jamActorHeaders(),
       body: JSON.stringify({
-        spotify_uri: track.spotify_uri,
-        name: track.name,
-        artist: track.artist,
-        album_art_url: track.album_art_url,
-        duration_ms: track.duration_ms,
-        generation: _jamState && _jamState.generation
+        spotify_uri: normalizedTrack.spotify_uri,
+        name: normalizedTrack.name,
+        artist: normalizedTrack.artist,
+        album_art_url: normalizedTrack.artwork_url,
+        duration_ms: normalizedTrack.duration_ms,
+        generation: generation,
+        request_id: requestRecord.request_id
       })
     });
     if (!resp.ok) {
-      var errText = await resp.text().catch(function() { return ""; });
-      showJamError("Add to queue failed" + (errText ? ": " + errText : " (status " + resp.status + ")"));
-      return;
+      if (jamTrackQueueOperationIsCurrent(operation)) jamForgetAmbiguousTrackRequest(requestRecord);
+      showJamError(await jamApiErrorMessage(resp, "add that song to the queue"));
+      return false;
     }
-    fetchJamState();
+    if (!jamTrackQueueOperationIsCurrent(operation)) return false;
+    jamForgetAmbiguousTrackRequest(requestRecord);
+    await fetchJamState();
+    return true;
   } catch (e) {
-    showJamError("Add to queue failed: " + e.message);
+    jamRememberAmbiguousTrackRequest(requestRecord);
+    if (jamTrackQueueOperationIsCurrent(operation)) {
+      showJamError("The add-to-queue response was interrupted. Try the same song again; Echo will reuse its request safely.");
+    }
     debugLog("[jam] addToQueue error: " + e);
+    return false;
+  } finally {
+    jamFinishTrackQueueOperation(operation);
   }
 }
 
@@ -2210,6 +3081,12 @@ async function leaveJam() {
 // State Polling
 // ──────────────────────────────────────────
 
+function jamHistoryNeedsRefresh(state) {
+  var revision = jamSafeOptionalInteger(state && state.history_revision);
+  return _jamActiveView === "history" && _jamHistoryLoaded && revision !== null &&
+    revision !== _jamHistoryLoadedRevision;
+}
+
 async function fetchJamState() {
   // Native source state is local to this PC and intentionally independent of
   // room/login state. Refresh it alongside each server Jam poll.
@@ -2238,6 +3115,7 @@ async function fetchJamState() {
     renderJamPanel();
     updateNowPlayingBanner(_jamState);
     startPendingJamAudioIfNeeded();
+    if (jamHistoryNeedsRefresh(_jamState)) loadJamHistory(_jamHistoryOffset);
   } catch (e) {
     if (!_jamStateRequestGate.isCurrent(requestId)) return;
     _jamState = null;
@@ -2342,6 +3220,7 @@ function renderJamPanel() {
 }
 
 function renderNowPlaying(np) {
+  syncJamAudioVisualizer(np);
   var container = document.getElementById("jam-now-playing");
   if (!container) return;
   if (!np || !np.name || !np.is_playing) {
@@ -2410,19 +3289,141 @@ function renderNowPlaying(np) {
   }
 }
 
+function jamQueueFallbackRenderSignature(queue) {
+  return JSON.stringify((Array.isArray(queue) ? queue : []).map(function(track) {
+    var playlist = track && track.playlist && typeof track.playlist === "object" ? track.playlist : {};
+    return [
+      jamQueueEntryId(track),
+      jamSafeString(track && track.delivery_state),
+      !!(track && track.can_remove),
+      jamSafeString(track && track.spotify_uri),
+      jamSafeString(track && track.name),
+      jamSafeString(track && track.artist),
+      jamSafeString(track && (track.album_art_url || track.artwork_url)),
+      jamSafeString(track && (track.added_by_name || track.added_by || track.added_by_actor_id)),
+      jamSafeString(playlist.spotify_uri || playlist.uri),
+      jamSafeString(playlist.name)
+    ];
+  }));
+}
+
+function jamQueueRenderSignature(queue) {
+  var revision = jamSafeOptionalInteger(_jamState && _jamState.queue_revision);
+  var queueKey = revision === null
+    ? "fallback:" + jamQueueFallbackRenderSignature(queue)
+    : "revision:" + revision;
+  var nowPlaying = _jamState && _jamState.now_playing;
+  return JSON.stringify([
+    jamSafeOptionalInteger(_jamState && _jamState.generation),
+    queueKey,
+    jamSafeString(nowPlaying && nowPlaying.spotify_uri),
+    !!(nowPlaying && nowPlaying.is_playing)
+  ]);
+}
+
+function captureJamQueueFocus(container) {
+  var active = document.activeElement;
+  if (!active || !container.contains(active)) return null;
+  var row = active.closest(".jam-queue-item");
+  if (!row) return null;
+  var rows = Array.prototype.slice.call(container.querySelectorAll(".jam-queue-item"));
+  return {
+    entry_id: jamSafeString(row.getAttribute("data-queue-entry-id")),
+    row_index: rows.indexOf(row),
+    control: jamSafeString(active.getAttribute("data-jam-queue-control"))
+  };
+}
+
+function restoreJamQueueFocus(container, focusState) {
+  if (!focusState) return;
+  var rows = Array.prototype.slice.call(container.querySelectorAll(".jam-queue-item"));
+  var row = rows.find(function(candidate) {
+    return candidate.getAttribute("data-queue-entry-id") === focusState.entry_id;
+  });
+  if (!row && rows.length) row = rows[Math.max(0, Math.min(focusState.row_index, rows.length - 1))];
+  var target = null;
+  if (row && focusState.control) {
+    target = Array.prototype.find.call(row.querySelectorAll("[data-jam-queue-control]"), function(candidate) {
+      return candidate.getAttribute("data-jam-queue-control") === focusState.control && !candidate.disabled;
+    });
+  }
+  if (!target && row) target = row.querySelector("input:not(:disabled), button:not(:disabled), a[href]");
+  if (!target) target = document.getElementById("jam-queue-remove-selected");
+  if (!target || target.disabled) target = document.getElementById("jam-view-queue-tab");
+  if (!target || target.disabled || typeof target.focus !== "function") return;
+  try { target.focus({ preventScroll: true }); } catch (_) { target.focus(); }
+}
+
+function syncJamQueueInteractiveState() {
+  var canControl = !!_jamContract && _jamContract.canControl;
+  document.querySelectorAll("#jam-queue-list .jam-queue-item").forEach(function(row) {
+    var entryId = jamSafeString(row.getAttribute("data-queue-entry-id"));
+    var checkbox = row.querySelector(".jam-queue-select");
+    var removeButton = row.querySelector(".jam-queue-remove-one");
+    if (checkbox) {
+      checkbox.checked = _jamQueueSelectedEntryIds.has(entryId);
+      checkbox.disabled = _jamQueueRemovalPending || !canControl;
+    }
+    if (removeButton) removeButton.disabled = _jamQueueRemovalPending || !canControl;
+  });
+}
+
 function renderQueue(queue) {
   var container = document.getElementById("jam-queue-list");
   if (!container) return;
+  queue = Array.isArray(queue) ? queue : [];
+  pruneJamQueueSelection(queue);
+  renderJamQueueRemovalControls(queue);
+  syncJamQueueInteractiveState();
+  var section = document.getElementById("jam-queue-section");
+  if (section && section.hidden) return;
+  var renderKey = jamQueueRenderSignature(queue);
+  if (_jamQueueRenderKey === renderKey) return;
+  var focusState = captureJamQueueFocus(container);
+  _jamQueueRenderKey = renderKey;
   if (!queue.length) {
-    container.innerHTML = '<div class="jam-queue-empty">Queue is empty</div>';
+    container.setAttribute("role", "list");
+    container.innerHTML = '<div class="jam-queue-empty" role="listitem">Queue is empty</div>';
+    restoreJamQueueFocus(container, focusState);
     return;
   }
+  container.setAttribute("role", "list");
   container.innerHTML = "";
-  queue.forEach(function(track) {
+  queue.forEach(function(track, index) {
     var normalizedTrack = normalizeSpotifyCatalogItem(Object.assign({}, track, { kind: "track" }), "track");
     var item = document.createElement("div");
     item.className = "jam-queue-item";
     item.setAttribute("role", "listitem");
+    var entryId = jamQueueEntryId(track);
+    var removable = jamQueueEntryRemovable(track);
+    if (entryId) item.setAttribute("data-queue-entry-id", entryId);
+    item.classList.toggle("jam-queue-item-removable", removable);
+    item.classList.toggle("jam-queue-item-locked", !removable);
+
+    var choice = document.createElement("label");
+    choice.className = "jam-queue-choice";
+    if (removable) {
+      var checkbox = document.createElement("input");
+      checkbox.type = "checkbox";
+      checkbox.className = "jam-queue-select";
+      checkbox.checked = _jamQueueSelectedEntryIds.has(entryId);
+      checkbox.disabled = _jamQueueRemovalPending || !(_jamContract && _jamContract.canControl);
+      checkbox.setAttribute("data-jam-queue-control", "select");
+      checkbox.setAttribute("aria-label", jamQueueSelectionLabel(track, index));
+      checkbox.onchange = function() {
+        if (checkbox.checked) _jamQueueSelectedEntryIds.add(entryId);
+        else _jamQueueSelectedEntryIds.delete(entryId);
+        renderJamQueueRemovalControls(queue);
+      };
+      choice.appendChild(checkbox);
+    } else {
+      var lockedIcon = document.createElement("span");
+      lockedIcon.className = "jam-queue-lock-icon";
+      lockedIcon.setAttribute("aria-hidden", "true");
+      lockedIcon.textContent = "\u2022";
+      choice.appendChild(lockedIcon);
+    }
+    item.appendChild(choice);
     item.appendChild(jamCreateArtwork({ artwork_url: jamSafeArtworkUrl(track.album_art_url || track.artwork_url) }, "jam-result-art"));
     var info = document.createElement("div");
     info.className = "jam-result-info";
@@ -2430,6 +3431,7 @@ function renderQueue(queue) {
     var name = normalizedTrack
       ? jamCreateSpotifyLink(normalizedTrack, trackName, "jam-result-name jam-spotify-link")
       : document.createElement("div");
+    if (normalizedTrack) name.setAttribute("data-jam-queue-control", "track-link");
     if (!normalizedTrack) {
       name.className = "jam-result-name";
       name.textContent = trackName;
@@ -2448,14 +3450,206 @@ function renderQueue(queue) {
       var provenance = document.createElement("div");
       provenance.className = "jam-queue-provenance";
       provenance.appendChild(document.createTextNode("From "));
-      provenance.appendChild(jamCreateSpotifyLink(playlist, playlist.name, "jam-spotify-link"));
+      var playlistLink = jamCreateSpotifyLink(playlist, playlist.name, "jam-spotify-link");
+      playlistLink.setAttribute("data-jam-queue-control", "playlist-link");
+      provenance.appendChild(playlistLink);
       info.appendChild(provenance);
     }
+    if (!removable) {
+      var lockedReason = document.createElement("div");
+      lockedReason.className = "jam-queue-lock-reason";
+      lockedReason.textContent = jamQueueLockedReason(track, index);
+      info.appendChild(lockedReason);
+    }
     item.appendChild(info);
+    if (removable) {
+      var removeButton = document.createElement("button");
+      removeButton.type = "button";
+      removeButton.className = "jam-secondary-btn jam-queue-remove-one";
+      removeButton.textContent = "Remove";
+      removeButton.disabled = _jamQueueRemovalPending || !(_jamContract && _jamContract.canControl);
+      removeButton.setAttribute("data-jam-queue-control", "remove");
+      removeButton.setAttribute("aria-label", jamQueueRemoveLabel(track, index));
+      removeButton.onclick = function() { removeJamQueueEntries([entryId]); };
+      item.appendChild(removeButton);
+    }
     name.title = name.textContent;
     artist.title = artist.textContent;
     container.appendChild(item);
   });
+  restoreJamQueueFocus(container, focusState);
+}
+
+function jamQueueEntryId(track) {
+  return jamSafeString(track && track.queue_entry_id);
+}
+
+function jamQueueEntryRemovable(track) {
+  return !!track && track.can_remove === true &&
+    jamSafeString(track.delivery_state) === "pending" && !!jamQueueEntryId(track);
+}
+
+function jamQueueTrackDescription(track, index) {
+  var name = jamSafeString(track && track.name) || "Unknown track";
+  var artist = jamSafeString(track && track.artist);
+  return name + (artist ? " by " + artist : "") + ", queue position " + (index + 1);
+}
+
+function jamQueueSelectionLabel(track, index) {
+  return "Select " + jamQueueTrackDescription(track, index) + " for removal";
+}
+
+function jamQueueRemoveLabel(track, index) {
+  return "Remove " + jamQueueTrackDescription(track, index) + " from queue";
+}
+
+function jamQueueLockedReason(track, index) {
+  var deliveryState = jamSafeString(track && track.delivery_state);
+  if (deliveryState === "commit_unknown") {
+    return "Spotify delivery could not be verified. End Jam and start a new one to recover.";
+  }
+  var nowPlayingUri = jamSafeString(_jamState && _jamState.now_playing && _jamState.now_playing.spotify_uri);
+  var trackUri = jamSafeString(track && track.spotify_uri);
+  if (index === 0 && nowPlayingUri && trackUri && nowPlayingUri === trackUri) {
+    return "Currently playing in Spotify; it cannot be removed.";
+  }
+  if (deliveryState === "spotify_committed") {
+    return "Already sent to Spotify; it cannot be removed.";
+  }
+  if (deliveryState === "pending") {
+    return "This pending song is temporarily locked and cannot be removed.";
+  }
+  return "Removal is unavailable until Echo's server update is complete.";
+}
+
+function pruneJamQueueSelection(queue) {
+  var removableIds = new Set();
+  (Array.isArray(queue) ? queue : []).forEach(function(track) {
+    if (jamQueueEntryRemovable(track)) removableIds.add(jamQueueEntryId(track));
+  });
+  _jamQueueSelectedEntryIds.forEach(function(entryId) {
+    if (!removableIds.has(entryId)) _jamQueueSelectedEntryIds.delete(entryId);
+  });
+}
+
+function renderJamQueueRemovalControls(queue) {
+  var count = _jamQueueSelectedEntryIds.size;
+  var countElement = document.getElementById("jam-queue-selection-count");
+  var button = document.getElementById("jam-queue-remove-selected");
+  if (countElement) countElement.textContent = count + " song" + (count === 1 ? "" : "s") + " selected";
+  if (!button) return;
+  var contractCanControl = !!_jamContract && _jamContract.canControl;
+  var hasRemovableEntries = (Array.isArray(queue) ? queue : []).some(jamQueueEntryRemovable);
+  button.disabled = _jamQueueRemovalPending || !contractCanControl || !count || !hasRemovableEntries;
+  button.textContent = _jamQueueRemovalPending ? "Removing..." : "Remove selected";
+  button.title = !contractCanControl
+    ? "Queue removal is unavailable until Jam controls are ready"
+    : count
+      ? "Remove the selected pending songs from Echo's queue"
+      : "Select one or more pending songs first";
+}
+
+function jamQueueRemovalEntries(entryIds) {
+  var selectedIds = new Set(Array.isArray(entryIds) ? entryIds : []);
+  return ((_jamState && Array.isArray(_jamState.queue)) ? _jamState.queue : []).filter(function(track) {
+    return jamQueueEntryRemovable(track) && selectedIds.has(jamQueueEntryId(track));
+  }).map(jamQueueEntryId);
+}
+
+async function removeJamQueueEntries(entryIds) {
+  if (_jamQueueRemovalPending || !jamActionAllowed("control")) return;
+  var generation = jamSafeOptionalInteger(_jamState && _jamState.generation);
+  var queueRevision = jamSafeOptionalInteger(_jamState && _jamState.queue_revision);
+  var removableIds = jamQueueRemovalEntries(entryIds);
+  if (generation === null || queueRevision === null) {
+    jamSetViewStatus("jam-queue-status", "Queue removal is unavailable until Echo's server update is complete.", "warning");
+    return;
+  }
+  if (!removableIds.length) {
+    pruneJamQueueSelection((_jamState && _jamState.queue) || []);
+    renderQueue((_jamState && _jamState.queue) || []);
+    jamSetViewStatus("jam-queue-status", "Those songs are no longer removable. Review the refreshed queue.", "warning");
+    return;
+  }
+
+  _jamQueueRemovalPending = true;
+  renderQueue((_jamState && _jamState.queue) || []);
+  jamSetViewStatus("jam-queue-status", "Removing " + removableIds.length + " song" + (removableIds.length === 1 ? "" : "s") + "...");
+  try {
+    var response = await fetch(apiUrl("/api/jam/queue/remove"), {
+      method: "POST",
+      headers: jamActorHeaders(),
+      body: JSON.stringify({
+        generation: generation,
+        request_id: jamRequestId(),
+        expected_queue_revision: queueRevision,
+        queue_entry_ids: removableIds
+      })
+    });
+    if (!response.ok) {
+      if (response.status === 409) {
+        await fetchJamState();
+        jamSetViewStatus(
+          "jam-queue-status",
+          _jamState
+            ? "The queue changed. Echo refreshed it; review your selections before removing again."
+            : "The queue changed, but Echo could not refresh it. Refresh before trying again.",
+          _jamState ? "warning" : "error"
+        );
+        return;
+      }
+      jamSetViewStatus("jam-queue-status", await jamApiErrorMessage(response, "remove songs from the queue"), "error");
+      return;
+    }
+    var result = await response.json();
+    var removedIds = Array.isArray(result.removed_entry_ids) ? result.removed_entry_ids : removableIds;
+    removedIds.forEach(function(entryId) { _jamQueueSelectedEntryIds.delete(jamSafeString(entryId)); });
+    if (_jamState && Array.isArray(_jamState.queue)) {
+      var removed = new Set(removedIds.map(jamSafeString));
+      _jamState.queue = _jamState.queue.filter(function(track) { return !removed.has(jamQueueEntryId(track)); });
+      if (jamSafeOptionalInteger(result.queue_revision) !== null) _jamState.queue_revision = jamSafeOptionalInteger(result.queue_revision);
+    }
+    renderQueue((_jamState && _jamState.queue) || []);
+    var removedCount = jamSafeOptionalInteger(result.removed_count);
+    if (removedCount === null) removedCount = removedIds.length;
+    jamSetViewStatus("jam-queue-status", "Removed " + removedCount + " song" + (removedCount === 1 ? "" : "s") + " from the queue.", "success");
+    await fetchJamState();
+  } catch (error) {
+    debugLog("[jam] queue removal error: " + error);
+    await fetchJamState();
+    if (_jamState) {
+      var refreshedIds = new Set((Array.isArray(_jamState.queue) ? _jamState.queue : []).map(jamQueueEntryId));
+      var missingCount = removableIds.filter(function(entryId) { return !refreshedIds.has(entryId); }).length;
+      if (missingCount === removableIds.length) {
+        jamSetViewStatus(
+          "jam-queue-status",
+          "The response was interrupted, but Echo refreshed the queue and confirmed " +
+            missingCount + " selected song" + (missingCount === 1 ? " is" : "s are") + " no longer queued.",
+          "success"
+        );
+      } else {
+        jamSetViewStatus(
+          "jam-queue-status",
+          "The response was interrupted. Echo refreshed the queue; review your selections before trying again.",
+          "warning"
+        );
+      }
+    } else {
+      jamSetViewStatus(
+        "jam-queue-status",
+        "The response was interrupted and Echo could not refresh the queue. Do not retry until the queue is available.",
+        "error"
+      );
+    }
+  } finally {
+    _jamQueueRemovalPending = false;
+    if (_jamState) renderQueue(_jamState.queue || []);
+    else renderJamQueueRemovalControls([]);
+  }
+}
+
+function removeSelectedJamQueueEntries() {
+  removeJamQueueEntries(Array.from(_jamQueueSelectedEntryIds));
 }
 
 // ──────────────────────────────────────────
@@ -2470,6 +3664,8 @@ function startJamAudioStream() {
   }
 
   try {
+    _jamAudioStreamReady = false;
+    syncJamAudioVisualizer();
     // Build WebSocket URL from current API base (wss for https, ws for http)
     var base = apiUrl("/api/jam/audio");
     var wsUrl;
@@ -2516,6 +3712,18 @@ function startJamAudioStream() {
       }
 
       _jamGainNode.connect(_jamAudioCtx.destination);
+
+      // Echo Pulse observes the real Jam PCM on a separate muted branch. The
+      // existing playback graph remains source -> Jam gain -> destination, so
+      // visualization setup can never change volume, routing, or reliability.
+      if (window.EchoJamVisualizer && typeof window.EchoJamVisualizer.createAnalysisGraph === "function") {
+        try {
+          _jamAudioAnalysisGraph = window.EchoJamVisualizer.createAnalysisGraph(_jamAudioCtx);
+        } catch (analysisError) {
+          _jamAudioAnalysisGraph = null;
+          disableJamAudioVisualizer(analysisError);
+        }
+      }
     }
 
     if (_jamAudioCtx.state === "suspended") {
@@ -2527,6 +3735,7 @@ function startJamAudioStream() {
     var ws = new WebSocket(wsUrl);
     ws.binaryType = "arraybuffer";
     _jamAudioWs = ws;
+    syncJamAudioVisualizer();
     var terminalHandled = false;
     var protocolReady = false;
     var readyTimer = null;
@@ -2539,6 +3748,8 @@ function startJamAudioStream() {
         readyTimer = null;
       }
       if (_jamAudioWs === ws) _jamAudioWs = null;
+      _jamAudioStreamReady = false;
+      syncJamAudioVisualizer();
       if (_jamSessionState && _jamSessionState.streamClosedTransient) {
         var closeState = _jamSessionState.streamClosedTransient(reason);
         syncJamButtonsFromState();
@@ -2582,6 +3793,8 @@ function startJamAudioStream() {
             readyTimer = null;
           }
           debugLog("[jam] audio WebSocket authenticated and ready");
+          _jamAudioStreamReady = true;
+          syncJamAudioVisualizer();
           if (_jamSessionState && _jamSessionState.streamOpen) {
             _jamSessionState.streamOpen();
             syncJamButtonsFromState();
@@ -2627,6 +3840,17 @@ function startJamAudioStream() {
       var source = _jamAudioCtx.createBufferSource();
       source.buffer = buffer;
       source.connect(_jamGainNode);
+      var analysisConnected = false;
+      if (_jamAudioAnalysisGraph && _jamAudioAnalysisGraph.available && _jamAudioAnalysisGraph.analyser) {
+        try {
+          source.connect(_jamAudioAnalysisGraph.analyser);
+          analysisConnected = true;
+        } catch (_analysisConnectError) {}
+      }
+      if (_jamAudioAnalysisGraph && _jamAudioAnalysisGraph.available && !analysisConnected) {
+        destroyJamAudioAnalysisGraph();
+        syncJamAudioVisualizer();
+      }
       source.start(schedule.startTime);
       _jamNextPlayTime = Number.isFinite(schedule.nextPlayTime)
         ? schedule.nextPlayTime
@@ -2658,16 +3882,19 @@ function startJamAudioStream() {
 
 function stopJamAudioStream() {
   clearJamReconnectTimer();
+  _jamAudioStreamReady = false;
   if (_jamAudioWs) {
     _jamAudioWs.close();
     _jamAudioWs = null;
   }
+  destroyJamAudioAnalysisGraph();
   if (_jamAudioCtx) {
     _jamAudioCtx.close().catch(function() {});
     _jamAudioCtx = null;
     _jamGainNode = null;
   }
   _jamNextPlayTime = 0;
+  syncJamAudioVisualizer();
 }
 
 // ──────────────────────────────────────────
@@ -2839,6 +4066,8 @@ function bindJamCatalogControls() {
   };
   var importButton = document.getElementById("jam-import-spotify");
   if (importButton) importButton.onclick = importSpotifyFavorites;
+  var libraryRefreshButton = document.getElementById("jam-library-refresh-spotify");
+  if (libraryRefreshButton) libraryRefreshButton.onclick = connectSpotify;
 
   var playlistBack = document.getElementById("jam-playlist-back");
   if (playlistBack) playlistBack.onclick = closeJamPlaylistDetail;
@@ -2848,6 +4077,10 @@ function bindJamCatalogControls() {
   };
   var playlistAddAll = document.getElementById("jam-playlist-add-all");
   if (playlistAddAll) playlistAddAll.onclick = addPlaylistToQueue;
+  var playlistAddSelected = document.getElementById("jam-playlist-add-selected");
+  if (playlistAddSelected) playlistAddSelected.onclick = addSelectedPlaylistTracksToQueue;
+  var playlistClearSelection = document.getElementById("jam-playlist-clear-selection");
+  if (playlistClearSelection) playlistClearSelection.onclick = clearJamPlaylistSelection;
   var playlistLoadMore = document.getElementById("jam-playlist-load-more");
   if (playlistLoadMore) playlistLoadMore.onclick = function() {
     if (_jamPlaylistNextOffset !== null) fetchJamPlaylistItems(_jamPlaylistNextOffset, true);
@@ -2865,6 +4098,8 @@ function bindJamCatalogControls() {
   if (historyNext) historyNext.onclick = function() {
     if (_jamHistoryNextOffset !== null) loadJamHistory(_jamHistoryNextOffset);
   };
+  var queueRemoveSelected = document.getElementById("jam-queue-remove-selected");
+  if (queueRemoveSelected) queueRemoveSelected.onclick = removeSelectedJamQueueEntries;
 }
 
 function initJam() {
@@ -2943,10 +4178,20 @@ function cleanupJam() {
   _jamPlaylistRequestSeq += 1;
   _jamHistoryRequestSeq += 1;
   _jamPlaylistLoading = false;
-  _jamPlaylistQueuePending = false;
+  invalidateJamPlaylistQueueLifecycle();
+  invalidateJamTrackQueueLifecycle();
+  _jamPlaylistAccessError = null;
+  _jamPlaylistFailedOffset = 0;
+  _jamPlaylistSelectedPositions.clear();
+  _jamPlaylistResumeRequired = false;
   _jamImportPending = false;
+  _jamQueueSelectedEntryIds.clear();
+  _jamQueueRemovalPending = false;
+  _jamQueueRenderKey = null;
   _jamLibraryLoaded = false;
+  _jamLibraryKnownEmpty = null;
   _jamHistoryLoaded = false;
+  _jamHistoryLoadedRevision = null;
   stopBannerPolling();
   updateNowPlayingBanner(null);
   _jamState = null;
@@ -2960,6 +4205,7 @@ function cleanupJam() {
   }
   stopJamAudioStream();
   closeJamPanel({ restoreFocus: false });
+  destroyJamAudioVisualizer();
 }
 
 // ──────────────────────────────────────────

--- a/docs/JAM-LIBRARY-HISTORY.md
+++ b/docs/JAM-LIBRARY-HISTORY.md
@@ -13,27 +13,123 @@ playlist provenance.
 
 Spotify items that are null, malformed, local-only, non-track, restricted, or
 unplayable are skipped and reported. Playlist discovery and contents are lazy;
-opening a playlist fetches one page and **Add all** performs the server-side
-expansion. The viewer must never loop the single-track endpoint.
+opening a playlist fetches one page of up to 50 positions and **Add entire
+playlist** performs the server-side expansion. The viewer must never loop the
+single-track endpoint.
 
-Echo queues at most 50 playlist items in one batch and requires confirmation
-when more than 25 playable tracks will be added. The control server serializes
-queue batches, preserves duplicate occurrences, and revalidates the active Jam
-generation and bound Spotify device while it applies the batch. Other Jam
-recovery controls are not held behind the full multi-request Spotify operation.
+Echo exposes playlist pages in chunks of 50 and can queue up to 1,000 playlist
+positions in one operation. Spotify's supported Web API and the bounded
+public-catalog fallback described below both use pages of at most 50. The
+1,000-position ceiling bounds memory,
+idempotency receipts, local cache size, and bulk queue mutations. A larger
+restricted public playlist remains browsable and individually selectable
+through its first 1,000 positions, but **Add entire playlist** is disabled and
+no public-catalog request is made past position 999. Echo
+requires confirmation when more than 25 playable tracks will be added. The
+control server serializes queue mutations, preserves duplicate occurrences,
+and revalidates the active Jam generation and bound Spotify device before it
+accepts a batch.
 
-Spotify Development Mode restricts playlist-item reads to playlists the
-connected account owns or collaborates on. Search and Echo-favoriting still
-work for other playlist metadata, but Echo cannot flatten a playlist when
-Spotify withholds its items; the API and viewer report that restriction
-explicitly. Spotify apps in Extended Quota Mode are not subject to that 2026
-Development Mode change. See Spotify's
+Echo, rather than Spotify, owns the removable tail of the Jam queue. It hands a
+maximum frontier of two entries to Spotify and promotes more pending entries as
+playback advances. A queue row reports `delivery_state` and `can_remove`:
+
+- `pending` entries have not been handed to Spotify and can be removed.
+- `spotify_committed` entries are already current or queued in Spotify and
+  cannot be removed; the current entry can still be skipped.
+- `commit_unknown` means Spotify may have accepted a request whose result was
+  ambiguous. Echo fails closed and does not remove or resend that occurrence.
+  Playback URI, progress, and play/pause state are not acceptance proof, so the
+  entry remains locked and unattributed until the Jam ends.
+
+Once a `commit_unknown` entry exists, Echo rejects new single-song and playlist
+adds with `queue_commit_unknown`; otherwise those entries would be permanently
+stranded behind an unresolved Spotify frontier. Idempotent retries of the
+original accepted Echo request still replay their receipt, and pending-tail
+removal remains available. End and restart the Jam to establish a clean queue.
+
+Any current Jam participant can remove one or many pending occurrences by their
+unique queue-entry IDs. Removal is atomic, generation-fenced, revision-fenced,
+and idempotent by request ID. A stale queue revision or a selection that now
+contains a committed/unknown entry returns a conflict without removing any
+rows. The API accepts at most 1,000 entry IDs per removal. Entry IDs, not Spotify
+track IDs, keep duplicate occurrences independently selectable.
+
+Single-track queue requests may also carry an idempotency request ID. The Jam
+state advertises support with `track_queue_request_id_supported`; retries with
+the same actor, generation, and Spotify track replay the original queue entry,
+while reuse for different inputs is rejected. The field remains optional so a
+cached older viewer continues to use the legacy one-shot request path during a
+coordinated rollout.
+
+Adjacent duplicate tracks require occurrence-level confirmation before Echo
+advances the frontier. A near-end-to-near-start progress wrap is accepted only
+when Spotify repeat-one is off and Spotify's queue observation confirms the
+next item is no longer the same track. A repeat-one loop, a backward seek that
+leaves the duplicate next item intact, or an unavailable queue observation
+fails closed and leaves the frontier locked rather than silently consuming an
+Echo occurrence.
+
+Echo also retains whether Spotify started an occurrence immediately or queued
+it behind the current item. A queued-next occurrence cannot match Play History
+or become Echo's current queue row until a different current track, a preceding
+Echo occurrence, or a confirmed same-track restart proves that boundary. This
+prevents an externally playing copy of the same Spotify track from stealing the
+queued occurrence's contributor and playlist provenance.
+
+A successful Spotify Skip proves exactly one occurrence boundary. Echo retires
+only the eligible front and unlocks only the first queued-next successor, even
+when both occurrences use the same Spotify track URI. An ambiguous successor
+remains `commit_unknown`, non-removable, locked, and excluded from Play History
+for the rest of that Jam generation.
+
+Skip's authoritative preflight is also a Play History observation. This keeps a
+short-lived queued song in history when Spotify advances between normal Jam
+state polls and someone immediately skips it. The normal consecutive-same-song
+run dedupe still applies. If the preflight's selected current candidate is
+`commit_unknown`—including a same-song candidate after a stale different
+predecessor—Echo rejects Skip before calling Spotify `/next`; it never promotes,
+attributes, or removes the ambiguous occurrence.
+
+Selected-song queueing uses a distinct capability-gated endpoint and requires
+the exact Spotify playlist snapshot shown in the viewer. A page whose snapshot
+changes is discarded and reloaded before any positions can be submitted. If a
+large operation is accepted, all playable positions enter Echo's queue as one
+batch while only the bounded Spotify frontier becomes non-removable.
+Unavailable/local skips are reported and never enter the queue.
+
+Spotify Development Mode restricts the supported playlist-item endpoint to
+playlists the connected account owns or collaborates on. Search and Echo
+favoriting still work for other public playlist metadata. When that one known
+restriction occurs, Echo makes a user-triggered, read-only public-catalog
+request for exactly 50 ordered positions and stores the normalized result in
+the private `jam-library/playlist-items-cache-v2.json` file. There is no
+background crawl, no export endpoint, and no account/browser cookie is read.
+The cache is keyed by Spotify playlist snapshot, preserves duplicate
+occurrences and unavailable positions, and is replaced automatically when the
+snapshot changes. HARDWAVE-sized playlists therefore load as five 50-position
+pages plus the remainder; the viewer reports both visible and locally cached
+counts. The 50-position request size is a bounded implementation and rate-safety
+guardrail; it is not, by itself, a statement or guarantee of Spotify policy or
+legal compliance.
+
+Bulk and selected-song queueing continue through the normal server-side
+`PlaylistExpansion` path, so snapshot checks, provenance, idempotency, and Jam
+race fences are unchanged. A durable Stop-admission fence also rejects any
+track or playlist request that began before **Stop Music**, even if a later
+request resumes the preserved queue before the older playlist finishes
+loading. If Spotify changes the public response contract,
+Echo fails closed with a **Retry 50-song chunk** action and keeps **Open in
+Spotify** available; it never substitutes guessed titles or IDs. Spotify apps
+in Extended Quota Mode are not subject to the supported-endpoint 2026
+Development Mode restriction. See Spotify's
 [migration guide](https://developer.spotify.com/documentation/web-api/tutorials/february-2026-migration-guide)
 and [Get Playlist Items contract](https://developer.spotify.com/documentation/web-api/reference/get-playlists-items).
 
-Echo does not claim that queued tracks can be removed individually. Removing a
-favorite changes the shared library only and never changes Spotify playback or
-an existing Jam queue.
+Echo never claims it can delete an item already handed to Spotify. Removing a
+pending Echo queue entry prevents that occurrence from being handed to Spotify;
+removing a favorite changes the shared library only and never changes playback
+or an existing Jam queue.
 
 ## Shared Echo favorites
 
@@ -45,6 +141,22 @@ Echo Favorites are deliberately distinct from Spotify's own Liked Songs and
 followed-playlist state. Viewer labels and controls say **Echo Favorites** so a
 local Echo action is never presented as a Spotify Like action.
 
+Library track cards expose distinct **Open in Spotify** and **Add to queue**
+actions. Library and Search playlist cards expose **Open in Spotify** and
+**Choose songs**; choosing songs opens Echo's playlist detail, where an allowed
+playlist can be selected song-by-song or added in full.
+
+When Echo Favorites is empty, **Copy Spotify saves** copies the connected
+account's Liked Songs and saved playlists into the shared library. It does not
+copy the songs inside those playlists, change Spotify, or add anything to the
+Jam queue. After first use, the compact **Check for new Spotify saves** action
+adds newly saved items; the operation is safe to rerun and never removes an Echo
+Favorite. Echo only shows **Connect Spotify** or **Grant Spotify Library Access**
+when that action is actually required. A playlist found through Search can
+instead be saved individually with the star or **Save to Echo**. **Add entire
+playlist** only expands the playlist into queued tracks; it does not favorite
+that playlist or backfill playlists queued before this feature existed.
+
 - **All favorites** shows each item once.
 - Contributor filters select items favorited by one Echo actor.
 - Favoriting an existing item adds the current actor relation idempotently.
@@ -55,8 +167,16 @@ local Echo action is never presented as a Spotify Like action.
 
 Imports and catalog pages follow Spotify pagination and share a server-wide
 request/cooldown gate for 429 responses. Playlist artwork URLs are temporary,
-so they are shown from fresh Spotify responses but are not persisted in the
-durable Echo Favorites file.
+so they are never persisted in the durable Echo Favorites file and image bytes
+are never downloaded by the control server. Echo keeps validated Spotify-CDN
+URLs in a bounded, one-hour process-memory cache seeded by import, Search, and
+playlist detail responses. After a restart, only playlist covers on the
+returned Favorites page are refreshed through Spotify's metadata-only images
+endpoint, with at most 50 cache misses and a five-second total deadline. Cover
+authorization, rate-limit, timeout, and image-load failures degrade to the
+standard placeholder without failing the Library. A successful new Spotify
+authorization clears the transient cache so private artwork cannot cross an
+account boundary.
 
 Library import and private/collaborative playlist access add the
 `user-library-read`, `playlist-read-private`, and
@@ -83,11 +203,22 @@ History uses run-based deduplication by Spotify track identity:
 - `A, B, A` records A, B, and A.
 - Pause/resume, looping, and adjacent duplicate queue entries do not create a
   new record until a different track is observed playing.
+- An external Spotify occurrence is not recorded. If an Echo-queued occurrence
+  of that same track follows it, Echo records the queued occurrence once the
+  occurrence boundary is confirmed; later consecutive Echo repeats remain
+  deduplicated.
 
 Records are retained for exactly 30 days in a dedicated, non-web-readable
 store. Retention is enforced during startup, append, periodic maintenance, and
 query cutoff. History begins when the feature is deployed; the existing
 join/leave session logs cannot reconstruct earlier plays.
+
+While the History tab is visible, the viewer reloads its current page only when
+the Jam state reports that a durable history append advanced the history
+revision. Unchanged state polls preserve the existing History DOM and focus.
+Each playable History row also exposes an explicit **Add to queue** action. It
+reuses the single-track idempotency contract, keeps the current History page and
+sort in place, and explains that a Jam must be started when queueing is disabled.
 
 At startup, Echo validates the favorites, history, actor-key, and Spotify-token
 paths against every web-served root. Existing private data in an overlapping or
@@ -108,9 +239,29 @@ Spotify attribution mark. Artwork uses contain sizing so Echo does not crop or
 overlay Spotify-provided images. The checked-in full wordmark comes from
 Spotify's official [design and branding assets](https://developer.spotify.com/documentation/design).
 
+## Echo Pulse
+
+The Jam workspace includes a compact audio-reactive spectrum beneath Now
+Playing. Echo Pulse analyzes the authenticated 48 kHz PCM that the joined Echo
+viewer already receives; it does not sample Spotify artwork, scrape Spotify
+audio, upload audio, or persist any audio-derived data.
+
+Analysis is an optional muted branch beside the existing playback graph. A
+missing or failing Web Audio analyser leaves Jam playback and output routing
+unchanged and shows a static fallback. The source PC can therefore visualize
+the communal feed even when its local relay gain is intentionally muted to
+prevent doubled Spotify audio.
+
+Full motion is capped at 24 frames per second, Ambient motion at 12 frames per
+second, and Still/system reduced-motion renders one non-animated spectrum.
+Animation pauses while the Jam panel or document is hidden and stops when no
+track is playing. Users who have not joined see a truthful static
+**Join Jam to activate** state; Echo never substitutes fake reactive motion.
+
 ## Release boundary
 
 The catalog, favorites, playlist expansion, history API, persistence, and
 server-served viewer are server changes. Guaranteed native Spotify deep links
 add a Windows desktop-binary change. Old clients remain compatible through the
-HTTPS fallback. Jam source/audio protocol version 3 is unchanged.
+HTTPS fallback. Echo Pulse is server-served viewer code and does not require a
+desktop update. Jam source/audio protocol version 3 is unchanged.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -89,12 +89,49 @@ start it, join it, search, add songs, skip, and use **Stop Music** from Echo's J
 do not need Spotify accounts and should add their songs through Echo, not through
 their own Spotify apps. Spotify playback is always targeted back to the one
 configured desktop device and Premium host account. Echo does
-not offer a fake queue-removal control because Spotify's API cannot remove an
-individual queued item. The configured source PC has local-only **Allow Echo
-Jam to use Spotify on this PC** and **Hear Jam on this PC** switches before Echo
-login and in the Jam panel. Hear Jam uses the independent Jam Volume without
-changing anyone else's level. Stop Music pauses playback for everyone but
-preserves the active Jam, queue, listeners, capture route, and audio sockets.
+not offer a fake removal control for entries already handed to Spotify because
+Spotify's API cannot delete an individual queued item. Echo keeps later entries
+pending behind a bounded Spotify frontier; any current Jam participant may
+remove one or many pending occurrences, while committed or ambiguous entries
+remain locked and the current track may be skipped. The configured source PC
+has local-only **Allow Echo Jam to use Spotify on this PC** and **Hear Jam on
+this PC** switches before Echo login and in the Jam panel. Hear Jam uses the
+independent Jam Volume without changing anyone else's level. Stop Music pauses
+playback for everyone and prevents automatic frontier promotion, but preserves
+the active Jam, pending queue, listeners, capture route, and audio sockets. An
+explicit later queue add resumes playback as before. Skip while stopped may
+advance Spotify's paused selection, but it does not resume audio or promote a
+new pending frontier entry. A timeout or source-safety loss during a Spotify
+mutation also marks that Jam generation stopped after Echo's best-effort device
+pause, preventing a later state poll from silently resuming or replacing the
+uncertain occurrence. Successful Skip retires the exactly observed Echo front
+and refills the bounded Spotify frontier before another Skip can run. A
+committed front observed stopped at its natural end (or followed by Spotify's
+no-content state after enough elapsed play time) is retired, so a later explicit
+add starts or resumes instead of being stranded behind a stale occurrence. That
+add-time retirement requires either an exact stopped-at-duration observation or
+a prior playing trajectory that corroborates the no-content transition; a
+legitimately paused near-end track is preserved and an explicit add resumes it
+before queueing the new track. Skip unlocks exactly the first queued-next
+accepted successor occurrence. An ambiguous successor remains non-removable,
+unmatched, and locked until the Jam ends. Playback URI/progress alone never
+promotes `commit_unknown`, and new track/playlist adds return
+`queue_commit_unknown` with instructions to end and restart the Jam; pending
+tail removal remains available.
+
+Skip performs a fresh bound-device preflight. If adjacent same-URI occurrences
+are ambiguous, Echo also requires Spotify's current/next queue observation
+before calling `/next`. A transport error, timeout, or Spotify 5xx after that
+mutation is treated as an unknown Skip result: Echo best-effort pauses the
+device, exposes `skip_reconciliation_pending`, and blocks another Skip, queue
+add, or playback resume. A later bound-device player/queue observation resolves
+accepted versus rejected exactly once. Spotify player `204 No Content` is not
+acceptance proof and leaves the fence in place; ending the Jam clears it.
+Skip also fails before `/next` whenever its authoritative current candidate is
+`commit_unknown`, regardless of whether Spotify reports a different next item,
+no next item, or Echo last observed a different predecessor. This prevents an
+external same-URI occurrence from inheriting Echo queue or Play History
+provenance.
 
 The shared Echo Favorites layer and 30-day Play History are defined in
 `docs/JAM-LIBRARY-HISTORY.md`. Playlists are always expanded server-side into
@@ -102,6 +139,18 @@ ordinary track queue entries; the queue and source protocol never contain a
 playlist object. Favorite removal never removes queued Spotify items. History
 records only Echo queue entries that Spotify is subsequently observed playing,
 with consecutive repeats collapsed until a different track plays.
+
+Restricted public playlists are cataloged only after a participant opens or
+queues them, in fixed 50-position requests. The normalized, snapshot-keyed
+cache is private at `session-logs/jam-library/playlist-items-cache-v2.json` and
+uses the same atomic primary/backup recovery model as Echo Favorites. Do not
+place that file under the viewer/admin/static roots. It contains track metadata,
+not Spotify credentials; the anonymous public-catalog token remains memory-only.
+Echo stops restricted public-catalog paging at 1,000 positions, disables bulk
+queueing for a larger playlist, and keeps selection available for the cached
+first 1,000. All public and supported Spotify requests share the same in-process
+429 cooldown. The 50-position boundary is an operational guardrail, not a
+policy-compliance guarantee.
 
 Listener audio uses `/api/jam/audio?jam_protocol_version=3&generation=...`.
 Credentials are not placed in that URL: the listener's first WebSocket frame is

--- a/docs/UI-RESPONSIVE-CONTRACT.md
+++ b/docs/UI-RESPONSIVE-CONTRACT.md
@@ -167,6 +167,13 @@ JavaScript must not write per-breakpoint pixel widths, move feature nodes betwee
 alternate parents, or decide which text happens to fit. A component that needs
 local adaptation declares a containment boundary and uses container queries.
 
+Jam's Echo Pulse canvas is a stable child of the session overview rather than
+the polling-rebuilt Now Playing metadata node. Its CSS surface owns width and
+height, remains within the overview or sheet scroll owner, and contracts only
+under the existing `data-ui-very-short` pressure flag. Its backing resolution
+is device-pixel-ratio and pixel-budget capped; resize and motion changes never
+recreate the canvas or alter the Jam audio graph.
+
 The screen-grid allocator calculates media tile geometry inside the stage. It
 receives the stage's available rectangle; it must not duplicate shell
 breakpoints or control utility-panel behavior. A single visible share owns the
@@ -222,8 +229,13 @@ and geometry change together.
 
 - Workspace columns are `minmax(0, 1fr)` plus a utility rail of
   `clamp(320px, 24vw, 360px)` with a `16px` gap.
-- Opening or switching a utility tool reuses the rail; it never adds another
-  workspace column.
+- People and Chat reuse that rail; opening either never adds another workspace
+  column.
+- Jam is the feature-dense exception: it opens as a centered workspace capped
+  at `1120px` wide and `840px` tall. At container widths of at least `820px`,
+  playback/listening controls occupy the left column and
+  Library/Search/Queue/History occupy the flexible right column. The obscured
+  stage is inert behind the utility scrim while the call dock stays available.
 - Closing an optional tool may return its width to the stage. If People is the
   product's persistent default tool, closing another tool returns to People
   rather than leaving an empty rail.
@@ -235,6 +247,8 @@ and geometry change together.
 - The stage owns the full workspace width.
 - The utility host becomes an end-edge drawer with an inline size of
   `clamp(320px, 42vw, 380px)`.
+- Jam keeps its centered workspace treatment where at least `820px` of
+  container width is available; otherwise it falls back to one column.
 - Opening the drawer overlays the stage; it does not resize the stage or trigger
   a media-grid mode change beyond normal occlusion/resize observation.
 - The drawer has a workspace-bounded scrim while open. The obscured stage is
@@ -312,8 +326,9 @@ must not remove the dock and cause the workspace to jump.
 - Tool selection and open/closed state survive geometry-mode transitions.
 - A mode transition changes the host from pinned rail to overlay drawer to
   sheet/full-screen without recreating the active tool.
-- Each tool owns one scrollable body. Its header and critical footer actions
-  remain visible.
+- Each rail or drawer tool owns one scrollable body. Wide Jam may split that
+  ownership into independent session-overview and music-browser scrollers so a
+  long catalog does not push playback controls away. Its header remains visible.
 - Utility rails, drawers, and sheets are not true modal dialogs. When a utility
   surface obscures the stage, only the obscured stage becomes inert; the active
   utility surface and the call dock remain keyboard-operable. Escape closes the
@@ -435,7 +450,8 @@ expected mode is the fresh-document classification without hysteresis history.
 
 | Viewport / condition | Expected mode | Required content case | Expected behavior |
 | --- | --- | --- | --- |
-| `1920 x 1080` | `theater` | Four shares, twelve people, utility open | Rail remains within `320-360px`; stage has no horizontal overflow |
+| `1920 x 1080` | `theater` | Four shares, twelve people, People or Chat open | Rail remains within `320-360px`; stage has no horizontal overflow |
+| `1920 x 1080` | `theater` | Populated Jam open | Jam is centered, at least `840px` and at most `1120px` wide, uses two columns, and leaves the dock interactive |
 | `1366 x 768` | `theater` | Two shares, eight long participant names | Dock stays one row; names truncate; stage remains usable |
 | `1280 x 720` | `theater` on initial load | One ultrawide share, People open | Rail uses its minimum range; share preserves aspect ratio |
 | `1024 x 768` | `lounge` | Two shares, Chat open with draft | Overlay does not shrink stage; draft survives close/reopen |

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Echo Chamber repo metadata. Active development lives under core/.",
   "scripts": {
     "verify:guardrails": "node tools/verify/guardrails.mjs",
-    "verify:viewer": "node --check core/viewer/app.js && node --check core/viewer/jam.js && node --check core/viewer/ui-shell.js && node --check core/viewer/theme-runtime.js && node --check core/viewer/theme-effects.js && node --check core/viewer/theme.js && node --check core/viewer/capture-picker.js && node --check core/admin/diagnostics/diagnostics.js && node --test core/viewer/*.test.js",
+    "verify:viewer": "node --check core/viewer/app.js && node --check core/viewer/jam-visualizer.js && node --check core/viewer/jam.js && node --check core/viewer/ui-shell.js && node --check core/viewer/theme-runtime.js && node --check core/viewer/theme-effects.js && node --check core/viewer/theme.js && node --check core/viewer/capture-picker.js && node --check core/admin/diagnostics/diagnostics.js && node --test core/viewer/*.test.js",
     "verify:viewer:layout": "npm --prefix core/viewer-tests test",
     "verify:quick": "npm run verify:guardrails && npm run verify:viewer"
   }


### PR DESCRIPTION
## What changed

- turns the Jam panel into a wider, responsive music workspace with Library, Search, Queue, and 30-day History views
- adds shared Echo Favorites with contributor filtering, Spotify Library import, playlist artwork hydration, Spotify links, and direct queue actions
- expands playlists into ordinary track queue entries, supporting both selected-song and entire-playlist adds with bounded 50-position catalog paging and private snapshot-aware caching
- adds safe single and bulk removal for still-pending queue entries while preserving Spotify-committed queue truth
- records provenance-aware Play History, collapses uninterrupted loops, refreshes visible History automatically, and lets users requeue prior tracks
- adds Echo Pulse, a responsive real-PCM audio visualizer with reduced-motion behavior and a failure-isolated muted analysis branch

## Why

The original Jam UI treated Library, playlists, queue state, and History as separate partial experiences. Playlist item access also needed a bounded fallback for public playlists that Spotify's app-scoped API would summarize but not expand. This completes the intended shared music workflow while keeping the canonical queue track-only and preserving exact Spotify mutation state.

## Release impact

- Server/control: yes
- Server-served viewer: yes
- Desktop binary: no
- Windows installer or updater release: no

## Validation

- Sam manually approved isolated test6 build `1fec7c768760` on the live Echo host
- `cargo test -p echo-core-control --locked`: 229 passed
- `npm run verify:viewer`: 267 passed
- `npm run verify:viewer:layout`: 141 passed
- `npm run verify:guardrails`: passed
- release control build completed and the deployed test6 binary/assets passed exact fingerprint, hash, health, loopback, and data-preservation checks
