### PR TITLE
Prevent localhost-only production activation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,8 @@ product development is centered in `core/`.
   `Restart`, or `Verify` action afterward as appropriate. Never copy a candidate
   loopback bind into production, and never treat the server's own hostname/LAN
   probes as the required genuine off-LAN verification. Run
-  `npm run verify:production-network:windows` before the production mutation.
+  `powershell.exe -NoProfile -ExecutionPolicy Bypass -File
+  core\deploy\test-production-network.ps1` before the production mutation.
 - Do not assume the running server is from the repo you are editing. Verify
   `/api/version`, `/health`, `EchoCoreHost`, and
   `C:\ProgramData\Echo Chamber\echo-core-host.json`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,13 @@ product development is centered in `core/`.
   fallback.
 - Before release, reboot validation, or live troubleshooting, run the Echo
   preflight in `docs/OPERATIONS.md`.
+- For every manual production `EchoCoreHost` start or restart, use
+  `core/deploy/echo-core-host-network-guard.ps1`; run its `Preflight` action
+  immediately before a controlled stop or promotion mutation, and its `Start`,
+  `Restart`, or `Verify` action afterward as appropriate. Never copy a candidate
+  loopback bind into production, and never treat the server's own hostname/LAN
+  probes as the required genuine off-LAN verification. Run
+  `npm run verify:production-network:windows` before the production mutation.
 - Do not assume the running server is from the repo you are editing. Verify
   `/api/version`, `/health`, `EchoCoreHost`, and
   `C:\ProgramData\Echo Chamber\echo-core-host.json`.

--- a/core/deploy/deploy-watcher.ps1
+++ b/core/deploy/deploy-watcher.ps1
@@ -25,8 +25,13 @@ $logFile = Join-Path $logDir "deploy-watcher.log"
 $envFile = Join-Path $coreDir "control\.env"
 $viewerSourceDir = Join-Path $coreDir "viewer"
 $viewerRuntimeLib = Join-Path $deployDir "viewer-runtime-lib.ps1"
+$productionNetworkLib = Join-Path $deployDir "production-network-lib.ps1"
 
 . $viewerRuntimeLib
+if (!(Test-Path -LiteralPath $productionNetworkLib -PathType Leaf)) {
+    throw "Required production network guard library is missing: $productionNetworkLib"
+}
+. $productionNetworkLib
 
 if (!$NoMain -and !(Test-Path $logDir)) { New-Item -ItemType Directory -Path $logDir | Out-Null }
 
