### PR TITLE
Restore durable Dashboard history and add time ranges

### DIFF
--- a/core/control/src/admin.rs
+++ b/core/control/src/admin.rs
@@ -6,14 +6,14 @@ use crate::rooms::SessionEvent;
 use crate::AppState;
 
 use axum::{
-    extract::{Json, State},
+    extract::{Json, Query, State},
     http::{HeaderMap, StatusCode},
 };
 use serde::{Deserialize, Serialize};
 use std::{
     collections::{HashMap, HashSet},
     fs,
-    path::PathBuf,
+    path::{Path, PathBuf},
     time::{SystemTime, UNIX_EPOCH},
 };
 use tracing::{info, warn};
@@ -314,6 +314,109 @@ pub(crate) struct AdminParticipantInfo {
 #[derive(Serialize)]
 pub(crate) struct AdminSessionsResponse {
     events: Vec<SessionEvent>,
+    next_cursor: Option<String>,
+    total_count: usize,
+    available_from: Option<u64>,
+    available_to: Option<u64>,
+    available_years: Vec<u32>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+pub(crate) struct AdminSessionsQuery {
+    #[serde(rename = "range")]
+    range_name: Option<String>,
+    limit: Option<usize>,
+    cursor: Option<String>,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+struct SessionEventKey {
+    timestamp: u64,
+    event_type: String,
+    identity: String,
+    name: String,
+    room_id: String,
+    duration_secs: Option<u64>,
+}
+
+impl From<&SessionEvent> for SessionEventKey {
+    fn from(event: &SessionEvent) -> Self {
+        Self {
+            timestamp: event.timestamp,
+            event_type: event.event_type.clone(),
+            identity: event.identity.clone(),
+            name: event.name.clone(),
+            room_id: event.room_id.clone(),
+            duration_secs: event.duration_secs,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum SessionHistoryRange {
+    RelativeDays(u64),
+    All,
+    CalendarYear(u32),
+}
+
+impl SessionHistoryRange {
+    fn parse(value: Option<&str>) -> Result<Self, StatusCode> {
+        let value = value.unwrap_or("month");
+        match value {
+            "week" => Ok(Self::RelativeDays(7)),
+            "month" => Ok(Self::RelativeDays(30)),
+            "quarter" => Ok(Self::RelativeDays(90)),
+            "year" => Ok(Self::RelativeDays(365)),
+            "all" => Ok(Self::All),
+            _ => {
+                let year = value
+                    .strip_prefix("year:")
+                    .filter(|raw| raw.len() == 4 && raw.bytes().all(|byte| byte.is_ascii_digit()))
+                    .and_then(|raw| raw.parse::<u32>().ok())
+                    .filter(|year| (1970..=9999).contains(year))
+                    .ok_or(StatusCode::BAD_REQUEST)?;
+                Ok(Self::CalendarYear(year))
+            }
+        }
+    }
+
+    fn cursor_scope(&self) -> String {
+        match self {
+            Self::RelativeDays(7) => "week".to_string(),
+            Self::RelativeDays(30) => "month".to_string(),
+            Self::RelativeDays(90) => "quarter".to_string(),
+            Self::RelativeDays(365) => "year".to_string(),
+            Self::RelativeDays(days) => format!("days:{days}"),
+            Self::All => "all".to_string(),
+            Self::CalendarYear(year) => format!("year:{year:04}"),
+        }
+    }
+
+    fn includes(&self, timestamp: u64, now: u64) -> bool {
+        match self {
+            Self::RelativeDays(days) => {
+                timestamp >= now.saturating_sub(days.saturating_mul(86_400)) && timestamp <= now
+            }
+            Self::All => true,
+            Self::CalendarYear(year) => {
+                let Some(start) = unix_timestamp_for_date(*year, 1, 1) else {
+                    return false;
+                };
+                let Some(end) = unix_timestamp_for_date(year.saturating_add(1), 1, 1) else {
+                    return false;
+                };
+                timestamp >= start && timestamp < end
+            }
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct SessionHistoryCursor {
+    version: u8,
+    range: String,
+    event: SessionEventKey,
 }
 
 #[derive(Serialize)]
@@ -432,34 +535,243 @@ pub(crate) async fn admin_dashboard(
 pub(crate) async fn admin_sessions(
     State(state): State<AppState>,
     headers: HeaderMap,
+    Query(query): Query<AdminSessionsQuery>,
 ) -> Result<Json<AdminSessionsResponse>, StatusCode> {
     ensure_admin(&state, &headers)?;
-
-    // Read today's and yesterday's session logs
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
         .as_secs();
-    let today_days = now / 86400;
-    let mut all_events = Vec::new();
+    load_admin_sessions(&state.session_log_dir, query, now).map(Json)
+}
 
-    for offset in 0..30 {
-        let days = today_days - offset;
-        let (year, month, day) = epoch_days_to_date(days);
-        let file_name = format!("sessions-{:04}-{:02}-{:02}.json", year, month, day);
-        let file_path = state.session_log_dir.join(&file_name);
-        if let Ok(data) = fs::read_to_string(&file_path) {
-            if let Ok(events) = serde_json::from_str::<Vec<SessionEvent>>(&data) {
-                all_events.extend(events);
-            }
-        }
+const ADMIN_SESSIONS_DEFAULT_LIMIT: usize = 1_000;
+const ADMIN_SESSIONS_MAX_LIMIT: usize = 1_000;
+const ADMIN_SESSIONS_MAX_CURSOR_BYTES: usize = 4_096;
+
+fn load_admin_sessions(
+    session_log_dir: &Path,
+    query: AdminSessionsQuery,
+    now: u64,
+) -> Result<AdminSessionsResponse, StatusCode> {
+    let range = SessionHistoryRange::parse(query.range_name.as_deref())?;
+    let limit = query.limit.unwrap_or(ADMIN_SESSIONS_DEFAULT_LIMIT);
+    if limit == 0 || limit > ADMIN_SESSIONS_MAX_LIMIT {
+        return Err(StatusCode::BAD_REQUEST);
     }
 
-    // Sort by timestamp descending (most recent first), limit to 1000
-    all_events.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
-    all_events.truncate(1000);
+    let mut all_events = read_session_history_files(session_log_dir);
+    let mut seen = HashSet::new();
+    all_events.retain(|event| seen.insert(SessionEventKey::from(&*event)));
+    sort_session_events(&mut all_events);
 
-    Ok(Json(AdminSessionsResponse { events: all_events }))
+    let available_from = all_events.iter().map(|event| event.timestamp).min();
+    let available_to = all_events.iter().map(|event| event.timestamp).max();
+    let mut available_years: Vec<u32> = all_events
+        .iter()
+        .filter_map(|event| year_from_unix_timestamp(event.timestamp))
+        .collect();
+    available_years.sort_unstable_by(|a, b| b.cmp(a));
+    available_years.dedup();
+
+    let mut events: Vec<SessionEvent> = all_events
+        .into_iter()
+        .filter(|event| range.includes(event.timestamp, now))
+        .collect();
+    let total_count = events.len();
+    let range_scope = range.cursor_scope();
+
+    let start = if let Some(raw_cursor) = query.cursor.as_deref() {
+        let cursor = decode_session_cursor(raw_cursor)?;
+        if cursor.range != range_scope {
+            return Err(StatusCode::BAD_REQUEST);
+        }
+        events
+            .iter()
+            .position(|event| SessionEventKey::from(event) == cursor.event)
+            .map(|index| index + 1)
+            .ok_or(StatusCode::BAD_REQUEST)?
+    } else {
+        0
+    };
+
+    if start > events.len() {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+    let end = start.saturating_add(limit).min(events.len());
+    let page_events: Vec<SessionEvent> = events.drain(start..end).collect();
+    let next_cursor = if end < total_count {
+        page_events.last().map(|event| {
+            encode_session_cursor(&SessionHistoryCursor {
+                version: 1,
+                range: range_scope,
+                event: SessionEventKey::from(event),
+            })
+        })
+    } else {
+        None
+    };
+
+    Ok(AdminSessionsResponse {
+        events: page_events,
+        next_cursor,
+        total_count,
+        available_from,
+        available_to,
+        available_years,
+    })
+}
+
+fn read_session_history_files(session_log_dir: &Path) -> Vec<SessionEvent> {
+    let entries = match fs::read_dir(session_log_dir) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Vec::new(),
+        Err(error) => {
+            warn!(
+                "failed to read session history directory {:?}: {}",
+                session_log_dir, error
+            );
+            return Vec::new();
+        }
+    };
+
+    let mut files: Vec<PathBuf> = entries
+        .filter_map(Result::ok)
+        .filter(|entry| {
+            entry
+                .file_type()
+                .map(|kind| kind.is_file())
+                .unwrap_or(false)
+        })
+        .filter(|entry| {
+            entry
+                .file_name()
+                .to_str()
+                .and_then(parse_session_history_file_name)
+                .is_some()
+        })
+        .map(|entry| entry.path())
+        .collect();
+    files.sort();
+
+    let mut events = Vec::new();
+    for file_path in files {
+        let file_name = file_path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("<invalid>");
+        match fs::read_to_string(&file_path) {
+            Ok(contents) => match serde_json::from_str::<Vec<SessionEvent>>(&contents) {
+                Ok(mut file_events) => events.append(&mut file_events),
+                Err(error) => warn!(
+                    "ignoring malformed session history file {}: {}",
+                    file_name, error
+                ),
+            },
+            Err(error) => warn!(
+                "failed to read session history file {}: {}",
+                file_name, error
+            ),
+        }
+    }
+    events
+}
+
+fn parse_session_history_file_name(file_name: &str) -> Option<(u32, u32, u32)> {
+    let raw_date = file_name.strip_prefix("sessions-")?.strip_suffix(".json")?;
+    if raw_date.len() != 10 {
+        return None;
+    }
+    let bytes = raw_date.as_bytes();
+    if bytes[4] != b'-'
+        || bytes[7] != b'-'
+        || !bytes[..4].iter().all(u8::is_ascii_digit)
+        || !bytes[5..7].iter().all(u8::is_ascii_digit)
+        || !bytes[8..].iter().all(u8::is_ascii_digit)
+    {
+        return None;
+    }
+    let year = raw_date[..4].parse::<u32>().ok()?;
+    let month = raw_date[5..7].parse::<u32>().ok()?;
+    let day = raw_date[8..].parse::<u32>().ok()?;
+    unix_days_for_date(year, month, day)?;
+    Some((year, month, day))
+}
+
+fn sort_session_events(events: &mut [SessionEvent]) {
+    events.sort_by(|a, b| {
+        b.timestamp
+            .cmp(&a.timestamp)
+            .then_with(|| a.event_type.cmp(&b.event_type))
+            .then_with(|| a.identity.cmp(&b.identity))
+            .then_with(|| a.name.cmp(&b.name))
+            .then_with(|| a.room_id.cmp(&b.room_id))
+            .then_with(|| a.duration_secs.cmp(&b.duration_secs))
+    });
+}
+
+fn encode_session_cursor(cursor: &SessionHistoryCursor) -> String {
+    let bytes = serde_json::to_vec(cursor).expect("session cursor serialization cannot fail");
+    base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes)
+}
+
+fn decode_session_cursor(raw_cursor: &str) -> Result<SessionHistoryCursor, StatusCode> {
+    if raw_cursor.is_empty() || raw_cursor.len() > ADMIN_SESSIONS_MAX_CURSOR_BYTES {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+    let bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(raw_cursor)
+        .map_err(|_| StatusCode::BAD_REQUEST)?;
+    let cursor: SessionHistoryCursor =
+        serde_json::from_slice(&bytes).map_err(|_| StatusCode::BAD_REQUEST)?;
+    if cursor.version != 1 || encode_session_cursor(&cursor) != raw_cursor {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+    Ok(cursor)
+}
+
+fn unix_timestamp_for_date(year: u32, month: u32, day: u32) -> Option<u64> {
+    unix_days_for_date(year, month, day)?.checked_mul(86_400)
+}
+
+fn unix_days_for_date(year: u32, month: u32, day: u32) -> Option<u64> {
+    if !(1970..=10_000).contains(&year) || !(1..=12).contains(&month) {
+        return None;
+    }
+    let leap = (year % 4 == 0 && year % 100 != 0) || year % 400 == 0;
+    let days_in_month = match month {
+        2 if leap => 29,
+        2 => 28,
+        4 | 6 | 9 | 11 => 30,
+        _ => 31,
+    };
+    if day == 0 || day > days_in_month {
+        return None;
+    }
+
+    let year = i64::from(year) - i64::from(month <= 2);
+    let era = year.div_euclid(400);
+    let year_of_era = year - era * 400;
+    let month_prime = i64::from(month) + if month > 2 { -3 } else { 9 };
+    let day_of_year = (153 * month_prime + 2) / 5 + i64::from(day) - 1;
+    let day_of_era = year_of_era * 365 + year_of_era / 4 - year_of_era / 100 + day_of_year;
+    let unix_days = era * 146_097 + day_of_era - 719_468;
+    u64::try_from(unix_days).ok()
+}
+
+fn year_from_unix_timestamp(timestamp: u64) -> Option<u32> {
+    let unix_days = i64::try_from(timestamp / 86_400).ok()?;
+    let shifted = unix_days.checked_add(719_468)?;
+    let era = shifted.div_euclid(146_097);
+    let day_of_era = shifted - era * 146_097;
+    let year_of_era =
+        (day_of_era - day_of_era / 1_460 + day_of_era / 36_524 - day_of_era / 146_096) / 365;
+    let mut year = year_of_era + era * 400;
+    let day_of_year = day_of_era - (365 * year_of_era + year_of_era / 4 - year_of_era / 100);
+    let month_prime = (5 * day_of_year + 2) / 153;
+    let month = month_prime + if month_prime < 10 { 3 } else { -9 };
+    year += i64::from(month <= 2);
+    u32::try_from(year).ok().filter(|year| *year <= 9999)
 }
 
 pub(crate) async fn admin_dashboard_metrics(
@@ -1437,6 +1749,266 @@ pub(crate) async fn admin_force_reload(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static SESSION_HISTORY_TEST_ID: AtomicU64 = AtomicU64::new(0);
+
+    struct TestSessionHistoryDir(PathBuf);
+
+    impl TestSessionHistoryDir {
+        fn new() -> Self {
+            let id = SESSION_HISTORY_TEST_ID.fetch_add(1, Ordering::Relaxed);
+            let path = std::env::temp_dir().join(format!(
+                "echo-admin-session-history-{}-{}",
+                std::process::id(),
+                id
+            ));
+            fs::create_dir_all(&path).expect("create session history test directory");
+            Self(path)
+        }
+
+        fn write(&self, file_name: &str, events: &[SessionEvent]) {
+            let payload = serde_json::to_string(events).expect("serialize session events");
+            fs::write(self.0.join(file_name), payload).expect("write session history fixture");
+        }
+    }
+
+    impl Drop for TestSessionHistoryDir {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn session_event(
+        timestamp: u64,
+        identity: &str,
+        event_type: &str,
+        duration_secs: Option<u64>,
+    ) -> SessionEvent {
+        SessionEvent {
+            event_type: event_type.to_string(),
+            identity: identity.to_string(),
+            name: identity.to_string(),
+            room_id: "main".to_string(),
+            timestamp,
+            duration_secs,
+        }
+    }
+
+    fn session_query(
+        range_name: Option<&str>,
+        limit: Option<usize>,
+        cursor: Option<String>,
+    ) -> AdminSessionsQuery {
+        AdminSessionsQuery {
+            range_name: range_name.map(str::to_string),
+            limit,
+            cursor,
+        }
+    }
+
+    fn assert_bad_session_query(result: Result<AdminSessionsResponse, StatusCode>) {
+        assert!(matches!(result, Err(StatusCode::BAD_REQUEST)));
+    }
+
+    #[test]
+    fn admin_sessions_defaults_to_month_and_reports_full_availability() {
+        let dir = TestSessionHistoryDir::new();
+        let now = unix_timestamp_for_date(2026, 7, 31).unwrap() + 12 * 3_600;
+        let newest = session_event(now - 10, "newest", "join", None);
+        let month_old = session_event(now - 29 * 86_400, "month-old", "leave", Some(20));
+        let quarter_old = session_event(now - 31 * 86_400, "quarter-old", "join", None);
+        let prior_year = session_event(
+            unix_timestamp_for_date(2025, 1, 1).unwrap(),
+            "prior-year",
+            "leave",
+            Some(60),
+        );
+        dir.write(
+            "sessions-2026-07-31.json",
+            &[newest.clone(), month_old.clone()],
+        );
+        dir.write(
+            "sessions-2026-07-30.json",
+            &[newest.clone(), quarter_old.clone(), prior_year.clone()],
+        );
+        dir.write("sessions-2026-13-40.json", &[newest.clone()]);
+        dir.write("sessions-2026-07-31.json.bak", &[newest.clone()]);
+
+        let response = load_admin_sessions(&dir.0, session_query(None, None, None), now)
+            .expect("default month history");
+
+        assert_eq!(response.total_count, 2);
+        assert_eq!(response.events.len(), 2);
+        assert_eq!(response.events[0].identity, "newest");
+        assert_eq!(response.events[1].identity, "month-old");
+        assert_eq!(response.next_cursor, None);
+        assert_eq!(response.available_from, Some(prior_year.timestamp));
+        assert_eq!(response.available_to, Some(newest.timestamp));
+        assert_eq!(response.available_years, vec![2026, 2025]);
+    }
+
+    #[test]
+    fn admin_sessions_paginates_equal_timestamps_without_duplicates() {
+        let dir = TestSessionHistoryDir::new();
+        let timestamp = unix_timestamp_for_date(2026, 7, 31).unwrap();
+        dir.write(
+            "sessions-2026-07-31.json",
+            &[
+                session_event(timestamp, "charlie", "join", None),
+                session_event(timestamp, "alpha", "join", None),
+                session_event(timestamp, "bravo", "join", None),
+                session_event(timestamp - 1, "older", "join", None),
+            ],
+        );
+
+        let first = load_admin_sessions(
+            &dir.0,
+            session_query(Some("all"), Some(2), None),
+            timestamp + 1,
+        )
+        .expect("first history page");
+        assert_eq!(first.total_count, 4);
+        assert_eq!(
+            first
+                .events
+                .iter()
+                .map(|event| event.identity.as_str())
+                .collect::<Vec<_>>(),
+            vec!["alpha", "bravo"]
+        );
+        let cursor = first.next_cursor.expect("next cursor");
+
+        let second = load_admin_sessions(
+            &dir.0,
+            session_query(Some("all"), Some(2), Some(cursor)),
+            timestamp + 1,
+        )
+        .expect("second history page");
+        assert_eq!(second.total_count, 4);
+        assert_eq!(
+            second
+                .events
+                .iter()
+                .map(|event| event.identity.as_str())
+                .collect::<Vec<_>>(),
+            vec!["charlie", "older"]
+        );
+        assert_eq!(second.next_cursor, None);
+    }
+
+    #[test]
+    fn admin_sessions_deduplicates_only_exact_events() {
+        let dir = TestSessionHistoryDir::new();
+        let timestamp = unix_timestamp_for_date(2026, 7, 31).unwrap();
+        let join = session_event(timestamp, "sam", "join", None);
+        let leave_without_duration = session_event(timestamp, "sam", "leave", None);
+        let leave_with_duration = session_event(timestamp, "sam", "leave", Some(30));
+        dir.write(
+            "sessions-2026-07-31.json",
+            &[
+                join.clone(),
+                join,
+                leave_without_duration,
+                leave_with_duration,
+            ],
+        );
+
+        let response =
+            load_admin_sessions(&dir.0, session_query(Some("all"), None, None), timestamp)
+                .expect("deduplicated history");
+        assert_eq!(response.total_count, 3);
+        assert_eq!(response.events.len(), 3);
+    }
+
+    #[test]
+    fn admin_sessions_calendar_year_uses_exact_utc_boundaries() {
+        let dir = TestSessionHistoryDir::new();
+        let start = unix_timestamp_for_date(2025, 1, 1).unwrap();
+        let end = unix_timestamp_for_date(2026, 1, 1).unwrap();
+        dir.write(
+            "sessions-2025-01-01.json",
+            &[
+                session_event(start - 1, "before", "join", None),
+                session_event(start, "start", "join", None),
+                session_event(end - 1, "end", "leave", Some(1)),
+                session_event(end, "after", "join", None),
+            ],
+        );
+
+        let response = load_admin_sessions(
+            &dir.0,
+            session_query(Some("year:2025"), None, None),
+            end + 1,
+        )
+        .expect("calendar year history");
+        assert_eq!(response.total_count, 2);
+        assert_eq!(response.events[0].identity, "end");
+        assert_eq!(response.events[1].identity, "start");
+    }
+
+    #[test]
+    fn admin_sessions_rejects_invalid_range_limit_and_cursor() {
+        let dir = TestSessionHistoryDir::new();
+        let timestamp = unix_timestamp_for_date(2026, 7, 31).unwrap();
+        let event = session_event(timestamp, "sam", "join", None);
+        dir.write("sessions-2026-07-31.json", std::slice::from_ref(&event));
+
+        for invalid_range in ["years", "year:", "year:26", "year:1969", "year:10000"] {
+            assert_bad_session_query(load_admin_sessions(
+                &dir.0,
+                session_query(Some(invalid_range), None, None),
+                timestamp,
+            ));
+        }
+        for invalid_limit in [0, ADMIN_SESSIONS_MAX_LIMIT + 1] {
+            assert_bad_session_query(load_admin_sessions(
+                &dir.0,
+                session_query(Some("all"), Some(invalid_limit), None),
+                timestamp,
+            ));
+        }
+        assert_bad_session_query(load_admin_sessions(
+            &dir.0,
+            session_query(Some("all"), None, Some("not-a-cursor".to_string())),
+            timestamp,
+        ));
+
+        let cursor = encode_session_cursor(&SessionHistoryCursor {
+            version: 1,
+            range: "week".to_string(),
+            event: SessionEventKey::from(&event),
+        });
+        assert_bad_session_query(load_admin_sessions(
+            &dir.0,
+            session_query(Some("month"), None, Some(cursor)),
+            timestamp,
+        ));
+
+        let stale_cursor = encode_session_cursor(&SessionHistoryCursor {
+            version: 1,
+            range: "all".to_string(),
+            event: SessionEventKey::from(&session_event(timestamp - 1, "missing", "join", None)),
+        });
+        assert_bad_session_query(load_admin_sessions(
+            &dir.0,
+            session_query(Some("all"), None, Some(stale_cursor)),
+            timestamp,
+        ));
+    }
+
+    #[test]
+    fn session_history_date_helpers_validate_leap_days() {
+        assert!(parse_session_history_file_name("sessions-2024-02-29.json").is_some());
+        assert!(parse_session_history_file_name("sessions-2025-02-29.json").is_none());
+        assert!(parse_session_history_file_name("sessions-2025-00-01.json").is_none());
+        assert!(parse_session_history_file_name("sessions-2025-01-00.json").is_none());
+        assert!(parse_session_history_file_name("sessions-2025-01-01.json.bak").is_none());
+        assert_eq!(
+            year_from_unix_timestamp(unix_timestamp_for_date(2026, 12, 31).unwrap()),
+            Some(2026)
+        );
+    }
 
     #[test]
     fn github_screenshot_embedding_accepts_only_generated_upload_names() {

--- a/core/control/src/config.rs
+++ b/core/control/src/config.rs
@@ -154,6 +154,36 @@ pub fn resolve_deploy_dir() -> PathBuf {
     PathBuf::from("deploy")
 }
 
+pub(crate) const VIEWER_WATCHED_FILES: &[&str] = &[
+    "app.js",
+    "style.css",
+    "clubhouse-shell.css",
+    "themes.css",
+    "layout-policy.js",
+    "ui-shell.js",
+    "theme-runtime.js",
+    "theme-effects.js",
+    "theme.js",
+    "diagnostics-client.js",
+    "grid-layout.js",
+    "index.html",
+    "connect.js",
+    "room-status.js",
+    "participants.js",
+    "audio-routing.js",
+    "media-controls.js",
+    "admin-history.js",
+    "admin.js",
+    "chat.js",
+    "soundboard.js",
+    "state.js",
+    "settings.js",
+    "capture-picker.js",
+    "jam.js",
+    "jam-session-state.js",
+    "jam.css",
+];
+
 /// Stamp cache-busting version query strings into viewer/index.html on disk.
 /// Called once at server startup so ServeDir serves the already-stamped file.
 /// Idempotent — strips old ?v= params before re-stamping.
@@ -173,7 +203,7 @@ pub fn stamp_viewer_index(viewer_dir: &PathBuf, v: &str) {
                 "screen-share-adaptive.js", "screen-share-native.js",
                 "participants-grid.js", "grid-layout.js", "camera-lobby-layout.js", "participants-avatar.js", "participants-fullscreen.js",
                 "participants.js",
-                "audio-routing.js", "media-controls.js", "admin.js", "connect.js",
+                "audio-routing.js", "media-controls.js", "admin-history.js", "admin.js", "connect.js",
                 "app.js", "jam.js", "changelog.js",
                 "capture-picker.js", "capture-picker.css",
             ];
@@ -225,7 +255,7 @@ pub fn urlencoded(s: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::stamp_viewer_index;
+    use super::{stamp_viewer_index, VIEWER_WATCHED_FILES};
     use std::fs;
 
     #[test]
@@ -252,6 +282,7 @@ mod tests {
             <script src="display-status.js?v=old"></script>
             <script src="native-presenter.js?v=old"></script>
             <script src="admin-panel.js?v=old"></script>
+            <script src="admin-history.js?v=old"></script>
             "#,
         )
         .unwrap();
@@ -272,9 +303,16 @@ mod tests {
         assert!(stamped.contains("display-status.js?v=0.6.12.test"));
         assert!(stamped.contains("native-presenter.js?v=0.6.12.test"));
         assert!(stamped.contains("admin-panel.js?v=0.6.12.test"));
+        assert!(stamped.contains("admin-history.js?v=0.6.12.test"));
         assert!(!stamped.contains("?v=old"));
 
         let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn viewer_watcher_tracks_admin_history_assets() {
+        assert!(VIEWER_WATCHED_FILES.contains(&"admin-history.js"));
+        assert!(VIEWER_WATCHED_FILES.contains(&"admin.js"));
     }
 
     fn now_for_test() -> u128 {

--- a/core/control/src/main.rs
+++ b/core/control/src/main.rs
@@ -751,36 +751,9 @@ async fn main() {
         let vdir = viewer_dir.clone();
         let mut startup = SystemTime::now();
         tokio::spawn(async move {
-            let watched_files = [
-                "app.js",
-                "style.css",
-                "clubhouse-shell.css",
-                "themes.css",
-                "layout-policy.js",
-                "ui-shell.js",
-                "theme-runtime.js",
-                "theme-effects.js",
-                "theme.js",
-                "diagnostics-client.js",
-                "grid-layout.js",
-                "index.html",
-                "connect.js",
-                "room-status.js",
-                "participants.js",
-                "audio-routing.js",
-                "media-controls.js",
-                "chat.js",
-                "soundboard.js",
-                "state.js",
-                "settings.js",
-                "capture-picker.js",
-                "jam.js",
-                "jam-session-state.js",
-                "jam.css",
-            ];
             loop {
                 tokio::time::sleep(std::time::Duration::from_secs(15)).await;
-                let changed = watched_files.iter().any(|f| {
+                let changed = VIEWER_WATCHED_FILES.iter().any(|f| {
                     vdir.join(f)
                         .metadata()
                         .and_then(|m| m.modified())

--- a/core/deploy/merge-session-history.ps1
+++ b/core/deploy/merge-session-history.ps1
@@ -1,0 +1,581 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string[]]$SourceDirectory,
+
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]$DestinationDirectory,
+
+    [string]$BackupDirectory,
+
+    [switch]$Apply
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$sessionFilePattern = '^sessions-(?<date>\d{4}-\d{2}-\d{2})\.json$'
+$allowedEventProperties = @(
+    'event_type',
+    'identity',
+    'name',
+    'room_id',
+    'timestamp',
+    'duration_secs'
+)
+$utf8WithoutBom = New-Object System.Text.UTF8Encoding($false)
+
+function Get-NormalizedPath {
+    param([Parameter(Mandatory = $true)][string]$Path)
+
+    $fullPath = [System.IO.Path]::GetFullPath($Path)
+    $root = [System.IO.Path]::GetPathRoot($fullPath)
+    if ($fullPath.Length -gt $root.Length) {
+        $fullPath = $fullPath.TrimEnd([char[]]@('\', '/'))
+    }
+    return $fullPath
+}
+
+function Resolve-SafeExistingDirectory {
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [Parameter(Mandatory = $true)][string]$Role
+    )
+
+    $item = Get-Item -LiteralPath $Path -Force
+    if (-not $item.PSIsContainer) {
+        throw "$Role is not a directory: $Path"
+    }
+    if (($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0) {
+        throw "$Role may not be a symlink or junction: $($item.FullName)"
+    }
+
+    $fullPath = Get-NormalizedPath -Path $item.FullName
+    $root = Get-NormalizedPath -Path ([System.IO.Path]::GetPathRoot($fullPath))
+    if ([string]::Equals($fullPath, $root, [System.StringComparison]::OrdinalIgnoreCase)) {
+        throw "$Role may not be a filesystem root: $fullPath"
+    }
+    return $fullPath
+}
+
+function Resolve-SafeNewDirectoryPath {
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [Parameter(Mandatory = $true)][string]$Role
+    )
+
+    $fullPath = Get-NormalizedPath -Path $Path
+    $root = Get-NormalizedPath -Path ([System.IO.Path]::GetPathRoot($fullPath))
+    if ([string]::Equals($fullPath, $root, [System.StringComparison]::OrdinalIgnoreCase)) {
+        throw "$Role may not be a filesystem root: $fullPath"
+    }
+    return $fullPath
+}
+
+function Test-PathEqual {
+    param(
+        [Parameter(Mandatory = $true)][string]$Left,
+        [Parameter(Mandatory = $true)][string]$Right
+    )
+
+    return [string]::Equals(
+        (Get-NormalizedPath -Path $Left),
+        (Get-NormalizedPath -Path $Right),
+        [System.StringComparison]::OrdinalIgnoreCase
+    )
+}
+
+function Test-PathWithin {
+    param(
+        [Parameter(Mandatory = $true)][string]$Child,
+        [Parameter(Mandatory = $true)][string]$Parent
+    )
+
+    $normalizedChild = (Get-NormalizedPath -Path $Child) + [System.IO.Path]::DirectorySeparatorChar
+    $normalizedParent = (Get-NormalizedPath -Path $Parent) + [System.IO.Path]::DirectorySeparatorChar
+    return $normalizedChild.StartsWith(
+        $normalizedParent,
+        [System.StringComparison]::OrdinalIgnoreCase
+    )
+}
+
+function Get-SessionFiles {
+    param(
+        [Parameter(Mandatory = $true)][string]$Directory,
+        [Parameter(Mandatory = $true)][string]$Role
+    )
+
+    $allFiles = @(Get-ChildItem -LiteralPath $Directory -File -Force)
+    $unsafeSessionNames = @(
+        $allFiles | Where-Object {
+            $_.Name -imatch '^sessions' -and $_.Name -cnotmatch $sessionFilePattern
+        }
+    )
+    if ($unsafeSessionNames.Count -gt 0) {
+        $names = ($unsafeSessionNames | ForEach-Object { $_.Name }) -join ', '
+        throw "$Role contains unsafe or non-session filenames with the reserved 'sessions' prefix: $names"
+    }
+
+    $sessionFiles = @($allFiles | Where-Object { $_.Name -cmatch $sessionFilePattern } | Sort-Object Name)
+    foreach ($file in $sessionFiles) {
+        if (($file.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0) {
+            throw "$Role contains a session file that is a symlink or junction: $($file.FullName)"
+        }
+
+        $null = $file.Name -cmatch $sessionFilePattern
+        $dateText = $Matches['date']
+        $parsedDate = [DateTime]::MinValue
+        $validDate = [DateTime]::TryParseExact(
+            $dateText,
+            'yyyy-MM-dd',
+            [System.Globalization.CultureInfo]::InvariantCulture,
+            [System.Globalization.DateTimeStyles]::None,
+            [ref]$parsedDate
+        )
+        if (-not $validDate -or $parsedDate.ToString('yyyy-MM-dd') -ne $dateText) {
+            throw "$Role contains a session filename with an invalid UTC date: $($file.Name)"
+        }
+    }
+
+    return $sessionFiles
+}
+
+function ConvertTo-UnsignedInteger {
+    param(
+        [Parameter(Mandatory = $true)]$Value,
+        [Parameter(Mandatory = $true)][string]$Field,
+        [Parameter(Mandatory = $true)][string]$Context
+    )
+
+    if ($null -eq $Value -or $Value -is [bool]) {
+        throw "$Context has an invalid $Field value"
+    }
+    $text = [System.Convert]::ToString($Value, [System.Globalization.CultureInfo]::InvariantCulture)
+    if ($text -cnotmatch '^\d+$') {
+        throw "$Context has a non-integer $Field value: $text"
+    }
+    $number = [UInt64]0
+    if (-not [UInt64]::TryParse(
+        $text,
+        [System.Globalization.NumberStyles]::None,
+        [System.Globalization.CultureInfo]::InvariantCulture,
+        [ref]$number
+    )) {
+        throw "$Context has an out-of-range $Field value: $text"
+    }
+    return $number
+}
+
+function ConvertTo-NormalizedEvent {
+    param(
+        [Parameter(Mandatory = $true)]$InputEvent,
+        [Parameter(Mandatory = $true)][string]$Context
+    )
+
+    if ($null -eq $InputEvent -or $InputEvent -is [string] -or $InputEvent -is [System.Array]) {
+        throw "$Context is not a session event object"
+    }
+
+    $properties = @($InputEvent.PSObject.Properties.Name)
+    foreach ($required in @('event_type', 'identity', 'name', 'room_id', 'timestamp')) {
+        if ($properties -cnotcontains $required) {
+            throw "$Context is missing required property '$required'"
+        }
+    }
+    $unknown = @($properties | Where-Object { $allowedEventProperties -cnotcontains $_ })
+    if ($unknown.Count -gt 0) {
+        throw "$Context contains unsupported properties: $($unknown -join ', ')"
+    }
+
+    foreach ($field in @('event_type', 'identity', 'name', 'room_id')) {
+        if ($InputEvent.$field -isnot [string]) {
+            throw "$Context has a non-string $field value"
+        }
+    }
+    if ($InputEvent.event_type -cnotin @('join', 'leave')) {
+        throw "$Context has an unsupported event_type: $($InputEvent.event_type)"
+    }
+
+    $timestamp = ConvertTo-UnsignedInteger -Value $InputEvent.timestamp -Field 'timestamp' -Context $Context
+    if ($timestamp -eq 0 -or $timestamp -gt 253402300799) {
+        throw "$Context has a timestamp outside the supported UTC calendar range: $timestamp"
+    }
+
+    $duration = $null
+    if ($properties -ccontains 'duration_secs' -and $null -ne $InputEvent.duration_secs) {
+        $duration = ConvertTo-UnsignedInteger -Value $InputEvent.duration_secs -Field 'duration_secs' -Context $Context
+    }
+
+    $normalized = [ordered]@{
+        event_type = [string]$InputEvent.event_type
+        identity = [string]$InputEvent.identity
+        name = [string]$InputEvent.name
+        room_id = [string]$InputEvent.room_id
+        timestamp = $timestamp
+    }
+    if ($null -ne $duration) {
+        $normalized['duration_secs'] = $duration
+    }
+
+    $dedupShape = [ordered]@{
+        event_type = [string]$InputEvent.event_type
+        identity = [string]$InputEvent.identity
+        name = [string]$InputEvent.name
+        room_id = [string]$InputEvent.room_id
+        timestamp = $timestamp
+        duration_secs = $duration
+    }
+    $key = ConvertTo-Json -InputObject $dedupShape -Compress -Depth 3
+    $utcDate = [DateTimeOffset]::FromUnixTimeSeconds([Int64]$timestamp).UtcDateTime.ToString('yyyy-MM-dd')
+
+    return [pscustomobject]@{
+        Key = $key
+        UtcDate = $utcDate
+        Event = [pscustomobject]$normalized
+    }
+}
+
+function Read-SessionFile {
+    param([Parameter(Mandatory = $true)][System.IO.FileInfo]$File)
+
+    $raw = [System.IO.File]::ReadAllText($File.FullName)
+    $trimmed = $raw.Trim()
+    if (-not $trimmed.StartsWith('[') -or -not $trimmed.EndsWith(']')) {
+        throw "$($File.FullName) must contain a JSON array"
+    }
+
+    $parsed = ConvertFrom-Json -InputObject $raw
+    if ($null -eq $parsed) {
+        $events = @()
+    }
+    elseif ($parsed -is [System.Array]) {
+        $events = @($parsed)
+    }
+    else {
+        $events = @($parsed)
+    }
+
+    $normalizedEvents = @()
+    for ($index = 0; $index -lt $events.Count; $index++) {
+        $normalizedEvents += ConvertTo-NormalizedEvent `
+            -InputEvent $events[$index] `
+            -Context "$($File.FullName) event[$index]"
+    }
+    return $normalizedEvents
+}
+
+function Get-FileSnapshot {
+    param([Parameter(Mandatory = $true)][System.IO.FileInfo]$File)
+
+    return [pscustomobject]@{
+        Name = $File.Name
+        FullName = $File.FullName
+        Length = [Int64]$File.Length
+        LastWriteTimeUtc = $File.LastWriteTimeUtc.ToString('o')
+        Sha256 = (Get-FileHash -LiteralPath $File.FullName -Algorithm SHA256).Hash
+    }
+}
+
+function Assert-DestinationUnchanged {
+    param(
+        [Parameter(Mandatory = $true)][string]$Destination,
+        [Parameter(Mandatory = $true)][hashtable]$Snapshots
+    )
+
+    $currentFiles = @(Get-SessionFiles -Directory $Destination -Role 'DestinationDirectory')
+    if ($currentFiles.Count -ne $Snapshots.Count) {
+        throw 'Destination session files changed after the merge scan; rerun the command.'
+    }
+    foreach ($file in $currentFiles) {
+        if (-not $Snapshots.ContainsKey($file.Name)) {
+            throw "Destination session file appeared after the merge scan: $($file.Name)"
+        }
+        $snapshot = $Snapshots[$file.Name]
+        $hash = (Get-FileHash -LiteralPath $file.FullName -Algorithm SHA256).Hash
+        if ($file.Length -ne $snapshot.Length -or $hash -ne $snapshot.Sha256) {
+            throw "Destination session file changed after the merge scan: $($file.Name)"
+        }
+    }
+}
+
+function ConvertTo-SessionJson {
+    param([Parameter(Mandatory = $true)][object[]]$Events)
+
+    if ($Events.Count -eq 0) {
+        return "[]`n"
+    }
+    $json = ConvertTo-Json -InputObject $Events -Depth 4
+    return $json + "`n"
+}
+
+function Write-AtomicSessionFile {
+    param(
+        [Parameter(Mandatory = $true)][string]$TargetPath,
+        [Parameter(Mandatory = $true)][string]$Contents,
+        [Parameter(Mandatory = $true)][System.Text.Encoding]$Encoding
+    )
+
+    $directory = [System.IO.Path]::GetDirectoryName($TargetPath)
+    $operationId = [Guid]::NewGuid().ToString('N')
+    $tempName = '.echo-session-merge-' + $operationId + '.tmp'
+    $tempPath = Join-Path $directory $tempName
+    $replaceBackupPath = Join-Path $directory ('.echo-session-replace-' + $operationId + '.bak')
+    try {
+        [System.IO.File]::WriteAllText($tempPath, $Contents, $Encoding)
+        if (Test-Path -LiteralPath $TargetPath -PathType Leaf) {
+            [System.IO.File]::Replace($tempPath, $TargetPath, $replaceBackupPath, $true)
+        }
+        else {
+            [System.IO.File]::Move($tempPath, $TargetPath)
+        }
+    }
+    finally {
+        if (Test-Path -LiteralPath $tempPath -PathType Leaf) {
+            Remove-Item -LiteralPath $tempPath -Force
+        }
+        if (Test-Path -LiteralPath $replaceBackupPath -PathType Leaf) {
+            Remove-Item -LiteralPath $replaceBackupPath -Force
+        }
+    }
+}
+
+$destination = Resolve-SafeExistingDirectory -Path $DestinationDirectory -Role 'DestinationDirectory'
+$sources = @()
+$sourceSet = @{}
+foreach ($sourcePath in $SourceDirectory) {
+    $source = Resolve-SafeExistingDirectory -Path $sourcePath -Role 'SourceDirectory'
+    if (Test-PathEqual -Left $source -Right $destination) {
+        throw "SourceDirectory must not equal DestinationDirectory: $source"
+    }
+    if ($sourceSet.ContainsKey($source.ToLowerInvariant())) {
+        throw "SourceDirectory was supplied more than once: $source"
+    }
+    $sourceSet[$source.ToLowerInvariant()] = $true
+    $sources += $source
+}
+
+$plannedBackup = if ([string]::IsNullOrWhiteSpace($BackupDirectory)) {
+    Join-Path `
+        ([System.IO.Path]::GetDirectoryName($destination)) `
+        ('session-history-backup-' + [DateTime]::UtcNow.ToString('yyyyMMddTHHmmssZ'))
+}
+else {
+    $BackupDirectory
+}
+$plannedBackup = Resolve-SafeNewDirectoryPath -Path $plannedBackup -Role 'BackupDirectory'
+if (Test-PathEqual -Left $plannedBackup -Right $destination) {
+    throw 'BackupDirectory must not equal DestinationDirectory.'
+}
+if (Test-PathWithin -Child $plannedBackup -Parent $destination) {
+    throw 'BackupDirectory must not be inside DestinationDirectory.'
+}
+foreach ($source in $sources) {
+    if ((Test-PathEqual -Left $plannedBackup -Right $source) -or
+        (Test-PathWithin -Child $plannedBackup -Parent $source)) {
+        throw 'BackupDirectory must not equal or be inside a SourceDirectory.'
+    }
+}
+if ($Apply -and (Test-Path -LiteralPath $plannedBackup)) {
+    throw "BackupDirectory already exists; choose a new path: $plannedBackup"
+}
+
+$eventsByDate = @{}
+$allEventKeys = New-Object 'System.Collections.Generic.HashSet[string]' ([System.StringComparer]::Ordinal)
+$changedDates = @{}
+$destinationSnapshots = @{}
+$destinationEvents = 0
+$destinationDuplicates = 0
+$destinationDateMismatches = 0
+
+$destinationFiles = @(Get-SessionFiles -Directory $destination -Role 'DestinationDirectory')
+foreach ($file in $destinationFiles) {
+    $null = $file.Name -cmatch $sessionFilePattern
+    $fileDate = $Matches['date']
+    $destinationSnapshots[$file.Name] = Get-FileSnapshot -File $file
+    $normalizedEvents = @(Read-SessionFile -File $file)
+    $destinationEvents += $normalizedEvents.Count
+
+    foreach ($normalizedEvent in $normalizedEvents) {
+        if ($normalizedEvent.UtcDate -ne $fileDate) {
+            $destinationDateMismatches++
+            $changedDates[$fileDate] = $true
+            $changedDates[$normalizedEvent.UtcDate] = $true
+        }
+        if (-not $allEventKeys.Add([string]$normalizedEvent.Key)) {
+            $destinationDuplicates++
+            $changedDates[$fileDate] = $true
+            continue
+        }
+
+        if (-not $eventsByDate.ContainsKey($normalizedEvent.UtcDate)) {
+            $eventsByDate[$normalizedEvent.UtcDate] = New-Object `
+                'System.Collections.Generic.Dictionary[string,object]' `
+                ([System.StringComparer]::Ordinal)
+        }
+        $eventsByDate[$normalizedEvent.UtcDate][$normalizedEvent.Key] = $normalizedEvent.Event
+    }
+}
+
+$sourceSummaries = @()
+$sourceEvents = 0
+$sourceDuplicates = 0
+$sourceEventsAdded = 0
+$sourceDateMismatches = 0
+foreach ($source in $sources) {
+    $files = @(Get-SessionFiles -Directory $source -Role "SourceDirectory '$source'")
+    if ($files.Count -eq 0) {
+        throw "SourceDirectory contains no session history files: $source"
+    }
+
+    $directoryEvents = 0
+    $directoryDuplicates = 0
+    $directoryAdded = 0
+    $directoryDateMismatches = 0
+    foreach ($file in $files) {
+        $null = $file.Name -cmatch $sessionFilePattern
+        $fileDate = $Matches['date']
+        $normalizedEvents = @(Read-SessionFile -File $file)
+        $directoryEvents += $normalizedEvents.Count
+
+        foreach ($normalizedEvent in $normalizedEvents) {
+            if ($normalizedEvent.UtcDate -ne $fileDate) {
+                $directoryDateMismatches++
+            }
+            if (-not $allEventKeys.Add([string]$normalizedEvent.Key)) {
+                $directoryDuplicates++
+                continue
+            }
+
+            if (-not $eventsByDate.ContainsKey($normalizedEvent.UtcDate)) {
+                $eventsByDate[$normalizedEvent.UtcDate] = New-Object `
+                    'System.Collections.Generic.Dictionary[string,object]' `
+                    ([System.StringComparer]::Ordinal)
+            }
+            $eventsByDate[$normalizedEvent.UtcDate][$normalizedEvent.Key] = $normalizedEvent.Event
+            $changedDates[$normalizedEvent.UtcDate] = $true
+            $directoryAdded++
+        }
+    }
+
+    $sourceEvents += $directoryEvents
+    $sourceDuplicates += $directoryDuplicates
+    $sourceEventsAdded += $directoryAdded
+    $sourceDateMismatches += $directoryDateMismatches
+    $sourceSummaries += [pscustomobject][ordered]@{
+        path = $source
+        files = $files.Count
+        events = $directoryEvents
+        exact_duplicates = $directoryDuplicates
+        unique_events_added = $directoryAdded
+        filename_date_mismatches = $directoryDateMismatches
+    }
+}
+
+$fileActions = @()
+foreach ($date in @($changedDates.Keys | Sort-Object)) {
+    $targetName = "sessions-$date.json"
+    $targetPath = Join-Path $destination $targetName
+    $events = @(
+        if ($eventsByDate.ContainsKey($date)) {
+            $eventsByDate[$date].GetEnumerator() |
+                Sort-Object { [UInt64]$_.Value.timestamp }, Key -CaseSensitive |
+                ForEach-Object { $_.Value }
+        }
+    )
+    $fileActions += [pscustomobject][ordered]@{
+        utc_date = $date
+        action = if (Test-Path -LiteralPath $targetPath -PathType Leaf) { 'replace' } else { 'create' }
+        events = $events.Count
+        target = $targetPath
+        contents = ConvertTo-SessionJson -Events $events
+    }
+}
+
+$backupFiles = 0
+if ($Apply -and $fileActions.Count -gt 0) {
+    Assert-DestinationUnchanged -Destination $destination -Snapshots $destinationSnapshots
+
+    $null = New-Item -ItemType Directory -Path $plannedBackup
+    foreach ($snapshot in $destinationSnapshots.Values) {
+        $backupPath = Join-Path $plannedBackup $snapshot.Name
+        [System.IO.File]::Copy($snapshot.FullName, $backupPath, $false)
+        $backupHash = (Get-FileHash -LiteralPath $backupPath -Algorithm SHA256).Hash
+        if ($backupHash -ne $snapshot.Sha256) {
+            throw "Destination backup verification failed for $($snapshot.Name)"
+        }
+        $backupFiles++
+    }
+
+    $manifest = [ordered]@{
+        schema_version = 2
+        created_at_utc = [DateTime]::UtcNow.ToString('o')
+        destination = $destination
+        created_paths = @(
+            $fileActions |
+                Where-Object { $_.action -eq 'create' } |
+                ForEach-Object { [System.IO.Path]::GetFileName([string]$_.target) } |
+                Sort-Object
+        )
+        destination_files = @(
+            $destinationSnapshots.Values |
+                Sort-Object Name |
+                ForEach-Object {
+                    [ordered]@{
+                        name = $_.Name
+                        length = $_.Length
+                        last_write_time_utc = $_.LastWriteTimeUtc
+                        sha256 = $_.Sha256
+                    }
+                }
+        )
+    }
+    $manifestJson = (ConvertTo-Json -InputObject $manifest -Depth 6) + "`n"
+    [System.IO.File]::WriteAllText(
+        (Join-Path $plannedBackup 'manifest.json'),
+        $manifestJson,
+        $utf8WithoutBom
+    )
+
+    Assert-DestinationUnchanged -Destination $destination -Snapshots $destinationSnapshots
+    foreach ($fileAction in $fileActions) {
+        Write-AtomicSessionFile `
+            -TargetPath $fileAction.target `
+            -Contents $fileAction.contents `
+            -Encoding $utf8WithoutBom
+    }
+}
+
+$summaryActions = @(
+    $fileActions | ForEach-Object {
+        [ordered]@{
+            utc_date = $_.utc_date
+            action = $_.action
+            events = $_.events
+            target = $_.target
+        }
+    }
+)
+$summary = [ordered]@{
+    ok = $true
+    mode = if ($Apply) { 'apply' } else { 'preview' }
+    applied = [bool]($Apply -and $fileActions.Count -gt 0)
+    destination = $destination
+    sources = $sourceSummaries
+    destination_files_before = $destinationFiles.Count
+    destination_events_before = $destinationEvents
+    source_events_read = $sourceEvents
+    exact_duplicates = $destinationDuplicates + $sourceDuplicates
+    destination_exact_duplicates = $destinationDuplicates
+    source_exact_duplicates = $sourceDuplicates
+    unique_source_events_added = $sourceEventsAdded
+    unique_events_after = $allEventKeys.Count
+    filename_date_mismatches = $destinationDateMismatches + $sourceDateMismatches
+    changed_files = $fileActions.Count
+    changes = $summaryActions
+    backup_directory = if ($Apply -and $fileActions.Count -eq 0) { $null } else { $plannedBackup }
+    backup_files = $backupFiles
+}
+
+$summary | ConvertTo-Json -Depth 8

--- a/core/deploy/test-merge-session-history.ps1
+++ b/core/deploy/test-merge-session-history.ps1
@@ -1,0 +1,277 @@
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+function Assert-True {
+    param(
+        [Parameter(Mandatory = $true)][bool]$Condition,
+        [Parameter(Mandatory = $true)][string]$Message
+    )
+    if (-not $Condition) {
+        throw "Assertion failed: $Message"
+    }
+}
+
+function Write-JsonArray {
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [Parameter(Mandatory = $true)][object[]]$Items
+    )
+    $encoding = New-Object System.Text.UTF8Encoding($false)
+    $json = if ($Items.Count -eq 0) { '[]' } else { ConvertTo-Json -InputObject $Items -Depth 4 }
+    [System.IO.File]::WriteAllText($Path, $json + "`n", $encoding)
+}
+
+function New-SessionEvent {
+    param(
+        [Parameter(Mandatory = $true)][string]$Type,
+        [Parameter(Mandatory = $true)][string]$Identity,
+        [Parameter(Mandatory = $true)][string]$Name,
+        [Parameter(Mandatory = $true)][string]$Room,
+        [Parameter(Mandatory = $true)][UInt64]$Timestamp,
+        [Nullable[UInt64]]$Duration
+    )
+    $event = [ordered]@{
+        event_type = $Type
+        identity = $Identity
+        name = $Name
+        room_id = $Room
+        timestamp = $Timestamp
+    }
+    if ($null -ne $Duration) {
+        $event['duration_secs'] = [UInt64]$Duration
+    }
+    return [pscustomobject]$event
+}
+
+$scriptPath = Join-Path $PSScriptRoot 'merge-session-history.ps1'
+$testRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('echo-session-merge-test-' + [Guid]::NewGuid().ToString('N'))
+$destination = Join-Path $testRoot 'destination'
+$sourceOne = Join-Path $testRoot 'source-one'
+$sourceTwo = Join-Path $testRoot 'source-two'
+$backup = Join-Path $testRoot 'backup'
+
+try {
+    $null = New-Item -ItemType Directory -Path $destination, $sourceOne, $sourceTwo
+
+    $jan1Join = New-SessionEvent `
+        -Type 'join' `
+        -Identity 'sam-1' `
+        -Name 'Sam' `
+        -Room 'main' `
+        -Timestamp ([DateTimeOffset]::Parse('2026-01-01T00:00:01Z').ToUnixTimeSeconds())
+    $jan1Leave = New-SessionEvent `
+        -Type 'leave' `
+        -Identity 'sam-1' `
+        -Name 'Sam' `
+        -Room 'main' `
+        -Timestamp ([DateTimeOffset]::Parse('2026-01-01T00:05:01Z').ToUnixTimeSeconds()) `
+        -Duration 300
+    $jan2Join = New-SessionEvent `
+        -Type 'join' `
+        -Identity 'friend-1' `
+        -Name 'Friend' `
+        -Room 'main' `
+        -Timestamp ([DateTimeOffset]::Parse('2026-01-02T01:00:00Z').ToUnixTimeSeconds())
+    $jan2CaseVariant = New-SessionEvent `
+        -Type 'join' `
+        -Identity 'FRIEND-1' `
+        -Name 'Friend' `
+        -Room 'main' `
+        -Timestamp ([DateTimeOffset]::Parse('2026-01-02T01:00:00Z').ToUnixTimeSeconds())
+
+    $destinationFile = Join-Path $destination 'sessions-2026-01-01.json'
+    Write-JsonArray -Path $destinationFile -Items @($jan1Join)
+    $destinationHashBefore = (Get-FileHash -LiteralPath $destinationFile -Algorithm SHA256).Hash
+    Write-JsonArray `
+        -Path (Join-Path $sourceOne 'sessions-2026-01-01.json') `
+        -Items @($jan1Join, $jan1Leave)
+    Write-JsonArray `
+        -Path (Join-Path $sourceTwo 'sessions-2026-01-02.json') `
+        -Items @($jan1Leave, $jan2Join, $jan2CaseVariant)
+
+    $previewJson = & $scriptPath `
+        -SourceDirectory @($sourceOne, $sourceTwo) `
+        -DestinationDirectory $destination `
+        -BackupDirectory $backup
+    $preview = $previewJson | ConvertFrom-Json
+    Assert-True ($preview.mode -eq 'preview') 'default mode must be preview'
+    Assert-True (-not $preview.applied) 'preview must not apply changes'
+    Assert-True ($preview.destination_events_before -eq 1) 'preview destination count'
+    Assert-True ($preview.source_events_read -eq 5) 'preview source count'
+    Assert-True ($preview.source_exact_duplicates -eq 2) 'preview exact dedup count'
+    Assert-True ($preview.unique_source_events_added -eq 3) 'preview added count'
+    Assert-True ($preview.unique_events_after -eq 4) 'preview union count'
+    Assert-True ($preview.changed_files -eq 2) 'preview changed file count'
+    Assert-True (-not (Test-Path -LiteralPath $backup)) 'preview must not create a backup'
+    Assert-True (
+        (Get-FileHash -LiteralPath $destinationFile -Algorithm SHA256).Hash -eq $destinationHashBefore
+    ) 'preview must not modify destination'
+
+    $applyJson = & $scriptPath `
+        -SourceDirectory @($sourceOne, $sourceTwo) `
+        -DestinationDirectory $destination `
+        -BackupDirectory $backup `
+        -Apply
+    $apply = $applyJson | ConvertFrom-Json
+    Assert-True ($apply.mode -eq 'apply') 'apply mode summary'
+    Assert-True $apply.applied 'apply must report applied changes'
+    Assert-True ($apply.backup_files -eq 1) 'apply must back up every original destination session file'
+    Assert-True (Test-Path -LiteralPath (Join-Path $backup 'manifest.json')) 'backup manifest'
+    $manifest = Get-Content -Raw -LiteralPath (Join-Path $backup 'manifest.json') | ConvertFrom-Json
+    Assert-True ($manifest.schema_version -eq 2) 'backup manifest schema'
+    Assert-True (@($manifest.created_paths).Count -eq 1) 'manifest must record every created day file'
+    Assert-True (
+        [string]::Equals(
+            [string]@($manifest.created_paths)[0],
+            'sessions-2026-01-02.json',
+            [System.StringComparison]::Ordinal
+        )
+    ) 'manifest created path must be an exact relative session filename'
+    Assert-True (
+        (Get-FileHash -LiteralPath (Join-Path $backup 'sessions-2026-01-01.json') -Algorithm SHA256).Hash -eq $destinationHashBefore
+    ) 'backup must preserve the original destination file'
+
+    $mergedEvents = @()
+    Get-ChildItem -LiteralPath $destination -File -Filter 'sessions-*.json' | ForEach-Object {
+        $parsed = Get-Content -Raw -LiteralPath $_.FullName | ConvertFrom-Json
+        if ($parsed -is [System.Array]) { $mergedEvents += $parsed } else { $mergedEvents += @($parsed) }
+    }
+    Assert-True ($mergedEvents.Count -eq 4) 'apply must preserve four exact unique events'
+    Assert-True (
+        @($mergedEvents | Where-Object { $_.identity -ceq 'friend-1' }).Count -eq 1
+    ) 'lowercase identity event must remain distinct'
+    Assert-True (
+        @($mergedEvents | Where-Object { $_.identity -ceq 'FRIEND-1' }).Count -eq 1
+    ) 'case-variant identity event must remain distinct'
+    Assert-True (
+        (Test-Path -LiteralPath (Join-Path $destination 'sessions-2026-01-02.json'))
+    ) 'apply must merge events into their UTC-date file'
+    Assert-True (
+        @(Get-ChildItem -LiteralPath $destination -File -Filter '.echo-session-merge-*.tmp').Count -eq 0
+    ) 'atomic writes must not leave temporary files'
+
+    $secondPreviewJson = & $scriptPath `
+        -SourceDirectory @($sourceOne, $sourceTwo) `
+        -DestinationDirectory $destination `
+        -BackupDirectory (Join-Path $testRoot 'second-backup')
+    $secondPreview = $secondPreviewJson | ConvertFrom-Json
+    Assert-True ($secondPreview.unique_source_events_added -eq 0) 'second merge must be idempotent'
+    Assert-True ($secondPreview.changed_files -eq 0) 'idempotent merge must plan no writes'
+
+    $samePathRejected = $false
+    try {
+        $null = & $scriptPath `
+            -SourceDirectory @($destination) `
+            -DestinationDirectory $destination `
+            -BackupDirectory (Join-Path $testRoot 'same-path-backup')
+    }
+    catch {
+        $samePathRejected = $_.Exception.Message -match 'must not equal'
+    }
+    Assert-True $samePathRejected 'source equal to destination must be rejected'
+
+    $unsafeSource = Join-Path $testRoot 'unsafe-source'
+    $null = New-Item -ItemType Directory -Path $unsafeSource
+    [System.IO.File]::WriteAllText(
+        (Join-Path $unsafeSource 'sessions-not-a-date.json'),
+        '[]',
+        (New-Object System.Text.UTF8Encoding($false))
+    )
+    $unsafeNameRejected = $false
+    try {
+        $null = & $scriptPath `
+            -SourceDirectory @($unsafeSource) `
+            -DestinationDirectory $destination `
+            -BackupDirectory (Join-Path $testRoot 'unsafe-backup')
+    }
+    catch {
+        $unsafeNameRejected = $_.Exception.Message -match 'unsafe or non-session filenames'
+    }
+    Assert-True $unsafeNameRejected 'unsafe session-like filenames must be rejected'
+
+    $normalizedDestination = [System.IO.Path]::GetFullPath($destination).TrimEnd([char[]]@('\', '/'))
+    $manifestDestination = [System.IO.Path]::GetFullPath([string]$manifest.destination).TrimEnd([char[]]@('\', '/'))
+    Assert-True (
+        [string]::Equals(
+            $manifestDestination,
+            $normalizedDestination,
+            [System.StringComparison]::OrdinalIgnoreCase
+        )
+    ) 'rollback manifest destination must match the exact intended directory'
+
+    foreach ($createdPath in @($manifest.created_paths)) {
+        $relativeName = [string]$createdPath
+        Assert-True (
+            $relativeName -cmatch '^sessions-\d{4}-\d{2}-\d{2}\.json$' -and
+            [string]::Equals(
+                [System.IO.Path]::GetFileName($relativeName),
+                $relativeName,
+                [System.StringComparison]::Ordinal
+            )
+        ) 'rollback may remove only a strict relative session filename'
+        $createdTarget = [System.IO.Path]::GetFullPath((Join-Path $normalizedDestination $relativeName))
+        Assert-True (
+            [string]::Equals(
+                [System.IO.Path]::GetDirectoryName($createdTarget),
+                $normalizedDestination,
+                [System.StringComparison]::OrdinalIgnoreCase
+            )
+        ) 'rollback created path must remain directly inside destination'
+        if (Test-Path -LiteralPath $createdTarget -PathType Leaf) {
+            Remove-Item -LiteralPath $createdTarget -Force
+        }
+    }
+
+    foreach ($destinationFileManifest in @($manifest.destination_files)) {
+        $originalName = [string]$destinationFileManifest.name
+        Assert-True (
+            $originalName -cmatch '^sessions-\d{4}-\d{2}-\d{2}\.json$' -and
+            [string]::Equals(
+                [System.IO.Path]::GetFileName($originalName),
+                $originalName,
+                [System.StringComparison]::Ordinal
+            )
+        ) 'rollback may restore only a strict relative session filename'
+        $backupFile = Join-Path $backup $originalName
+        Assert-True (
+            (Get-FileHash -LiteralPath $backupFile -Algorithm SHA256).Hash -eq
+                [string]$destinationFileManifest.sha256
+        ) 'rollback backup hash must match the manifest before restore'
+        [System.IO.File]::Copy(
+            $backupFile,
+            (Join-Path $normalizedDestination $originalName),
+            $true
+        )
+    }
+
+    $restoredNames = @(
+        Get-ChildItem -LiteralPath $normalizedDestination -File -Filter 'sessions-*.json' |
+            Sort-Object Name |
+            ForEach-Object { $_.Name }
+    )
+    Assert-True ($restoredNames.Count -eq 1) 'rollback must restore the original destination file set'
+    Assert-True ($restoredNames[0] -ceq 'sessions-2026-01-01.json') 'rollback must remove created day files'
+    Assert-True (
+        (Get-FileHash -LiteralPath $destinationFile -Algorithm SHA256).Hash -eq $destinationHashBefore
+    ) 'rollback must restore original destination bytes'
+
+    Write-Host 'merge-session-history tests passed'
+}
+finally {
+    if (Test-Path -LiteralPath $testRoot) {
+        $resolvedTestRoot = [System.IO.Path]::GetFullPath($testRoot)
+        $resolvedTempRoot = [System.IO.Path]::GetFullPath([System.IO.Path]::GetTempPath())
+        $expectedPrefix = $resolvedTempRoot.TrimEnd([char[]]@('\', '/')) + [System.IO.Path]::DirectorySeparatorChar
+        $safeTestRoot = $resolvedTestRoot.StartsWith(
+            $expectedPrefix,
+            [System.StringComparison]::OrdinalIgnoreCase
+        ) -and [System.IO.Path]::GetFileName($resolvedTestRoot).StartsWith(
+            'echo-session-merge-test-',
+            [System.StringComparison]::Ordinal
+        )
+        if (-not $safeTestRoot) {
+            throw "Refusing to remove unexpected test path: $resolvedTestRoot"
+        }
+        Remove-Item -LiteralPath $resolvedTestRoot -Recurse -Force
+    }
+}

--- a/core/viewer-tests/README.md
+++ b/core/viewer-tests/README.md
@@ -48,6 +48,17 @@ Jam state and never connects to production or Spotify. Echo Pulse therefore
 shows its truthful static **Join Jam to activate** state in this preview; the
 reactive spectrum requires a joined Jam audio stream.
 
+For a disconnected Dashboard History preview with synthetic multi-year data:
+
+```powershell
+$env:ECHO_HISTORY_PREVIEW = "1"
+node .\scripts\serve-viewer.mjs
+```
+
+Open the same local URL. The fixture opens Dashboard History automatically and
+supports rolling ranges, calendar years, and paged loading without reading or
+changing production session logs.
+
 Known legacy failures at `960x540`, `640x480`, and narrow Chat execute on every
 run under the explicit `?echo-ui-shell-v2=0` override. They retain the legacy
 rollback baseline while separate V2 tests assert a usable participant region

--- a/core/viewer-tests/scripts/serve-viewer.mjs
+++ b/core/viewer-tests/scripts/serve-viewer.mjs
@@ -10,7 +10,8 @@ const previewFixture = path.resolve(scriptDirectory, "..", "fixtures", "install-
 const port = Number.parseInt(process.env.PORT || "4175", 10);
 const isolatedThemePreview = process.env.ECHO_THEME_PREVIEW === "1";
 const isolatedJamPreview = process.env.ECHO_JAM_PREVIEW === "1";
-const isolatedPreview = isolatedThemePreview || isolatedJamPreview;
+const isolatedHistoryPreview = process.env.ECHO_HISTORY_PREVIEW === "1";
+const isolatedPreview = isolatedThemePreview || isolatedJamPreview || isolatedHistoryPreview;
 const transparentPng = Buffer.from(
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=",
   "base64",
@@ -27,6 +28,129 @@ const contentTypes = new Map([
   [".svg", "image/svg+xml"],
   [".wasm", "application/wasm"],
 ]);
+
+const historyPreviewNow = Math.floor(Date.now() / 1000);
+const historyPreviewPeople = ["Sam", "David", "Decker", "Zane", "Spencer", "Brad"];
+const historyPreviewOffsets = [
+  45 * 60,
+  2 * 60 * 60,
+  8 * 60 * 60,
+  24 * 60 * 60,
+  2 * 24 * 60 * 60,
+  4 * 24 * 60 * 60,
+  8 * 24 * 60 * 60,
+  18 * 24 * 60 * 60,
+  27 * 24 * 60 * 60,
+  45 * 24 * 60 * 60,
+  75 * 24 * 60 * 60,
+  140 * 24 * 60 * 60,
+  300 * 24 * 60 * 60,
+  430 * 24 * 60 * 60,
+  800 * 24 * 60 * 60,
+];
+const historyPreviewEvents = historyPreviewOffsets.map((offset, index) => ({
+  event_type: index % 2 === 0 ? "join" : "leave",
+  identity: `preview-${index + 1}`,
+  name: historyPreviewPeople[index % historyPreviewPeople.length],
+  room_id: index % 4 === 0 ? "Game Room" : index % 3 === 0 ? "Music Room" : "Main",
+  timestamp: historyPreviewNow - offset,
+  ...(index % 2 === 0 ? {} : { duration_secs: 900 + index * 420 }),
+}));
+
+const historyPreviewHeatmapJoins = [];
+for (let dayOffset = 29; dayOffset >= 0; dayOffset -= 1) {
+  const joinsForDay = 2 + (dayOffset % 4);
+  for (let index = 0; index < joinsForDay; index += 1) {
+    const joinedAt = new Date(historyPreviewNow * 1000);
+    const hour = [8, 12, 18, 21, 23][(dayOffset + index) % 5];
+    joinedAt.setDate(joinedAt.getDate() - dayOffset);
+    joinedAt.setHours(hour, (index * 13 + dayOffset * 3) % 60, 0, 0);
+    const timestamp = Math.floor(joinedAt.getTime() / 1000);
+    if (timestamp <= historyPreviewNow) {
+      historyPreviewHeatmapJoins.push({
+        timestamp,
+        name: historyPreviewPeople[(dayOffset + index) % historyPreviewPeople.length],
+      });
+    }
+  }
+}
+
+function historyPreviewMetricsPayload() {
+  const counts = new Map();
+  historyPreviewHeatmapJoins.forEach((join) => {
+    counts.set(join.name, (counts.get(join.name) || 0) + 1);
+  });
+  const perUser = Array.from(counts.entries())
+    .map(([name, sessionCount], index) => ({
+      identity: `preview-metric-${index + 1}`,
+      name,
+      session_count: sessionCount,
+      total_hours: Math.round(sessionCount * 7.5) / 10,
+    }))
+    .sort((left, right) => right.session_count - left.session_count);
+
+  const localNow = new Date(historyPreviewNow * 1000);
+  const todayStart = Math.floor(new Date(
+    localNow.getFullYear(),
+    localNow.getMonth(),
+    localNow.getDate(),
+  ).getTime() / 1000);
+  const elapsedToday = Math.max(60, historyPreviewNow - todayStart);
+  const timelinePoint = (fraction) => todayStart + Math.floor(elapsedToday * fraction);
+
+  return {
+    summary: {
+      total_sessions: historyPreviewHeatmapJoins.length,
+      unique_users: counts.size,
+      total_hours: Math.round(historyPreviewHeatmapJoins.length * 7.5) / 10,
+      avg_duration_mins: 45,
+    },
+    per_user: perUser,
+    heatmap_joins: historyPreviewHeatmapJoins,
+    timeline_events: [
+      { event_type: "join", identity: "preview-timeline-sam", name: "Sam", timestamp: timelinePoint(0.12) },
+      { event_type: "leave", identity: "preview-timeline-sam", name: "Sam", timestamp: timelinePoint(0.38) },
+      { event_type: "join", identity: "preview-timeline-david", name: "David", timestamp: timelinePoint(0.28) },
+      { event_type: "leave", identity: "preview-timeline-david", name: "David", timestamp: timelinePoint(0.66) },
+      { event_type: "join", identity: "preview-timeline-decker", name: "Decker", timestamp: timelinePoint(0.54) },
+    ],
+  };
+}
+
+function historyPreviewPayload(requestUrl) {
+  const range = requestUrl.searchParams.get("range") || "month";
+  const cursor = requestUrl.searchParams.get("cursor") || "";
+  let filtered = historyPreviewEvents;
+  const rollingDays = { week: 7, month: 30, quarter: 90, year: 365 }[range];
+  if (rollingDays) {
+    const cutoff = historyPreviewNow - rollingDays * 24 * 60 * 60;
+    filtered = filtered.filter((event) => event.timestamp >= cutoff);
+  } else if (range.startsWith("year:")) {
+    const year = Number.parseInt(range.slice(5), 10);
+    filtered = filtered.filter((event) => new Date(event.timestamp * 1000).getUTCFullYear() === year);
+  } else if (range !== "all") {
+    filtered = [];
+  }
+
+  const pageSize = 6;
+  const offset = cursor.startsWith("preview:")
+    ? Math.max(0, Number.parseInt(cursor.slice("preview:".length), 10) || 0)
+    : 0;
+  const events = filtered.slice(offset, offset + pageSize);
+  const nextOffset = offset + events.length;
+  const availableYears = Array.from(new Set(
+    historyPreviewEvents.map((event) => new Date(event.timestamp * 1000).getUTCFullYear()),
+  )).sort((a, b) => b - a);
+
+  return {
+    events,
+    next_cursor: nextOffset < filtered.length ? `preview:${nextOffset}` : null,
+    total_count: filtered.length,
+    available_from: historyPreviewEvents.at(-1)?.timestamp || null,
+    available_to: historyPreviewEvents[0]?.timestamp || null,
+    available_years: availableYears,
+  };
+}
 
 function send(response, statusCode, body, contentType) {
   response.writeHead(statusCode, {
@@ -63,7 +187,11 @@ function resolveStaticFile(requestUrl) {
 }
 
 function injectIsolatedPreview(html) {
-  const previewName = isolatedJamPreview ? "Isolated Jam Preview" : "Isolated Theme Preview";
+  const previewName = isolatedJamPreview
+    ? "Isolated Jam Preview"
+    : isolatedHistoryPreview
+      ? "Isolated Dashboard History Preview"
+      : "Isolated Theme Preview";
   const earlyBootstrap = `
     <script>
       (function () {
@@ -165,7 +293,21 @@ function injectIsolatedPreview(html) {
           if (typeof openJamPanel === "function") openJamPanel(jamButton);
           if (typeof setJamView === "function") setJamView("library", false);
       `
-    : `
+    : isolatedHistoryPreview
+      ? `
+          if (typeof setThemeStudioOpen === "function") setThemeStudioOpen(false);
+          if (typeof adminToken !== "undefined") adminToken = "isolated-history-preview-admin";
+          if (typeof currentAccessToken !== "undefined") currentAccessToken = "isolated-history-preview-participant";
+          var dashboardPanel = document.getElementById("admin-dash-panel");
+          if (dashboardPanel && dashboardPanel.classList.contains("hidden") && typeof toggleAdminDash === "function") {
+            toggleAdminDash();
+          }
+          var historyTab = document.getElementById("admin-dash-history-tab");
+          if (historyTab && typeof switchAdminTab === "function") {
+            switchAdminTab(historyTab, "admin-dash-history");
+          }
+      `
+      : `
           if (typeof setThemeStudioOpen === "function") setThemeStudioOpen(true);
       `;
   const scenario = `
@@ -218,6 +360,30 @@ const server = http.createServer(async (request, response) => {
     }
     if (requestUrl.pathname === "/api/version") {
       send(response, 200, JSON.stringify({ latest_client: "" }), "application/json; charset=utf-8");
+      return;
+    }
+    if (isolatedHistoryPreview && requestUrl.pathname === "/admin/api/dashboard") {
+      send(response, 200, JSON.stringify({
+        rooms: [],
+        total_online: 6,
+        server_version: "history-preview",
+      }), "application/json; charset=utf-8");
+      return;
+    }
+    if (isolatedHistoryPreview && requestUrl.pathname === "/admin/api/sessions") {
+      send(response, 200, JSON.stringify(historyPreviewPayload(requestUrl)), "application/json; charset=utf-8");
+      return;
+    }
+    if (isolatedHistoryPreview && requestUrl.pathname === "/admin/api/metrics/dashboard") {
+      send(response, 200, JSON.stringify(historyPreviewMetricsPayload()), "application/json; charset=utf-8");
+      return;
+    }
+    if (isolatedHistoryPreview && requestUrl.pathname === "/admin/api/metrics") {
+      send(response, 200, JSON.stringify({ users: [] }), "application/json; charset=utf-8");
+      return;
+    }
+    if (isolatedHistoryPreview && requestUrl.pathname === "/admin/api/bugs") {
+      send(response, 200, JSON.stringify({ reports: [] }), "application/json; charset=utf-8");
       return;
     }
     if (requestUrl.pathname.startsWith("/api/avatar/")) {
@@ -308,9 +474,15 @@ const server = http.createServer(async (request, response) => {
 });
 
 server.listen(port, "127.0.0.1", () => {
+  const previewLabel = isolatedJamPreview
+    ? " [ISOLATED JAM PREVIEW]"
+    : isolatedThemePreview
+      ? " [ISOLATED THEME PREVIEW]"
+      : isolatedHistoryPreview
+        ? " [ISOLATED HISTORY PREVIEW]"
+        : "";
   console.log(
-    `[viewer-tests] serving ${viewerRoot} and ${adminRoot} at http://127.0.0.1:${port}` +
-      (isolatedJamPreview ? " [ISOLATED JAM PREVIEW]" : isolatedThemePreview ? " [ISOLATED THEME PREVIEW]" : ""),
+    `[viewer-tests] serving ${viewerRoot} and ${adminRoot} at http://127.0.0.1:${port}${previewLabel}`,
   );
 });
 

--- a/core/viewer-tests/tests/dashboard.history.spec.js
+++ b/core/viewer-tests/tests/dashboard.history.spec.js
@@ -1,0 +1,336 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, test } from "@playwright/test";
+
+const testDirectory = path.dirname(fileURLToPath(import.meta.url));
+const fixturePath = path.resolve(testDirectory, "..", "fixtures", "install-scenario.js");
+const runtimeErrors = new WeakMap();
+const apiModels = new WeakMap();
+
+const unix = (iso) => Math.floor(new Date(iso).getTime() / 1000);
+
+const monthOverlap = {
+  event_type: "leave",
+  identity: "david-1",
+  name: "David",
+  room_id: "main",
+  timestamp: unix("2026-07-30T21:10:00Z"),
+  duration_secs: 5400,
+};
+
+function historyPayload(range, cursor) {
+  const available = {
+    available_from: unix("2024-02-03T12:00:00Z"),
+    available_to: unix("2026-07-31T14:00:00Z"),
+    available_years: [2026, 2025, 2024],
+  };
+
+  if (range === "month" && !cursor) {
+    return {
+      ...available,
+      events: [{
+        event_type: "join",
+        identity: "sam-1",
+        name: '<img src=x onerror="window.__historyXss=1"> Sam',
+        room_id: "<script>unsafe-room</script>",
+        timestamp: unix("2026-07-31T14:00:00Z"),
+      }, {
+        event_type: "join",
+        identity: "zane-1",
+        name: "Zane",
+        room_id: "game-room",
+        timestamp: unix("2026-07-31T13:50:00Z"),
+      }, monthOverlap],
+      next_cursor: "month-page-2+/=",
+      total_count: 4,
+    };
+  }
+  if (range === "month" && cursor === "month-page-2+/=") {
+    return {
+      ...available,
+      events: [{ ...monthOverlap }, {
+        event_type: "join",
+        identity: "spencer-1",
+        name: "Spencer",
+        room_id: "main",
+        timestamp: unix("2026-07-29T16:30:00Z"),
+      }],
+      next_cursor: null,
+      total_count: 4,
+    };
+  }
+
+  const eventByRange = {
+    week: {
+      event_type: "join",
+      identity: "week-1",
+      name: "Week Friend",
+      room_id: "main",
+      timestamp: unix("2026-07-31T12:00:00Z"),
+    },
+    quarter: {
+      event_type: "leave",
+      identity: "quarter-1",
+      name: "Quarter Friend",
+      room_id: "main",
+      timestamp: unix("2026-06-01T12:00:00Z"),
+      duration_secs: 900,
+    },
+    all: {
+      event_type: "join",
+      identity: "all-1",
+      name: "Old Friend",
+      room_id: "archive",
+      timestamp: unix("2024-02-03T12:00:00Z"),
+    },
+    "year:2025": {
+      event_type: "leave",
+      identity: "year-1",
+      name: "Calendar Friend",
+      room_id: "main",
+      timestamp: unix("2025-10-05T12:00:00Z"),
+      duration_secs: 3600,
+    },
+  };
+  const event = eventByRange[range];
+  return {
+    ...available,
+    events: event ? [event] : [],
+    next_cursor: null,
+    total_count: event ? 1 : 0,
+  };
+}
+
+test.beforeEach(async ({ page }) => {
+  const errors = [];
+  const model = {
+    historyRequests: [],
+    quarterFailuresRemaining: 1,
+    servedExpectedHistoryFailure: false,
+  };
+  runtimeErrors.set(page, errors);
+  apiModels.set(page, model);
+
+  page.on("pageerror", (error) => errors.push(`pageerror: ${error.message}`));
+  page.on("console", (message) => {
+    if (message.type() === "error") errors.push(`console.error: ${message.text()}`);
+  });
+
+  await page.route("**/api/**", async (route) => {
+    const request = route.request();
+    const url = new URL(request.url());
+
+    if (url.pathname === "/api/online") {
+      await route.fulfill({ status: 200, contentType: "application/json", body: "[]" });
+      return;
+    }
+    if (url.pathname === "/api/version") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ latest_client: "" }),
+      });
+      return;
+    }
+    if (url.pathname === "/admin/api/dashboard") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ rooms: [], total_online: 0, server_version: "history-test" }),
+      });
+      return;
+    }
+    if (url.pathname === "/admin/api/metrics/dashboard") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ summary: {}, per_user: [], heatmap_joins: [], timeline_events: [] }),
+      });
+      return;
+    }
+    if (url.pathname === "/admin/api/metrics") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ users: [] }),
+      });
+      return;
+    }
+    if (url.pathname === "/admin/api/bugs") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ reports: [] }),
+      });
+      return;
+    }
+    if (url.pathname === "/admin/api/sessions") {
+      const range = url.searchParams.get("range");
+      const cursor = url.searchParams.get("cursor");
+      model.historyRequests.push({
+        cursor,
+        limit: url.searchParams.get("limit"),
+        range,
+      });
+      if (range === "quarter" && model.quarterFailuresRemaining > 0) {
+        model.quarterFailuresRemaining -= 1;
+        model.servedExpectedHistoryFailure = true;
+        await route.fulfill({
+          status: 503,
+          contentType: "application/json",
+          body: JSON.stringify({ error: "temporary failure" }),
+        });
+        return;
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(historyPayload(range, cursor)),
+      });
+      return;
+    }
+
+    await route.fulfill({ status: 200, contentType: "application/json", body: "{}" });
+  });
+});
+
+test.afterEach(async ({ page }) => {
+  const model = apiModels.get(page);
+  const errors = (runtimeErrors.get(page) || []).filter((message) => !(
+    model.servedExpectedHistoryFailure && message.includes("status of 503")
+  ));
+  expect(errors, "Dashboard History must not emit unexpected runtime errors").toEqual([]);
+});
+
+async function openDashboardHistory(page) {
+  await page.goto("/?echo-ui-shell-v2=1", { waitUntil: "domcontentloaded" });
+  await page.addScriptTag({ path: fixturePath });
+  await page.evaluate(() => window.EchoLayoutTestScenario.install({
+    participants: 1,
+    cameras: 0,
+    screenShares: 0,
+  }));
+  await page.evaluate(() => {
+    adminToken = "dashboard-history-token";
+    currentAccessToken = "dashboard-history-participant-token";
+    room = {
+      localParticipant: {
+        identity: "layout-fixture-1",
+        name: "Fixture Host",
+        publishData: async function() {},
+      },
+    };
+    document.getElementById("open-admin-dash").classList.remove("hidden");
+  });
+
+  const more = page.getByRole("button", { name: "More clubhouse actions", exact: true });
+  await expect(more).toHaveCount(1);
+  await more.click();
+  const dashboard = page.getByRole("button", { name: "Dashboard", exact: true });
+  await expect(dashboard).toHaveCount(1);
+  await dashboard.click();
+  await expect(page.locator("#admin-dash-panel")).toBeVisible();
+
+  const historyTab = page.locator("#admin-dash-panel").getByRole("button", {
+    name: "History",
+    exact: true,
+  });
+  await expect(historyTab).toHaveCount(1);
+  await historyTab.click();
+  await expect(page.locator("#admin-dash-history")).toBeVisible();
+  await expect(page.locator("#admin-history-status")).toContainText("Last 30 days");
+}
+
+test("Dashboard History switches ranges and appends cursor pages without duplicate or unsafe markup", async ({ page }) => {
+  await page.setViewportSize({ width: 360, height: 640 });
+  await openDashboardHistory(page);
+  const model = apiModels.get(page);
+  const range = page.getByLabel("Time range", { exact: true });
+  await expect(range).toHaveCount(1);
+  await expect(range).toHaveValue("month");
+  expect(model.historyRequests[0]).toEqual({ cursor: null, limit: "200", range: "month" });
+
+  await expect(range.locator('option[value="year:2026"]')).toHaveText("2026 (year to date)");
+  await expect(range.locator('option[value="year:2025"]')).toHaveText("2025");
+  await expect(range.locator('option[value="year:2024"]')).toHaveText("2024");
+  const eventRows = page.locator("#admin-history-results tbody tr:not(.adm-date-sep)");
+  await expect(eventRows).toHaveCount(3);
+  await expect(page.locator("#admin-history-results")).toContainText('<img src=x onerror="window.__historyXss=1"> Sam');
+  await expect(page.locator("#admin-history-results")).toContainText("<script>unsafe-room</script>");
+  expect(await page.evaluate(() => ({
+    injectedNodeCount: document.querySelectorAll("#admin-history-results img, #admin-history-results script").length,
+    xssValue: window.__historyXss,
+  }))).toEqual({ injectedNodeCount: 0, xssValue: undefined });
+  const dateSeparators = page.locator(".adm-date-sep");
+  await expect(dateSeparators).toHaveCount(2);
+  await expect(dateSeparators).toContainText(["2026", "2026"]);
+
+  const loadOlder = page.getByRole("button", { name: "Load older", exact: true });
+  await expect(loadOlder).toHaveCount(1);
+  await loadOlder.click();
+  await expect(eventRows).toHaveCount(4);
+  await expect(page.locator("#admin-history-status")).toHaveText("Showing 4 of 4 events · Last 30 days");
+  await expect(loadOlder).toBeHidden();
+  expect(model.historyRequests.some((request) => (
+    request.range === "month" && request.cursor === "month-page-2+/=" && request.limit === "200"
+  ))).toBe(true);
+
+  await range.selectOption("week");
+  await expect(page.locator("#admin-history-status")).toHaveText("Showing 1 of 1 events · Last 7 days");
+  await range.selectOption("all");
+  await expect(page.locator("#admin-history-status")).toHaveText("Showing 1 of 1 events · All history");
+  await range.selectOption("year:2025");
+  await expect(page.locator("#admin-history-status")).toHaveText("Showing 1 of 1 events · 2025");
+  await expect(page.locator("#admin-history-results")).toContainText("Calendar Friend");
+  expect(model.historyRequests.slice(-3).map(({ range: selected, cursor }) => ({ selected, cursor }))).toEqual([
+    { selected: "week", cursor: null },
+    { selected: "all", cursor: null },
+    { selected: "year:2025", cursor: null },
+  ]);
+
+  const geometry = await page.evaluate(() => {
+    const panel = document.getElementById("admin-dash-panel").getBoundingClientRect();
+    const select = document.getElementById("admin-history-range").getBoundingClientRect();
+    const tableWrap = document.querySelector(".adm-history-table-wrap").getBoundingClientRect();
+    return {
+      bodyOverflow: document.body.scrollWidth - window.innerWidth,
+      documentOverflow: document.documentElement.scrollWidth - window.innerWidth,
+      panel: { left: panel.left, right: panel.right },
+      select: { left: select.left, right: select.right },
+      tableWrap: { left: tableWrap.left, right: tableWrap.right },
+      viewportWidth: window.innerWidth,
+    };
+  });
+  expect(geometry.documentOverflow).toBeLessThanOrEqual(1);
+  expect(geometry.bodyOverflow).toBeLessThanOrEqual(1);
+  expect(geometry.panel.left).toBeGreaterThanOrEqual(-1);
+  expect(geometry.panel.right).toBeLessThanOrEqual(geometry.viewportWidth + 1);
+  expect(geometry.select.left).toBeGreaterThanOrEqual(geometry.panel.left - 1);
+  expect(geometry.select.right).toBeLessThanOrEqual(geometry.panel.right + 1);
+  expect(geometry.tableWrap.left).toBeGreaterThanOrEqual(geometry.panel.left - 1);
+  expect(geometry.tableWrap.right).toBeLessThanOrEqual(geometry.panel.right + 1);
+});
+
+test("Dashboard History reports a failed range request and Retry repeats that range", async ({ page }) => {
+  await page.setViewportSize({ width: 900, height: 700 });
+  await openDashboardHistory(page);
+  const model = apiModels.get(page);
+  const range = page.getByLabel("Time range", { exact: true });
+  await range.selectOption("quarter");
+
+  const error = page.locator("#admin-history-error");
+  await expect(error).toBeVisible();
+  await expect(error).toContainText("History request failed (503)");
+  await expect(page.locator("#admin-history-status")).toHaveText("History unavailable · Last 90 days");
+
+  const retry = error.getByRole("button", { name: "Retry", exact: true });
+  await expect(retry).toHaveCount(1);
+  await retry.click();
+  await expect(error).toBeHidden();
+  await expect(page.locator("#admin-history-status")).toHaveText("Showing 1 of 1 events · Last 90 days");
+  await expect(page.locator("#admin-history-results")).toContainText("Quarter Friend");
+  expect(model.historyRequests.filter((request) => request.range === "quarter")).toEqual([
+    { cursor: null, limit: "200", range: "quarter" },
+    { cursor: null, limit: "200", range: "quarter" },
+  ]);
+});

--- a/core/viewer/admin-history.js
+++ b/core/viewer/admin-history.js
@@ -1,0 +1,143 @@
+(function (root, factory) {
+  if (typeof module === "object" && module.exports) {
+    module.exports = factory();
+  } else {
+    root.EchoAdminHistory = factory();
+  }
+})(typeof globalThis !== "undefined" ? globalThis : this, function () {
+  "use strict";
+
+  var DEFAULT_RANGE = "month";
+  var PAGE_LIMIT = 200;
+  var RANGE_LABELS = {
+    week: "Last 7 days",
+    month: "Last 30 days",
+    quarter: "Last 90 days",
+    year: "Last 365 days",
+    all: "All history",
+  };
+
+  function normalizeRange(value) {
+    var range = String(value || "").trim().toLowerCase();
+    if (Object.prototype.hasOwnProperty.call(RANGE_LABELS, range)) return range;
+    var yearMatch = /^year:(\d{4})$/.exec(range);
+    if (yearMatch) {
+      var year = Number(yearMatch[1]);
+      if (year >= 1970 && year <= 9999) return "year:" + year;
+    }
+    return DEFAULT_RANGE;
+  }
+
+  function rangeLabel(value) {
+    var range = normalizeRange(value);
+    if (range.indexOf("year:") === 0) return range.slice(5);
+    return RANGE_LABELS[range];
+  }
+
+  function buildSessionsPath(range, cursor) {
+    var path = "/admin/api/sessions?range=" + encodeURIComponent(normalizeRange(range)) +
+      "&limit=" + PAGE_LIMIT;
+    if (cursor !== null && cursor !== undefined && String(cursor) !== "") {
+      path += "&cursor=" + encodeURIComponent(String(cursor));
+    }
+    return path;
+  }
+
+  function normalizeAvailableYears(values, selectedRange) {
+    var seen = Object.create(null);
+    var years = [];
+    (Array.isArray(values) ? values : []).forEach(function (value) {
+      var year = Number(value);
+      if (!Number.isInteger(year) || year < 1970 || year > 9999 || seen[year]) return;
+      seen[year] = true;
+      years.push(year);
+    });
+
+    var normalizedRange = normalizeRange(selectedRange);
+    if (normalizedRange.indexOf("year:") === 0) {
+      var selectedYear = Number(normalizedRange.slice(5));
+      if (!seen[selectedYear]) years.push(selectedYear);
+    }
+
+    return years.sort(function (a, b) { return b - a; });
+  }
+
+  function eventKey(event) {
+    var item = event && typeof event === "object" ? event : {};
+    return JSON.stringify([
+      item.event_type == null ? "" : item.event_type,
+      item.identity == null ? "" : item.identity,
+      item.name == null ? "" : item.name,
+      item.room_id == null ? "" : item.room_id,
+      item.timestamp == null ? null : item.timestamp,
+      item.duration_secs == null ? null : item.duration_secs,
+    ]);
+  }
+
+  function mergeEvents(existing, incoming) {
+    var merged = [];
+    var seen = Object.create(null);
+    var source = (Array.isArray(existing) ? existing : []).concat(
+      Array.isArray(incoming) ? incoming : [],
+    );
+
+    source.forEach(function (event) {
+      if (!event || typeof event !== "object") return;
+      var key = eventKey(event);
+      if (seen[key]) return;
+      seen[key] = true;
+      merged.push(event);
+    });
+
+    return merged.sort(function (a, b) {
+      var aTimestamp = Number(a.timestamp) || 0;
+      var bTimestamp = Number(b.timestamp) || 0;
+      return bTimestamp - aTimestamp;
+    });
+  }
+
+  function formatDateSeparator(timestamp, locales) {
+    var date = new Date(Number(timestamp) * 1000);
+    if (!Number.isFinite(date.getTime())) return "Unknown date";
+    return date.toLocaleDateString(locales || [], {
+      weekday: "long",
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    });
+  }
+
+  function formatStatus(loadedCount, totalCount, range) {
+    var loaded = Math.max(0, Number(loadedCount) || 0);
+    var total = Number(totalCount);
+    var suffix = " \u00b7 " + rangeLabel(range);
+    if (loaded === 0) return "No events" + suffix;
+    if (Number.isFinite(total) && total >= loaded) {
+      return "Showing " + loaded + " of " + total + " events" + suffix;
+    }
+    return "Showing " + loaded + " events" + suffix;
+  }
+
+  function emptyMessage(range) {
+    var normalizedRange = normalizeRange(range);
+    if (normalizedRange === "all") return "No session history is available yet.";
+    if (normalizedRange.indexOf("year:") === 0) {
+      return "No session history is available for " + rangeLabel(normalizedRange) + ".";
+    }
+    return "No session history is available for the " + rangeLabel(normalizedRange).toLowerCase() + ".";
+  }
+
+  return {
+    DEFAULT_RANGE: DEFAULT_RANGE,
+    PAGE_LIMIT: PAGE_LIMIT,
+    buildSessionsPath: buildSessionsPath,
+    emptyMessage: emptyMessage,
+    eventKey: eventKey,
+    formatDateSeparator: formatDateSeparator,
+    formatStatus: formatStatus,
+    mergeEvents: mergeEvents,
+    normalizeAvailableYears: normalizeAvailableYears,
+    normalizeRange: normalizeRange,
+    rangeLabel: rangeLabel,
+  };
+});

--- a/core/viewer/admin-history.test.js
+++ b/core/viewer/admin-history.test.js
@@ -1,0 +1,89 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  DEFAULT_RANGE,
+  PAGE_LIMIT,
+  buildSessionsPath,
+  emptyMessage,
+  formatDateSeparator,
+  formatStatus,
+  mergeEvents,
+  normalizeAvailableYears,
+  normalizeRange,
+  rangeLabel,
+} = require("./admin-history.js");
+
+test("normalizes rolling and calendar-year history ranges", () => {
+  assert.equal(DEFAULT_RANGE, "month");
+  assert.equal(normalizeRange("week"), "week");
+  assert.equal(normalizeRange("YEAR:2025"), "year:2025");
+  assert.equal(normalizeRange("year:1969"), "month");
+  assert.equal(normalizeRange("not-a-range"), "month");
+  assert.equal(rangeLabel("quarter"), "Last 90 days");
+  assert.equal(rangeLabel("year:2024"), "2024");
+});
+
+test("builds the paged session-history request contract", () => {
+  assert.equal(PAGE_LIMIT, 200);
+  assert.equal(
+    buildSessionsPath("month"),
+    "/admin/api/sessions?range=month&limit=200",
+  );
+  assert.equal(
+    buildSessionsPath("year:2025", "opaque+/= cursor"),
+    "/admin/api/sessions?range=year%3A2025&limit=200&cursor=opaque%2B%2F%3D%20cursor",
+  );
+  assert.equal(
+    buildSessionsPath("invalid", ""),
+    "/admin/api/sessions?range=month&limit=200",
+  );
+});
+
+test("calendar-year options are unique, descending, and retain the selection", () => {
+  assert.deepEqual(
+    normalizeAvailableYears([2024, "2026", 2025, 2024, "bad"], "year:2023"),
+    [2026, 2025, 2024, 2023],
+  );
+  assert.deepEqual(normalizeAvailableYears(null, "month"), []);
+});
+
+test("paged events merge newest-first and remove exact overlap only", () => {
+  const newest = {
+    event_type: "join",
+    identity: "sam-1",
+    name: "Sam",
+    room_id: "main",
+    timestamp: 300,
+  };
+  const overlap = {
+    event_type: "leave",
+    identity: "david-1",
+    name: "David",
+    room_id: "main",
+    timestamp: 200,
+    duration_secs: 90,
+  };
+  const sameSecondDifferentEvent = { ...overlap, duration_secs: 91 };
+  const oldest = { ...newest, timestamp: 100 };
+
+  const merged = mergeEvents(
+    [overlap, newest],
+    [{ ...overlap }, oldest, sameSecondDifferentEvent],
+  );
+
+  assert.deepEqual(merged, [newest, overlap, sameSecondDifferentEvent, oldest]);
+  assert.equal(mergeEvents(merged, null).length, 4);
+});
+
+test("history labels always identify the year and selected range", () => {
+  const separator = formatDateSeparator(Date.UTC(2024, 4, 3, 12) / 1000, "en-US");
+  assert.match(separator, /2024/);
+  assert.match(separator, /May/);
+  assert.equal(formatDateSeparator("bad", "en-US"), "Unknown date");
+  assert.equal(formatStatus(200, 432, "month"), "Showing 200 of 432 events \u00b7 Last 30 days");
+  assert.equal(formatStatus(0, 0, "year:2023"), "No events \u00b7 2023");
+  assert.equal(emptyMessage("week"), "No session history is available for the last 7 days.");
+  assert.equal(emptyMessage("year:2022"), "No session history is available for 2022.");
+  assert.equal(emptyMessage("all"), "No session history is available yet.");
+});

--- a/core/viewer/admin.js
+++ b/core/viewer/admin.js
@@ -185,6 +185,16 @@ if (bugReportModal) {
 
 var _adminDashTimer = null;
 var _adminDashOpen = false;
+var _admHistoryState = {
+  range: "month",
+  events: [],
+  nextCursor: null,
+  totalCount: null,
+  availableYears: [],
+  controller: null,
+  requestId: 0,
+  retryAppend: false,
+};
 
 function adminKickParticipant(identity) {
   if (!confirm("Kick " + identity + " from the room?")) return;
@@ -251,6 +261,11 @@ function toggleAdminDash() {
     }, 3000);
   } else {
     panel.classList.add("hidden");
+    if (_admHistoryState.controller) {
+      _admHistoryState.controller.abort();
+      _admHistoryState.controller = null;
+      _admHistoryState.requestId += 1;
+    }
     if (_adminDashTimer) {
       clearInterval(_adminDashTimer);
       _adminDashTimer = null;
@@ -298,6 +313,7 @@ function switchAdminTab(btn, tabId) {
   var tab = document.getElementById(tabId);
   if (tab) tab.classList.remove("hidden");
   btn.classList.add("active");
+  if (tabId === "admin-dash-history") fetchAdminHistory();
   if (tabId === "admin-dash-deploys") fetchAdminDeploys();
 }
 
@@ -364,36 +380,182 @@ async function fetchAdminDashboard() {
   } catch (e) {}
 }
 
-async function fetchAdminHistory() {
-  try {
-    var res = await fetch(apiUrl("/admin/api/sessions"), {
-      headers: { "Authorization": "Bearer " + adminToken }
-    });
-    if (!res.ok) return;
-    var data = await res.json();
-    var el = document.getElementById("admin-dash-history");
-    if (!el) return;
-    var events = data.events || [];
-    if (events.length === 0) {
-      el.innerHTML = '<div class="adm-empty">No session history</div>';
-      return;
-    }
-    var html = '<table class="adm-table"><thead><tr><th>Time</th><th>Event</th><th>User</th><th>Room</th><th>Duration</th></tr></thead><tbody>';
+function _admHistorySetError(message) {
+  var error = document.getElementById("admin-history-error");
+  var errorMessage = document.getElementById("admin-history-error-message");
+  if (errorMessage) errorMessage.textContent = message || "Session history could not be loaded.";
+  if (error) error.hidden = false;
+}
+
+function _admHistoryClearError() {
+  var error = document.getElementById("admin-history-error");
+  if (error) error.hidden = true;
+}
+
+function _admHistorySetLoading(loading, append) {
+  var results = document.getElementById("admin-history-results");
+  var loadMore = document.getElementById("admin-history-load-more");
+  var status = document.getElementById("admin-history-status");
+  if (results) results.setAttribute("aria-busy", loading ? "true" : "false");
+  if (loadMore) loadMore.disabled = loading;
+  if (loading && status) {
+    status.textContent = append
+      ? "Loading older events..."
+      : "Loading " + EchoAdminHistory.rangeLabel(_admHistoryState.range).toLowerCase() + "...";
+  }
+}
+
+function _admHistoryUpdateYears(values) {
+  var years = EchoAdminHistory.normalizeAvailableYears(values, _admHistoryState.range);
+  if (years.join(",") === _admHistoryState.availableYears.join(",")) return;
+  _admHistoryState.availableYears = years;
+
+  var group = document.getElementById("admin-history-years");
+  var select = document.getElementById("admin-history-range");
+  if (!group || !select) return;
+  var selected = _admHistoryState.range;
+  while (group.firstChild) group.removeChild(group.firstChild);
+  years.forEach(function(year) {
+    var option = document.createElement("option");
+    option.value = "year:" + year;
+    option.textContent = year === new Date().getFullYear() ? year + " (year to date)" : String(year);
+    group.appendChild(option);
+  });
+  select.value = selected;
+}
+
+function _admHistoryRenderEvents() {
+  var results = document.getElementById("admin-history-results");
+  var loadMore = document.getElementById("admin-history-load-more");
+  var status = document.getElementById("admin-history-status");
+  if (!results) return;
+
+  var events = _admHistoryState.events;
+  if (events.length === 0) {
+    results.innerHTML = '<div class="adm-empty">' +
+      escAdm(EchoAdminHistory.emptyMessage(_admHistoryState.range)) + '</div>';
+  } else {
+    var html = '<div class="adm-history-table-wrap"><table class="adm-table" aria-label="Session join and leave history"><thead><tr><th>Time</th><th>Event</th><th>User</th><th>Room</th><th>Duration</th></tr></thead><tbody>';
     var lastDateKey = "";
     events.forEach(function(ev) {
-      var d = new Date(ev.timestamp * 1000);
-      var dateKey = d.toLocaleDateString([], { weekday: "long", month: "short", day: "numeric" });
+      var dateKey = EchoAdminHistory.formatDateSeparator(ev.timestamp);
       if (dateKey !== lastDateKey) {
-        html += '<tr class="adm-date-sep"><td colspan="5">' + dateKey + '</td></tr>';
+        html += '<tr class="adm-date-sep"><td colspan="5">' + escAdm(dateKey) + '</td></tr>';
         lastDateKey = dateKey;
       }
       var isJoin = ev.event_type === "join";
-      html += '<tr><td>' + fmtTime(ev.timestamp) + '</td><td><span class="adm-badge ' + (isJoin ? 'adm-join' : 'adm-leave') + '">' + (isJoin ? 'JOIN' : 'LEAVE') + '</span></td><td>' + escAdm(ev.name || ev.identity) + '</td><td>' + escAdm(ev.room_id) + '</td><td>' + (ev.duration_secs != null ? fmtDur(ev.duration_secs) : '') + '</td></tr>';
+      var isLeave = ev.event_type === "leave";
+      var eventClass = isJoin ? "adm-join" : isLeave ? "adm-leave" : "adm-event";
+      var eventLabel = isJoin ? "JOIN" : isLeave ? "LEAVE" : "EVENT";
+      html += '<tr><td>' + escAdm(fmtTime(ev.timestamp)) + '</td><td><span class="adm-badge ' + eventClass + '">' + eventLabel + '</span></td><td>' + escAdm(ev.name || ev.identity || "Unknown") + '</td><td>' + escAdm(ev.room_id || "") + '</td><td>' + (ev.duration_secs != null ? escAdm(fmtDur(ev.duration_secs)) : '') + '</td></tr>';
     });
-    html += '</tbody></table>';
-    el.innerHTML = html;
-  } catch (e) {}
+    html += '</tbody></table></div>';
+    results.innerHTML = html;
+  }
+
+  if (status) {
+    status.textContent = EchoAdminHistory.formatStatus(
+      events.length,
+      _admHistoryState.totalCount,
+      _admHistoryState.range,
+    );
+  }
+  if (loadMore) {
+    loadMore.hidden = !_admHistoryState.nextCursor;
+    loadMore.disabled = false;
+  }
+  results.setAttribute("aria-busy", "false");
 }
+
+async function fetchAdminHistory(options) {
+  var append = !!(options && options.append);
+  var cursor = append ? _admHistoryState.nextCursor : null;
+  if (append && !cursor) return;
+
+  if (_admHistoryState.controller) _admHistoryState.controller.abort();
+  var requestId = _admHistoryState.requestId + 1;
+  _admHistoryState.requestId = requestId;
+  _admHistoryState.retryAppend = append;
+  _admHistoryState.controller = typeof AbortController !== "undefined" ? new AbortController() : null;
+
+  var results = document.getElementById("admin-history-results");
+  var loadMore = document.getElementById("admin-history-load-more");
+  if (!append) {
+    _admHistoryState.events = [];
+    _admHistoryState.nextCursor = null;
+    _admHistoryState.totalCount = null;
+    if (results) results.innerHTML = '<div class="adm-empty">Loading...</div>';
+    if (loadMore) loadMore.hidden = true;
+  }
+  _admHistoryClearError();
+  _admHistorySetLoading(true, append);
+
+  try {
+    var requestOptions = {
+      headers: { "Authorization": "Bearer " + adminToken }
+    };
+    if (_admHistoryState.controller) requestOptions.signal = _admHistoryState.controller.signal;
+    var path = EchoAdminHistory.buildSessionsPath(_admHistoryState.range, cursor);
+    var res = await fetch(apiUrl(path), requestOptions);
+    if (!res.ok) throw new Error("History request failed (" + res.status + ")");
+    var data = await res.json();
+    if (requestId !== _admHistoryState.requestId) return;
+
+    _admHistoryState.events = EchoAdminHistory.mergeEvents(
+      append ? _admHistoryState.events : [],
+      data.events,
+    );
+    _admHistoryState.nextCursor = data.next_cursor == null || data.next_cursor === ""
+      ? null
+      : String(data.next_cursor);
+    var totalCount = Number(data.total_count);
+    _admHistoryState.totalCount = Number.isFinite(totalCount) && totalCount >= 0
+      ? Math.max(totalCount, _admHistoryState.events.length)
+      : null;
+    _admHistoryUpdateYears(data.available_years);
+    _admHistoryClearError();
+    _admHistoryRenderEvents();
+  } catch (e) {
+    if (e && e.name === "AbortError") return;
+    if (requestId !== _admHistoryState.requestId) return;
+    _admHistorySetError(e && e.message ? e.message : "Session history could not be loaded.");
+    if (append && _admHistoryState.events.length > 0) {
+      _admHistoryRenderEvents();
+    } else {
+      if (results) results.innerHTML = '<div class="adm-empty">Session history is temporarily unavailable.</div>';
+      var status = document.getElementById("admin-history-status");
+      if (status) status.textContent = "History unavailable \u00b7 " + EchoAdminHistory.rangeLabel(_admHistoryState.range);
+    }
+  } finally {
+    if (requestId === _admHistoryState.requestId) {
+      _admHistoryState.controller = null;
+      _admHistorySetLoading(false, append);
+    }
+  }
+}
+
+(function initAdminHistoryControls() {
+  var range = document.getElementById("admin-history-range");
+  var retry = document.getElementById("admin-history-retry");
+  var loadMore = document.getElementById("admin-history-load-more");
+  if (range) {
+    _admHistoryState.range = EchoAdminHistory.normalizeRange(range.value);
+    range.addEventListener("change", function() {
+      _admHistoryState.range = EchoAdminHistory.normalizeRange(range.value);
+      fetchAdminHistory();
+    });
+  }
+  if (retry) {
+    retry.addEventListener("click", function() {
+      fetchAdminHistory({ append: _admHistoryState.retryAppend });
+    });
+  }
+  if (loadMore) {
+    loadMore.addEventListener("click", function() {
+      fetchAdminHistory({ append: true });
+    });
+  }
+})();
 
 var _admUserColors = [
   "#e8922f","#3b9dda","#49b86d","#c75dba","#d65757","#c9b83e","#6ec4c4","#8b7dd6",

--- a/core/viewer/index.html
+++ b/core/viewer/index.html
@@ -38,7 +38,7 @@
         }
       })();
     </script>
-    <link rel="stylesheet" href="style.css?v=0.6.11.1777930912" />
+    <link rel="stylesheet" href="style.css?v=0.6.34.1785470400" />
     <link rel="stylesheet" href="jam.css?v=0.6.34.1785384000" />
     <link rel="stylesheet" href="capture-picker.css?v=0.6.11.1777930912" />
     <link rel="stylesheet" href="clubhouse-shell.css?v=0.6.11.1777930912" />
@@ -712,17 +712,42 @@
       <div id="admin-dash-panel" class="hidden admin-dash-panel">
         <div class="admin-dash-header">
           <h3>Dashboard</h3>
-          <button type="button" class="admin-dash-close" onclick="toggleAdminDash()">&times;</button>
+          <button type="button" class="admin-dash-close" aria-label="Close Dashboard" onclick="toggleAdminDash()">&times;</button>
         </div>
         <div class="admin-dash-tabs">
           <button type="button" class="adm-tab active" onclick="switchAdminTab(this,'admin-dash-live')">Live</button>
-          <button type="button" class="adm-tab" onclick="switchAdminTab(this,'admin-dash-history')">History</button>
+          <button id="admin-dash-history-tab" type="button" class="adm-tab" onclick="switchAdminTab(this,'admin-dash-history')">History</button>
           <button type="button" class="adm-tab" onclick="switchAdminTab(this,'admin-dash-metrics')">Metrics</button>
           <button type="button" class="adm-tab" onclick="switchAdminTab(this,'admin-dash-bugs')">Bugs</button>
           <button type="button" class="adm-tab" onclick="switchAdminTab(this,'admin-dash-deploys')">Deploys</button>
         </div>
         <div id="admin-dash-live" class="admin-dash-content"><div class="adm-empty">Loading...</div></div>
-        <div id="admin-dash-history" class="admin-dash-content hidden"><div class="adm-empty">Loading...</div></div>
+        <div id="admin-dash-history" class="admin-dash-content hidden">
+          <div class="adm-history-toolbar">
+            <label for="admin-history-range">Time range</label>
+            <select id="admin-history-range" aria-controls="admin-history-results">
+              <optgroup label="Rolling ranges">
+                <option value="week">Last 7 days</option>
+                <option value="month" selected>Last 30 days</option>
+                <option value="quarter">Last 90 days</option>
+                <option value="year">Last 365 days</option>
+              </optgroup>
+              <option value="all">All history</option>
+              <optgroup id="admin-history-years" label="Calendar years"></optgroup>
+            </select>
+          </div>
+          <div id="admin-history-status" class="adm-history-status" role="status" aria-live="polite">Loading session history...</div>
+          <div id="admin-history-error" class="adm-history-error" role="alert" hidden>
+            <span id="admin-history-error-message">Session history could not be loaded.</span>
+            <button id="admin-history-retry" type="button">Retry</button>
+          </div>
+          <div id="admin-history-results" class="adm-history-results" aria-label="Session history results" aria-busy="true">
+            <div class="adm-empty">Loading...</div>
+          </div>
+          <div class="adm-history-footer">
+            <button id="admin-history-load-more" type="button" hidden>Load older</button>
+          </div>
+        </div>
         <div id="admin-dash-metrics" class="admin-dash-content hidden"><div class="adm-empty">Loading...</div></div>
         <div id="admin-dash-bugs" class="admin-dash-content hidden"><div class="adm-empty">Loading...</div></div>
         <div id="admin-dash-deploys" class="admin-dash-content hidden"><div class="adm-empty">Loading...</div></div>
@@ -789,7 +814,8 @@
     <script src="participants.js?v=0.6.11.1777930912"></script>
     <script src="audio-routing.js?v=0.6.11.1777930912"></script>
     <script src="media-controls.js?v=0.6.11.1777930912"></script>
-    <script src="admin.js?v=0.6.11.1777930912"></script>
+    <script src="admin-history.js?v=0.6.34.1785470400"></script>
+    <script src="admin.js?v=0.6.34.1785470400"></script>
     <script src="connect.js?v=0.6.11.1777930912"></script>
     <script src="app.js?v=0.6.11.1777930912"></script>
     <script src="capture-picker.js?v=0.6.11.1777930912"></script>

--- a/core/viewer/style.css
+++ b/core/viewer/style.css
@@ -5091,10 +5091,19 @@ body.admin-mode .room-top {
   color: var(--text-muted);
   font-size: 20px;
   cursor: pointer;
-  padding: 0 4px;
+  padding: 4px;
+  min-width: 32px;
+  min-height: 32px;
   line-height: 1;
 }
 .admin-dash-close:hover { color: var(--text); }
+.admin-dash-close:focus-visible,
+.adm-history-toolbar select:focus-visible,
+.adm-history-error button:focus-visible,
+.adm-history-footer button:focus-visible {
+  outline: 2px solid #f59e0b;
+  outline-offset: 2px;
+}
 
 .admin-dash-tabs {
   display: flex;
@@ -5219,6 +5228,143 @@ body.admin-mode .room-top {
   border-bottom: 1px solid rgba(255,255,255,0.03);
 }
 
+.adm-history-toolbar {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 8px;
+}
+.adm-history-toolbar label {
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+.adm-history-toolbar select {
+  width: 100%;
+  min-width: 0;
+  min-height: 38px;
+  padding: 7px 30px 7px 10px;
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  background: rgba(255,255,255,0.05);
+  color: var(--text);
+  color-scheme: dark;
+  cursor: pointer;
+  font: inherit;
+  font-size: 12px;
+}
+.adm-history-status {
+  min-height: 18px;
+  margin-bottom: 10px;
+  color: var(--text-muted);
+  font-size: 11px;
+}
+.adm-history-error {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 10px;
+  padding: 10px 12px;
+  border: 1px solid rgba(239, 68, 68, 0.4);
+  border-radius: 7px;
+  background: rgba(239, 68, 68, 0.1);
+  color: #fca5a5;
+  font-size: 12px;
+  line-height: 1.35;
+}
+.adm-history-error[hidden] { display: none; }
+.adm-history-error button,
+.adm-history-footer button {
+  min-height: 38px;
+  border: 1px solid rgba(245,158,11,0.4);
+  border-radius: 6px;
+  background: rgba(245,158,11,0.14);
+  color: #fbbf24;
+  cursor: pointer;
+  font: inherit;
+  font-size: 12px;
+  font-weight: 700;
+}
+.adm-history-error button {
+  flex: 0 0 auto;
+  padding: 6px 12px;
+}
+.adm-history-error button:hover,
+.adm-history-footer button:hover {
+  background: rgba(245,158,11,0.24);
+}
+.adm-history-error button:disabled,
+.adm-history-footer button:disabled {
+  cursor: wait;
+  opacity: 0.55;
+}
+.adm-history-results {
+  min-width: 0;
+}
+.adm-history-table-wrap {
+  width: 100%;
+  overflow: hidden;
+  border: 1px solid rgba(255,255,255,0.05);
+  border-radius: 7px;
+}
+.adm-history-table-wrap .adm-table {
+  min-width: 0;
+  table-layout: fixed;
+}
+.adm-history-table-wrap .adm-table th,
+.adm-history-table-wrap .adm-table td {
+  padding-inline: 5px;
+}
+.adm-history-table-wrap .adm-table th:nth-child(1),
+.adm-history-table-wrap .adm-table td:nth-child(1) {
+  width: 24%;
+  white-space: nowrap;
+}
+.adm-history-table-wrap .adm-table th:nth-child(2),
+.adm-history-table-wrap .adm-table td:nth-child(2) {
+  width: 17%;
+  white-space: nowrap;
+}
+.adm-history-table-wrap .adm-table th:nth-child(3),
+.adm-history-table-wrap .adm-table td:nth-child(3) {
+  width: 23%;
+  overflow-wrap: anywhere;
+}
+.adm-history-table-wrap .adm-table th:nth-child(4),
+.adm-history-table-wrap .adm-table td:nth-child(4) {
+  width: 21%;
+  overflow-wrap: anywhere;
+}
+.adm-history-table-wrap .adm-table th:nth-child(5),
+.adm-history-table-wrap .adm-table td:nth-child(5) {
+  width: 15%;
+  text-align: right;
+  white-space: nowrap;
+}
+.adm-history-table-wrap .adm-table th {
+  background: rgba(10, 15, 28, 0.96);
+}
+.adm-history-table-wrap .adm-table tr:last-child td {
+  border-bottom: 0;
+}
+.adm-history-footer {
+  margin-top: 10px;
+}
+.adm-history-footer button {
+  width: 100%;
+  padding: 8px 14px;
+}
+.adm-history-footer button[hidden] { display: none; }
+.adm-event {
+  background: rgba(148,163,184,0.15);
+  color: #cbd5e1;
+}
+
 .adm-bug {
   background: rgba(255,255,255,0.03);
   border: 1px solid rgba(255,255,255,0.06);
@@ -5268,6 +5414,29 @@ body.admin-mode .room-top {
 }
 .adm-date-sep td::before { margin-right: 10px; }
 .adm-date-sep td::after { margin-left: 10px; }
+
+@media (max-width: 600px) {
+  .admin-dash-panel {
+    width: 100vw;
+    min-width: 0;
+    max-width: 100vw;
+  }
+  .admin-dash-resize-handle { display: none; }
+  .admin-dash-content { padding: 14px 12px; }
+  .adm-history-toolbar {
+    grid-template-columns: 1fr;
+    gap: 5px;
+  }
+  .adm-history-toolbar select,
+  .adm-history-error button,
+  .adm-history-footer button {
+    min-height: 42px;
+  }
+  .adm-history-error {
+    align-items: stretch;
+    flex-direction: column;
+  }
+}
 
 /* ── Metrics Dashboard ── */
 .adm-cards {

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -267,6 +267,81 @@ Service-started production logs are written under `C:\ProgramData\Echo Chamber\l
 - `turn.out.log`
 - `turn.err.log`
 
+## Durable Dashboard History
+
+Dashboard session history is durable application data, not a release artifact.
+Production `CORE_SESSION_LOG_DIR` must point at the stable data root
+`C:\ProgramData\Echo Chamber\data\sessions`. The data root must disable inherited
+permissions and grant access only to `SYSTEM`, local Administrators, and the
+designated Echo operator; never place `spotify-token.json` or the Jam actor key
+under a broadly readable runtime directory. A release candidate may use an isolated
+session directory while it is being tested, but promoting that candidate must
+not leave production pointed at the candidate directory. Doing so makes the
+Dashboard appear to lose its history even though the earlier daily JSON files
+still exist.
+
+The session files are UTC-day arrays named exactly
+`sessions-YYYY-MM-DD.json`. `stats-YYYY-MM-DD.json`, `jam-history/`, and
+`jam-library/` share the parent directory but are separate stores. Never merge
+those through the session-history tool.
+
+Use the merge utility to preview and recover split session stores. Preview is
+the default and does not write anything:
+
+```powershell
+& .\core\deploy\merge-session-history.ps1 `
+  -SourceDirectory @(
+    "F:\Codex AI\The Echo Chamber\core\logs\sessions",
+    "C:\ProgramData\Echo Chamber\private-web-diagnostics\candidates\<candidate>\data\sessions"
+  ) `
+  -DestinationDirectory "C:\ProgramData\Echo Chamber\data\sessions"
+```
+
+Review the JSON summary, especially `unique_source_events_added`,
+`exact_duplicates`, `filename_date_mismatches`, and every entry under
+`changes`. Do not add worktree-local, `core\control\logs`, or discarded test
+candidate directories merely because they contain session-shaped files; those
+are developer/test records unless an incident audit proves otherwise.
+
+For an approved recovery outage:
+
+1. Run the Echo preflight and record the active `control_env_file` and its
+   `CORE_SESSION_LOG_DIR`.
+2. Stop `EchoCoreHost`; the utility deliberately never stops or starts the
+   service and must not race the control plane's read-modify-write logger.
+3. Rerun the reviewed command with `-Apply` and, preferably, an explicit new
+   `-BackupDirectory`. The tool snapshots and hashes every existing destination
+   session file before any destination write, deduplicates exact events, routes
+   them by UTC date, and replaces each changed file atomically.
+4. Set the production environment's `CORE_SESSION_LOG_DIR` to the restricted,
+   stable data root as a separate, reviewed configuration change. The merge tool
+   never mutates service configuration. Keep private web diagnostics at its own
+   stable restricted root so its existing identity key is never replaced by a
+   release candidate's key.
+5. Start `EchoCoreHost`, confirm the control log reports the stable session
+   directory, then verify `/api/version`, `/health`, and Dashboard History.
+
+Candidate promotion can fork more than Dashboard History. Audit every mutable
+path in the candidate environment, including `CORE_SOUNDBOARD_DIR`,
+`CORE_CHAT_DIR`, `CORE_CHAT_UPLOADS_DIR`, `CORE_SESSION_LOG_DIR`, and
+`CORE_DIAGNOSTICS_DIR`, before switching production. Candidate-owned
+`jam-history/`, `jam-library/`, playlist caches, and the newest Spotify token
+also require their own feature-aware, backed-up migration during the controlled
+stop. The session-history utility intentionally does not copy or merge any of
+that state.
+
+Rollback is mechanical, but restoring the original files alone is incomplete
+when the merge created new UTC-day files. Stop the service and first verify that
+`manifest.json`'s `destination` is the exact intended session directory. For
+each entry in `created_paths`, require a plain leaf name matching exactly
+`sessions-YYYY-MM-DD.json`, verify it resolves directly under that destination,
+and remove only that exact file. Never use a glob or recursive deletion for this
+step. Then hash-verify every backup named in `destination_files`, restore it to
+the destination (prefer a same-directory staged atomic replacement), and verify
+the restored SHA-256 values plus the absence of every `created_paths` entry.
+Restore the prior environment file if it changed, then start and verify the
+service. Source files are read-only and remain untouched throughout recovery.
+
 ## Quick incident flow
 
 1. Confirm health endpoint and viewer/admin reachability.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Echo Chamber repo metadata. Active development lives under core/.",
   "scripts": {
     "verify:guardrails": "node tools/verify/guardrails.mjs",
-    "verify:viewer": "node --check core/viewer/app.js && node --check core/viewer/jam-visualizer.js && node --check core/viewer/jam.js && node --check core/viewer/ui-shell.js && node --check core/viewer/theme-runtime.js && node --check core/viewer/theme-effects.js && node --check core/viewer/theme.js && node --check core/viewer/capture-picker.js && node --check core/admin/diagnostics/diagnostics.js && node --test core/viewer/*.test.js",
+    "verify:viewer": "node --check core/viewer/app.js && node --check core/viewer/admin-history.js && node --check core/viewer/admin.js && node --check core/viewer/jam-visualizer.js && node --check core/viewer/jam.js && node --check core/viewer/ui-shell.js && node --check core/viewer/theme-runtime.js && node --check core/viewer/theme-effects.js && node --check core/viewer/theme.js && node --check core/viewer/capture-picker.js && node --check core/admin/diagnostics/diagnostics.js && node --test core/viewer/*.test.js",
     "verify:viewer:layout": "npm --prefix core/viewer-tests test",
     "verify:quick": "npm run verify:guardrails && npm run verify:viewer"
   }


### PR DESCRIPTION
## What changed

- restore Dashboard session history from durable daily logs without silently losing split-store records
- add 7/30/90/365-day, all-time, and calendar-year History ranges
- add deterministic cursor pagination, exact deduplication, availability metadata, retry/error states, and responsive table layout
- retain the existing Metrics activity heat map
- add a preview-first, backup-first recovery tool with complete rollback metadata
- document restricted durable-state promotion so releases cannot fork History, Jam/Spotify, chat, soundboard, avatars, chimes, bugs, or diagnostics again
- include the new History helper in viewer cache stamping and reload watching

## Root cause

The July 30 production promotion left mutable data paths pointing at a release-candidate directory. Earlier session files were still intact, but Dashboard only queried the new candidate store.

## User impact

Dashboard History can browse rolling windows, all retained history, and individual calendar years. Older records are recovered into one durable restricted store. The Metrics heat map remains available.

## Release impact

- Server-only control-plane and server-served viewer update
- No desktop binary or installer required
- Controlled production data migration required

## Verification

- 236 Rust control-plane tests
- release-mode control binary build
- 272 viewer unit/guardrail tests
- 2 focused Chromium Dashboard History scenarios
- viewer snapshot publisher tests
- session merge, case-sensitive dedup, backup, and full rollback tests
- production recovery preview: 6,218 exact-unique events at preflight, zero filename/date mismatches