@@ -123,16 +128,26 @@ function Start-OldProcess {
     $pidFile = Join-Path $coreDir "control\core-control.pid"
     $outLog = Join-Path $logDir "core-control.out.log"
     $errLog = Join-Path $logDir "core-control.err.log"
+    $proc = $null
     try {
+        # A rollback is still a production activation. Never restore a process
+        # from a localhost-only or otherwise unsafe production environment.
+        Assert-WatcherProductionEnvironment | Out-Null
         Load-Env $envFile
         Write-Log "Restarting control plane..."
         $proc = Start-Process -FilePath $exe -WorkingDirectory $coreDir -PassThru -WindowStyle Hidden -RedirectStandardOutput $outLog -RedirectStandardError $errLog
         if (!$proc) { throw "Start-Process returned no process" }
         [System.IO.File]::WriteAllText($pidFile, "$($proc.Id)")
-        Write-Log "Control plane restarted (PID $($proc.Id))"
+        Write-Log "Control plane restarted (PID $($proc.Id)); verifying rollback safety..."
+        if (-not (Complete-WatcherRollbackActivation -Process $proc)) {
+            return $false
+        }
         return $true
     }
     catch {
+        if ($proc) {
+            Stop-TrackedControlProcess $proc | Out-Null
+        }
         Write-Log "Control plane restart failed: $_" "ERROR"
         return $false
     }
@@ -144,6 +159,200 @@ function Test-Health {
         if ($result -match '"ok"\s*:\s*true') { return $true }
     } catch {}
     return $false
+}
+
+function Assert-WatcherProductionEnvironment {
+    param(
+        [string]$EnvFilePath = $envFile,
+        # Test-only injection forwarded to the shared guard. Production omits
+        # this and reads the exact environment file it is about to activate.
+        [scriptblock]$ReadEnvironmentFile
+    )
+
+    $guardArgs = @{ EnvFilePath = $EnvFilePath }
+    if ($PSBoundParameters.ContainsKey("ReadEnvironmentFile")) {
+        $guardArgs.ReadEnvironmentFile = $ReadEnvironmentFile
+    }
+    $result = Assert-ProductionControlEnvironment @guardArgs
+    Write-Log "Production network configuration passed: CORE_BIND=$($result.Bind) CORE_PORT=$($result.Port)"
+    return $result
+}
+
+function Assert-WatcherProductionIngress {
+    param(
+        [Parameter(Mandatory = $true)]
+        [int]$ExpectedControlProcessId,
+        # Test-only providers are forwarded only when explicitly supplied.
+        [scriptblock]$ListenerProvider,
+        [scriptblock]$DefaultRouteLanIPv4Provider,
+        [scriptblock]$TcpProbeProvider
+    )
+
+    $guardArgs = @{ ExpectedControlProcessId = $ExpectedControlProcessId }
+    foreach ($providerName in @("ListenerProvider", "DefaultRouteLanIPv4Provider", "TcpProbeProvider")) {
+        if ($PSBoundParameters.ContainsKey($providerName)) {
+            $guardArgs[$providerName] = $PSBoundParameters[$providerName]
+        }
+    }
+    $result = Assert-ProductionControlIngress @guardArgs
+    Write-Log "Production ingress passed: PID=$($result.ControlProcessId) listener=$($result.ListenerAddress):$($result.Port) probe=$($result.ProbeAddress)"
+    return $result
+}
+
+function Wait-ControlHealth {
+    Start-Sleep -Seconds 3
+    for ($i = 0; $i -lt $healthTimeout; $i++) {
+        if (Test-Health) { return $true }
+        Start-Sleep -Seconds 1
+    }
+    return $false
+}
+
+function Assert-WatcherProductionActivation {
+    param(
+        [Parameter(Mandatory = $true)]
+        [int]$ExpectedControlProcessId,
+        [scriptblock]$HealthProbe = { Wait-ControlHealth },
+        [scriptblock]$ListenerProvider,
+        [scriptblock]$DefaultRouteLanIPv4Provider,
+        [scriptblock]$TcpProbeProvider
+    )
+
+    if (-not (& $HealthProbe)) {
+        throw "control plane failed its health check"
+    }
+
+    $guardArgs = @{ ExpectedControlProcessId = $ExpectedControlProcessId }
+    foreach ($providerName in @("ListenerProvider", "DefaultRouteLanIPv4Provider", "TcpProbeProvider")) {
+        if ($PSBoundParameters.ContainsKey($providerName)) {
+            $guardArgs[$providerName] = $PSBoundParameters[$providerName]
+        }
+    }
+    Assert-WatcherProductionIngress @guardArgs | Out-Null
+}
+
+function Assert-WatcherLiveProductionIngress {
+    param(
+        [string]$EnvFilePath = $envFile,
+        [scriptblock]$ReadEnvironmentFile,
+        [int]$ExpectedControlProcessId = 0,
+        [scriptblock]$HealthProbe = { Wait-ControlHealth },
+        [scriptblock]$ListenerProvider,
+        [scriptblock]$DefaultRouteLanIPv4Provider,
+        [scriptblock]$TcpProbeProvider
+    )
+
+    $environmentArgs = @{ EnvFilePath = $EnvFilePath }
+    if ($PSBoundParameters.ContainsKey("ReadEnvironmentFile")) {
+        $environmentArgs.ReadEnvironmentFile = $ReadEnvironmentFile
+    }
+    Assert-WatcherProductionEnvironment @environmentArgs | Out-Null
+
+    $controlProcessId = $ExpectedControlProcessId
+    if ($controlProcessId -le 0) {
+        $pidFile = Join-Path $coreDir "control\core-control.pid"
+        $controlProcessId = 0
+        if (-not [int]::TryParse(
+                [System.IO.File]::ReadAllText($pidFile).Trim(),
+                [ref]$controlProcessId
+            ) -or $controlProcessId -le 0) {
+            throw "tracked production control PID is invalid"
+        }
+        $process = Get-Process -Id $controlProcessId -ErrorAction Stop
+        if ($process.ProcessName -ne "echo-core-control") {
+            throw "tracked production PID $controlProcessId is not echo-core-control"
+        }
+    }
+
+    $activationArgs = @{
+        ExpectedControlProcessId = $controlProcessId
+        HealthProbe = $HealthProbe
+    }
+    foreach ($providerName in @("ListenerProvider", "DefaultRouteLanIPv4Provider", "TcpProbeProvider")) {
+        if ($PSBoundParameters.ContainsKey($providerName)) {
+            $activationArgs[$providerName] = $PSBoundParameters[$providerName]
+        }
+    }
+    Assert-WatcherProductionActivation @activationArgs
+    Write-Log "Live production ingress preflight passed for PID $controlProcessId"
+
+    return $controlProcessId
+}
+
+function Complete-WatcherRollbackActivation {
+    param(
+        [Parameter(Mandatory = $true)]
+        [object]$Process,
+        [scriptblock]$HealthProbe = { Wait-ControlHealth },
+        [scriptblock]$ListenerProvider,
+        [scriptblock]$DefaultRouteLanIPv4Provider,
+        [scriptblock]$TcpProbeProvider,
+        [ValidateRange(1, 10)]
+        [int]$AncillaryProbeAttempts = 3,
+        [ValidateRange(0, 60000)]
+        [int]$AncillaryProbeDelayMilliseconds = 1000,
+        [scriptblock]$RetryDelayProvider = {
+            param([int]$Milliseconds)
+            if ($Milliseconds -gt 0) {
+                Start-Sleep -Milliseconds $Milliseconds
+            }
+        },
+        [scriptblock]$StopProcessProvider = {
+            param([object]$TrackedProcess)
+            Stop-TrackedControlProcess $TrackedProcess
+        }
+    )
+
+    try {
+        if (-not (& $HealthProbe)) {
+            throw "rollback control plane failed its health check"
+        }
+
+        $listenerArgs = @{ ExpectedControlProcessId = [int]$Process.Id }
+        if ($PSBoundParameters.ContainsKey("ListenerProvider")) {
+            $listenerArgs.ListenerProvider = $ListenerProvider
+        }
+        $listener = Assert-ProductionControlListener @listenerArgs
+        Write-Log "Rollback hard listener passed: PID=$($listener.ControlProcessId) listener=$($listener.ListenerAddress):$($listener.Port)"
+
+        $probeArgs = @{}
+        foreach ($providerName in @("DefaultRouteLanIPv4Provider", "TcpProbeProvider")) {
+            if ($PSBoundParameters.ContainsKey($providerName)) {
+                $probeArgs[$providerName] = $PSBoundParameters[$providerName]
+            }
+        }
+        $lastProbeError = $null
+        for ($attempt = 1; $attempt -le $AncillaryProbeAttempts; $attempt++) {
+            try {
+                $probe = Assert-ProductionControlLanProbe @probeArgs
+                Write-Log "Rollback LAN probe passed: $($probe.ProbeAddress):$($probe.Port)"
+                return $true
+            }
+            catch {
+                $lastProbeError = "$($_.Exception.Message)"
+                if ($attempt -lt $AncillaryProbeAttempts) {
+                    Write-Log "Rollback LAN probe attempt $attempt/$AncillaryProbeAttempts failed; retrying: $lastProbeError" "WARN"
+                    & $RetryDelayProvider $AncillaryProbeDelayMilliseconds | Out-Null
+                }
+            }
+        }
+
+        # The route table or a self-LAN probe can be transiently unavailable
+        # during recovery. Reassert the hard safety boundary before preserving
+        # the known-old process; never trade a degraded rollback for an outage.
+        if (-not (& $HealthProbe)) {
+            throw "rollback control plane lost health after ancillary ingress probe failure"
+        }
+        Assert-ProductionControlListener @listenerArgs | Out-Null
+        Write-Log "Rollback restored a healthy wildcard-bound control process, but LAN ingress remained unverified after $AncillaryProbeAttempts attempts; leaving the known-old process running. Last probe error: $lastProbeError" "WARN"
+        return $true
+    }
+    catch {
+        $failure = "$($_.Exception.Message)"
+        $stopped = [bool](& $StopProcessProvider $Process)
+        Write-Log "Rollback control activation failed hard safety checks: $failure (stopped=$stopped)" "ERROR"
+        return $false
+    }
 }
 
 function Run-Tests {
@@ -453,10 +662,14 @@ function Deploy-BlueGreen($viewerPublish) {
     $outLog = Join-Path $logDir "core-control.out.log"
     $errLog = Join-Path $logDir "core-control.err.log"
 
-    Load-Env $envFile
     Write-Log "Starting new control plane..."
     $proc = $null
     try {
+        # Re-read and validate the exact file at the last responsible moment.
+        # The watcher also checks it before polling, but this closes the window
+        # for an unsafe edit while a release is building.
+        Assert-WatcherProductionEnvironment | Out-Null
+        Load-Env $envFile
         $proc = Start-Process -FilePath $exe -WorkingDirectory $coreDir -PassThru -WindowStyle Hidden -RedirectStandardOutput $outLog -RedirectStandardError $errLog
         if (!$proc) { throw "Start-Process returned no process" }
         [System.IO.File]::WriteAllText($pidFile, "$($proc.Id)")
@@ -475,25 +688,19 @@ function Deploy-BlueGreen($viewerPublish) {
     }
 
     Write-Log "Waiting for health check..."
-    Start-Sleep -Seconds 3
-    $healthy = $false
-    for ($i = 0; $i -lt $healthTimeout; $i++) {
-        if (Test-Health) {
-            $healthy = $true
-            break
-        }
-        Start-Sleep -Seconds 1
-    }
-
-    if ($healthy) {
-        Write-Log "Health check PASSED - deploy successful"
+    try {
+        # Loopback health alone is insufficient: the production process must
+        # own the wildcard listener and answer on the host LAN IP.
+        Assert-WatcherProductionActivation -ExpectedControlProcessId $proc.Id
+        Write-Log "Health and production ingress checks PASSED - deploy successful"
         if (Test-Path -LiteralPath $bak) {
             Remove-Item -LiteralPath $bak -Force -ErrorAction SilentlyContinue
         }
         return New-DeployResult -Succeeded $true -RollbackAttempted $false -RollbackSucceeded $false -ErrorMessage $null
     }
-
-    $healthError = "New control plane failed its health check"
+    catch {
+        $healthError = "New control plane failed its production activation guard: $_"
+    }
     Write-Log "$healthError - rolling back" "ERROR"
     $newProcessStopped = Stop-TrackedControlProcess $proc
 
@@ -514,9 +721,19 @@ if (!$NoMain) {
     Write-Log "Max consecutive failures: $maxFailures"
     Write-Log "========================================="
 
-    # This gate MUST run before Get-RemoteSha or git pull. If control serves the
-    # checkout directly, pulling first would already publish a mismatched viewer
-    # before the watcher had a chance to reject the deployment.
+    # These gates MUST run before Get-RemoteSha or git pull. Validate the live
+    # process, not only its environment: a healthy loopback-only listener would
+    # otherwise survive preflight while remote users remain locked out.
+    try {
+        Assert-WatcherLiveProductionIngress | Out-Null
+    }
+    catch {
+        Write-Log "CIRCUIT BREAKER: live production ingress preflight failed" "ERROR"
+        Write-Log "$_" "ERROR"
+        Write-Log "No remote poll or git pull was attempted" "ERROR"
+        exit 1
+    }
+
     $startupViewerPreflight = Get-ViewerRuntimePreflight
     if (!$startupViewerPreflight.Succeeded) {
         Write-Log "CIRCUIT BREAKER: viewer runtime preflight failed" "ERROR"
@@ -537,6 +754,19 @@ if (!$NoMain) {
         $shortLocal = $localSha.Substring(0, 7)
         Write-Log "New commit detected: $shortRemote (was: $shortLocal)"
 
+        # The watcher can remain resident for days. Recheck the full live path
+        # before every release transaction so neither an environment edit nor
+        # a degraded listener/probe can reach git pull or production mutation.
+        try {
+            Assert-WatcherLiveProductionIngress | Out-Null
+        }
+        catch {
+            Write-Log "CIRCUIT BREAKER: live production ingress pre-mutation check failed" "ERROR"
+            Write-Log "$_" "ERROR"
+            Write-Log "No git pull or production mutation was attempted" "ERROR"
+            exit 1
+        }
+
         # Pull
         Write-Log "Pulling latest from origin/main..."
         $pullOutput = git -C $root pull origin main --ff-only 2>&1 | Out-String
@@ -556,6 +786,19 @@ if (!$NoMain) {
                 Write-DeployEvent $remoteSha "failed" $dur "Tests failed"
                 $consecutiveFailures++
             } else {
+                # Tests can take long enough for live state or the environment
+                # to change. Recheck at the last responsible moment, before
+                # copying artifacts or stopping any production process.
+                try {
+                    Assert-WatcherLiveProductionIngress | Out-Null
+                }
+                catch {
+                    Write-Log "CIRCUIT BREAKER: final live production ingress check failed" "ERROR"
+                    Write-Log "$_" "ERROR"
+                    Write-Log "No production artifact or process was mutated" "ERROR"
+                    exit 1
+                }
+
                 # Kill process BEFORE build so cargo can overwrite the .exe
                 Write-Log "Stopping control plane for rebuild..."
                 $exe = Join-Path $coreDir "target\debug\echo-core-control.exe"

--- a/core/deploy/deploy-watcher.ps1
+++ b/core/deploy/deploy-watcher.ps1
@@ -367,16 +367,32 @@ function Run-Tests {
     $testExitCode = $LASTEXITCODE
     Pop-Location
 
-    if ($testExitCode -eq 0) {
-        Write-Log "Tests PASSED"
-        return $true
-    } else {
+    if ($testExitCode -ne 0) {
         Write-Log "Tests FAILED (exit code $testExitCode)" "ERROR"
         # Log first 50 lines of output to avoid huge logs
         $lines = $testOutput -split "`n" | Select-Object -First 50
         foreach ($l in $lines) { Write-Log "  test: $l" "ERROR" }
         return $false
     }
+
+    # This is the Windows production deployment path, so run the PowerShell
+    # network/service regression gate here instead of routing it through the
+    # cross-platform npm suite (which also triggers unrelated viewer CI).
+    $productionNetworkTest = Join-Path $deployDir "test-production-network.ps1"
+    $networkTestOutput = & powershell.exe `
+        -NoProfile `
+        -ExecutionPolicy Bypass `
+        -File $productionNetworkTest 2>&1 | Out-String
+    $networkTestExitCode = $LASTEXITCODE
+    if ($networkTestExitCode -ne 0) {
+        Write-Log "Production network tests FAILED (exit code $networkTestExitCode)" "ERROR"
+        $lines = $networkTestOutput -split "`n" | Select-Object -First 50
+        foreach ($l in $lines) { Write-Log "  network test: $l" "ERROR" }
+        return $false
+    }
+
+    Write-Log "Tests PASSED"
+    return $true
 }
 
 function Build-Control {

--- a/core/deploy/echo-core-host-network-guard.ps1
+++ b/core/deploy/echo-core-host-network-guard.ps1
@@ -1,0 +1,691 @@
+[CmdletBinding()]
+param(
+    [ValidateSet("Preflight", "Verify", "Start", "Restart")]
+    [string]$Action = "Verify",
+
+    [ValidateRange(1, 120)]
+    [int]$VerificationAttempts = 15,
+
+    [ValidateRange(0, 30000)]
+    [int]$RetryDelayMilliseconds = 1000,
+
+    # Loads the functions for isolated tests without reading or mutating the
+    # live EchoCoreHost service. Production never passes this switch.
+    [switch]$NoMain
+)
+
+$ErrorActionPreference = "Stop"
+
+$productionNetworkLib = Join-Path $PSScriptRoot "production-network-lib.ps1"
+if (!(Test-Path -LiteralPath $productionNetworkLib -PathType Leaf)) {
+    throw "Required production network guard library is missing: $productionNetworkLib"
+}
+. $productionNetworkLib
+
+$canonicalHostConfigPath = "C:\ProgramData\Echo Chamber\echo-core-host.json"
+
+function Get-EchoCoreHostProductionConfiguration {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$ConfigPath,
+
+        [scriptblock]$ReadHostConfig = {
+            param([string]$Path)
+            $rawJson = [System.IO.File]::ReadAllText($Path)
+            if ([string]::IsNullOrWhiteSpace($rawJson) -or $rawJson.TrimStart()[0] -cne '{') {
+                throw [System.IO.InvalidDataException]::new(
+                    "EchoCoreHost configuration root must be a top-level JSON object."
+                )
+            }
+            $rawJson | ConvertFrom-Json
+        },
+
+        [scriptblock]$ReadEnvironmentFile = {
+            param([string]$Path)
+            [System.IO.File]::ReadAllLines($Path)
+        }
+    )
+
+    try {
+        $resolvedConfigPath = [System.IO.Path]::GetFullPath($ConfigPath)
+        $hostConfigs = @(& $ReadHostConfig $resolvedConfigPath)
+    }
+    catch {
+        throw [System.IO.InvalidDataException]::new(
+            "EchoCoreHost configuration could not be read: $($_.Exception.Message)"
+        )
+    }
+
+    if ($hostConfigs.Count -ne 1 -or $null -eq $hostConfigs[0]) {
+        throw [System.IO.InvalidDataException]::new(
+            "EchoCoreHost configuration must contain exactly one JSON object."
+        )
+    }
+
+    $hostConfig = $hostConfigs[0]
+    if ($hostConfig -isnot [System.Management.Automation.PSCustomObject]) {
+        throw [System.IO.InvalidDataException]::new(
+            "EchoCoreHost configuration root must deserialize to a PSCustomObject."
+        )
+    }
+
+    $environmentProperties = @(
+        $hostConfig.PSObject.Properties |
+            Where-Object { $_.Name -ceq "control_env_file" }
+    )
+    if ($environmentProperties.Count -ne 1) {
+        throw [System.IO.InvalidDataException]::new(
+            "EchoCoreHost configuration must define exactly one case-sensitive control_env_file property."
+        )
+    }
+    if ($environmentProperties[0].Value -isnot [string]) {
+        throw [System.IO.InvalidDataException]::new(
+            "EchoCoreHost control_env_file must be a JSON string."
+        )
+    }
+
+    $rawEnvironmentPath = [string]$environmentProperties[0].Value
+    if ([string]::IsNullOrWhiteSpace($rawEnvironmentPath)) {
+        throw [System.IO.InvalidDataException]::new(
+            "EchoCoreHost configuration must define control_env_file."
+        )
+    }
+
+    if ($rawEnvironmentPath -notmatch '^[A-Za-z]:[\\/]') {
+        throw [System.IO.InvalidDataException]::new(
+            "EchoCoreHost control_env_file must be a fully qualified Windows drive-rooted path."
+        )
+    }
+
+    try {
+        $environmentPath = [System.IO.Path]::GetFullPath($rawEnvironmentPath)
+    }
+    catch {
+        throw [System.IO.InvalidDataException]::new(
+            "EchoCoreHost control_env_file path is invalid: $($_.Exception.Message)"
+        )
+    }
+
+    $environment = Assert-ProductionControlEnvironment `
+        -EnvFilePath $environmentPath `
+        -ReadEnvironmentFile $ReadEnvironmentFile
+
+    return [PSCustomObject]@{
+        HostConfigPath = $resolvedConfigPath
+        EnvironmentFilePath = $environmentPath
+        Bind = $environment.Bind
+        Port = $environment.Port
+    }
+}
+
+function Get-EchoCoreHostServiceRecord {
+    param(
+        [scriptblock]$ServiceProvider = {
+            Get-CimInstance Win32_Service `
+                -Filter "Name='EchoCoreHost'" `
+                -ErrorAction Stop |
+                Select-Object Name, State, ProcessId
+        }
+    )
+
+    $services = @(& $ServiceProvider)
+    if ($services.Count -ne 1 -or $null -eq $services[0]) {
+        throw [System.InvalidOperationException]::new(
+            "Expected exactly one EchoCoreHost service record; found $($services.Count)."
+        )
+    }
+
+    $service = $services[0]
+    if ([string]$service.Name -cne "EchoCoreHost") {
+        throw [System.InvalidOperationException]::new(
+            "The service provider did not return EchoCoreHost."
+        )
+    }
+    $serviceProcessId = 0L
+    if (-not [long]::TryParse([string]$service.ProcessId, [ref]$serviceProcessId) -or
+        $serviceProcessId -lt 0 -or
+        $serviceProcessId -gt [int]::MaxValue) {
+        throw [System.InvalidOperationException]::new(
+            "EchoCoreHost does not have a valid service process ID."
+        )
+    }
+
+    return [PSCustomObject]@{
+        Name = "EchoCoreHost"
+        State = [string]$service.State
+        ProcessId = [int]$serviceProcessId
+    }
+}
+
+function Get-EchoCoreHostDirectControlChild {
+    param(
+        [object]$ServiceRecord,
+
+        [scriptblock]$ServiceProvider = {
+            Get-CimInstance Win32_Service `
+                -Filter "Name='EchoCoreHost'" `
+                -ErrorAction Stop |
+                Select-Object Name, State, ProcessId
+        },
+
+        [scriptblock]$ControlProcessProvider = {
+            Get-CimInstance Win32_Process `
+                -Filter "Name='echo-core-control.exe'" `
+                -ErrorAction Stop |
+                Select-Object Name, ProcessId, ParentProcessId
+        }
+    )
+
+    $service = if ($PSBoundParameters.ContainsKey("ServiceRecord")) {
+        $ServiceRecord
+    }
+    else {
+        Get-EchoCoreHostServiceRecord -ServiceProvider $ServiceProvider
+    }
+    if ($null -eq $service -or [string]$service.State -ine "Running" -or [int]$service.ProcessId -lt 1) {
+        throw [System.InvalidOperationException]::new(
+            "EchoCoreHost is not running; current state is '$($service.State)'."
+        )
+    }
+    $serviceProcessId = [int]$service.ProcessId
+
+    $directChildren = @()
+    foreach ($process in @(& $ControlProcessProvider)) {
+        if ($null -eq $process -or [string]$process.Name -ine "echo-core-control.exe") {
+            continue
+        }
+
+        $processId = 0L
+        $parentProcessId = 0L
+        if (-not [long]::TryParse([string]$process.ProcessId, [ref]$processId) -or
+            -not [long]::TryParse([string]$process.ParentProcessId, [ref]$parentProcessId)) {
+            continue
+        }
+        if ($parentProcessId -eq $serviceProcessId -and
+            $processId -ge 1 -and
+            $processId -le [int]::MaxValue) {
+            $directChildren += $process
+        }
+    }
+
+    if ($directChildren.Count -ne 1) {
+        throw [System.InvalidOperationException]::new(
+            "Expected exactly one direct echo-core-control.exe child of EchoCoreHost PID $serviceProcessId; found $($directChildren.Count)."
+        )
+    }
+
+    return [PSCustomObject]@{
+        ServiceProcessId = [int]$serviceProcessId
+        ControlProcessId = [int]$directChildren[0].ProcessId
+    }
+}
+
+function Assert-EchoCoreHostProductionHardSafetyOnce {
+    param(
+        [scriptblock]$ServiceProvider,
+        [scriptblock]$ControlProcessProvider,
+        [scriptblock]$ListenerProvider,
+        [scriptblock]$HealthProbeProvider = {
+            $response = curl.exe -sk --max-time 5 https://127.0.0.1:9443/health 2>&1
+            return $LASTEXITCODE -eq 0 -and $response -match '"ok"\s*:\s*true'
+        }
+    )
+
+    $processArgs = @{}
+    if ($null -ne $ServiceProvider) {
+        $processArgs.ServiceProvider = $ServiceProvider
+    }
+    if ($null -ne $ControlProcessProvider) {
+        $processArgs.ControlProcessProvider = $ControlProcessProvider
+    }
+    $processes = Get-EchoCoreHostDirectControlChild @processArgs
+
+    $healthResults = @(& $HealthProbeProvider)
+    if ($healthResults.Count -ne 1 -or $healthResults[0] -isnot [bool] -or -not $healthResults[0]) {
+        throw [System.InvalidOperationException]::new(
+            "EchoCoreHost direct control child failed its loopback health check."
+        )
+    }
+
+    $listenerArgs = @{ ExpectedControlProcessId = $processes.ControlProcessId }
+    if ($null -ne $ListenerProvider) {
+        $listenerArgs.ListenerProvider = $ListenerProvider
+    }
+    $listener = Assert-ProductionControlListener @listenerArgs
+
+    return [PSCustomObject]@{
+        ServiceProcessId = $processes.ServiceProcessId
+        ControlProcessId = $processes.ControlProcessId
+        ListenerAddress = $listener.ListenerAddress
+        Port = $listener.Port
+    }
+}
+
+function Assert-EchoCoreHostProductionIngressOnce {
+    param(
+        [scriptblock]$ServiceProvider,
+        [scriptblock]$ControlProcessProvider,
+        [scriptblock]$ListenerProvider,
+        [scriptblock]$DefaultRouteLanIPv4Provider,
+        [scriptblock]$TcpProbeProvider,
+        [scriptblock]$HealthProbeProvider
+    )
+
+    $hardArgs = @{}
+    foreach ($providerName in @(
+        "ServiceProvider",
+        "ControlProcessProvider",
+        "ListenerProvider",
+        "HealthProbeProvider"
+    )) {
+        $provider = Get-Variable -Name $providerName -ValueOnly
+        if ($null -ne $provider) {
+            $hardArgs[$providerName] = $provider
+        }
+    }
+    $hardSafety = Assert-EchoCoreHostProductionHardSafetyOnce @hardArgs
+
+    $probeArgs = @{}
+    foreach ($providerName in @("DefaultRouteLanIPv4Provider", "TcpProbeProvider")) {
+        $provider = Get-Variable -Name $providerName -ValueOnly
+        if ($null -ne $provider) {
+            $probeArgs[$providerName] = $provider
+        }
+    }
+    $probe = Assert-ProductionControlLanProbe @probeArgs
+
+    return [PSCustomObject]@{
+        ServiceProcessId = $hardSafety.ServiceProcessId
+        ControlProcessId = $hardSafety.ControlProcessId
+        ListenerAddress = $hardSafety.ListenerAddress
+        Port = $hardSafety.Port
+        ProbeAddress = $probe.ProbeAddress
+    }
+}
+
+function Wait-EchoCoreHostProductionIngress {
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateRange(1, 120)]
+        [int]$Attempts,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateRange(0, 30000)]
+        [int]$DelayMilliseconds,
+
+        [scriptblock]$ServiceProvider,
+        [scriptblock]$ControlProcessProvider,
+        [scriptblock]$ListenerProvider,
+        [scriptblock]$DefaultRouteLanIPv4Provider,
+        [scriptblock]$TcpProbeProvider,
+        [scriptblock]$HealthProbeProvider,
+        [scriptblock]$SleepProvider = {
+            param([int]$Milliseconds)
+            Start-Sleep -Milliseconds $Milliseconds
+        }
+    )
+
+    $lastError = "verification did not run"
+    for ($attempt = 1; $attempt -le $Attempts; $attempt++) {
+        try {
+            $assertArgs = @{}
+            foreach ($providerName in @(
+                "ServiceProvider",
+                "ControlProcessProvider",
+                "ListenerProvider",
+                "DefaultRouteLanIPv4Provider",
+                "TcpProbeProvider",
+                "HealthProbeProvider"
+            )) {
+                $provider = Get-Variable -Name $providerName -ValueOnly
+                if ($null -ne $provider) {
+                    $assertArgs[$providerName] = $provider
+                }
+            }
+            $ingress = Assert-EchoCoreHostProductionIngressOnce @assertArgs
+            $ingress | Add-Member -NotePropertyName Attempts -NotePropertyValue $attempt
+            return $ingress
+        }
+        catch {
+            $lastError = $_.Exception.Message
+        }
+
+        if ($attempt -lt $Attempts -and $DelayMilliseconds -gt 0) {
+            & $SleepProvider $DelayMilliseconds | Out-Null
+        }
+    }
+
+    # Separate a hard post-activation failure from an ancillary LAN-route/probe
+    # failure. The former must stop the partial-live service; the latter must
+    # leave a healthy wildcard-bound service running for manual LAN/WAN checks.
+    try {
+        $hardArgs = @{}
+        foreach ($providerName in @(
+            "ServiceProvider",
+            "ControlProcessProvider",
+            "ListenerProvider",
+            "HealthProbeProvider"
+        )) {
+            $provider = Get-Variable -Name $providerName -ValueOnly
+            if ($null -ne $provider) {
+                $hardArgs[$providerName] = $provider
+            }
+        }
+        $hardSafety = Assert-EchoCoreHostProductionHardSafetyOnce @hardArgs
+    }
+    catch {
+        $hardFailure = [System.InvalidOperationException]::new(
+            "EchoCoreHost hard production safety failed after $Attempts attempts: $($_.Exception.Message)"
+        )
+        $hardFailure.Data["EchoHardSafetyFailure"] = $true
+        throw $hardFailure
+    }
+
+    try {
+        $probeArgs = @{}
+        foreach ($providerName in @("DefaultRouteLanIPv4Provider", "TcpProbeProvider")) {
+            $provider = Get-Variable -Name $providerName -ValueOnly
+            if ($null -ne $provider) {
+                $probeArgs[$providerName] = $provider
+            }
+        }
+        $probe = Assert-ProductionControlLanProbe @probeArgs
+        return [PSCustomObject]@{
+            ServiceProcessId = $hardSafety.ServiceProcessId
+            ControlProcessId = $hardSafety.ControlProcessId
+            ListenerAddress = $hardSafety.ListenerAddress
+            Port = $hardSafety.Port
+            ProbeAddress = $probe.ProbeAddress
+            Attempts = $Attempts
+        }
+    }
+    catch {
+        $ancillaryFailure = [System.InvalidOperationException]::new(
+            "EchoCoreHost remained healthy and wildcard-bound, but LAN ingress was not verified after $Attempts attempts: $($_.Exception.Message)"
+        )
+        $ancillaryFailure.Data["EchoAncillaryLanFailure"] = $true
+        throw $ancillaryFailure
+    }
+}
+
+function Stop-EchoCoreHostAfterFailedMutation {
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateRange(1, 120)]
+        [int]$Attempts,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateRange(0, 30000)]
+        [int]$DelayMilliseconds,
+
+        [scriptblock]$ServiceCleanupProvider = {
+            Stop-Service -Name "EchoCoreHost" -ErrorAction Stop
+        },
+        [scriptblock]$ServiceProvider,
+        [scriptblock]$SleepProvider = {
+            param([int]$Milliseconds)
+            Start-Sleep -Milliseconds $Milliseconds
+        }
+    )
+
+    & $ServiceCleanupProvider | Out-Null
+    for ($attempt = 1; $attempt -le $Attempts; $attempt++) {
+        $serviceArgs = @{}
+        if ($null -ne $ServiceProvider) {
+            $serviceArgs.ServiceProvider = $ServiceProvider
+        }
+        $service = Get-EchoCoreHostServiceRecord @serviceArgs
+        if ($service.State -ieq "Stopped" -and $service.ProcessId -eq 0) {
+            return $true
+        }
+        if ($attempt -lt $Attempts -and $DelayMilliseconds -gt 0) {
+            & $SleepProvider $DelayMilliseconds | Out-Null
+        }
+    }
+
+    throw [System.InvalidOperationException]::new(
+        "EchoCoreHost cleanup did not reach Stopped/PID 0 after $Attempts attempts."
+    )
+}
+
+function Invoke-EchoCoreHostNetworkGuard {
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateSet("Preflight", "Verify", "Start", "Restart")]
+        [string]$RequestedAction,
+
+        [Parameter(Mandatory = $true)]
+        [string]$ConfigPath,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateRange(1, 120)]
+        [int]$Attempts,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateRange(0, 30000)]
+        [int]$DelayMilliseconds,
+
+        [scriptblock]$ReadHostConfig,
+        [scriptblock]$ReadEnvironmentFile,
+        [scriptblock]$ServiceMutationProvider = {
+            param([string]$Mutation, [string]$ServiceName)
+            if ($Mutation -eq "Start") {
+                Start-Service -Name $ServiceName -ErrorAction Stop
+            }
+            elseif ($Mutation -eq "Restart") {
+                Restart-Service -Name $ServiceName -ErrorAction Stop
+            }
+            else {
+                throw "Unsupported EchoCoreHost service mutation '$Mutation'."
+            }
+        },
+        [scriptblock]$ServiceProvider,
+        [scriptblock]$ControlProcessProvider,
+        [scriptblock]$ListenerProvider,
+        [scriptblock]$DefaultRouteLanIPv4Provider,
+        [scriptblock]$TcpProbeProvider,
+        [scriptblock]$HealthProbeProvider,
+        [scriptblock]$ServiceCleanupProvider,
+        [scriptblock]$SleepProvider
+    )
+
+    $configurationArgs = @{ ConfigPath = $ConfigPath }
+    if ($null -ne $ReadHostConfig) {
+        $configurationArgs.ReadHostConfig = $ReadHostConfig
+    }
+    if ($null -ne $ReadEnvironmentFile) {
+        $configurationArgs.ReadEnvironmentFile = $ReadEnvironmentFile
+    }
+
+    # This is the pre-mutation circuit breaker. It reads the canonical host
+    # JSON and validates the exact environment file that EchoCoreHost will use.
+    $configuration = Get-EchoCoreHostProductionConfiguration @configurationArgs
+
+    if ($RequestedAction -eq "Preflight") {
+        return [PSCustomObject]@{
+            Action = $RequestedAction
+            HostConfigPath = $configuration.HostConfigPath
+            EnvironmentFilePath = $configuration.EnvironmentFilePath
+            Bind = $configuration.Bind
+            Port = $configuration.Port
+            ServiceProcessId = $null
+            ControlProcessId = $null
+            ListenerAddress = $null
+            ProbeAddress = $null
+            Attempts = 0
+        }
+    }
+
+    $preMutationService = $null
+    $preMutationControlProcessId = 0
+    $mutationPerformed = $false
+    $mutationProviderFailed = $false
+    if ($RequestedAction -eq "Start" -or $RequestedAction -eq "Restart") {
+        $serviceRecordArgs = @{}
+        if ($null -ne $ServiceProvider) {
+            $serviceRecordArgs.ServiceProvider = $ServiceProvider
+        }
+        $preMutationService = Get-EchoCoreHostServiceRecord @serviceRecordArgs
+
+        if ($RequestedAction -eq "Start") {
+            if ($preMutationService.State -ine "Stopped" -or $preMutationService.ProcessId -ne 0) {
+                throw [System.InvalidOperationException]::new(
+                    "Guarded Start requires EchoCoreHost to be Stopped with process ID 0; found state '$($preMutationService.State)' PID $($preMutationService.ProcessId)."
+                )
+            }
+        }
+        else {
+            if ($preMutationService.State -ine "Running" -or $preMutationService.ProcessId -lt 1) {
+                throw [System.InvalidOperationException]::new(
+                    "Guarded Restart requires EchoCoreHost to be Running before mutation."
+                )
+            }
+            $preChildArgs = @{ ServiceRecord = $preMutationService }
+            if ($null -ne $ControlProcessProvider) {
+                $preChildArgs.ControlProcessProvider = $ControlProcessProvider
+            }
+            $preMutationChild = Get-EchoCoreHostDirectControlChild @preChildArgs
+            $preMutationControlProcessId = $preMutationChild.ControlProcessId
+        }
+    }
+
+    try {
+        if ($RequestedAction -eq "Start" -or $RequestedAction -eq "Restart") {
+            $mutationPerformed = $true
+            try {
+                & $ServiceMutationProvider $RequestedAction "EchoCoreHost" | Out-Null
+            }
+            catch {
+                $mutationProviderFailed = $true
+                throw
+            }
+
+            # Close the host-config race around the service mutation. A
+            # promotion must not swap the active environment between
+            # validation and startup.
+            $postMutationConfiguration = Get-EchoCoreHostProductionConfiguration @configurationArgs
+            if ($postMutationConfiguration.EnvironmentFilePath -ine $configuration.EnvironmentFilePath) {
+                throw [System.InvalidOperationException]::new(
+                    "EchoCoreHost control_env_file changed during the service mutation."
+                )
+            }
+        }
+
+        $waitArgs = @{
+            Attempts = $Attempts
+            DelayMilliseconds = $DelayMilliseconds
+        }
+        foreach ($providerName in @(
+            "ServiceProvider",
+            "ControlProcessProvider",
+            "ListenerProvider",
+            "DefaultRouteLanIPv4Provider",
+            "TcpProbeProvider",
+            "HealthProbeProvider",
+            "SleepProvider"
+        )) {
+            $provider = Get-Variable -Name $providerName -ValueOnly
+            if ($null -ne $provider) {
+                $waitArgs[$providerName] = $provider
+            }
+        }
+        $ingress = Wait-EchoCoreHostProductionIngress @waitArgs
+
+        if ($RequestedAction -eq "Restart" -and
+            $ingress.ServiceProcessId -eq $preMutationService.ProcessId -and
+            $ingress.ControlProcessId -eq $preMutationControlProcessId) {
+            $noTransition = [System.InvalidOperationException]::new(
+                "Guarded Restart did not replace either the EchoCoreHost service PID or its direct control child PID."
+            )
+            $noTransition.Data["EchoSafeNoTransition"] = $true
+            throw $noTransition
+        }
+    }
+    catch {
+        $activationFailure = $_.Exception
+        $ancillaryOnly = [bool]$activationFailure.Data["EchoAncillaryLanFailure"]
+        $safeNoTransition = [bool]$activationFailure.Data["EchoSafeNoTransition"]
+        $safeUnchangedMutationFailure = $false
+        if ($mutationProviderFailed -and $RequestedAction -eq "Restart") {
+            try {
+                $postErrorConfiguration = Get-EchoCoreHostProductionConfiguration @configurationArgs
+                if ($postErrorConfiguration.EnvironmentFilePath -ine $configuration.EnvironmentFilePath) {
+                    throw "EchoCoreHost control_env_file changed while the service mutation failed."
+                }
+
+                $hardArgs = @{}
+                foreach ($providerName in @(
+                    "ServiceProvider",
+                    "ControlProcessProvider",
+                    "ListenerProvider",
+                    "HealthProbeProvider"
+                )) {
+                    $provider = Get-Variable -Name $providerName -ValueOnly
+                    if ($null -ne $provider) {
+                        $hardArgs[$providerName] = $provider
+                    }
+                }
+                $postErrorSafety = Assert-EchoCoreHostProductionHardSafetyOnce @hardArgs
+                $safeUnchangedMutationFailure =
+                    $postErrorSafety.ServiceProcessId -eq $preMutationService.ProcessId -and
+                    $postErrorSafety.ControlProcessId -eq $preMutationControlProcessId
+            }
+            catch {
+                $safeUnchangedMutationFailure = $false
+            }
+        }
+
+        if ($mutationPerformed -and
+            -not $ancillaryOnly -and
+            -not $safeNoTransition -and
+            -not $safeUnchangedMutationFailure) {
+            try {
+                $cleanupArgs = @{
+                    Attempts = $Attempts
+                    DelayMilliseconds = $DelayMilliseconds
+                }
+                foreach ($providerName in @("ServiceCleanupProvider", "ServiceProvider", "SleepProvider")) {
+                    $provider = Get-Variable -Name $providerName -ValueOnly
+                    if ($null -ne $provider) {
+                        $cleanupArgs[$providerName] = $provider
+                    }
+                }
+                Stop-EchoCoreHostAfterFailedMutation @cleanupArgs | Out-Null
+            }
+            catch {
+                throw [System.InvalidOperationException]::new(
+                    "EchoCoreHost activation failed ('$($activationFailure.Message)') and cleanup also failed: $($_.Exception.Message)"
+                )
+            }
+        }
+        throw $activationFailure
+    }
+
+    return [PSCustomObject]@{
+        Action = $RequestedAction
+        HostConfigPath = $configuration.HostConfigPath
+        EnvironmentFilePath = $configuration.EnvironmentFilePath
+        Bind = $configuration.Bind
+        Port = $configuration.Port
+        ServiceProcessId = $ingress.ServiceProcessId
+        ControlProcessId = $ingress.ControlProcessId
+        ListenerAddress = $ingress.ListenerAddress
+        ProbeAddress = $ingress.ProbeAddress
+        Attempts = $ingress.Attempts
+    }
+}
+
+if (!$NoMain) {
+    $result = Invoke-EchoCoreHostNetworkGuard `
+        -RequestedAction $Action `
+        -ConfigPath $canonicalHostConfigPath `
+        -Attempts $VerificationAttempts `
+        -DelayMilliseconds $RetryDelayMilliseconds
+
+    if ($Action -eq "Preflight") {
+        Write-Host "EchoCoreHost production network preflight passed: CORE_BIND=$($result.Bind) CORE_PORT=$($result.Port) env=$($result.EnvironmentFilePath)"
+    }
+    else {
+        Write-Host "EchoCoreHost production network verification passed: servicePID=$($result.ServiceProcessId) controlPID=$($result.ControlProcessId) listener=$($result.ListenerAddress):$($result.Port) probe=$($result.ProbeAddress) attempts=$($result.Attempts)"
+    }
+}

--- a/core/deploy/production-network-lib.ps1
+++ b/core/deploy/production-network-lib.ps1
@@ -90,28 +90,10 @@ function Test-ProductionListenerAddress {
         [string]$Address
     )
 
-    $parsed = $null
-    if (-not [System.Net.IPAddress]::TryParse($Address, [ref]$parsed)) {
-        return $false
-    }
-
-    if ($parsed.Equals([System.Net.IPAddress]::Any) -or
-        $parsed.Equals([System.Net.IPAddress]::IPv6Any)) {
-        return $true
-    }
-
-    if ([System.Net.IPAddress]::IsLoopback($parsed) -or $parsed.IsIPv6Multicast) {
-        return $false
-    }
-
-    if ($parsed.AddressFamily -eq [System.Net.Sockets.AddressFamily]::InterNetwork) {
-        $bytes = $parsed.GetAddressBytes()
-        if ($parsed.Equals([System.Net.IPAddress]::Broadcast) -or $bytes[0] -ge 224) {
-            return $false
-        }
-    }
-
-    return $true
+    # Production is configured for the IPv4 wildcard specifically. A concrete
+    # LAN address can disappear after an adapter or DHCP change, and IPv6Any
+    # does not prove that the required IPv4 ingress path exists.
+    return $Address -ceq "0.0.0.0"
 }
 
 function Test-ProductionLanIPv4Address {
@@ -196,7 +178,7 @@ function Test-ProductionTcpProbe {
     }
 }
 
-function Assert-ProductionControlIngress {
+function Assert-ProductionControlListener {
     param(
         [Parameter(Mandatory = $true)]
         [ValidateRange(1, [int]::MaxValue)]
@@ -206,15 +188,6 @@ function Assert-ProductionControlIngress {
             param([int]$Port)
             Get-NetTCPConnection -State Listen -LocalPort $Port -ErrorAction Stop |
                 Select-Object LocalAddress, LocalPort, OwningProcess
-        },
-
-        [scriptblock]$DefaultRouteLanIPv4Provider = {
-            Get-ProductionDefaultRouteLanIPv4
-        },
-
-        [scriptblock]$TcpProbeProvider = {
-            param([string]$Address, [int]$Port)
-            Test-ProductionTcpProbe -Address $Address -Port $Port
         }
     )
 
@@ -251,10 +224,30 @@ function Assert-ProductionControlIngress {
 
     if ($null -eq $ownedListener) {
         throw [System.InvalidOperationException]::new(
-            "Expected control PID $ExpectedControlProcessId does not own a wildcard or non-loopback TCP listener on port $requiredPort."
+            "Expected control PID $ExpectedControlProcessId does not own the IPv4 wildcard TCP listener 0.0.0.0 on port $requiredPort."
         )
     }
 
+    return [PSCustomObject]@{
+        ControlProcessId = $ExpectedControlProcessId
+        ListenerAddress = [string]$ownedListener.LocalAddress
+        Port = $requiredPort
+    }
+}
+
+function Assert-ProductionControlLanProbe {
+    param(
+        [scriptblock]$DefaultRouteLanIPv4Provider = {
+            Get-ProductionDefaultRouteLanIPv4
+        },
+
+        [scriptblock]$TcpProbeProvider = {
+            param([string]$Address, [int]$Port)
+            Test-ProductionTcpProbe -Address $Address -Port $Port
+        }
+    )
+
+    $requiredPort = 9443
     try {
         $probeAddresses = @(& $DefaultRouteLanIPv4Provider)
     } catch {
@@ -289,9 +282,44 @@ function Assert-ProductionControlIngress {
     }
 
     return [PSCustomObject]@{
-        ControlProcessId = $ExpectedControlProcessId
-        ListenerAddress = [string]$ownedListener.LocalAddress
         Port = $requiredPort
         ProbeAddress = $probeAddress
+    }
+}
+
+function Assert-ProductionControlIngress {
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateRange(1, [int]::MaxValue)]
+        [int]$ExpectedControlProcessId,
+
+        [scriptblock]$ListenerProvider = {
+            param([int]$Port)
+            Get-NetTCPConnection -State Listen -LocalPort $Port -ErrorAction Stop |
+                Select-Object LocalAddress, LocalPort, OwningProcess
+        },
+
+        [scriptblock]$DefaultRouteLanIPv4Provider = {
+            Get-ProductionDefaultRouteLanIPv4
+        },
+
+        [scriptblock]$TcpProbeProvider = {
+            param([string]$Address, [int]$Port)
+            Test-ProductionTcpProbe -Address $Address -Port $Port
+        }
+    )
+
+    $listener = Assert-ProductionControlListener `
+        -ExpectedControlProcessId $ExpectedControlProcessId `
+        -ListenerProvider $ListenerProvider
+    $probe = Assert-ProductionControlLanProbe `
+        -DefaultRouteLanIPv4Provider $DefaultRouteLanIPv4Provider `
+        -TcpProbeProvider $TcpProbeProvider
+
+    return [PSCustomObject]@{
+        ControlProcessId = $listener.ControlProcessId
+        ListenerAddress = $listener.ListenerAddress
+        Port = $listener.Port
+        ProbeAddress = $probe.ProbeAddress
     }
 }

--- a/core/deploy/production-network-lib.ps1
+++ b/core/deploy/production-network-lib.ps1
@@ -1,0 +1,297 @@
+function Get-ProductionEnvironmentAssignments {
+    param(
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyCollection()]
+        [object[]]$Lines,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Name
+    )
+
+    $assignments = New-Object System.Collections.Generic.List[string]
+    foreach ($rawLine in $Lines) {
+        if ($null -eq $rawLine) {
+            continue
+        }
+
+        $line = ([string]$rawLine).Trim()
+        if ([string]::IsNullOrWhiteSpace($line) -or $line.StartsWith("#")) {
+            continue
+        }
+
+        $separatorIndex = $line.IndexOf("=")
+        if ($separatorIndex -lt 1) {
+            continue
+        }
+
+        $assignmentName = $line.Substring(0, $separatorIndex).Trim()
+        if ([string]::Equals($assignmentName, $Name, [System.StringComparison]::OrdinalIgnoreCase)) {
+            $assignments.Add($line.Substring($separatorIndex + 1).Trim())
+        }
+    }
+
+    return $assignments.ToArray()
+}
+
+function Assert-ProductionControlEnvironment {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$EnvFilePath,
+
+        [scriptblock]$ReadEnvironmentFile = {
+            param([string]$Path)
+            [System.IO.File]::ReadAllLines($Path)
+        }
+    )
+
+    try {
+        $environmentLines = @(& $ReadEnvironmentFile $EnvFilePath)
+    } catch {
+        throw [System.IO.InvalidDataException]::new("Production control environment could not be read: $($_.Exception.Message)")
+    }
+
+    $bindAssignments = @(Get-ProductionEnvironmentAssignments `
+        -Lines $environmentLines `
+        -Name "CORE_BIND")
+    if ($bindAssignments.Count -ne 1) {
+        throw [System.IO.InvalidDataException]::new(
+            "Production control environment must contain exactly one CORE_BIND assignment; found $($bindAssignments.Count)."
+        )
+    }
+    if ($bindAssignments[0] -cne "0.0.0.0") {
+        throw [System.IO.InvalidDataException]::new(
+            "Production CORE_BIND must be exactly 0.0.0.0; found '$($bindAssignments[0])'."
+        )
+    }
+
+    $portAssignments = @(Get-ProductionEnvironmentAssignments `
+        -Lines $environmentLines `
+        -Name "CORE_PORT")
+    if ($portAssignments.Count -ne 1) {
+        throw [System.IO.InvalidDataException]::new(
+            "Production control environment must contain exactly one CORE_PORT assignment; found $($portAssignments.Count)."
+        )
+    }
+    if ($portAssignments[0] -cne "9443") {
+        throw [System.IO.InvalidDataException]::new(
+            "Production CORE_PORT must be exactly 9443; found '$($portAssignments[0])'."
+        )
+    }
+
+    return [PSCustomObject]@{
+        Bind = "0.0.0.0"
+        Port = 9443
+    }
+}
+
+function Test-ProductionListenerAddress {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Address
+    )
+
+    $parsed = $null
+    if (-not [System.Net.IPAddress]::TryParse($Address, [ref]$parsed)) {
+        return $false
+    }
+
+    if ($parsed.Equals([System.Net.IPAddress]::Any) -or
+        $parsed.Equals([System.Net.IPAddress]::IPv6Any)) {
+        return $true
+    }
+
+    if ([System.Net.IPAddress]::IsLoopback($parsed) -or $parsed.IsIPv6Multicast) {
+        return $false
+    }
+
+    if ($parsed.AddressFamily -eq [System.Net.Sockets.AddressFamily]::InterNetwork) {
+        $bytes = $parsed.GetAddressBytes()
+        if ($parsed.Equals([System.Net.IPAddress]::Broadcast) -or $bytes[0] -ge 224) {
+            return $false
+        }
+    }
+
+    return $true
+}
+
+function Test-ProductionLanIPv4Address {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Address
+    )
+
+    $parsed = $null
+    if (-not [System.Net.IPAddress]::TryParse($Address, [ref]$parsed) -or
+        $parsed.AddressFamily -ne [System.Net.Sockets.AddressFamily]::InterNetwork) {
+        return $false
+    }
+
+    $bytes = $parsed.GetAddressBytes()
+    if ($parsed.Equals([System.Net.IPAddress]::Any) -or
+        $parsed.Equals([System.Net.IPAddress]::Broadcast) -or
+        [System.Net.IPAddress]::IsLoopback($parsed) -or
+        ($bytes[0] -eq 169 -and $bytes[1] -eq 254) -or
+        $bytes[0] -ge 224) {
+        return $false
+    }
+
+    return $true
+}
+
+function Get-ProductionDefaultRouteLanIPv4 {
+    $routes = @(Get-NetRoute `
+        -AddressFamily IPv4 `
+        -DestinationPrefix "0.0.0.0/0" `
+        -ErrorAction Stop |
+        Sort-Object -Property RouteMetric, InterfaceMetric, InterfaceIndex)
+
+    foreach ($route in $routes) {
+        $addresses = @(Get-NetIPAddress `
+            -AddressFamily IPv4 `
+            -InterfaceIndex $route.InterfaceIndex `
+            -ErrorAction Stop |
+            Sort-Object -Property SkipAsSource, IPAddress)
+
+        foreach ($address in $addresses) {
+            $candidate = [string]$address.IPAddress
+            if (Test-ProductionLanIPv4Address -Address $candidate) {
+                return $candidate
+            }
+        }
+    }
+
+    throw [System.InvalidOperationException]::new(
+        "No usable LAN IPv4 address was found on an IPv4 default route."
+    )
+}
+
+function Test-ProductionTcpProbe {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Address,
+
+        [Parameter(Mandatory = $true)]
+        [int]$Port
+    )
+
+    $client = New-Object System.Net.Sockets.TcpClient(
+        [System.Net.Sockets.AddressFamily]::InterNetwork
+    )
+    $asyncResult = $null
+    try {
+        $asyncResult = $client.BeginConnect($Address, $Port, $null, $null)
+        if (-not $asyncResult.AsyncWaitHandle.WaitOne(3000, $false)) {
+            return $false
+        }
+
+        $client.EndConnect($asyncResult)
+        return $client.Connected
+    } catch {
+        return $false
+    } finally {
+        if ($null -ne $asyncResult) {
+            $asyncResult.AsyncWaitHandle.Close()
+        }
+        $client.Close()
+    }
+}
+
+function Assert-ProductionControlIngress {
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateRange(1, [int]::MaxValue)]
+        [int]$ExpectedControlProcessId,
+
+        [scriptblock]$ListenerProvider = {
+            param([int]$Port)
+            Get-NetTCPConnection -State Listen -LocalPort $Port -ErrorAction Stop |
+                Select-Object LocalAddress, LocalPort, OwningProcess
+        },
+
+        [scriptblock]$DefaultRouteLanIPv4Provider = {
+            Get-ProductionDefaultRouteLanIPv4
+        },
+
+        [scriptblock]$TcpProbeProvider = {
+            param([string]$Address, [int]$Port)
+            Test-ProductionTcpProbe -Address $Address -Port $Port
+        }
+    )
+
+    $requiredPort = 9443
+    try {
+        $listeners = @(& $ListenerProvider $requiredPort)
+    } catch {
+        throw [System.InvalidOperationException]::new(
+            "Production control listener query failed: $($_.Exception.Message)"
+        )
+    }
+
+    $ownedListener = $null
+    foreach ($listener in $listeners) {
+        if ($null -eq $listener) {
+            continue
+        }
+
+        $listenerPort = 0
+        $listenerProcessId = 0L
+        if (-not [int]::TryParse([string]$listener.LocalPort, [ref]$listenerPort) -or
+            -not [long]::TryParse([string]$listener.OwningProcess, [ref]$listenerProcessId)) {
+            continue
+        }
+
+        $listenerAddress = [string]$listener.LocalAddress
+        if ($listenerPort -eq $requiredPort -and
+            $listenerProcessId -eq $ExpectedControlProcessId -and
+            (Test-ProductionListenerAddress -Address $listenerAddress)) {
+            $ownedListener = $listener
+            break
+        }
+    }
+
+    if ($null -eq $ownedListener) {
+        throw [System.InvalidOperationException]::new(
+            "Expected control PID $ExpectedControlProcessId does not own a wildcard or non-loopback TCP listener on port $requiredPort."
+        )
+    }
+
+    try {
+        $probeAddresses = @(& $DefaultRouteLanIPv4Provider)
+    } catch {
+        throw [System.InvalidOperationException]::new(
+            "Production default-route LAN IPv4 lookup failed: $($_.Exception.Message)"
+        )
+    }
+    if ($probeAddresses.Count -ne 1) {
+        throw [System.InvalidOperationException]::new(
+            "Production ingress verification requires exactly one default-route LAN IPv4 address; found $($probeAddresses.Count)."
+        )
+    }
+
+    $probeAddress = [string]$probeAddresses[0]
+    if (-not (Test-ProductionLanIPv4Address -Address $probeAddress)) {
+        throw [System.InvalidOperationException]::new(
+            "Production default-route address '$probeAddress' is not a usable LAN IPv4 address."
+        )
+    }
+
+    try {
+        $probeResults = @(& $TcpProbeProvider $probeAddress $requiredPort)
+    } catch {
+        throw [System.InvalidOperationException]::new(
+            "Production LAN TCP probe failed: $($_.Exception.Message)"
+        )
+    }
+    if ($probeResults.Count -ne 1 -or $probeResults[0] -isnot [bool] -or -not $probeResults[0]) {
+        throw [System.InvalidOperationException]::new(
+            "Production control did not accept a TCP connection at ${probeAddress}:$requiredPort."
+        )
+    }
+
+    return [PSCustomObject]@{
+        ControlProcessId = $ExpectedControlProcessId
+        ListenerAddress = [string]$ownedListener.LocalAddress
+        Port = $requiredPort
+        ProbeAddress = $probeAddress
+    }
+}

--- a/core/deploy/test-echo-core-host-network-guard.ps1
+++ b/core/deploy/test-echo-core-host-network-guard.ps1
@@ -1,0 +1,474 @@
+$ErrorActionPreference = "Stop"
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+. (Join-Path $scriptDir "echo-core-host-network-guard.ps1") -NoMain
+
+function Assert-True([bool]$Condition, [string]$Message) {
+    if (-not $Condition) {
+        throw "Assertion failed: $Message"
+    }
+}
+
+function Assert-Equal([object]$Expected, [object]$Actual, [string]$Message) {
+    if ($Expected -ne $Actual) {
+        throw "Assertion failed: $Message. Expected '$Expected', got '$Actual'"
+    }
+}
+
+function Assert-ThrowsLike([scriptblock]$Action, [string]$Pattern, [string]$Message) {
+    try {
+        & $Action
+    }
+    catch {
+        if ($_.Exception.Message -notlike $Pattern) {
+            throw "Assertion failed: $Message. Wrong error '$($_.Exception.Message)'"
+        }
+        return
+    }
+
+    throw "Assertion failed: $Message. Expected an exception"
+}
+
+function New-TestService([string]$State = "Running", [int]$ProcessId = 7000) {
+    return [PSCustomObject]@{
+        Name = "EchoCoreHost"
+        State = $State
+        ProcessId = $ProcessId
+    }
+}
+
+function New-TestControlProcess([int]$ProcessId, [int]$ParentProcessId) {
+    return [PSCustomObject]@{
+        Name = "echo-core-control.exe"
+        ProcessId = $ProcessId
+        ParentProcessId = $ParentProcessId
+    }
+}
+
+function New-TestListener([string]$Address, [int]$Port, [int]$ProcessId) {
+    return [PSCustomObject]@{
+        LocalAddress = $Address
+        LocalPort = $Port
+        OwningProcess = $ProcessId
+    }
+}
+
+function Write-TestHostConfig([string]$Path, [string]$EnvironmentFilePath) {
+    $json = [PSCustomObject]@{ control_env_file = $EnvironmentFilePath } |
+        ConvertTo-Json -Compress
+    [System.IO.File]::WriteAllText($Path, $json)
+}
+
+$testRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("echo-core-host-network-guard-" + [Guid]::NewGuid().ToString("N"))
+New-Item -ItemType Directory -Path $testRoot | Out-Null
+
+try {
+    $hostConfigPath = Join-Path $testRoot "echo-core-host.json"
+    $environmentPath = Join-Path $testRoot "production.env"
+    [System.IO.File]::WriteAllLines($environmentPath, @(
+        "CORE_BIND=0.0.0.0",
+        "CORE_PORT=9443"
+    ))
+    Write-TestHostConfig -Path $hostConfigPath -EnvironmentFilePath $environmentPath
+
+    $preflight = Invoke-EchoCoreHostNetworkGuard `
+        -RequestedAction Preflight `
+        -ConfigPath $hostConfigPath `
+        -Attempts 1 `
+        -DelayMilliseconds 0
+    Assert-Equal ([System.IO.Path]::GetFullPath($environmentPath)) $preflight.EnvironmentFilePath "fully qualified control_env_file is preserved"
+    Assert-Equal "0.0.0.0" $preflight.Bind "preflight validates the production wildcard bind"
+    Assert-Equal 9443 $preflight.Port "preflight validates the production port"
+    Assert-Equal 0 $preflight.Attempts "preflight does not inspect or mutate the service"
+
+    foreach ($invalidRootJson in @(
+        '[{"control_env_file":"C:\\production.env"}]',
+        '"not-an-object"',
+        '42',
+        'true',
+        'null'
+    )) {
+        [System.IO.File]::WriteAllText($hostConfigPath, $invalidRootJson)
+        Assert-ThrowsLike {
+            Invoke-EchoCoreHostNetworkGuard `
+                -RequestedAction Preflight `
+                -ConfigPath $hostConfigPath `
+                -Attempts 1 `
+                -DelayMilliseconds 0
+        } "*root must be a top-level JSON object*" "non-object host JSON root is rejected"
+    }
+
+    Assert-ThrowsLike {
+        Invoke-EchoCoreHostNetworkGuard `
+            -RequestedAction Preflight `
+            -ConfigPath $hostConfigPath `
+            -Attempts 1 `
+            -DelayMilliseconds 0 `
+            -ReadHostConfig { @{ control_env_file = $environmentPath } }
+    } "*root must deserialize to a PSCustomObject*" "injected non-PSCustomObject host root is rejected"
+
+    foreach ($nonStringValueJson in @(
+        'null',
+        '9443',
+        'true',
+        '["C:\\production.env"]',
+        '{"path":"C:\\production.env"}'
+    )) {
+        [System.IO.File]::WriteAllText(
+            $hostConfigPath,
+            '{"control_env_file":' + $nonStringValueJson + '}'
+        )
+        Assert-ThrowsLike {
+            Invoke-EchoCoreHostNetworkGuard `
+                -RequestedAction Preflight `
+                -ConfigPath $hostConfigPath `
+                -Attempts 1 `
+                -DelayMilliseconds 0
+        } "*control_env_file must be a JSON string*" "non-string control_env_file is rejected"
+    }
+
+    [System.IO.File]::WriteAllText(
+        $hostConfigPath,
+        '{"CONTROL_ENV_FILE":"C:\\production.env"}'
+    )
+    Assert-ThrowsLike {
+        Invoke-EchoCoreHostNetworkGuard `
+            -RequestedAction Preflight `
+            -ConfigPath $hostConfigPath `
+            -Attempts 1 `
+            -DelayMilliseconds 0
+    } "*exactly one case-sensitive control_env_file property*" "wrong-case control_env_file does not match Rust HostConfig"
+
+    Write-TestHostConfig -Path $hostConfigPath -EnvironmentFilePath $environmentPath
+
+    foreach ($unsafeEnvironmentPath in @("production.env", "C:production.env", "\production.env")) {
+        Write-TestHostConfig -Path $hostConfigPath -EnvironmentFilePath $unsafeEnvironmentPath
+        Assert-ThrowsLike {
+            Invoke-EchoCoreHostNetworkGuard `
+                -RequestedAction Preflight `
+                -ConfigPath $hostConfigPath `
+                -Attempts 1 `
+                -DelayMilliseconds 0
+        } "*fully qualified Windows drive-rooted path*" "non-fully-qualified control_env_file '$unsafeEnvironmentPath' is rejected"
+    }
+    Write-TestHostConfig -Path $hostConfigPath -EnvironmentFilePath $environmentPath
+
+    $script:mutationCount = 0
+    [System.IO.File]::WriteAllLines($environmentPath, @(
+        "CORE_BIND=127.0.0.1",
+        "CORE_PORT=9443"
+    ))
+    Assert-ThrowsLike {
+        Invoke-EchoCoreHostNetworkGuard `
+            -RequestedAction Restart `
+            -ConfigPath $hostConfigPath `
+            -Attempts 1 `
+            -DelayMilliseconds 0 `
+            -ServiceMutationProvider { $script:mutationCount++ }
+    } "*CORE_BIND must be exactly 0.0.0.0*" "localhost-only config is rejected before service mutation"
+    Assert-Equal 0 $script:mutationCount "unsafe config never reaches the service mutation provider"
+
+    [System.IO.File]::WriteAllLines($environmentPath, @(
+        "CORE_BIND=0.0.0.0",
+        "CORE_PORT=9443"
+    ))
+    $script:mutationCount = 0
+    Assert-ThrowsLike {
+        Invoke-EchoCoreHostNetworkGuard `
+            -RequestedAction Start `
+            -ConfigPath $hostConfigPath `
+            -Attempts 1 `
+            -DelayMilliseconds 0 `
+            -ServiceMutationProvider { $script:mutationCount++ } `
+            -ServiceProvider { New-TestService }
+    } "*Guarded Start requires EchoCoreHost to be Stopped with process ID 0*" "Start rejects an already-running service before mutation"
+    Assert-Equal 0 $script:mutationCount "already-running Start never reaches the mutation provider"
+
+    $script:startCompleted = $false
+    $start = Invoke-EchoCoreHostNetworkGuard `
+        -RequestedAction Start `
+        -ConfigPath $hostConfigPath `
+        -Attempts 1 `
+        -DelayMilliseconds 0 `
+        -ServiceMutationProvider { $script:startCompleted = $true } `
+        -ServiceProvider {
+            if ($script:startCompleted) { New-TestService -ProcessId 8000 }
+            else { New-TestService -State "Stopped" -ProcessId 0 }
+        } `
+        -ControlProcessProvider { New-TestControlProcess -ProcessId 8200 -ParentProcessId 8000 } `
+        -HealthProbeProvider { $true } `
+        -ListenerProvider { New-TestListener -Address "0.0.0.0" -Port 9443 -ProcessId 8200 } `
+        -DefaultRouteLanIPv4Provider { "192.168.5.70" } `
+        -TcpProbeProvider { $true }
+    Assert-True $script:startCompleted "guarded Start invokes the service mutation"
+    Assert-Equal 8000 $start.ServiceProcessId "guarded Start verifies the newly running service"
+    Assert-Equal 8200 $start.ControlProcessId "guarded Start verifies the new direct control child"
+
+    $script:mutationAction = $null
+    $script:mutationService = $null
+    $script:restartCompleted = $false
+    $restart = Invoke-EchoCoreHostNetworkGuard `
+        -RequestedAction Restart `
+        -ConfigPath $hostConfigPath `
+        -Attempts 2 `
+        -DelayMilliseconds 0 `
+        -ServiceMutationProvider {
+            param([string]$Mutation, [string]$ServiceName)
+            $script:mutationAction = $Mutation
+            $script:mutationService = $ServiceName
+            $script:restartCompleted = $true
+        } `
+        -ServiceProvider {
+            if ($script:restartCompleted) { New-TestService -ProcessId 9000 }
+            else { New-TestService -ProcessId 7000 }
+        } `
+        -ControlProcessProvider {
+            @(
+                (New-TestControlProcess -ProcessId 7100 -ParentProcessId 9999),
+                (New-TestControlProcess -ProcessId 7200 -ParentProcessId 7000),
+                (New-TestControlProcess -ProcessId 9200 -ParentProcessId 9000)
+            )
+        } `
+        -HealthProbeProvider { $true } `
+        -ListenerProvider {
+            param([int]$Port)
+            New-TestListener -Address "0.0.0.0" -Port $Port -ProcessId 9200
+        } `
+        -DefaultRouteLanIPv4Provider { "192.168.5.70" } `
+        -TcpProbeProvider {
+            param([string]$Address, [int]$Port)
+            $Address -eq "192.168.5.70" -and $Port -eq 9443
+        }
+    Assert-Equal "Restart" $script:mutationAction "the guarded restart performs the requested mutation"
+    Assert-Equal "EchoCoreHost" $script:mutationService "the mutation is scoped to EchoCoreHost"
+    Assert-Equal 9000 $restart.ServiceProcessId "the replacement EchoCoreHost PID is reported"
+    Assert-Equal 9200 $restart.ControlProcessId "the replacement direct control child is reported"
+    Assert-Equal "0.0.0.0" $restart.ListenerAddress "the wildcard listener is verified"
+    Assert-Equal "192.168.5.70" $restart.ProbeAddress "the LAN ingress target is verified"
+
+    $script:unchangedRestartCleanupCount = 0
+    Assert-ThrowsLike {
+        Invoke-EchoCoreHostNetworkGuard `
+            -RequestedAction Restart `
+            -ConfigPath $hostConfigPath `
+            -Attempts 1 `
+            -DelayMilliseconds 0 `
+            -ServiceMutationProvider { } `
+            -ServiceCleanupProvider { $script:unchangedRestartCleanupCount++ } `
+            -ServiceProvider { New-TestService -ProcessId 7000 } `
+            -ControlProcessProvider { New-TestControlProcess -ProcessId 7200 -ParentProcessId 7000 } `
+            -HealthProbeProvider { $true } `
+            -ListenerProvider { New-TestListener -Address "0.0.0.0" -Port 9443 -ProcessId 7200 } `
+            -DefaultRouteLanIPv4Provider { "192.168.5.70" } `
+            -TcpProbeProvider { $true }
+    } "*Guarded Restart did not replace either*" "Restart rejects an unchanged service and control PID"
+    Assert-Equal 0 $script:unchangedRestartCleanupCount "safe no-op Restart preserves the proven healthy wildcard-bound service"
+
+    $script:throwingSafeCleanupCount = 0
+    Assert-ThrowsLike {
+        Invoke-EchoCoreHostNetworkGuard `
+            -RequestedAction Restart `
+            -ConfigPath $hostConfigPath `
+            -Attempts 1 `
+            -DelayMilliseconds 0 `
+            -ServiceMutationProvider { throw "simulated unchanged mutation failure" } `
+            -ServiceCleanupProvider { $script:throwingSafeCleanupCount++ } `
+            -ServiceProvider { New-TestService -ProcessId 7000 } `
+            -ControlProcessProvider { New-TestControlProcess -ProcessId 7200 -ParentProcessId 7000 } `
+            -HealthProbeProvider { $true } `
+            -ListenerProvider { New-TestListener -Address "0.0.0.0" -Port 9443 -ProcessId 7200 }
+    } "*simulated unchanged mutation failure*" "throwing Restart preserves an unchanged hard-safe process"
+    Assert-Equal 0 $script:throwingSafeCleanupCount "throwing provider does not stop unchanged hard-safe service and control PIDs"
+
+    $script:throwingChangedPhase = "old"
+    Assert-ThrowsLike {
+        Invoke-EchoCoreHostNetworkGuard `
+            -RequestedAction Restart `
+            -ConfigPath $hostConfigPath `
+            -Attempts 1 `
+            -DelayMilliseconds 0 `
+            -ServiceMutationProvider {
+                $script:throwingChangedPhase = "changed"
+                throw "simulated changed mutation failure"
+            } `
+            -ServiceCleanupProvider { $script:throwingChangedPhase = "stopped" } `
+            -ServiceProvider {
+                if ($script:throwingChangedPhase -eq "old") { New-TestService -ProcessId 7000 }
+                elseif ($script:throwingChangedPhase -eq "changed") { New-TestService -ProcessId 9000 }
+                else { New-TestService -State "Stopped" -ProcessId 0 }
+            } `
+            -ControlProcessProvider {
+                @(
+                    (New-TestControlProcess -ProcessId 7200 -ParentProcessId 7000),
+                    (New-TestControlProcess -ProcessId 9200 -ParentProcessId 9000)
+                )
+            } `
+            -HealthProbeProvider { $true } `
+            -ListenerProvider { New-TestListener -Address "0.0.0.0" -Port 9443 -ProcessId 9200 }
+    } "*simulated changed mutation failure*" "throwing Restart cleans up a changed service/control process"
+    Assert-Equal "stopped" $script:throwingChangedPhase "throwing provider with changed PIDs stops the partial-live service"
+
+    $script:throwingUnsafeCleanup = $false
+    Assert-ThrowsLike {
+        Invoke-EchoCoreHostNetworkGuard `
+            -RequestedAction Restart `
+            -ConfigPath $hostConfigPath `
+            -Attempts 1 `
+            -DelayMilliseconds 0 `
+            -ServiceMutationProvider { throw "simulated unsafe mutation failure" } `
+            -ServiceCleanupProvider { $script:throwingUnsafeCleanup = $true } `
+            -ServiceProvider {
+                if ($script:throwingUnsafeCleanup) { New-TestService -State "Stopped" -ProcessId 0 }
+                else { New-TestService -ProcessId 7000 }
+            } `
+            -ControlProcessProvider { New-TestControlProcess -ProcessId 7200 -ParentProcessId 7000 } `
+            -HealthProbeProvider { $true } `
+            -ListenerProvider { New-TestListener -Address "127.0.0.1" -Port 9443 -ProcessId 7200 }
+    } "*simulated unsafe mutation failure*" "throwing Restart cleans up an unchanged but unsafe listener"
+    Assert-True $script:throwingUnsafeCleanup "throwing provider stops unchanged PIDs when hard safety cannot be proven"
+
+    $script:unsafeNoOpCleanup = $false
+    Assert-ThrowsLike {
+        Invoke-EchoCoreHostNetworkGuard `
+            -RequestedAction Restart `
+            -ConfigPath $hostConfigPath `
+            -Attempts 1 `
+            -DelayMilliseconds 0 `
+            -ServiceMutationProvider { } `
+            -ServiceCleanupProvider { $script:unsafeNoOpCleanup = $true } `
+            -ServiceProvider {
+                if ($script:unsafeNoOpCleanup) { New-TestService -State "Stopped" -ProcessId 0 }
+                else { New-TestService -ProcessId 7000 }
+            } `
+            -ControlProcessProvider { New-TestControlProcess -ProcessId 7200 -ParentProcessId 7000 } `
+            -HealthProbeProvider { $true } `
+            -ListenerProvider { New-TestListener -Address "127.0.0.1" -Port 9443 -ProcessId 7200 } `
+            -DefaultRouteLanIPv4Provider { "192.168.5.70" } `
+            -TcpProbeProvider { $true }
+    } "*hard production safety failed*IPv4 wildcard TCP listener*" "unsafe no-op Restart listener fails hard"
+    Assert-True $script:unsafeNoOpCleanup "unsafe no-op Restart stops the partial-live service"
+
+    $script:ancillaryFailurePhase = "old"
+    $script:ancillaryCleanupCount = 0
+    Assert-ThrowsLike {
+        Invoke-EchoCoreHostNetworkGuard `
+            -RequestedAction Restart `
+            -ConfigPath $hostConfigPath `
+            -Attempts 1 `
+            -DelayMilliseconds 0 `
+            -ServiceMutationProvider { $script:ancillaryFailurePhase = "new" } `
+            -ServiceCleanupProvider { $script:ancillaryCleanupCount++ } `
+            -ServiceProvider {
+                if ($script:ancillaryFailurePhase -eq "old") { New-TestService -ProcessId 7000 }
+                else { New-TestService -ProcessId 9000 }
+            } `
+            -ControlProcessProvider {
+                @(
+                    (New-TestControlProcess -ProcessId 7200 -ParentProcessId 7000),
+                    (New-TestControlProcess -ProcessId 9200 -ParentProcessId 9000)
+                )
+            } `
+            -HealthProbeProvider { $true } `
+            -ListenerProvider { New-TestListener -Address "0.0.0.0" -Port 9443 -ProcessId 9200 } `
+            -DefaultRouteLanIPv4Provider { "192.168.5.70" } `
+            -TcpProbeProvider { $false }
+    } "*remained healthy and wildcard-bound*LAN ingress was not verified*" "ancillary LAN failure remains visible"
+    Assert-Equal 0 $script:ancillaryCleanupCount "ancillary LAN failure does not stop a healthy wildcard-bound service"
+    Assert-Equal "new" $script:ancillaryFailurePhase "healthy replacement remains running for external verification"
+
+    $script:serviceAttempt = 0
+    $script:sleepCount = 0
+    $retried = Invoke-EchoCoreHostNetworkGuard `
+        -RequestedAction Verify `
+        -ConfigPath $hostConfigPath `
+        -Attempts 3 `
+        -DelayMilliseconds 1 `
+        -ServiceProvider {
+            $script:serviceAttempt++
+            if ($script:serviceAttempt -eq 1) {
+                New-TestService -State "Start Pending" -ProcessId 0
+            }
+            else {
+                New-TestService
+            }
+        } `
+        -ControlProcessProvider { New-TestControlProcess -ProcessId 7200 -ParentProcessId 7000 } `
+        -HealthProbeProvider { $true } `
+        -ListenerProvider {
+            param([int]$Port)
+            New-TestListener -Address "0.0.0.0" -Port $Port -ProcessId 7200
+        } `
+        -DefaultRouteLanIPv4Provider { "192.168.5.70" } `
+        -TcpProbeProvider { $true } `
+        -SleepProvider { $script:sleepCount++ }
+    Assert-Equal 2 $retried.Attempts "post-start verification retries transient service state"
+    Assert-Equal 1 $script:sleepCount "bounded retry sleeps only between failed attempts"
+
+    Assert-ThrowsLike {
+        Invoke-EchoCoreHostNetworkGuard `
+            -RequestedAction Verify `
+            -ConfigPath $hostConfigPath `
+            -Attempts 2 `
+            -DelayMilliseconds 0 `
+            -ServiceProvider { New-TestService } `
+            -ControlProcessProvider {
+                @(
+                    (New-TestControlProcess -ProcessId 7200 -ParentProcessId 7000),
+                    (New-TestControlProcess -ProcessId 7300 -ParentProcessId 7000)
+                )
+            } `
+            -HealthProbeProvider { $true } `
+            -ListenerProvider { New-TestListener -Address "0.0.0.0" -Port 9443 -ProcessId 7200 } `
+            -DefaultRouteLanIPv4Provider { "192.168.5.70" } `
+            -TcpProbeProvider { $true }
+    } "*after 2 attempts*exactly one direct echo-core-control.exe child*found 2*" "multiple direct control children fail closed after bounded retries"
+
+    Assert-ThrowsLike {
+        Invoke-EchoCoreHostNetworkGuard `
+            -RequestedAction Verify `
+            -ConfigPath $hostConfigPath `
+            -Attempts 2 `
+            -DelayMilliseconds 0 `
+            -ServiceProvider { New-TestService } `
+            -ControlProcessProvider { New-TestControlProcess -ProcessId 7200 -ParentProcessId 7000 } `
+            -HealthProbeProvider { $true } `
+            -ListenerProvider { New-TestListener -Address "127.0.0.1" -Port 9443 -ProcessId 7200 } `
+            -DefaultRouteLanIPv4Provider { "192.168.5.70" } `
+            -TcpProbeProvider { $true }
+    } "*after 2 attempts*does not own the IPv4 wildcard TCP listener*9443*" "a localhost-only live child never passes post-start verification"
+
+    $alternateEnvironmentPath = Join-Path $testRoot "alternate.env"
+    [System.IO.File]::WriteAllLines($alternateEnvironmentPath, @(
+        "CORE_BIND=0.0.0.0",
+        "CORE_PORT=9443"
+    ))
+    $script:configRaceCleanup = $false
+    Assert-ThrowsLike {
+        Invoke-EchoCoreHostNetworkGuard `
+            -RequestedAction Restart `
+            -ConfigPath $hostConfigPath `
+            -Attempts 1 `
+            -DelayMilliseconds 0 `
+            -ServiceMutationProvider {
+                Write-TestHostConfig -Path $hostConfigPath -EnvironmentFilePath $alternateEnvironmentPath
+            } `
+            -ServiceCleanupProvider { $script:configRaceCleanup = $true } `
+            -ServiceProvider {
+                if ($script:configRaceCleanup) { New-TestService -State "Stopped" -ProcessId 0 }
+                else { New-TestService }
+            } `
+            -ControlProcessProvider { New-TestControlProcess -ProcessId 7200 -ParentProcessId 7000 } `
+            -HealthProbeProvider { $true } `
+            -ListenerProvider { New-TestListener -Address "0.0.0.0" -Port 9443 -ProcessId 7200 } `
+            -DefaultRouteLanIPv4Provider { "192.168.5.70" } `
+            -TcpProbeProvider { $true }
+    } "*control_env_file changed during the service mutation*" "a host-config swap during restart fails closed"
+    Assert-True $script:configRaceCleanup "host-config race stops the partial-live service"
+
+    Write-Host "echo-core-host-network-guard tests passed"
+}
+finally {
+    if (Test-Path -LiteralPath $testRoot -PathType Container) {
+        Remove-Item -LiteralPath $testRoot -Recurse -Force
+    }
+}

--- a/core/deploy/test-production-network-lib.ps1
+++ b/core/deploy/test-production-network-lib.ps1
@@ -1,0 +1,198 @@
+$ErrorActionPreference = "Stop"
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+. (Join-Path $scriptDir "production-network-lib.ps1")
+
+function Assert-True([bool]$Condition, [string]$Message) {
+    if (-not $Condition) {
+        throw "Assertion failed: $Message"
+    }
+}
+
+function Assert-Equal([object]$Expected, [object]$Actual, [string]$Message) {
+    if ($Expected -ne $Actual) {
+        throw "Assertion failed: $Message. Expected '$Expected', got '$Actual'"
+    }
+}
+
+function Assert-ThrowsLike([scriptblock]$Action, [string]$Pattern, [string]$Message) {
+    try {
+        & $Action
+    } catch {
+        if ($_.Exception.Message -notlike $Pattern) {
+            throw "Assertion failed: $Message. Wrong error '$($_.Exception.Message)'"
+        }
+        return
+    }
+
+    throw "Assertion failed: $Message. Expected an exception"
+}
+
+function New-TestListener([string]$Address, [int]$Port, [long]$ProcessId) {
+    return [PSCustomObject]@{
+        LocalAddress = $Address
+        LocalPort = $Port
+        OwningProcess = $ProcessId
+    }
+}
+
+$validEnvironmentReader = {
+    param([string]$Path)
+    @(
+        "# production control network",
+        "UNRELATED=value",
+        " CORE_BIND = 0.0.0.0 ",
+        "CORE_PORT=9443"
+    )
+}
+
+$environmentReadCount = 0
+$singleReadEnvironmentReader = {
+    param([string]$Path)
+    $script:environmentReadCount++
+    & $validEnvironmentReader $Path
+}
+$environment = Assert-ProductionControlEnvironment `
+    -EnvFilePath "injected-production.env" `
+    -ReadEnvironmentFile $singleReadEnvironmentReader
+Assert-Equal "0.0.0.0" $environment.Bind "the public IPv4 wildcard is accepted"
+Assert-Equal 9443 $environment.Port "the production control port is accepted"
+Assert-Equal 1 $environmentReadCount "the active environment is read once to avoid mixed snapshots"
+
+Assert-ThrowsLike {
+    Assert-ProductionControlEnvironment -EnvFilePath "injected.env" -ReadEnvironmentFile {
+        @("CORE_BIND=127.0.0.1", "CORE_PORT=9443")
+    }
+} "*CORE_BIND must be exactly 0.0.0.0*" "an IPv4 loopback bind is rejected"
+
+Assert-ThrowsLike {
+    Assert-ProductionControlEnvironment -EnvFilePath "injected.env" -ReadEnvironmentFile {
+        @("CORE_BIND=::1", "CORE_PORT=9443")
+    }
+} "*CORE_BIND must be exactly 0.0.0.0*" "an IPv6 loopback bind is rejected"
+
+Assert-ThrowsLike {
+    Assert-ProductionControlEnvironment -EnvFilePath "injected.env" -ReadEnvironmentFile {
+        @("CORE_PORT=9443")
+    }
+} "*exactly one CORE_BIND assignment; found 0*" "a missing bind assignment is rejected"
+
+Assert-ThrowsLike {
+    Assert-ProductionControlEnvironment -EnvFilePath "injected.env" -ReadEnvironmentFile {
+        @("CORE_BIND=0.0.0.0", "core_bind=0.0.0.0", "CORE_PORT=9443")
+    }
+} "*exactly one CORE_BIND assignment; found 2*" "duplicate bind assignments are rejected case-insensitively"
+
+Assert-ThrowsLike {
+    Assert-ProductionControlEnvironment -EnvFilePath "injected.env" -ReadEnvironmentFile {
+        @("CORE_BIND=0.0.0.0")
+    }
+} "*exactly one CORE_PORT assignment; found 0*" "a missing port assignment is rejected"
+
+Assert-ThrowsLike {
+    Assert-ProductionControlEnvironment -EnvFilePath "injected.env" -ReadEnvironmentFile {
+        @("CORE_BIND=0.0.0.0", "CORE_PORT=9443", "CORE_PORT=9443")
+    }
+} "*exactly one CORE_PORT assignment; found 2*" "duplicate port assignments are rejected"
+
+Assert-ThrowsLike {
+    Assert-ProductionControlEnvironment -EnvFilePath "injected.env" -ReadEnvironmentFile {
+        @("CORE_BIND=0.0.0.0", "CORE_PORT=8443")
+    }
+} "*CORE_PORT must be exactly 9443*" "the wrong production port is rejected"
+
+$expectedPid = 4242
+$listenerProvider = {
+    param([int]$Port)
+    New-TestListener -Address "0.0.0.0" -Port $Port -ProcessId 4242
+}
+$routeProvider = { "192.168.50.20" }
+$probeProvider = {
+    param([string]$Address, [int]$Port)
+    return $Address -eq "192.168.50.20" -and $Port -eq 9443
+}
+
+$ingress = Assert-ProductionControlIngress `
+    -ExpectedControlProcessId $expectedPid `
+    -ListenerProvider $listenerProvider `
+    -DefaultRouteLanIPv4Provider $routeProvider `
+    -TcpProbeProvider $probeProvider
+Assert-Equal $expectedPid $ingress.ControlProcessId "the expected control PID is reported"
+Assert-Equal "0.0.0.0" $ingress.ListenerAddress "the verified listener is reported"
+Assert-Equal 9443 $ingress.Port "the verified port is reported"
+Assert-Equal "192.168.50.20" $ingress.ProbeAddress "the probed LAN address is reported"
+
+$nonLoopbackIngress = Assert-ProductionControlIngress `
+    -ExpectedControlProcessId $expectedPid `
+    -ListenerProvider {
+        New-TestListener -Address "192.168.50.20" -Port 9443 -ProcessId 4242
+    } `
+    -DefaultRouteLanIPv4Provider $routeProvider `
+    -TcpProbeProvider { $true }
+Assert-Equal "192.168.50.20" $nonLoopbackIngress.ListenerAddress "a concrete non-loopback listener is accepted"
+
+Assert-ThrowsLike {
+    Assert-ProductionControlIngress `
+        -ExpectedControlProcessId $expectedPid `
+        -ListenerProvider { New-TestListener -Address "0.0.0.0" -Port 8443 -ProcessId 4242 } `
+        -DefaultRouteLanIPv4Provider $routeProvider `
+        -TcpProbeProvider { $true }
+} "*does not own*port 9443*" "a listener on the wrong port is rejected"
+
+Assert-ThrowsLike {
+    Assert-ProductionControlIngress `
+        -ExpectedControlProcessId $expectedPid `
+        -ListenerProvider { New-TestListener -Address "0.0.0.0" -Port 9443 -ProcessId 9001 } `
+        -DefaultRouteLanIPv4Provider $routeProvider `
+        -TcpProbeProvider { $true }
+} "*PID 4242 does not own*" "a listener owned by the wrong process is rejected"
+
+Assert-ThrowsLike {
+    Assert-ProductionControlIngress `
+        -ExpectedControlProcessId $expectedPid `
+        -ListenerProvider { New-TestListener -Address "127.0.0.1" -Port 9443 -ProcessId 4242 } `
+        -DefaultRouteLanIPv4Provider $routeProvider `
+        -TcpProbeProvider { $true }
+} "*does not own*" "an IPv4 loopback listener is rejected"
+
+Assert-ThrowsLike {
+    Assert-ProductionControlIngress `
+        -ExpectedControlProcessId $expectedPid `
+        -ListenerProvider { New-TestListener -Address "::1" -Port 9443 -ProcessId 4242 } `
+        -DefaultRouteLanIPv4Provider $routeProvider `
+        -TcpProbeProvider { $true }
+} "*does not own*" "an IPv6 loopback listener is rejected"
+
+Assert-ThrowsLike {
+    Assert-ProductionControlIngress `
+        -ExpectedControlProcessId $expectedPid `
+        -ListenerProvider { @() } `
+        -DefaultRouteLanIPv4Provider $routeProvider `
+        -TcpProbeProvider { $true }
+} "*does not own*" "a missing listener is rejected"
+
+Assert-ThrowsLike {
+    Assert-ProductionControlIngress `
+        -ExpectedControlProcessId $expectedPid `
+        -ListenerProvider $listenerProvider `
+        -DefaultRouteLanIPv4Provider { "127.0.0.1" } `
+        -TcpProbeProvider { $true }
+} "*not a usable LAN IPv4*" "a loopback probe target is rejected"
+
+Assert-ThrowsLike {
+    Assert-ProductionControlIngress `
+        -ExpectedControlProcessId $expectedPid `
+        -ListenerProvider $listenerProvider `
+        -DefaultRouteLanIPv4Provider $routeProvider `
+        -TcpProbeProvider { $false }
+} "*did not accept a TCP connection*" "a failed LAN TCP probe is rejected"
+
+Assert-ThrowsLike {
+    Assert-ProductionControlIngress `
+        -ExpectedControlProcessId $expectedPid `
+        -ListenerProvider $listenerProvider `
+        -DefaultRouteLanIPv4Provider $routeProvider `
+        -TcpProbeProvider { @($true, $true) }
+} "*did not accept a TCP connection*" "an ambiguous TCP probe result fails closed"
+
+Write-Host "production-network-lib tests passed"

--- a/core/deploy/test-production-network-lib.ps1
+++ b/core/deploy/test-production-network-lib.ps1
@@ -112,6 +112,17 @@ $probeProvider = {
     return $Address -eq "192.168.50.20" -and $Port -eq 9443
 }
 
+$listener = Assert-ProductionControlListener `
+    -ExpectedControlProcessId $expectedPid `
+    -ListenerProvider $listenerProvider
+Assert-Equal $expectedPid $listener.ControlProcessId "the listener-only guard reports the expected PID"
+Assert-Equal "0.0.0.0" $listener.ListenerAddress "the listener-only guard requires the IPv4 wildcard"
+
+$lanProbe = Assert-ProductionControlLanProbe `
+    -DefaultRouteLanIPv4Provider $routeProvider `
+    -TcpProbeProvider $probeProvider
+Assert-Equal "192.168.50.20" $lanProbe.ProbeAddress "the ancillary LAN guard reports its probe address"
+
 $ingress = Assert-ProductionControlIngress `
     -ExpectedControlProcessId $expectedPid `
     -ListenerProvider $listenerProvider `
@@ -122,14 +133,21 @@ Assert-Equal "0.0.0.0" $ingress.ListenerAddress "the verified listener is report
 Assert-Equal 9443 $ingress.Port "the verified port is reported"
 Assert-Equal "192.168.50.20" $ingress.ProbeAddress "the probed LAN address is reported"
 
-$nonLoopbackIngress = Assert-ProductionControlIngress `
-    -ExpectedControlProcessId $expectedPid `
-    -ListenerProvider {
-        New-TestListener -Address "192.168.50.20" -Port 9443 -ProcessId 4242
-    } `
-    -DefaultRouteLanIPv4Provider $routeProvider `
-    -TcpProbeProvider { $true }
-Assert-Equal "192.168.50.20" $nonLoopbackIngress.ListenerAddress "a concrete non-loopback listener is accepted"
+Assert-ThrowsLike {
+    Assert-ProductionControlListener `
+        -ExpectedControlProcessId $expectedPid `
+        -ListenerProvider {
+            New-TestListener -Address "192.168.50.20" -Port 9443 -ProcessId 4242
+        }
+} "*does not own*port 9443*" "a concrete non-loopback listener is rejected because production requires the wildcard"
+
+Assert-ThrowsLike {
+    Assert-ProductionControlListener `
+        -ExpectedControlProcessId $expectedPid `
+        -ListenerProvider {
+            New-TestListener -Address "::" -Port 9443 -ProcessId 4242
+        }
+} "*does not own*port 9443*" "the IPv6 wildcard does not substitute for required IPv4 ingress"
 
 Assert-ThrowsLike {
     Assert-ProductionControlIngress `

--- a/core/deploy/test-production-network.ps1
+++ b/core/deploy/test-production-network.ps1
@@ -1,0 +1,33 @@
+[CmdletBinding()]
+param()
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$windowsPowerShell = Join-Path $env:SystemRoot "System32\WindowsPowerShell\v1.0\powershell.exe"
+if (!(Test-Path -LiteralPath $windowsPowerShell -PathType Leaf)) {
+    throw "Windows PowerShell 5.1 is required for the production network verification gate."
+}
+
+$testScripts = @(
+    (Join-Path $PSScriptRoot "test-production-network-lib.ps1"),
+    (Join-Path $PSScriptRoot "test-echo-core-host-network-guard.ps1"),
+    (Join-Path $PSScriptRoot "test-viewer-runtime-lib.ps1")
+)
+
+foreach ($testScript in $testScripts) {
+    if (!(Test-Path -LiteralPath $testScript -PathType Leaf)) {
+        throw "Production network verification prerequisite is missing: $testScript"
+    }
+
+    Write-Host "[production-network] Running $(Split-Path -Leaf $testScript)"
+    & $windowsPowerShell `
+        -NoProfile `
+        -ExecutionPolicy Bypass `
+        -File $testScript
+    if ($LASTEXITCODE -ne 0) {
+        throw "Production network verification failed with exit code $LASTEXITCODE`: $testScript"
+    }
+}
+
+Write-Host "production network Windows verification passed"

--- a/core/deploy/test-viewer-runtime-lib.ps1
+++ b/core/deploy/test-viewer-runtime-lib.ps1
@@ -17,6 +17,154 @@ $runtime = Join-Path $testRoot "runtime"
 New-Item -ItemType Directory -Path $source, $runtime | Out-Null
 
 try {
+    # Exercise the watcher's production-only adapters with isolated providers.
+    # This proves the standard deploy path forwards the exact environment file
+    # and expected process ID to the shared guard without inspecting live state.
+    $networkEnvFile = Join-Path $testRoot "production.env"
+    Set-Content -LiteralPath $networkEnvFile -Value @(
+        "CORE_BIND=0.0.0.0",
+        "CORE_PORT=9443"
+    )
+    $networkEnvironment = Assert-WatcherProductionEnvironment -EnvFilePath $networkEnvFile
+    Assert-True ($networkEnvironment.Bind -eq "0.0.0.0") "watcher forwards its production environment to the network guard"
+    Assert-True ($networkEnvironment.Port -eq 9443) "watcher production environment requires the public control port"
+
+    $networkIngress = Assert-WatcherProductionIngress `
+        -ExpectedControlProcessId 4242 `
+        -ListenerProvider {
+            param([int]$Port)
+            [pscustomobject]@{ LocalAddress = "0.0.0.0"; LocalPort = $Port; OwningProcess = 4242 }
+        } `
+        -DefaultRouteLanIPv4Provider { "192.168.50.10" } `
+        -TcpProbeProvider {
+            param([string]$Address, [int]$Port)
+            ($Address -eq "192.168.50.10" -and $Port -eq 9443)
+        }
+    Assert-True ($networkIngress.ControlProcessId -eq 4242) "watcher forwards the activated control PID to the ingress guard"
+    Assert-True ($networkIngress.ProbeAddress -eq "192.168.50.10") "watcher ingress guard probes a LAN address"
+
+    Assert-WatcherProductionActivation `
+        -ExpectedControlProcessId 4242 `
+        -HealthProbe { $true } `
+        -ListenerProvider {
+            param([int]$Port)
+            [pscustomobject]@{ LocalAddress = "0.0.0.0"; LocalPort = $Port; OwningProcess = 4242 }
+        } `
+        -DefaultRouteLanIPv4Provider { "192.168.50.10" } `
+        -TcpProbeProvider { $true }
+
+    $failedPostActivationRejected = $false
+    try {
+        Assert-WatcherProductionActivation `
+            -ExpectedControlProcessId 4242 `
+            -HealthProbe { $true } `
+            -ListenerProvider {
+                param([int]$Port)
+                [pscustomobject]@{ LocalAddress = "127.0.0.1"; LocalPort = $Port; OwningProcess = 4242 }
+            } `
+            -DefaultRouteLanIPv4Provider { "192.168.50.10" } `
+            -TcpProbeProvider { $true }
+    }
+    catch { $failedPostActivationRejected = $true }
+    Assert-True $failedPostActivationRejected "watcher rejects a healthy localhost-only post-activation listener"
+
+    $liveIngress = Assert-WatcherLiveProductionIngress `
+        -EnvFilePath $networkEnvFile `
+        -ExpectedControlProcessId 4242 `
+        -HealthProbe { $true } `
+        -ListenerProvider {
+            param([int]$Port)
+            [pscustomobject]@{ LocalAddress = "0.0.0.0"; LocalPort = $Port; OwningProcess = 4242 }
+        } `
+        -DefaultRouteLanIPv4Provider { "192.168.50.10" } `
+        -TcpProbeProvider { $true }
+    Assert-True ($liveIngress -eq 4242) "pre-mutation preflight validates environment, health, listener, and LAN ingress"
+
+    # A restored known-old process must survive a transient route/LAN probe
+    # failure once its environment, health, and wildcard listener are safe.
+    $script:rollbackStopCount = 0
+    $script:rollbackRouteCount = 0
+    $script:rollbackProbeCount = 0
+    $script:rollbackRetryDelayCount = 0
+    $degradedRollbackKeptRunning = Complete-WatcherRollbackActivation `
+        -Process ([pscustomobject]@{ Id = 4242 }) `
+        -HealthProbe { $true } `
+        -ListenerProvider {
+            param([int]$Port)
+            [pscustomobject]@{ LocalAddress = "0.0.0.0"; LocalPort = $Port; OwningProcess = 4242 }
+        } `
+        -DefaultRouteLanIPv4Provider {
+            $script:rollbackRouteCount++
+            if ($script:rollbackRouteCount -ne 2) { throw "route temporarily unavailable" }
+            "192.168.50.10"
+        } `
+        -TcpProbeProvider {
+            $script:rollbackProbeCount++
+            $false
+        } `
+        -AncillaryProbeAttempts 3 `
+        -AncillaryProbeDelayMilliseconds 1 `
+        -RetryDelayProvider {
+            param([int]$Milliseconds)
+            $script:rollbackRetryDelayCount++
+        } `
+        -StopProcessProvider {
+            param([object]$TrackedProcess)
+            $script:rollbackStopCount++
+            $true
+        }
+    Assert-True $degradedRollbackKeptRunning "ancillary LAN probe failure does not fail a hard-safe rollback"
+    Assert-True ($script:rollbackRouteCount -eq 3) "rollback default-route lookup retries are bounded"
+    Assert-True ($script:rollbackProbeCount -eq 1) "rollback also tolerates a LAN TCP failure within the bounded attempts"
+    Assert-True ($script:rollbackRetryDelayCount -eq 2) "rollback waits only between bounded ancillary attempts"
+    Assert-True ($script:rollbackStopCount -eq 0) "ancillary LAN probe failure does not kill the known-old process"
+
+    $script:rollbackStopCount = 0
+    $script:rollbackProbeCount = 0
+    $loopbackRollbackRejected = Complete-WatcherRollbackActivation `
+        -Process ([pscustomobject]@{ Id = 4242 }) `
+        -HealthProbe { $true } `
+        -ListenerProvider {
+            param([int]$Port)
+            [pscustomobject]@{ LocalAddress = "127.0.0.1"; LocalPort = $Port; OwningProcess = 4242 }
+        } `
+        -DefaultRouteLanIPv4Provider {
+            $script:rollbackProbeCount++
+            "192.168.50.10"
+        } `
+        -TcpProbeProvider { $true } `
+        -StopProcessProvider {
+            param([object]$TrackedProcess)
+            $script:rollbackStopCount++
+            $true
+        }
+    Assert-True (!$loopbackRollbackRejected) "a loopback-only rollback listener fails hard safety"
+    Assert-True ($script:rollbackStopCount -eq 1) "a loopback-only rollback process is stopped"
+    Assert-True ($script:rollbackProbeCount -eq 0) "hard listener safety fails before ancillary probes"
+
+    $deployDefinition = (Get-Command Deploy-BlueGreen).Definition
+    $rollbackStartDefinition = (Get-Command Start-OldProcess).Definition
+    Assert-True ($deployDefinition.Contains("Assert-WatcherProductionEnvironment")) "new deployment rechecks production config immediately before activation"
+    Assert-True ($deployDefinition.Contains("Assert-WatcherProductionActivation")) "new deployment verifies production ingress after activation"
+    Assert-True ($rollbackStartDefinition.Contains("Assert-WatcherProductionEnvironment")) "rollback restart validates production config before activation"
+    Assert-True ($rollbackStartDefinition.Contains("Complete-WatcherRollbackActivation")) "rollback delegates the keep-or-stop decision to the rollback safety guard"
+
+    $watcherScript = Get-Content -Raw -LiteralPath (Join-Path $scriptDir "deploy-watcher.ps1")
+    $liveIngressReferences = [regex]::Matches(
+        $watcherScript,
+        [regex]::Escape("Assert-WatcherLiveProductionIngress")
+    ).Count
+    Assert-True ($liveIngressReferences -ge 4) "watcher defines and invokes full live ingress at startup, before pull, and immediately before production mutation"
+
+    Set-Content -LiteralPath $networkEnvFile -Value @(
+        "CORE_BIND=127.0.0.1",
+        "CORE_PORT=9443"
+    )
+    $unsafeNetworkRejected = $false
+    try { Assert-WatcherProductionEnvironment -EnvFilePath $networkEnvFile | Out-Null }
+    catch { $unsafeNetworkRejected = $true }
+    Assert-True $unsafeNetworkRejected "watcher fails closed on a localhost-only production environment"
+
     $requiredFiles = @(
         "app.js", "state.js", "settings.js", "urls.js", "debug.js",
         "identity.js", "auth.js", "connect.js", "room-status.js",

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -106,7 +106,8 @@ git status -sb
 git branch --show-current
 git rev-parse --short HEAD
 git rev-parse --short origin/main
-npm run verify:production-network:windows
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File `
+  .\core\deploy\test-production-network.ps1
 
 $activeHost = Get-Content "C:\ProgramData\Echo Chamber\echo-core-host.json" -Raw |
   ConvertFrom-Json
@@ -262,7 +263,8 @@ Use the full-snapshot publisher during an approved control-service outage:
 ```powershell
 # From a clean, up-to-date main checkout, verify code first.
 npm run verify:quick
-npm run verify:production-network:windows
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File `
+  .\core\deploy\test-production-network.ps1
 
 # Stop EchoCoreHost/control before the swap. Deploy the matching control binary
 # in the same outage, then publish every viewer asset as one verified snapshot.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -19,6 +19,83 @@ Important gotcha from the v0.6.12 screen-share release: the service executable p
 
 The deploy watcher is separate. It watches/builds/deploys from the clean repo path, but it is not the boot owner for the core stack.
 
+### Production network reachability invariant
+
+Production must run with `CORE_BIND=0.0.0.0` and `CORE_PORT=9443`. Treat both
+values as release invariants, verify them in the active `control_env_file`, and
+confirm the listener is on `0.0.0.0:9443` after every promotion or rollback.
+The host config must be a top-level JSON object and `control_env_file` must be a
+case-sensitive JSON string containing a fully qualified Windows drive-rooted
+path; arrays, scalar roots, relative, drive-relative, root-relative, and UNC
+paths fail closed.
+`CORE_BIND=127.0.0.1` is valid only for an isolated candidate or local test. A
+candidate loopback bind must never be copied into the production environment.
+Do not promote a candidate environment wholesale; preserve and independently
+verify the production network values.
+
+The server's Windows `hosts` file overrides public DNS resolution. When it maps
+the public Echo hostname to loopback, a public-hostname `curl` run on the server
+is a local-only service check, not proof that LAN or internet clients can
+connect. Hairpin NAT is also not external-path proof. A production network
+change is complete only after all three independent checks pass:
+
+1. **Loopback (server):** verify `/health` and `/api/version` through
+   `https://127.0.0.1:9443` and confirm the port listener is bound to
+   `0.0.0.0:9443`, not `127.0.0.1:9443`.
+2. **LAN (another device):** connect to the server's LAN address on port 9443
+   from a different machine on the local network. A request made by the server
+   to its own LAN address does not satisfy this check.
+3. **External (off-LAN):** connect to the public Echo hostname from a genuine
+   internet path, such as a friend's connection or a phone with Wi-Fi disabled.
+   The server itself and another device using the same LAN do not satisfy this
+   check.
+
+The committed `echo-core-host-network-guard.ps1` wrapper is mandatory for every
+manual production service start or restart. It reads the canonical host JSON,
+resolves and validates its `control_env_file` before the service mutation, then
+uses bounded retries to require one running `EchoCoreHost`, exactly one direct
+`echo-core-control.exe` child, that child's `0.0.0.0:9443` listener, and a TCP
+probe through the server's default-route LAN address. Do not call
+`Start-Service EchoCoreHost` or `Restart-Service EchoCoreHost` directly.
+`Start` requires the service to be stopped first. `Restart` must replace the
+service or direct-control PID. A hard post-mutation failure stops the
+partial-live service; an ancillary LAN-route/probe failure leaves a healthy,
+loopback-responsive, wildcard-bound service running but still fails the release
+gate for explicit LAN/WAN verification. A no-op `Restart` also fails the release
+gate, but preserves the old process only after health, wildcard ownership, and
+LAN ingress have all passed. If the Windows service mutation itself throws, the
+wrapper preserves only the exact unchanged service/control PIDs after rechecking
+the canonical config, loopback health, and wildcard ownership; changed, partial,
+or unsafe post-error state is stopped.
+
+Run the read-only verification after a reboot and before a release or rollback:
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File `
+  .\core\deploy\echo-core-host-network-guard.ps1 -Action Verify
+curl.exe -sk https://127.0.0.1:9443/health
+curl.exe -sk https://127.0.0.1:9443/api/version
+```
+
+For a controlled promotion that requires an outage, run `Preflight` immediately
+before the stop. After the reviewed artifact/config swap, use the wrapper to
+start and verify production as one operation:
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File `
+  .\core\deploy\echo-core-host-network-guard.ps1 -Action Preflight
+Stop-Service EchoCoreHost
+# Perform the reviewed, backed-up release mutation while Echo is stopped.
+powershell -NoProfile -ExecutionPolicy Bypass -File `
+  .\core\deploy\echo-core-host-network-guard.ps1 -Action Start
+```
+
+For a routine restart, use `-Action Restart`; it validates before mutation and
+verifies the new service/control PIDs and ingress afterward. These server-side
+assertions prove the process is not localhost-only, but they do not replace the
+separate-device LAN check or a genuine off-LAN check. Obtain both before the
+release is declared live.
+
 ## Echo preflight
 
 Run this before a release claim, after a reboot, or before live troubleshooting:
@@ -29,15 +106,22 @@ git status -sb
 git branch --show-current
 git rev-parse --short HEAD
 git rev-parse --short origin/main
+npm run verify:production-network:windows
 
-curl.exe -sk https://echo.fellowshipoftheboatrace.party:9443/api/version
-curl.exe -sk https://echo.fellowshipoftheboatrace.party:9443/health
-
+$activeHost = Get-Content "C:\ProgramData\Echo Chamber\echo-core-host.json" -Raw |
+  ConvertFrom-Json
+curl.exe -sk https://127.0.0.1:9443/api/version
+curl.exe -sk https://127.0.0.1:9443/health
 Get-Service EchoCoreHost
-Get-Content "C:\ProgramData\Echo Chamber\logs\echo-core-host.log" -Tail 20
+Get-Content (Join-Path $activeHost.logs_dir "echo-core-host.log") -Tail 20
+powershell -NoProfile -ExecutionPolicy Bypass -File `
+  .\core\deploy\echo-core-host-network-guard.ps1 -Action Verify
 ```
 
-Expected production state after v0.6.12: `/api/version` reports `0.6.12`, `/health` is OK, and the host log shows `control started ... F:\EC-worktrees\main\core\target\release\echo-core-control.exe`.
+Expected production state: `/api/version` reports the reviewed release version
+and Git SHA, `/health` is OK, and the host log's control path exactly matches
+the immutable `control_exe` path in the active host JSON. Do not use a stale
+hard-coded version or checkout path as release evidence.
 
 ## Start / stop
 
@@ -178,14 +262,17 @@ Use the full-snapshot publisher during an approved control-service outage:
 ```powershell
 # From a clean, up-to-date main checkout, verify code first.
 npm run verify:quick
-powershell -NoProfile -ExecutionPolicy Bypass -File .\core\deploy\test-viewer-runtime-lib.ps1
+npm run verify:production-network:windows
 
 # Stop EchoCoreHost/control before the swap. Deploy the matching control binary
 # in the same outage, then publish every viewer asset as one verified snapshot.
+powershell -NoProfile -ExecutionPolicy Bypass -File `
+  .\core\deploy\echo-core-host-network-guard.ps1 -Action Preflight
 Stop-Service EchoCoreHost
 powershell -NoProfile -ExecutionPolicy Bypass -File .\core\deploy\publish-viewer-runtime.ps1 `
   -RuntimeDirectory "F:\EC-runtime\echo-viewer"
-Start-Service EchoCoreHost
+powershell -NoProfile -ExecutionPolicy Bypass -File `
+  .\core\deploy\echo-core-host-network-guard.ps1 -Action Start
 
 # The verifier normalizes only control's expected index.html cache stamps.
 powershell -NoProfile -ExecutionPolicy Bypass -File .\core\deploy\publish-viewer-runtime.ps1 `
@@ -307,8 +394,9 @@ For an approved recovery outage:
 
 1. Run the Echo preflight and record the active `control_env_file` and its
    `CORE_SESSION_LOG_DIR`.
-2. Stop `EchoCoreHost`; the utility deliberately never stops or starts the
-   service and must not race the control plane's read-modify-write logger.
+2. Run the service guard's `Preflight` action immediately before stopping
+   `EchoCoreHost`; the utility deliberately never stops or starts the service
+   and must not race the control plane's read-modify-write logger.
 3. Rerun the reviewed command with `-Apply` and, preferably, an explicit new
    `-BackupDirectory`. The tool snapshots and hashes every existing destination
    session file before any destination write, deduplicates exact events, routes
@@ -318,8 +406,10 @@ For an approved recovery outage:
    never mutates service configuration. Keep private web diagnostics at its own
    stable restricted root so its existing identity key is never replaced by a
    release candidate's key.
-5. Start `EchoCoreHost`, confirm the control log reports the stable session
-   directory, then verify `/api/version`, `/health`, and Dashboard History.
+5. Start `EchoCoreHost` through the service guard's `Start` action, confirm the
+   control log reports the stable session directory, then verify `/api/version`,
+   `/health`, Dashboard History, another-device LAN access, and genuine off-LAN
+   access.
 
 Candidate promotion can fork more than Dashboard History. Audit every mutable
 path in the candidate environment, including `CORE_SOUNDBOARD_DIR`,
@@ -339,8 +429,9 @@ and remove only that exact file. Never use a glob or recursive deletion for this
 step. Then hash-verify every backup named in `destination_files`, restore it to
 the destination (prefer a same-directory staged atomic replacement), and verify
 the restored SHA-256 values plus the absence of every `created_paths` entry.
-Restore the prior environment file if it changed, then start and verify the
-service. Source files are read-only and remain untouched throughout recovery.
+Restore the prior environment file if it changed, then use the service guard's
+`Start` action to start and verify the service. Source files are read-only and
+remain untouched throughout recovery.
 
 ## Quick incident flow
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "Echo Chamber repo metadata. Active development lives under core/.",
   "scripts": {
     "verify:guardrails": "node tools/verify/guardrails.mjs",
-    "verify:production-network:windows": "powershell.exe -NoProfile -ExecutionPolicy Bypass -File core/deploy/test-production-network.ps1",
     "verify:viewer": "node --check core/viewer/app.js && node --check core/viewer/admin-history.js && node --check core/viewer/admin.js && node --check core/viewer/jam-visualizer.js && node --check core/viewer/jam.js && node --check core/viewer/ui-shell.js && node --check core/viewer/theme-runtime.js && node --check core/viewer/theme-effects.js && node --check core/viewer/theme.js && node --check core/viewer/capture-picker.js && node --check core/admin/diagnostics/diagnostics.js && node --test core/viewer/*.test.js",
     "verify:viewer:layout": "npm --prefix core/viewer-tests test",
     "verify:quick": "npm run verify:guardrails && npm run verify:viewer"

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Echo Chamber repo metadata. Active development lives under core/.",
   "scripts": {
     "verify:guardrails": "node tools/verify/guardrails.mjs",
+    "verify:production-network:windows": "powershell.exe -NoProfile -ExecutionPolicy Bypass -File core/deploy/test-production-network.ps1",
     "verify:viewer": "node --check core/viewer/app.js && node --check core/viewer/admin-history.js && node --check core/viewer/admin.js && node --check core/viewer/jam-visualizer.js && node --check core/viewer/jam.js && node --check core/viewer/ui-shell.js && node --check core/viewer/theme-runtime.js && node --check core/viewer/theme-effects.js && node --check core/viewer/theme.js && node --check core/viewer/capture-picker.js && node --check core/admin/diagnostics/diagnostics.js && node --test core/viewer/*.test.js",
     "verify:viewer:layout": "npm --prefix core/viewer-tests test",
     "verify:quick": "npm run verify:guardrails && npm run verify:viewer"

--- a/tools/verify/guardrails.mjs
+++ b/tools/verify/guardrails.mjs
@@ -171,7 +171,6 @@ function checkProductionNetworkGuardrails() {
   const serviceGuard = exists(serviceGuardPath) ? read(serviceGuardPath) : '';
   const serviceGuardTest = exists(serviceGuardTestPath) ? read(serviceGuardTestPath) : '';
   const windowsNetworkGate = exists(windowsNetworkGatePath) ? read(windowsNetworkGatePath) : '';
-  const packageJson = JSON.parse(read('package.json'));
 
   assert(
     /Production network reachability invariant[\s\S]*`CORE_BIND=0\.0\.0\.0`[\s\S]*`CORE_PORT=9443`/i.test(operations),
@@ -255,12 +254,11 @@ function checkProductionNetworkGuardrails() {
     'The Windows production network gate must execute library, canonical service, and watcher integration tests.',
   );
   assert(
-    packageJson.scripts?.['verify:production-network:windows'] ===
-      'powershell.exe -NoProfile -ExecutionPolicy Bypass -File core/deploy/test-production-network.ps1',
-    'package.json must expose the Windows production network verification gate.',
+    /function Run-Tests[\s\S]*test-production-network\.ps1[\s\S]*Production network tests FAILED/i.test(deployWatcher),
+    'The Windows deploy watcher must execute the production network verification gate.',
   );
   assert(
-    /npm run verify:production-network:windows/i.test(operations),
+    /powershell\.exe -NoProfile -ExecutionPolicy Bypass -File[\s\S]*test-production-network\.ps1/i.test(operations),
     'docs/OPERATIONS.md must run the Windows production network verification gate during release preflight.',
   );
   assert(

--- a/tools/verify/guardrails.mjs
+++ b/tools/verify/guardrails.mjs
@@ -157,11 +157,132 @@ function checkCodexOperatingModelGuardrails() {
   );
 }
 
+function checkProductionNetworkGuardrails() {
+  const operations = read('docs/OPERATIONS.md');
+  const networkGuard = read('core/deploy/production-network-lib.ps1');
+  const deployWatcher = read('core/deploy/deploy-watcher.ps1');
+  const agents = read('AGENTS.md');
+  const serviceGuardPath = 'core/deploy/echo-core-host-network-guard.ps1';
+  const serviceGuardTestPath = 'core/deploy/test-echo-core-host-network-guard.ps1';
+  const windowsNetworkGatePath = 'core/deploy/test-production-network.ps1';
+  assert(exists(serviceGuardPath), `${serviceGuardPath} must guard the canonical production service.`);
+  assert(exists(serviceGuardTestPath), `${serviceGuardTestPath} must cover the canonical production service guard.`);
+  assert(exists(windowsNetworkGatePath), `${windowsNetworkGatePath} must execute the Windows production network tests.`);
+  const serviceGuard = exists(serviceGuardPath) ? read(serviceGuardPath) : '';
+  const serviceGuardTest = exists(serviceGuardTestPath) ? read(serviceGuardTestPath) : '';
+  const windowsNetworkGate = exists(windowsNetworkGatePath) ? read(windowsNetworkGatePath) : '';
+  const packageJson = JSON.parse(read('package.json'));
+
+  assert(
+    /Production network reachability invariant[\s\S]*`CORE_BIND=0\.0\.0\.0`[\s\S]*`CORE_PORT=9443`/i.test(operations),
+    'docs/OPERATIONS.md must preserve the production CORE_BIND=0.0.0.0 and CORE_PORT=9443 invariant.',
+  );
+  assert(
+    /candidate loopback bind must never be copied into the production environment/i.test(operations),
+    'docs/OPERATIONS.md must forbid promoting a candidate loopback bind to production.',
+  );
+  assert(
+    /`hosts` file overrides public DNS resolution[\s\S]*public-hostname `curl`[\s\S]*local-only service check/i.test(operations),
+    'docs/OPERATIONS.md must warn that a server hosts override makes public-hostname curl local-only.',
+  );
+  assert(
+    /Loopback \(server\):[\s\S]*LAN \(another device\):[\s\S]*External \(off-LAN\):/i.test(operations),
+    'docs/OPERATIONS.md must require independent loopback, LAN, and external production verification.',
+  );
+  assert(
+    /echo-core-host-network-guard\.ps1[\s\S]*-Action Preflight[\s\S]*-Action Start[\s\S]*-Action Restart/i.test(operations),
+    'docs/OPERATIONS.md must require the canonical guard before and after manual service mutations.',
+  );
+  assert(
+    /function Assert-ProductionControlEnvironment[\s\S]*function Assert-ProductionControlIngress/i.test(networkGuard),
+    'The committed production network guard must expose environment and ingress assertions.',
+  );
+  assert(
+    /production-network-lib\.ps1[\s\S]*Assert-WatcherProductionEnvironment[\s\S]*Assert-WatcherProductionActivation/i.test(deployWatcher),
+    'The deploy watcher must load and enforce the production network guard before and after activation.',
+  );
+  assert(
+    /C:\\ProgramData\\Echo Chamber\\echo-core-host\.json[\s\S]*Assert-ProductionControlEnvironment[\s\S]*ServiceMutationProvider[\s\S]*Wait-EchoCoreHostProductionIngress/i.test(serviceGuard),
+    'The canonical service guard must validate the active host environment before mutating and verify ingress afterward.',
+  );
+  assert(
+    /exactly one direct echo-core-control\.exe child[\s\S]*Assert-ProductionControlListener[\s\S]*Assert-ProductionControlLanProbe/i.test(serviceGuard),
+    'The canonical service guard must bind ingress verification to exactly one direct control child.',
+  );
+  assert(
+    /VerificationAttempts[\s\S]*for \(\$attempt = 1; \$attempt -le \$Attempts; \$attempt\+\+\)/i.test(serviceGuard),
+    'The canonical service guard must use bounded post-start verification retries.',
+  );
+  assert(
+    /CORE_BIND=127\.0\.0\.1[\s\S]*unsafe config never reaches the service mutation provider[\s\S]*localhost-only live child never passes post-start verification/i.test(serviceGuardTest),
+    'The canonical service guard tests must reject localhost-only configuration before and after activation.',
+  );
+  assert(
+    !/\[string\]\$HostConfigPath/i.test(serviceGuard) &&
+      /\$canonicalHostConfigPath = "C:\\ProgramData\\Echo Chamber\\echo-core-host\.json"[\s\S]*-ConfigPath \$canonicalHostConfigPath/i.test(serviceGuard),
+    'The production service entry point must not expose a host-config override and must always use the canonical ProgramData JSON.',
+  );
+  assert(
+    /fully qualified Windows drive-rooted path[\s\S]*Guarded Start requires EchoCoreHost to be Stopped[\s\S]*Guarded Restart did not replace either/i.test(serviceGuard),
+    'The canonical service guard must reject ambiguous env paths and prove Start/Restart transitions.',
+  );
+  assert(
+    /top-level JSON object[\s\S]*root must deserialize to a PSCustomObject[\s\S]*control_env_file must be a JSON string/i.test(serviceGuard),
+    'The canonical service guard must enforce the Rust HostConfig JSON object/string shape under PowerShell 5.1.',
+  );
+  assert(
+    /Stop-EchoCoreHostAfterFailedMutation[\s\S]*EchoAncillaryLanFailure[\s\S]*EchoSafeNoTransition[\s\S]*Stop-EchoCoreHostAfterFailedMutation @cleanupArgs/i.test(serviceGuard),
+    'Hard post-mutation failures must stop partial-live state without treating ancillary LAN failures or a proven-safe no-op as hard.',
+  );
+  assert(
+    /mutationProviderFailed[\s\S]*Assert-EchoCoreHostProductionHardSafetyOnce[\s\S]*safeUnchangedMutationFailure[\s\S]*Stop-EchoCoreHostAfterFailedMutation @cleanupArgs/i.test(serviceGuard),
+    'A throwing service mutation must preserve only unchanged hard-safe service/control PIDs and clean up all other post-error states.',
+  );
+  assert(
+    /already-running service before mutation[\s\S]*unchanged service and control PID[\s\S]*safe no-op Restart preserves[\s\S]*unsafe no-op Restart stops[\s\S]*ancillary LAN failure does not stop/i.test(serviceGuardTest),
+    'The canonical service tests must cover transition proof and hard-versus-ancillary cleanup behavior.',
+  );
+  assert(
+    /non-object host JSON root is rejected[\s\S]*non-PSCustomObject host root is rejected[\s\S]*non-string control_env_file is rejected/i.test(serviceGuardTest),
+    'The canonical service tests must cover PowerShell 5.1 HostConfig root and field type rejection.',
+  );
+  assert(
+    /throwing provider does not stop unchanged hard-safe[\s\S]*throwing provider with changed PIDs stops[\s\S]*throwing provider stops unchanged PIDs when hard safety cannot be proven/i.test(serviceGuardTest),
+    'The canonical service tests must cover safe preservation and cleanup after a throwing mutation provider.',
+  );
+  assert(
+    /test-production-network-lib\.ps1[\s\S]*test-echo-core-host-network-guard\.ps1[\s\S]*test-viewer-runtime-lib\.ps1/i.test(windowsNetworkGate),
+    'The Windows production network gate must execute library, canonical service, and watcher integration tests.',
+  );
+  assert(
+    packageJson.scripts?.['verify:production-network:windows'] ===
+      'powershell.exe -NoProfile -ExecutionPolicy Bypass -File core/deploy/test-production-network.ps1',
+    'package.json must expose the Windows production network verification gate.',
+  );
+  assert(
+    /npm run verify:production-network:windows/i.test(operations),
+    'docs/OPERATIONS.md must run the Windows production network verification gate during release preflight.',
+  );
+  assert(
+    /echo-core-host-network-guard\.ps1[\s\S]*Preflight[\s\S]*genuine off-LAN verification/i.test(agents),
+    'AGENTS.md must require the canonical service guard and genuine off-LAN verification.',
+  );
+
+  for (const file of listFiles('core/deploy', (candidate) => /\.ps1$/i.test(candidate))) {
+    if (file === serviceGuardPath) continue;
+    assert(
+      !/(?:Start|Restart)-Service\s+(?:-Name\s+)?["']?EchoCoreHost\b/i.test(read(file)),
+      `${file} must route EchoCoreHost Start/Restart through the canonical production service guard.`,
+    );
+  }
+}
+
 checkWorkflowGuardrails();
 checkRootPackageGuardrails();
 checkCargoWorkspaceGuardrails();
 checkArchiveGuardrails();
 checkCodexOperatingModelGuardrails();
+checkProductionNetworkGuardrails();
 
 if (failures.length > 0) {
   console.error('[guardrails] failed');


### PR DESCRIPTION
## Summary

- require production `CORE_BIND=0.0.0.0` and `CORE_PORT=9443` before activation
- add a canonical `EchoCoreHost` Start/Restart/Verify guard tied to the ProgramData host config and exact service-owned control PID
- require loopback health, wildcard listener ownership, LAN ingress, real service transitions, and hard-failure cleanup
- preserve a proven-safe old process for no-op restart errors or transient ancillary LAN probe failures
- harden the legacy deploy watcher preflight/rollback path
- document independent loopback, separate-device LAN, and genuine off-LAN verification

## Incident

Production was accidentally promoted with `CORE_BIND=127.0.0.1`. A local hosts-file override made the public-hostname smoke test hit loopback, so local checks passed while remote users could not reach Echo.

## Verification

- `npm run verify:production-network:windows`
- `npm run verify:quick` (272 viewer tests)
- PowerShell 5.1 parser checks for all 7 affected scripts
- `git diff --check`
- canonical live read-only guard: service PID -> exact control child -> loopback health -> `0.0.0.0:9443` -> LAN probe, attempt 1
- fresh external HTTP probes: 4 independent regions returned 200
- two independent final reviews: PASS, no remaining P1/P2 findings

## Release impact

Server operations/deployment safeguards and documentation only. No desktop binary or installer change. The production service was repaired separately and is not restarted by merging this PR.