### PR TITLE
Fix responsive Stage and fullscreen geometry

### DIFF
--- a/core/viewer-tests/README.md
+++ b/core/viewer-tests/README.md
@@ -35,6 +35,23 @@ npm test
 ```
 
 From the repository root, use `npm run verify:viewer:layout` after setup.
+Set `PORT` to an available loopback port when a fixed test port is unsuitable;
+the Playwright base URL and test server use the same value. Set
+`ECHO_VIEWER_TEST_OUTPUT_DIR` to keep reports and failure artifacts outside the
+worktree.
+
+For a clearly labeled, disconnected Stage/layout preview on Windows:
+
+```powershell
+$env:PORT = "0"
+$env:ECHO_LAYOUT_PREVIEW = "1"
+node .\scripts\serve-viewer.mjs
+```
+
+Open the loopback URL printed by the server. Query options can select
+`aspect=16-9|16-10|21-9|32-9|4-3|portrait`, `shares=1..6`,
+`participants=0..12`, and `cameras=0..participants`. The fixture uses
+deterministic canvas media and does not connect to LiveKit or production.
 
 For a clearly labeled, disconnected Jam workspace preview on Windows:
 

--- a/core/viewer-tests/playwright.config.mjs
+++ b/core/viewer-tests/playwright.config.mjs
@@ -1,4 +1,17 @@
+import path from "node:path";
 import { defineConfig, devices } from "@playwright/test";
+
+const port = Number.parseInt(process.env.PORT || "4175", 10);
+if (!Number.isInteger(port) || port < 1 || port > 65535 || port === 9443) {
+  throw new Error(`unsafe viewer test port: ${process.env.PORT || ""}`);
+}
+
+const baseURL = `http://127.0.0.1:${port}`;
+const artifactRoot = process.env.ECHO_VIEWER_TEST_OUTPUT_DIR
+  ? path.resolve(process.env.ECHO_VIEWER_TEST_OUTPUT_DIR)
+  : null;
+const htmlReport = artifactRoot ? path.join(artifactRoot, "playwright-report") : "playwright-report";
+const testResults = artifactRoot ? path.join(artifactRoot, "test-results") : "test-results";
 
 export default defineConfig({
   testDir: "./tests",
@@ -7,14 +20,15 @@ export default defineConfig({
   retries: process.env.CI ? 1 : 0,
   workers: process.env.CI ? 1 : undefined,
   reporter: process.env.CI
-    ? [["line"], ["html", { open: "never" }]]
-    : [["list"], ["html", { open: "never" }]],
+    ? [["line"], ["html", { open: "never", outputFolder: htmlReport }]]
+    : [["list"], ["html", { open: "never", outputFolder: htmlReport }]],
+  outputDir: testResults,
   timeout: 30_000,
   expect: {
     timeout: 5_000,
   },
   use: {
-    baseURL: "http://127.0.0.1:4175",
+    baseURL,
     headless: true,
     reducedMotion: "reduce",
     screenshot: "only-on-failure",
@@ -31,7 +45,11 @@ export default defineConfig({
   ],
   webServer: {
     command: "node ./scripts/serve-viewer.mjs",
-    url: "http://127.0.0.1:4175/healthz",
+    env: {
+      ...process.env,
+      PORT: String(port),
+    },
+    url: `${baseURL}/healthz`,
     reuseExistingServer: false,
     timeout: 30_000,
   },

--- a/core/viewer-tests/scripts/serve-viewer.mjs
+++ b/core/viewer-tests/scripts/serve-viewer.mjs
@@ -8,10 +8,11 @@ const viewerRoot = path.resolve(scriptDirectory, "..", "..", "viewer");
 const adminRoot = path.resolve(scriptDirectory, "..", "..", "admin");
 const previewFixture = path.resolve(scriptDirectory, "..", "fixtures", "install-scenario.js");
 const port = Number.parseInt(process.env.PORT || "4175", 10);
+const isolatedLayoutPreview = process.env.ECHO_LAYOUT_PREVIEW === "1";
 const isolatedThemePreview = process.env.ECHO_THEME_PREVIEW === "1";
 const isolatedJamPreview = process.env.ECHO_JAM_PREVIEW === "1";
 const isolatedHistoryPreview = process.env.ECHO_HISTORY_PREVIEW === "1";
-const isolatedPreview = isolatedThemePreview || isolatedJamPreview || isolatedHistoryPreview;
+const isolatedPreview = isolatedLayoutPreview || isolatedThemePreview || isolatedJamPreview || isolatedHistoryPreview;
 const transparentPng = Buffer.from(
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=",
   "base64",
@@ -162,6 +163,51 @@ function send(response, statusCode, body, contentType) {
   response.end(body);
 }
 
+const layoutPreviewAspects = Object.freeze({
+  "16-9": 16 / 9,
+  "16-10": 16 / 10,
+  "21-9": 21 / 9,
+  "32-9": 32 / 9,
+  "4-3": 4 / 3,
+  portrait: 9 / 16,
+});
+
+function boundedPreviewCount(searchParams, name, fallback, minimum, maximum) {
+  const raw = searchParams.get(name);
+  if (raw === null || !/^\d{1,2}$/.test(raw)) return fallback;
+  const value = Number.parseInt(raw, 10);
+  return Math.min(maximum, Math.max(minimum, value));
+}
+
+function layoutPreviewScenario(requestUrl) {
+  const aspectName = requestUrl.searchParams.get("aspect")
+    || requestUrl.searchParams.get("source-aspect")
+    || "16-9";
+  const aspect = Object.prototype.hasOwnProperty.call(layoutPreviewAspects, aspectName)
+    ? layoutPreviewAspects[aspectName]
+    : layoutPreviewAspects["16-9"];
+  const participants = boundedPreviewCount(requestUrl.searchParams, "participants", 5, 0, 12);
+  const screenShares = boundedPreviewCount(requestUrl.searchParams, "shares", 1, 1, 6);
+  const requestedCameras = boundedPreviewCount(
+    requestUrl.searchParams,
+    "cameras",
+    Math.min(3, participants),
+    0,
+    participants,
+  );
+  const localCamera = requestedCameras > 0;
+
+  return {
+    participants,
+    cameras: Math.max(0, requestedCameras - (localCamera ? 1 : 0)),
+    screenShares,
+    shareAspects: Array(screenShares).fill(aspect),
+    chatOpen: false,
+    localCamera,
+    screenOwners: Array(screenShares).fill(0),
+  };
+}
+
 function resolveStaticFile(requestUrl) {
   const url = new URL(requestUrl, `http://127.0.0.1:${port}`);
   const pathname = decodeURIComponent(url.pathname);
@@ -186,12 +232,15 @@ function resolveStaticFile(requestUrl) {
   return candidate;
 }
 
-function injectIsolatedPreview(html) {
-  const previewName = isolatedJamPreview
-    ? "Isolated Jam Preview"
-    : isolatedHistoryPreview
-      ? "Isolated Dashboard History Preview"
-      : "Isolated Theme Preview";
+function injectIsolatedPreview(html, rawRequestUrl) {
+  const requestUrl = new URL(rawRequestUrl, `http://127.0.0.1:${port}`);
+  const previewName = isolatedLayoutPreview
+    ? "Isolated Layout Preview"
+    : isolatedJamPreview
+      ? "Isolated Jam Preview"
+      : isolatedHistoryPreview
+        ? "Isolated Dashboard History Preview"
+        : "Isolated Theme Preview";
   const earlyBootstrap = `
     <script>
       (function () {
@@ -283,8 +332,13 @@ function injectIsolatedPreview(html) {
       <small>localhost fixture · no production connection</small>
     </div>
   `;
-  const openPreview = isolatedJamPreview
+  const openPreview = isolatedLayoutPreview
     ? `
+          if (typeof setThemeStudioOpen === "function") setThemeStudioOpen(false);
+          if (typeof closeJamPanel === "function") closeJamPanel({ restoreFocus: false });
+      `
+    : isolatedJamPreview
+      ? `
           if (typeof setThemeStudioOpen === "function") setThemeStudioOpen(false);
           if (typeof adminToken !== "undefined") adminToken = "isolated-jam-preview-admin";
           if (typeof currentAccessToken !== "undefined") currentAccessToken = "isolated-jam-preview-participant";
@@ -307,24 +361,27 @@ function injectIsolatedPreview(html) {
             switchAdminTab(historyTab, "admin-dash-history");
           }
       `
-      : `
+        : `
           if (typeof setThemeStudioOpen === "function") setThemeStudioOpen(true);
-      `;
+        `;
+  const scenarioOptions = isolatedLayoutPreview
+    ? layoutPreviewScenario(requestUrl)
+    : {
+        participants: 5,
+        cameras: 3,
+        screenShares: 1,
+        shareAspects: [16 / 9],
+        chatOpen: false,
+        localCamera: true,
+        screenOwners: [0],
+      };
   const scenario = `
     <script src="/__echo-preview-fixture.js"></script>
     <script>
       window.addEventListener("load", function () {
         var fixture = window.EchoLayoutTestScenario;
         if (!fixture) return;
-        fixture.install({
-          participants: 5,
-          cameras: 3,
-          screenShares: 1,
-          shareAspects: [16 / 9],
-          chatOpen: false,
-          localCamera: true,
-          screenOwners: [0]
-        }).then(function () {
+        fixture.install(${JSON.stringify(scenarioOptions)}).then(function () {
           document.documentElement.dataset.echoIsolatedPreviewReady = "true";
           ${openPreview}
         }).catch(function (error) {
@@ -458,7 +515,7 @@ const server = http.createServer(async (request, response) => {
       isolatedPreview &&
       filePath === path.join(viewerRoot, "index.html")
     ) {
-      body = injectIsolatedPreview(body.toString("utf8"));
+      body = injectIsolatedPreview(body.toString("utf8"), request.url || "/");
     }
     const contentType = contentTypes.get(path.extname(filePath).toLowerCase()) || "application/octet-stream";
     response.writeHead(200, {
@@ -474,15 +531,19 @@ const server = http.createServer(async (request, response) => {
 });
 
 server.listen(port, "127.0.0.1", () => {
-  const previewLabel = isolatedJamPreview
-    ? " [ISOLATED JAM PREVIEW]"
-    : isolatedThemePreview
-      ? " [ISOLATED THEME PREVIEW]"
-      : isolatedHistoryPreview
-        ? " [ISOLATED HISTORY PREVIEW]"
-        : "";
+  const address = server.address();
+  const boundPort = address && typeof address === "object" ? address.port : port;
+  const previewLabel = isolatedLayoutPreview
+    ? " [ISOLATED LAYOUT PREVIEW]"
+    : isolatedJamPreview
+      ? " [ISOLATED JAM PREVIEW]"
+      : isolatedThemePreview
+        ? " [ISOLATED THEME PREVIEW]"
+        : isolatedHistoryPreview
+          ? " [ISOLATED HISTORY PREVIEW]"
+          : "";
   console.log(
-    `[viewer-tests] serving ${viewerRoot} and ${adminRoot} at http://127.0.0.1:${port}${previewLabel}`,
+    `[viewer-tests pid=${process.pid}] serving ${viewerRoot} and ${adminRoot} at http://127.0.0.1:${boundPort}${previewLabel}`,
   );
 });
 

--- a/core/viewer-tests/tests/admin-diagnostics.spec.js
+++ b/core/viewer-tests/tests/admin-diagnostics.spec.js
@@ -198,6 +198,7 @@ test("test server keeps admin assets isolated while preserving the viewer root",
 });
 
 test("a blocked diagnostics script cannot serialize the owner secret into a request or URL", async ({
+  baseURL,
   page,
 }) => {
   const observedRequests = [];
@@ -215,7 +216,7 @@ test("a blocked diagnostics script cannot serialize the owner secret into a requ
 
   const finalUrl = new URL(page.url());
   expect(`${finalUrl.origin}${finalUrl.pathname}`).toBe(
-    "http://127.0.0.1:4175/admin/diagnostics/",
+    new URL("/admin/diagnostics/", baseURL).href,
   );
   expect([...finalUrl.searchParams]).toHaveLength(0);
   expect(finalUrl.hash).toBe("");
@@ -224,6 +225,7 @@ test("a blocked diagnostics script cannot serialize the owner secret into a requ
 });
 
 test("credentials stay memory-only, exact, omitted from cookies, and clear on lifecycle boundaries", async ({
+  baseURL,
   page,
 }) => {
   const loginBodies = [];
@@ -232,7 +234,7 @@ test("credentials stay memory-only, exact, omitted from cookies, and clear on li
   await page.context().addCookies([{
     name: "unrelated-cookie",
     value: "must-not-be-sent",
-    url: "http://127.0.0.1:4175",
+    url: new URL("/", baseURL).href,
   }]);
   await installApiMock(page, {
     login: async (route) => {

--- a/core/viewer-tests/tests/shell.phase1.spec.js
+++ b/core/viewer-tests/tests/shell.phase1.spec.js
@@ -538,6 +538,13 @@ test("a retained hidden share enters solo presentation and restores the multi-sh
   await expect(firstTile).toHaveAttribute("data-grid-visible", "");
   await expect(secondTile).not.toHaveAttribute("data-grid-visible", "");
   await expect(grid.locator(":scope > .tile[data-grid-visible]")).toHaveCount(1);
+  await expect.poll(() => page.evaluate(() => {
+    const gridElement = document.getElementById("screen-grid");
+    const visibleTile = gridElement.querySelector(":scope > .tile[data-grid-visible]");
+    const gridRect = gridElement.getBoundingClientRect();
+    const visibleRect = visibleTile.getBoundingClientRect();
+    return (visibleRect.width * visibleRect.height) / (gridRect.width * gridRect.height);
+  }), { message: "the retained share should settle into solo Stage geometry" }).toBeGreaterThanOrEqual(0.95);
 
   const solo = await page.evaluate(() => {
     const gridElement = document.getElementById("screen-grid");

--- a/core/viewer-tests/tests/stage.fullscreen.spec.js
+++ b/core/viewer-tests/tests/stage.fullscreen.spec.js
@@ -1,0 +1,982 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, test } from "@playwright/test";
+
+const testDirectory = path.dirname(fileURLToPath(import.meta.url));
+const fixturePath = path.resolve(testDirectory, "..", "fixtures", "install-scenario.js");
+const runtimeErrors = new WeakMap();
+const transparentPng = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=",
+  "base64",
+);
+const viewerMatrix = Object.freeze([
+  Object.freeze({ height: 768, label: "1366x768", width: 1366 }),
+  Object.freeze({ height: 1080, label: "1920x1080", width: 1920 }),
+  Object.freeze({ height: 1440, label: "2560x1440", width: 2560 }),
+  Object.freeze({ height: 2160, label: "3840x2160", width: 3840 }),
+  Object.freeze({ height: 1440, label: "3440x1440", width: 3440 }),
+  Object.freeze({ height: 1440, label: "5120x1440", width: 5120 }),
+]);
+const sourceMatrix = Object.freeze([
+  Object.freeze({ aspect: 16 / 9, label: "16:9" }),
+  Object.freeze({ aspect: 16 / 10, label: "16:10" }),
+  Object.freeze({ aspect: 21 / 9, label: "21:9" }),
+  Object.freeze({ aspect: 32 / 9, label: "32:9" }),
+  Object.freeze({ aspect: 4 / 3, label: "4:3" }),
+  Object.freeze({ aspect: 9 / 16, label: "portrait" }),
+]);
+
+test.beforeEach(async ({ page }) => {
+  const errors = [];
+  runtimeErrors.set(page, errors);
+  page.on("pageerror", (error) => errors.push(`pageerror: ${error.message}`));
+  page.on("console", (message) => {
+    if (message.type() === "error") errors.push(`console.error: ${message.text()}`);
+  });
+
+  await page.route("**/api/**", async (route) => {
+    const url = new URL(route.request().url());
+    if (url.pathname === "/api/online") {
+      await route.fulfill({ status: 200, contentType: "application/json", body: "[]" });
+      return;
+    }
+    if (url.pathname.startsWith("/api/avatar/")) {
+      await route.fulfill({ status: 200, contentType: "image/png", body: transparentPng });
+      return;
+    }
+    if (url.pathname === "/api/version") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ latest_client: "" }),
+      });
+      return;
+    }
+    errors.push(`unexpected API request: ${route.request().method()} ${url.pathname}`);
+    await route.fulfill({
+      status: 501,
+      contentType: "application/json",
+      body: JSON.stringify({ error: "unmodeled viewer-test endpoint" }),
+    });
+  });
+});
+
+test.afterEach(async ({ page }) => {
+  await page.waitForTimeout(25);
+  expect(runtimeErrors.get(page) || [], "production page must run without runtime errors").toEqual([]);
+});
+
+async function waitForLayout(page, frameCount = 2) {
+  await page.evaluate((count) => new Promise((resolve) => {
+    function nextFrame(remaining) {
+      if (remaining <= 0) {
+        resolve();
+        return;
+      }
+      requestAnimationFrame(() => nextFrame(remaining - 1));
+    }
+    nextFrame(count);
+  }), frameCount);
+}
+
+async function resizeViewport(page, viewport) {
+  await page.setViewportSize({ height: viewport.height, width: viewport.width });
+  await expect.poll(
+    () => page.evaluate(() => ({ height: window.innerHeight, width: window.innerWidth })),
+    { message: `viewport should settle at ${viewport.width}x${viewport.height}` },
+  ).toEqual({ height: viewport.height, width: viewport.width });
+  await waitForLayout(page, 3);
+}
+
+async function emulateFullscreenViewport(page, viewport, deviceScaleFactor = 1) {
+  const session = await page.context().newCDPSession(page);
+  await session.send("Emulation.setDeviceMetricsOverride", {
+    deviceScaleFactor,
+    height: viewport.height,
+    mobile: false,
+    screenHeight: viewport.height,
+    screenWidth: viewport.width,
+    width: viewport.width,
+  });
+  await expect.poll(
+    () => page.evaluate(() => ({ height: window.innerHeight, width: window.innerWidth })),
+    { message: `fullscreen viewport should settle at ${viewport.width}x${viewport.height}` },
+  ).toEqual({ height: viewport.height, width: viewport.width });
+  await waitForLayout(page, 3);
+  return session;
+}
+
+async function openStageFixture(page, scenario) {
+  await page.goto("/?echo-ui-shell-v2=1", { waitUntil: "domcontentloaded" });
+  await expect(page.locator("html")).toHaveAttribute("data-ui-shell", "v2");
+  await page.addScriptTag({ path: fixturePath });
+  return page.evaluate((options) => window.EchoLayoutTestScenario.install(options), scenario);
+}
+
+async function closeClubhouseTools(page) {
+  const toolsToggle = page.getByRole("button", { name: "Hide clubhouse tools" });
+  if (await toolsToggle.isVisible()) {
+    await toolsToggle.click();
+    await waitForLayout(page, 3);
+  }
+}
+
+function screenTile(page, index = 0) {
+  return page.locator("#screen-grid > .tile").nth(index);
+}
+
+async function rememberStableNodes(page, key, index = 0) {
+  await page.evaluate(({ index: tileIndex, key: storageKey }) => {
+    const tile = document.querySelectorAll("#screen-grid > .tile")[tileIndex];
+    if (!tile) throw new Error(`missing screen tile ${tileIndex}`);
+    window.__fullscreenRegressionNodes ||= Object.create(null);
+    window.__fullscreenRegressionNodes[storageKey] = {
+      button: tile.querySelector(".tile-fullscreen-btn"),
+      tile,
+      video: tile.querySelector("video.screen-video-surface"),
+    };
+  }, { index, key });
+}
+
+async function readStableNodeState(page, key, index = 0) {
+  return page.evaluate(({ index: tileIndex, key: storageKey }) => {
+    const remembered = window.__fullscreenRegressionNodes?.[storageKey];
+    const tile = document.querySelectorAll("#screen-grid > .tile")[tileIndex];
+    const video = tile?.querySelector("video.screen-video-surface") || null;
+    const button = tile?.querySelector(".tile-fullscreen-btn") || null;
+    return {
+      buttonIdentityPreserved: button === remembered?.button,
+      fullscreenHints: document.querySelectorAll(".fullscreen-hint").length,
+      fullscreenHosts: document.querySelectorAll(".fullscreen-video-wrapper").length,
+      tileIdentityPreserved: tile === remembered?.tile,
+      tileOwnsVideo: video?.parentElement === tile,
+      topLevelFullscreenHosts: document.querySelectorAll("body > .fullscreen-video-wrapper").length,
+      videoCount: tile?.querySelectorAll("video.screen-video-surface").length || 0,
+      videoIdentityPreserved: video === remembered?.video,
+    };
+  }, { index, key });
+}
+
+async function enterStableFullscreen(page, index = 0) {
+  const tile = screenTile(page, index);
+  await tile.locator(".tile-fullscreen-btn").click();
+  await expect.poll(
+    () => tile.evaluate((element) => document.fullscreenElement === element),
+    { message: `tile ${index} should become the fullscreen element` },
+  ).toBe(true);
+  await waitForLayout(page);
+  return tile;
+}
+
+async function exitFullscreenProgrammatically(page) {
+  await page.evaluate(async () => {
+    if (document.fullscreenElement) await document.exitFullscreen();
+  });
+  await expect.poll(() => page.evaluate(() => document.fullscreenElement === null)).toBe(true);
+  await waitForLayout(page, 3);
+}
+
+async function exitFullscreenThroughControl(page, index = 0) {
+  const tile = screenTile(page, index);
+  await tile.getByRole("button", { name: "Exit shared screen fullscreen" }).click();
+  await expect.poll(() => page.evaluate(() => document.fullscreenElement === null)).toBe(true);
+  await waitForLayout(page, 3);
+}
+
+async function ensureFullscreenExited(page) {
+  if (page.isClosed()) return;
+  await page.evaluate(async () => {
+    if (document.fullscreenElement) {
+      try {
+        await document.exitFullscreen();
+      } catch (_error) {
+        // The assertion that triggered cleanup reports the useful failure.
+      }
+    }
+  });
+  await expect.poll(() => page.evaluate(() => document.fullscreenElement === null)).toBe(true);
+  await expect.poll(
+    () => page.locator(".fullscreen-video-wrapper").count(),
+    { message: "fullscreen presentation classes should be cleaned up" },
+  ).toBe(0);
+  await waitForLayout(page, 3);
+}
+
+async function showOnlyShare(page, index) {
+  await page.evaluate((visibleIndex) => {
+    const grid = document.getElementById("screen-grid");
+    grid.classList.remove("is-focused");
+    Array.from(grid.querySelectorAll(":scope > .tile")).forEach((tile, tileIndex) => {
+      tile.classList.remove("is-focused");
+      tile.style.display = tileIndex === visibleIndex ? "" : "none";
+    });
+    if (typeof window._echoRecalcGrid === "function") window._echoRecalcGrid();
+  }, index);
+  await waitForLayout(page, 3);
+  await expect(page.locator("#screen-grid")).toHaveAttribute("data-visible-tiles", "1");
+  await expect(screenTile(page, index)).toBeVisible();
+  await expect.poll(() => page.evaluate((visibleIndex) => {
+    const grid = document.getElementById("screen-grid");
+    const tile = grid.querySelectorAll(":scope > .tile")[visibleIndex];
+    const gridBounds = grid.getBoundingClientRect();
+    const tileBounds = tile.getBoundingClientRect();
+    const gridArea = gridBounds.width * gridBounds.height;
+    return gridArea > 0 ? (tileBounds.width * tileBounds.height) / gridArea : 0;
+  }, index), { message: `share ${index} should settle into the solo Stage` }).toBeGreaterThanOrEqual(0.96);
+}
+
+async function capturePresentation(page, index = 0) {
+  return page.evaluate((tileIndex) => {
+    function rect(element) {
+      const bounds = element.getBoundingClientRect();
+      return {
+        area: bounds.width * bounds.height,
+        bottom: bounds.bottom,
+        height: bounds.height,
+        left: bounds.left,
+        right: bounds.right,
+        top: bounds.top,
+        width: bounds.width,
+      };
+    }
+
+    function contain(bounds, aspectRatio) {
+      let width = bounds.width;
+      let height = width / aspectRatio;
+      if (height > bounds.height) {
+        height = bounds.height;
+        width = height * aspectRatio;
+      }
+      const left = bounds.left + (bounds.width - width) / 2;
+      const top = bounds.top + (bounds.height - height) / 2;
+      return {
+        area: width * height,
+        bottom: top + height,
+        height,
+        left,
+        right: left + width,
+        top,
+        width,
+      };
+    }
+
+    const grid = document.getElementById("screen-grid");
+    const tile = grid.querySelectorAll(":scope > .tile")[tileIndex];
+    const video = tile.querySelector("video.screen-video-surface");
+    const control = tile.querySelector(".tile-fullscreen-btn");
+    const stage = tile.closest(".room-main");
+    const dock = document.getElementById("call-controls");
+    const fullscreenIsTile = document.fullscreenElement === tile;
+    const gridRect = rect(grid);
+    const tileRect = rect(tile);
+    const videoRect = rect(video);
+    const controlRect = rect(control);
+    const containerRect = fullscreenIsTile ? tileRect : gridRect;
+    const sourceAspect = video.videoWidth / video.videoHeight;
+    const contentRect = contain(videoRect, sourceAspect);
+    const optimalContentRect = contain(containerRect, sourceAspect);
+    const controlStyle = getComputedStyle(control);
+    const hitTarget = document.elementFromPoint(
+      controlRect.left + controlRect.width / 2,
+      controlRect.top + controlRect.height / 2,
+    );
+
+    return {
+      container: containerRect,
+      content: contentRect,
+      contentCoverage: optimalContentRect.area > 0 ? contentRect.area / optimalContentRect.area : 0,
+      control: controlRect,
+      controlHitTarget: control === hitTarget || control.contains(hitTarget),
+      controlVisible: controlRect.width > 0 && controlRect.height > 0 &&
+        controlStyle.display !== "none" && controlStyle.visibility !== "hidden",
+      datasetAspect: Number.parseFloat(tile.dataset.aspectRatio),
+      dock: rect(dock),
+      fullscreenIsTile,
+      grid: gridRect,
+      gridOverflowX: grid.scrollWidth - grid.clientWidth,
+      gridOverflowY: grid.scrollHeight - grid.clientHeight,
+      objectFit: getComputedStyle(video).objectFit,
+      pageOverflowX: document.documentElement.scrollWidth - document.documentElement.clientWidth,
+      pageOverflowY: document.documentElement.scrollHeight - document.documentElement.clientHeight,
+      publishedAspect: Number.parseFloat(tile.style.getPropertyValue("--screen-source-aspect-ratio")),
+      sourceAspect,
+      sourceHeight: video.videoHeight,
+      sourceWidth: video.videoWidth,
+      stage: rect(stage),
+      tile: tileRect,
+      tileCoverage: containerRect.area > 0 ? tileRect.area / containerRect.area : 0,
+      video: videoRect,
+      viewport: { dpr: window.devicePixelRatio, height: window.innerHeight, width: window.innerWidth },
+    };
+  }, index);
+}
+
+function expectContainedRect(child, parent, message, tolerance = 2) {
+  expect(child.left, `${message}: left edge`).toBeGreaterThanOrEqual(parent.left - tolerance);
+  expect(child.right, `${message}: right edge`).toBeLessThanOrEqual(parent.right + tolerance);
+  expect(child.top, `${message}: top edge`).toBeGreaterThanOrEqual(parent.top - tolerance);
+  expect(child.bottom, `${message}: bottom edge`).toBeLessThanOrEqual(parent.bottom + tolerance);
+}
+
+function expectPresentationGeometry(presentation, expectedAspect, label, fullscreen = false) {
+  expect(presentation.fullscreenIsTile, `${label}: fullscreen host`).toBe(fullscreen);
+  expect(presentation.objectFit, `${label}: media fit policy`).toBe("contain");
+  expect(presentation.sourceWidth, `${label}: decoded width`).toBeGreaterThan(0);
+  expect(presentation.sourceHeight, `${label}: decoded height`).toBeGreaterThan(0);
+  expect(presentation.sourceAspect, `${label}: decoded aspect`).toBeCloseTo(expectedAspect, 3);
+  expect(presentation.publishedAspect, `${label}: published tile aspect`).toBeCloseTo(expectedAspect, 3);
+  expect(presentation.datasetAspect, `${label}: diagnostic tile aspect`).toBeCloseTo(expectedAspect, 1);
+  expect(presentation.tileCoverage, `${label}: stable tile should use the available Stage`).toBeGreaterThanOrEqual(0.96);
+  expect(presentation.contentCoverage, `${label}: media should use the maximal contained rectangle`).toBeGreaterThanOrEqual(0.96);
+  expect(presentation.controlVisible, `${label}: fullscreen control visibility`).toBe(true);
+  expect(presentation.controlHitTarget, `${label}: fullscreen control hit target`).toBe(true);
+  expect(presentation.control.width, `${label}: fullscreen control width`).toBeGreaterThanOrEqual(39.5);
+  expect(presentation.control.height, `${label}: fullscreen control height`).toBeGreaterThanOrEqual(39.5);
+  expectContainedRect(presentation.tile, presentation.container, `${label}: tile containment`);
+  expectContainedRect(presentation.video, presentation.container, `${label}: video containment`);
+  expectContainedRect(presentation.content, presentation.container, `${label}: fitted frame containment`);
+  expectContainedRect(presentation.control, presentation.tile, `${label}: fullscreen control containment`);
+  expect(presentation.pageOverflowX, `${label}: horizontal page overflow`).toBeLessThanOrEqual(1);
+  expect(presentation.pageOverflowY, `${label}: vertical page overflow`).toBeLessThanOrEqual(1);
+  if (!fullscreen) {
+    expectContainedRect(presentation.grid, presentation.stage, `${label}: grid containment`);
+    expect(presentation.gridOverflowX, `${label}: horizontal Stage overflow`).toBeLessThanOrEqual(1);
+    expect(presentation.gridOverflowY, `${label}: vertical Stage overflow`).toBeLessThanOrEqual(1);
+  }
+}
+
+test("shared-screen fullscreen keeps the live video and controls in their stable Stage tile", async ({ page }) => {
+  await resizeViewport(page, { width: 1280, height: 720 });
+  await openStageFixture(page, {
+    participants: 2,
+    cameras: 0,
+    screenShares: 1,
+    shareAspects: [32 / 9],
+  });
+  await rememberStableNodes(page, "stable");
+
+  const tile = screenTile(page);
+  await expect(tile.locator("video.screen-video-surface")).toHaveCount(1);
+  await expect(tile.getByRole("button", { name: "Open shared screen fullscreen" })).toBeVisible();
+
+  await enterStableFullscreen(page);
+  try {
+    expect(await readStableNodeState(page, "stable")).toEqual({
+      buttonIdentityPreserved: true,
+      fullscreenHints: 1,
+      fullscreenHosts: 1,
+      tileIdentityPreserved: true,
+      tileOwnsVideo: true,
+      topLevelFullscreenHosts: 0,
+      videoCount: 1,
+      videoIdentityPreserved: true,
+    });
+  } finally {
+    await ensureFullscreenExited(page);
+  }
+});
+
+test("camera fullscreen keeps its stable avatar video and contained frame", async ({ page }) => {
+  await resizeViewport(page, { width: 1366, height: 768 });
+  await openStageFixture(page, {
+    participants: 2,
+    cameras: 1,
+    screenShares: 0,
+    shareAspects: [],
+  });
+
+  const camera = page.locator(".user-avatar video.layout-fixture-camera").first();
+  const avatar = camera.locator("xpath=..");
+  await expect(camera).toBeVisible();
+  await expect.poll(() => camera.evaluate((video) => getComputedStyle(video).objectFit)).toBe("contain");
+  await camera.evaluate((video) => {
+    window.__cameraFullscreenVideo = video;
+    window.__cameraFullscreenHost = video.parentElement;
+  });
+
+  await camera.click();
+  try {
+    await expect.poll(() => avatar.evaluate((host) => document.fullscreenElement === host)).toBe(true);
+    const fullscreenState = await camera.evaluate((video) => {
+      const host = document.fullscreenElement;
+      const hostBounds = host.getBoundingClientRect();
+      const videoBounds = video.getBoundingClientRect();
+      return {
+        borderRadius: getComputedStyle(video).borderRadius,
+        hostIdentity: host === window.__cameraFullscreenHost,
+        hostSize: { height: hostBounds.height, width: hostBounds.width },
+        objectFit: getComputedStyle(video).objectFit,
+        sourceAspect: video.videoWidth / video.videoHeight,
+        videoIdentity: video === window.__cameraFullscreenVideo,
+        videoSize: { height: videoBounds.height, width: videoBounds.width },
+        viewport: { height: innerHeight, width: innerWidth },
+      };
+    });
+    expect(fullscreenState.hostIdentity).toBe(true);
+    expect(fullscreenState.videoIdentity).toBe(true);
+    expect(fullscreenState.objectFit).toBe("contain");
+    expect(fullscreenState.borderRadius).toBe("0px");
+    expect(fullscreenState.sourceAspect).toBeCloseTo(16 / 9, 3);
+    expect(fullscreenState.hostSize.width).toBeCloseTo(fullscreenState.viewport.width, 0);
+    expect(fullscreenState.hostSize.height).toBeCloseTo(fullscreenState.viewport.height, 0);
+    expect(fullscreenState.videoSize.width).toBeCloseTo(fullscreenState.hostSize.width, 0);
+    expect(fullscreenState.videoSize.height).toBeCloseTo(fullscreenState.hostSize.height, 0);
+  } finally {
+    await ensureFullscreenExited(page);
+  }
+
+  const restoredState = await camera.evaluate((video) => ({
+    hostIdentity: video.parentElement === window.__cameraFullscreenHost,
+    objectFit: getComputedStyle(video).objectFit,
+    videoIdentity: video === window.__cameraFullscreenVideo,
+  }));
+  expect(restoredState).toEqual({ hostIdentity: true, objectFit: "contain", videoIdentity: true });
+});
+
+test("a rejected fullscreen request cleans up and allows a later retry", async ({ page }) => {
+  await resizeViewport(page, { width: 1280, height: 720 });
+  await openStageFixture(page, {
+    participants: 2,
+    cameras: 0,
+    screenShares: 1,
+    shareAspects: [16 / 9],
+  });
+
+  const tile = screenTile(page);
+  const button = tile.getByRole("button", { name: "Open shared screen fullscreen" });
+  await tile.evaluate((host) => {
+    Object.defineProperty(host, "requestFullscreen", {
+      configurable: true,
+      value: () => Promise.reject(new DOMException("fixture rejection", "NotAllowedError")),
+    });
+  });
+  await button.click();
+  await expect.poll(() => tile.evaluate((host) => ({
+    fullscreen: document.fullscreenElement,
+    hint: host.querySelectorAll(".fullscreen-hint").length,
+    marked: host.classList.contains("fullscreen-video-wrapper"),
+  }))).toEqual({ fullscreen: null, hint: 0, marked: false });
+  await expect(button).toHaveAccessibleName("Open shared screen fullscreen");
+
+  await tile.evaluate((host) => delete host.requestFullscreen);
+  await enterStableFullscreen(page);
+  try {
+    await exitFullscreenThroughControl(page);
+  } finally {
+    await ensureFullscreenExited(page);
+  }
+});
+
+test("removing the video's poster sibling during fullscreen still exits cleanly", async ({ page }) => {
+  await resizeViewport(page, { width: 1366, height: 768 });
+  await openStageFixture(page, {
+    participants: 2,
+    cameras: 0,
+    screenShares: 1,
+    shareAspects: [21 / 9],
+  });
+  await rememberStableNodes(page, "poster-removal");
+
+  await screenTile(page).evaluate((tile) => {
+    const poster = document.createElement("div");
+    poster.className = "tile-poster fullscreen-regression-poster";
+    tile.querySelector("video.screen-video-surface").after(poster);
+  });
+  await expect(page.locator(".fullscreen-regression-poster")).toHaveCount(1);
+
+  await enterStableFullscreen(page);
+  try {
+    await page.locator(".fullscreen-regression-poster").evaluate((poster) => poster.remove());
+    await exitFullscreenProgrammatically(page);
+
+    expect(await readStableNodeState(page, "poster-removal")).toEqual({
+      buttonIdentityPreserved: true,
+      fullscreenHints: 0,
+      fullscreenHosts: 0,
+      tileIdentityPreserved: true,
+      tileOwnsVideo: true,
+      topLevelFullscreenHosts: 0,
+      videoCount: 1,
+      videoIdentityPreserved: true,
+    });
+    await expect(screenTile(page)).toBeVisible();
+  } finally {
+    await ensureFullscreenExited(page);
+  }
+});
+
+test("repeated enter and exit cycles preserve one stable tile, video, and button", async ({ page }) => {
+  await resizeViewport(page, { width: 1920, height: 1080 });
+  await openStageFixture(page, {
+    participants: 3,
+    cameras: 0,
+    screenShares: 1,
+    shareAspects: [16 / 10],
+  });
+  await rememberStableNodes(page, "cycles");
+
+  try {
+    for (let cycle = 1; cycle <= 3; cycle += 1) {
+      await enterStableFullscreen(page);
+      await expect(screenTile(page).getByRole("button", { name: "Exit shared screen fullscreen" })).toBeVisible();
+      await exitFullscreenThroughControl(page);
+      await expect(screenTile(page).getByRole("button", { name: "Open shared screen fullscreen" })).toBeFocused();
+      expect(await readStableNodeState(page, "cycles"), `cycle ${cycle}`).toEqual({
+        buttonIdentityPreserved: true,
+        fullscreenHints: 0,
+        fullscreenHosts: 0,
+        tileIdentityPreserved: true,
+        tileOwnsVideo: true,
+        topLevelFullscreenHosts: 0,
+        videoCount: 1,
+        videoIdentityPreserved: true,
+      });
+    }
+  } finally {
+    await ensureFullscreenExited(page);
+  }
+});
+
+test("a fullscreen resize and a later Stage resize leave current geometry and responsive state fresh", async ({ page }) => {
+  await resizeViewport(page, { width: 1366, height: 768 });
+  await openStageFixture(page, {
+    participants: 2,
+    cameras: 0,
+    screenShares: 1,
+    shareAspects: [32 / 9],
+  });
+  await expect(page.locator("html")).toHaveAttribute("data-ui-mode", "theater");
+
+  await enterStableFullscreen(page);
+  let fullscreenMetrics = null;
+  try {
+    fullscreenMetrics = await emulateFullscreenViewport(page, { width: 900, height: 500 });
+    expectPresentationGeometry(
+      await capturePresentation(page),
+      32 / 9,
+      "900x500 while fullscreen",
+      true,
+    );
+    await exitFullscreenProgrammatically(page);
+  } finally {
+    await ensureFullscreenExited(page);
+  }
+
+  if (fullscreenMetrics) {
+    await fullscreenMetrics.send("Emulation.clearDeviceMetricsOverride");
+    await fullscreenMetrics.detach();
+  }
+  await resizeViewport(page, { width: 900, height: 500 });
+
+  await expect(page.locator("html")).toHaveAttribute("data-ui-mode", "compact");
+  await expect(page.locator("html")).toHaveAttribute("data-ui-short", "");
+  await expect(page.locator("html")).toHaveAttribute("data-ui-very-short", "");
+  await closeClubhouseTools(page);
+  expectPresentationGeometry(await capturePresentation(page), 32 / 9, "900x500 after exit");
+
+  await resizeViewport(page, { width: 1920, height: 1080 });
+  await expect(page.locator("html")).toHaveAttribute("data-ui-mode", "theater");
+  await expect(page.locator("html")).not.toHaveAttribute("data-ui-short", "");
+  await expect(page.locator("html")).not.toHaveAttribute("data-ui-very-short", "");
+  expectPresentationGeometry(await capturePresentation(page), 32 / 9, "1920x1080 after post-exit resize");
+});
+
+test("fullscreen restores the previously enlarged Stage tile without replacing either share", async ({ page }) => {
+  await resizeViewport(page, { width: 5120, height: 1440 });
+  await openStageFixture(page, {
+    participants: 3,
+    cameras: 0,
+    screenShares: 2,
+    shareAspects: [32 / 9, 9 / 16],
+  });
+  const grid = page.locator("#screen-grid");
+  const tiles = grid.locator(":scope > .tile");
+  await expect(tiles).toHaveCount(2);
+  await page.waitForTimeout(250);
+  const mixedGeometry = await page.evaluate(() => {
+    const gridElement = document.getElementById("screen-grid");
+    const gridBounds = gridElement.getBoundingClientRect();
+    const tileElements = Array.from(gridElement.querySelectorAll(":scope > .tile"));
+    const tileBounds = tileElements.map((tile) => tile.getBoundingClientRect());
+    const overlapWidth = Math.max(0, Math.min(tileBounds[0].right, tileBounds[1].right) -
+      Math.max(tileBounds[0].left, tileBounds[1].left));
+    const overlapHeight = Math.max(0, Math.min(tileBounds[0].bottom, tileBounds[1].bottom) -
+      Math.max(tileBounds[0].top, tileBounds[1].top));
+    return {
+      grid: { bottom: gridBounds.bottom, left: gridBounds.left, right: gridBounds.right, top: gridBounds.top },
+      gridTracks: {
+        columns: gridElement.style.gridTemplateColumns,
+        rows: gridElement.style.gridTemplateRows,
+      },
+      overlapArea: overlapWidth * overlapHeight,
+      pageOverflowX: document.documentElement.scrollWidth - document.documentElement.clientWidth,
+      tiles: tileElements.map((tile, index) => ({
+        aspect: tileBounds[index].width / tileBounds[index].height,
+        bounds: {
+          bottom: tileBounds[index].bottom,
+          left: tileBounds[index].left,
+          right: tileBounds[index].right,
+          top: tileBounds[index].top,
+        },
+        publishedAspect: Number.parseFloat(tile.style.getPropertyValue("--screen-source-aspect-ratio")),
+      })),
+    };
+  });
+  expect(mixedGeometry.gridTracks.columns).not.toBe("");
+  expect(mixedGeometry.gridTracks.rows).not.toBe("");
+  expect(mixedGeometry.overlapArea).toBeLessThanOrEqual(1);
+  expect(mixedGeometry.pageOverflowX).toBeLessThanOrEqual(1);
+  for (const [index, expectedAspect] of [[0, 32 / 9], [1, 9 / 16]]) {
+    expect(mixedGeometry.tiles[index].aspect, `mixed tile ${index} aspect`).toBeCloseTo(expectedAspect, 2);
+    expect(mixedGeometry.tiles[index].publishedAspect, `mixed tile ${index} published aspect`).toBeCloseTo(expectedAspect, 3);
+    expectContainedRect(mixedGeometry.tiles[index].bounds, mixedGeometry.grid, `mixed tile ${index} containment`);
+  }
+
+  await tiles.nth(0).click({ position: { x: 16, y: 56 } });
+  await expect(grid).toHaveClass(/is-focused/);
+  await expect(tiles.nth(0)).toHaveClass(/is-focused/);
+  const expectFocusedGeometry = async (label) => {
+    const readGeometry = () => page.evaluate(() => {
+      const gridElement = document.getElementById("screen-grid");
+      const tile = gridElement.querySelector(":scope > .tile.is-focused");
+      const video = tile.querySelector("video.screen-video-surface");
+      const gridBounds = gridElement.getBoundingClientRect();
+      const tileBounds = tile.getBoundingClientRect();
+      return {
+        gridHeight: gridBounds.height,
+        gridWidth: gridBounds.width,
+        objectFit: getComputedStyle(video).objectFit,
+        sourceAspect: video.videoWidth / video.videoHeight,
+        tileHeight: tileBounds.height,
+        tileWidth: tileBounds.width,
+      };
+    });
+    await expect.poll(async () => {
+      const settled = await readGeometry();
+      return settled.tileWidth / settled.gridWidth;
+    }, { message: `${label}: focused share should settle across the Stage` }).toBeGreaterThanOrEqual(0.96);
+    const geometry = await readGeometry();
+    expect(geometry.tileWidth / geometry.gridWidth, `${label}: focused width usage`).toBeGreaterThanOrEqual(0.96);
+    expect(geometry.tileHeight / geometry.gridHeight, `${label}: focused height usage`).toBeGreaterThanOrEqual(0.72);
+    expect(geometry.objectFit, `${label}: fit policy`).toBe("contain");
+    expect(geometry.sourceAspect, `${label}: source aspect`).toBeCloseTo(32 / 9, 3);
+  };
+  await expectFocusedGeometry("before fullscreen");
+  await rememberStableNodes(page, "focused-share", 0);
+  await rememberStableNodes(page, "unfocused-share", 1);
+
+  await enterStableFullscreen(page, 0);
+  try {
+    await exitFullscreenThroughControl(page, 0);
+  } finally {
+    await ensureFullscreenExited(page);
+  }
+
+  await expect(grid).toHaveClass(/is-focused/);
+  await expect(tiles.nth(0)).toHaveClass(/is-focused/);
+  await expect(tiles.nth(1)).not.toHaveClass(/is-focused/);
+  await expectFocusedGeometry("after fullscreen");
+  for (const [key, index] of [["focused-share", 0], ["unfocused-share", 1]]) {
+    const state = await readStableNodeState(page, key, index);
+    expect(state.tileIdentityPreserved, `${key}: tile identity`).toBe(true);
+    expect(state.videoIdentityPreserved, `${key}: video identity`).toBe(true);
+    expect(state.videoCount, `${key}: video count`).toBe(1);
+  }
+});
+
+test("the in-tile fullscreen control remains visible, hittable, and keyboard-reachable for exit", async ({ page }) => {
+  await resizeViewport(page, { width: 1366, height: 768 });
+  await openStageFixture(page, {
+    participants: 2,
+    cameras: 0,
+    screenShares: 1,
+    shareAspects: [16 / 10],
+  });
+
+  const tile = await enterStableFullscreen(page);
+  try {
+    const exitControl = tile.getByRole("button", { name: "Exit shared screen fullscreen" });
+    await expect(exitControl).toBeVisible();
+    const reachability = await exitControl.evaluate((control) => {
+      const bounds = control.getBoundingClientRect();
+      const hostBounds = document.fullscreenElement.getBoundingClientRect();
+      const hit = document.elementFromPoint(
+        bounds.left + bounds.width / 2,
+        bounds.top + bounds.height / 2,
+      );
+      control.focus();
+      return {
+        active: document.activeElement === control,
+        contained: bounds.left >= hostBounds.left - 1 && bounds.right <= hostBounds.right + 1 &&
+          bounds.top >= hostBounds.top - 1 && bounds.bottom <= hostBounds.bottom + 1,
+        height: bounds.height,
+        hittable: hit === control || control.contains(hit),
+        width: bounds.width,
+      };
+    });
+    expect(reachability.active).toBe(true);
+    expect(reachability.contained).toBe(true);
+    expect(reachability.hittable).toBe(true);
+    expect(reachability.width).toBeGreaterThanOrEqual(39.5);
+    expect(reachability.width).toBeLessThanOrEqual(40.5);
+    expect(reachability.height).toBeGreaterThanOrEqual(39.5);
+    expect(reachability.height).toBeLessThanOrEqual(40.5);
+
+    await exitControl.press("Enter");
+    await expect.poll(() => page.evaluate(() => document.fullscreenElement === null)).toBe(true);
+    await waitForLayout(page, 3);
+    await expect(tile.getByRole("button", { name: "Open shared screen fullscreen" })).toBeFocused();
+  } finally {
+    await ensureFullscreenExited(page);
+  }
+});
+
+test("representative viewer and source ratios use the maximal contained Stage and fullscreen geometry", async ({ page }) => {
+  test.slow();
+  await resizeViewport(page, viewerMatrix[0]);
+  await openStageFixture(page, {
+    participants: sourceMatrix.length,
+    cameras: 0,
+    screenShares: sourceMatrix.length,
+    shareAspects: sourceMatrix.map((source) => source.aspect),
+  });
+  await expect(page.locator("#screen-grid > .tile")).toHaveCount(sourceMatrix.length);
+  await page.evaluate(() => {
+    window.__fullscreenMatrixNodes = Array.from(document.querySelectorAll("#screen-grid > .tile")).map((tile) => ({
+      button: tile.querySelector(".tile-fullscreen-btn"),
+      tile,
+      video: tile.querySelector("video.screen-video-surface"),
+    }));
+  });
+
+  const policyFits = await page.evaluate(({ sources, viewers }) => viewers.flatMap((viewer) =>
+    sources.map((source) => {
+      const fitted = window.EchoLayoutPolicy.fitAspectRatio(
+        viewer.width,
+        viewer.height,
+        source.aspect,
+      );
+      return {
+        height: fitted.height,
+        source: source.label,
+        viewer: viewer.label,
+        width: fitted.width,
+      };
+    })), {
+    sources: sourceMatrix.map(({ aspect, label }) => ({ aspect, label })),
+    viewers: viewerMatrix.map(({ height, label, width }) => ({ height, label, width })),
+  });
+  expect(policyFits).toHaveLength(viewerMatrix.length * sourceMatrix.length);
+  for (const viewer of viewerMatrix) {
+    for (const source of sourceMatrix) {
+      const fitted = policyFits.find((entry) => entry.viewer === viewer.label && entry.source === source.label);
+      const expectedWidth = Math.min(viewer.width, viewer.height * source.aspect);
+      const expectedHeight = Math.min(viewer.height, viewer.width / source.aspect);
+      const label = `${viewer.label} policy fit for ${source.label}`;
+      expect(fitted.width, `${label}: width`).toBeCloseTo(expectedWidth, 6);
+      expect(fitted.height, `${label}: height`).toBeCloseTo(expectedHeight, 6);
+      expect(fitted.width, `${label}: viewport width constraint`).toBeLessThanOrEqual(viewer.width);
+      expect(fitted.height, `${label}: viewport height constraint`).toBeLessThanOrEqual(viewer.height);
+      expect(fitted.width / fitted.height, `${label}: undistorted aspect`).toBeCloseTo(source.aspect, 6);
+      expect(
+        Math.abs(fitted.width - viewer.width) < 1e-6 ||
+          Math.abs(fitted.height - viewer.height) < 1e-6,
+        `${label}: maximal fit must touch one viewport axis`,
+      ).toBe(true);
+    }
+  }
+
+  for (let viewerIndex = 0; viewerIndex < viewerMatrix.length; viewerIndex += 1) {
+    const viewer = viewerMatrix[viewerIndex];
+    const sourceIndex = viewerIndex % sourceMatrix.length;
+    const source = sourceMatrix[sourceIndex];
+    await resizeViewport(page, viewer);
+    await showOnlyShare(page, sourceIndex);
+    expectPresentationGeometry(
+      await capturePresentation(page, sourceIndex),
+      source.aspect,
+      `${viewer.label} Stage with ${source.label} source`,
+    );
+
+    // The complete 6x6 policy matrix above is synchronous. These six real
+    // pairwise transitions cover every required viewer and source exactly once.
+    await enterStableFullscreen(page, sourceIndex);
+    try {
+      expectPresentationGeometry(
+        await capturePresentation(page, sourceIndex),
+        source.aspect,
+        `${viewer.label} fullscreen with ${source.label} source`,
+        true,
+      );
+      await exitFullscreenThroughControl(page, sourceIndex);
+    } finally {
+      await ensureFullscreenExited(page);
+    }
+    expectPresentationGeometry(
+      await capturePresentation(page, sourceIndex),
+      source.aspect,
+      `${viewer.label} restored Stage with ${source.label} source`,
+    );
+  }
+
+  const identities = await page.evaluate(() => {
+    const current = Array.from(document.querySelectorAll("#screen-grid > .tile"));
+    return current.map((tile, index) => ({
+      button: tile.querySelector(".tile-fullscreen-btn") === window.__fullscreenMatrixNodes[index].button,
+      tile: tile === window.__fullscreenMatrixNodes[index].tile,
+      video: tile.querySelector("video.screen-video-surface") === window.__fullscreenMatrixNodes[index].video,
+      videoCount: tile.querySelectorAll("video.screen-video-surface").length,
+    }));
+  });
+  expect(identities).toEqual(sourceMatrix.map(() => ({
+    button: true,
+    tile: true,
+    video: true,
+    videoCount: 1,
+  })));
+});
+
+test("display scaling and browser zoom feed CSS viewport pixels into the same layout policy", async ({ page }) => {
+  const physicalViewport = { height: 1080, width: 1920 };
+  const scales = [
+    { css: { height: 1080, width: 1920 }, mode: "theater", scale: 1 },
+    { css: { height: 864, width: 1536 }, mode: "theater", scale: 1.25 },
+    { css: { height: 720, width: 1280 }, mode: "theater", scale: 1.5 },
+    { css: { height: 540, width: 960 }, mode: "compact", scale: 2 },
+  ];
+
+  await resizeViewport(page, physicalViewport);
+  await openStageFixture(page, {
+    participants: 2,
+    cameras: 0,
+    screenShares: 1,
+    shareAspects: [21 / 9],
+  });
+  await closeClubhouseTools(page);
+  const session = await page.context().newCDPSession(page);
+  try {
+    for (const entry of scales) {
+      await session.send("Emulation.setDeviceMetricsOverride", {
+        deviceScaleFactor: entry.scale,
+        height: entry.css.height,
+        mobile: false,
+        screenHeight: entry.css.height,
+        screenWidth: entry.css.width,
+        width: entry.css.width,
+      });
+      await expect.poll(() => page.evaluate(() => ({
+        dpr: devicePixelRatio,
+        height: innerHeight,
+        mode: document.documentElement.dataset.uiMode,
+        width: innerWidth,
+      })), { message: `${entry.scale * 100}% scale should settle in CSS pixels` }).toEqual({
+        dpr: entry.scale,
+        height: entry.css.height,
+        mode: entry.mode,
+        width: entry.css.width,
+      });
+      await waitForLayout(page, 3);
+      const presentation = await capturePresentation(page);
+      expectPresentationGeometry(
+        presentation,
+        21 / 9,
+        `${entry.scale * 100}% scale at ${entry.css.width}x${entry.css.height} CSS pixels`,
+      );
+      expect(Math.round(presentation.viewport.width * presentation.viewport.dpr)).toBe(physicalViewport.width);
+      expect(Math.round(presentation.viewport.height * presentation.viewport.dpr)).toBe(physicalViewport.height);
+    }
+  } finally {
+    await session.send("Emulation.clearDeviceMetricsOverride");
+    await session.detach();
+  }
+});
+
+test("compact and mini heights keep the Stage, call dock, and fullscreen exit control usable", async ({ page }) => {
+  await resizeViewport(page, { width: 900, height: 480 });
+  await openStageFixture(page, {
+    participants: 2,
+    cameras: 0,
+    screenShares: 1,
+    shareAspects: [4 / 3],
+  });
+  await closeClubhouseTools(page);
+
+  for (const viewport of [
+    { height: 480, mode: "compact", visibleDockControls: 5, width: 900 },
+    { height: 420, mode: "mini", visibleDockControls: 4, width: 640 },
+  ]) {
+    await resizeViewport(page, viewport);
+    await expect(page.locator("html")).toHaveAttribute("data-ui-mode", viewport.mode);
+
+    const stageHeights = [];
+    for (const connectedControls of [false, true]) {
+      await page.locator("#call-controls").evaluate((dock, connected) => {
+        dock.classList.toggle("hidden", !connected);
+      }, connectedControls);
+      await waitForLayout(page);
+      const controls = await page.evaluate(() => {
+        function rect(element) {
+          const bounds = element.getBoundingClientRect();
+          return {
+            bottom: bounds.bottom,
+            height: bounds.height,
+            left: bounds.left,
+            right: bounds.right,
+            top: bounds.top,
+            width: bounds.width,
+          };
+        }
+        const dock = document.getElementById("call-controls");
+        const stage = document.querySelector(".room-main");
+        const dockRect = rect(dock);
+        const stageRect = rect(stage);
+        const buttons = Array.from(dock.querySelectorAll("button")).filter((button) => {
+          const style = getComputedStyle(button);
+          return button.getClientRects().length > 0 && style.display !== "none" && style.visibility !== "hidden";
+        });
+        return {
+          buttons: buttons.map((button) => ({ id: button.id, rect: rect(button) })),
+          dock: dockRect,
+          overlap: Math.max(0, Math.min(stageRect.bottom, dockRect.bottom) - Math.max(stageRect.top, dockRect.top)),
+          pageOverflowX: document.documentElement.scrollWidth - document.documentElement.clientWidth,
+          pageOverflowY: document.documentElement.scrollHeight - document.documentElement.clientHeight,
+          stage: stageRect,
+          viewport: { height: window.innerHeight, width: window.innerWidth },
+        };
+      });
+
+      stageHeights.push(controls.stage.height);
+      expect(controls.buttons, `${viewport.width}x${viewport.height}: visible call controls`).toHaveLength(
+        viewport.visibleDockControls,
+      );
+      expect(controls.overlap, `${viewport.width}x${viewport.height}: Stage/dock overlap`).toBeLessThanOrEqual(1);
+      expect(controls.pageOverflowX, `${viewport.width}x${viewport.height}: horizontal overflow`).toBeLessThanOrEqual(1);
+      expect(controls.pageOverflowY, `${viewport.width}x${viewport.height}: vertical overflow`).toBeLessThanOrEqual(1);
+      expectContainedRect(
+        controls.dock,
+        { bottom: controls.viewport.height, left: 0, right: controls.viewport.width, top: 0 },
+        `${viewport.width}x${viewport.height}: dock containment`,
+      );
+      for (const button of controls.buttons) {
+        expect(button.rect.width, `${viewport.width}x${viewport.height}: ${button.id} width`).toBeGreaterThanOrEqual(39.5);
+        expect(button.rect.height, `${viewport.width}x${viewport.height}: ${button.id} height`).toBeGreaterThanOrEqual(39.5);
+        expectContainedRect(button.rect, controls.dock, `${viewport.width}x${viewport.height}: ${button.id} containment`);
+      }
+      expectPresentationGeometry(
+        await capturePresentation(page),
+        4 / 3,
+        `${viewport.width}x${viewport.height} with ${connectedControls ? "connected" : "pre-connect"} controls`,
+      );
+    }
+    expect(Math.abs(stageHeights[0] - stageHeights[1]), `${viewport.width}x${viewport.height}: dock state geometry`).toBeLessThanOrEqual(1);
+  }
+
+  await enterStableFullscreen(page);
+  try {
+    expectPresentationGeometry(await capturePresentation(page), 4 / 3, "640x420 fullscreen", true);
+    await exitFullscreenThroughControl(page);
+  } finally {
+    await ensureFullscreenExited(page);
+  }
+  expectPresentationGeometry(await capturePresentation(page), 4 / 3, "640x420 restored Stage");
+});

--- a/core/viewer/clubhouse-shell.css
+++ b/core/viewer/clubhouse-shell.css
@@ -553,7 +553,7 @@
 :root[data-ui-shell="v2"] .screens-grid .tile {
   padding: 0;
   gap: 0;
-  overflow: hidden;
+  overflow: visible;
   border-color: var(--club-border);
   border-radius: var(--club-radius-card);
   background: #05070a;

--- a/core/viewer/grid-layout.js
+++ b/core/viewer/grid-layout.js
@@ -75,6 +75,26 @@
     return Math.max(0, Number(value) || 0).toFixed(3).replace(/\.?0+$/, "") + "px";
   }
 
+  function tileAspectRatio(tile, fallback) {
+    var video = tile && tile.querySelector("video.screen-video-surface");
+    var videoWidth = Number(video && video.videoWidth);
+    var videoHeight = Number(video && video.videoHeight);
+    if (Number.isFinite(videoWidth) && videoWidth > 0 &&
+        Number.isFinite(videoHeight) && videoHeight > 0) {
+      return videoWidth / videoHeight;
+    }
+
+    var published = Number.parseFloat(
+      tile && tile.style.getPropertyValue("--screen-source-aspect-ratio")
+    );
+    if (Number.isFinite(published) && published > 0) return published;
+
+    var tagged = Number.parseFloat(tile && tile.dataset.aspectRatio);
+    if (Number.isFinite(tagged) && tagged > 0) return tagged;
+    var fallbackAspect = Number(fallback);
+    return Number.isFinite(fallbackAspect) && fallbackAspect > 0 ? fallbackAspect : (16 / 9);
+  }
+
   function updateGridLayout() {
     var grid = document.getElementById("screen-grid");
     if (!grid) return;
@@ -112,6 +132,9 @@
       tileCount: tiles.length,
       gap: numericGap(grid, policy),
       aspectRatio: policy.DEFAULT_TILE_ASPECT_RATIO,
+      aspectRatios: tiles.map(function (tile) {
+        return tileAspectRatio(tile, policy.DEFAULT_TILE_ASPECT_RATIO);
+      }),
     });
     if (!layout || !layout.valid || layout.columns < 1 || layout.rows < 1 ||
         layout.tileWidth <= 0 || layout.tileHeight <= 0) {
@@ -119,19 +142,27 @@
       return;
     }
 
+    var sourceAware = Array.isArray(layout.tileLayouts) &&
+      layout.tileLayouts.length === tiles.length &&
+      Array.isArray(layout.columnWidths) &&
+      Array.isArray(layout.rowHeights);
     setStyleValue(
       grid,
       "gridTemplateColumns",
-      "repeat(" + layout.columns + ", " + pixelTrack(layout.tileWidth) + ")"
+      sourceAware
+        ? layout.columnWidths.map(pixelTrack).join(" ")
+        : "repeat(" + layout.columns + ", " + pixelTrack(layout.tileWidth) + ")"
     );
     setStyleValue(
       grid,
       "gridTemplateRows",
-      "repeat(" + layout.rows + ", " + pixelTrack(layout.tileHeight) + ")"
+      sourceAware
+        ? layout.rowHeights.map(pixelTrack).join(" ")
+        : "repeat(" + layout.rows + ", " + pixelTrack(layout.tileHeight) + ")"
     );
 
-    // The selected tracks are the canonical tile bounds. Filling those tracks
-    // prevents decoded WebRTC resolution changes from resizing the UI.
+    // The selected tracks are the canonical tile cells. Uniform sources fill
+    // those cells exactly; mixed sources use the policy's contained geometry.
     var visibleSet = new Set(tiles);
     _managedTiles.forEach(function (tile) {
       if (!visibleSet.has(tile)) {
@@ -140,9 +171,10 @@
         _managedTiles.delete(tile);
       }
     });
-    tiles.forEach(function (tile) {
-      setStyleValue(tile, "width", "100%");
-      setStyleValue(tile, "height", "100%");
+    tiles.forEach(function (tile, index) {
+      var tileLayout = sourceAware ? layout.tileLayouts[index] : null;
+      setStyleValue(tile, "width", tileLayout ? pixelTrack(tileLayout.width) : "100%");
+      setStyleValue(tile, "height", tileLayout ? pixelTrack(tileLayout.height) : "100%");
       _managedTiles.add(tile);
     });
   }
@@ -189,7 +221,7 @@
       });
       _mutationObserver.observe(grid, {
         attributes: true,
-        attributeFilter: ["class", "hidden", "style"],
+        attributeFilter: ["class", "data-aspect-ratio", "hidden", "style"],
         childList: true,
         subtree: true,
       });

--- a/core/viewer/index.html
+++ b/core/viewer/index.html
@@ -4,8 +4,8 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Echo Chamber</title>
-    <script src="layout-policy.js?v=0.6.11.1777930912"></script>
-    <script src="ui-shell.js?v=0.6.11.1777930912"></script>
+    <script src="layout-policy.js?v=0.6.34.1786210901"></script>
+    <script src="ui-shell.js?v=0.6.34.1786210901"></script>
     <script src="theme-runtime.js?v=0.6.11.1777930912"></script>
     <script>
       (function () {
@@ -38,10 +38,10 @@
         }
       })();
     </script>
-    <link rel="stylesheet" href="style.css?v=0.6.34.1785470400" />
+    <link rel="stylesheet" href="style.css?v=0.6.34.1786210901" />
     <link rel="stylesheet" href="jam.css?v=0.6.34.1785384000" />
     <link rel="stylesheet" href="capture-picker.css?v=0.6.11.1777930912" />
-    <link rel="stylesheet" href="clubhouse-shell.css?v=0.6.11.1777930912" />
+    <link rel="stylesheet" href="clubhouse-shell.css?v=0.6.34.1786210901" />
     <link rel="stylesheet" href="themes.css?v=0.6.11.1777930912" />
   </head>
   <body>
@@ -806,11 +806,11 @@
     <script src="screen-share-quality.js?v=0.6.11.1777930912"></script>
     <script src="screen-share-adaptive.js?v=0.6.11.1777930912"></script>
     <script src="screen-share-native.js?v=0.6.11.1777930912"></script>
-    <script src="participants-grid.js?v=0.6.11.1777930912"></script>
-    <script src="grid-layout.js?v=0.6.11.1777930912"></script>
+    <script src="participants-grid.js?v=0.6.34.1786210901"></script>
+    <script src="grid-layout.js?v=0.6.34.1786210901"></script>
     <script src="camera-lobby-layout.js?v=0.6.11.1777930912"></script>
     <script src="participants-avatar.js?v=0.6.11.1777930912"></script>
-    <script src="participants-fullscreen.js?v=0.6.11.1777930912"></script>
+    <script src="participants-fullscreen.js?v=0.6.34.1786210901"></script>
     <script src="participants.js?v=0.6.11.1777930912"></script>
     <script src="audio-routing.js?v=0.6.11.1777930912"></script>
     <script src="media-controls.js?v=0.6.11.1777930912"></script>

--- a/core/viewer/layout-policy.js
+++ b/core/viewer/layout-policy.js
@@ -36,6 +36,7 @@
     balance: 0.2,
     occupancy: 0.08,
   });
+  const ASPECT_RATIO_EPSILON = 1e-9;
 
   function finiteNonNegative(value, fallback) {
     const number = Number(value);
@@ -202,12 +203,41 @@
 
   function normalizeGridOptions(options) {
     const input = options || {};
+    const tileCount = Math.max(0, Math.floor(finiteNonNegative(input.tileCount, 0)));
+    const fallbackAspectRatio = finitePositive(input.aspectRatio, DEFAULT_TILE_ASPECT_RATIO);
+    let aspectRatios = null;
+
+    if (tileCount > 0 && Array.isArray(input.aspectRatios) && input.aspectRatios.length > 0) {
+      const normalized = Array.from({ length: tileCount }, function (_, index) {
+        return finitePositive(input.aspectRatios[index], fallbackAspectRatio);
+      });
+      const first = normalized[0];
+      const isUniform = normalized.every(function (aspectRatio) {
+        return Math.abs(aspectRatio - first) <= ASPECT_RATIO_EPSILON;
+      });
+
+      if (isUniform) {
+        // A uniform per-tile list is equivalent to the original single-aspect
+        // API. Collapse it so existing callers retain identical output.
+        return {
+          width: finiteNonNegative(input.width, 0),
+          height: finiteNonNegative(input.height, 0),
+          tileCount,
+          gap: finiteNonNegative(input.gap, DEFAULT_GRID_GAP),
+          aspectRatio: first,
+          aspectRatios: null,
+        };
+      }
+      aspectRatios = normalized;
+    }
+
     return {
       width: finiteNonNegative(input.width, 0),
       height: finiteNonNegative(input.height, 0),
-      tileCount: Math.max(0, Math.floor(finiteNonNegative(input.tileCount, 0))),
+      tileCount,
       gap: finiteNonNegative(input.gap, DEFAULT_GRID_GAP),
-      aspectRatio: finitePositive(input.aspectRatio, DEFAULT_TILE_ASPECT_RATIO),
+      aspectRatio: fallbackAspectRatio,
+      aspectRatios,
     };
   }
 
@@ -242,13 +272,69 @@
 
     const cellWidth = availableWidth / columns;
     const cellHeight = availableHeight / rows;
-    const fitted = fitAspectRatio(cellWidth, cellHeight, input.aspectRatio);
     const balance = Math.min(columns, rows) / Math.max(columns, rows);
     const occupancy = input.tileCount / (columns * rows);
     const quality =
       GRID_SCORE_WEIGHTS.area +
       GRID_SCORE_WEIGHTS.balance * balance +
       GRID_SCORE_WEIGHTS.occupancy * occupancy;
+
+    if (input.aspectRatios) {
+      const columnWidths = Array.from({ length: columns }, function () { return 0; });
+      const rowHeights = Array.from({ length: rows }, function () { return 0; });
+      let totalTileArea = 0;
+      const tileLayouts = input.aspectRatios.map(function (aspectRatio, index) {
+        const fitted = fitAspectRatio(cellWidth, cellHeight, aspectRatio);
+        const column = index % columns;
+        const row = Math.floor(index / columns);
+        columnWidths[column] = Math.max(columnWidths[column], fitted.width);
+        rowHeights[row] = Math.max(rowHeights[row], fitted.height);
+        totalTileArea += fitted.area;
+        return {
+          index,
+          column,
+          row,
+          aspectRatio,
+          width: fitted.width,
+          height: fitted.height,
+          area: fitted.area,
+        };
+      });
+      const tileArea = totalTileArea / input.tileCount;
+      const totalWidth = columnWidths.reduce(function (sum, width) { return sum + width; }, 0) +
+        input.gap * (columns - 1);
+      const totalHeight = rowHeights.reduce(function (sum, height) { return sum + height; }, 0) +
+        input.gap * (rows - 1);
+
+      return {
+        valid: true,
+        reason: null,
+        columns,
+        rows,
+        tileCount: input.tileCount,
+        gap: input.gap,
+        aspectRatio: input.aspectRatio,
+        aspectRatios: input.aspectRatios.slice(),
+        cellWidth,
+        cellHeight,
+        tileWidth: cellWidth,
+        tileHeight: cellHeight,
+        tileArea,
+        totalTileArea,
+        tileLayouts,
+        columnWidths,
+        rowHeights,
+        balance,
+        occupancy,
+        score: tileArea * quality,
+        totalWidth,
+        totalHeight,
+        unusedWidth: Math.max(0, input.width - totalWidth),
+        unusedHeight: Math.max(0, input.height - totalHeight),
+      };
+    }
+
+    const fitted = fitAspectRatio(cellWidth, cellHeight, input.aspectRatio);
     const score = fitted.area * quality;
     const totalWidth = fitted.width * columns + input.gap * (columns - 1);
     const totalHeight = fitted.height * rows + input.gap * (rows - 1);
@@ -280,14 +366,16 @@
     const input = normalizeGridOptions(options);
     const candidates = [];
     for (let columns = 1; columns <= input.tileCount; columns += 1) {
-      candidates.push(scoreGridCandidate({
+      const candidateOptions = {
         width: input.width,
         height: input.height,
         tileCount: input.tileCount,
         gap: input.gap,
         aspectRatio: input.aspectRatio,
         columns,
-      }));
+      };
+      if (input.aspectRatios) candidateOptions.aspectRatios = input.aspectRatios;
+      candidates.push(scoreGridCandidate(candidateOptions));
     }
     return candidates;
   }

--- a/core/viewer/layout-policy.test.js
+++ b/core/viewer/layout-policy.test.js
@@ -250,6 +250,37 @@ test("aspect fitting honors landscape and portrait constraints exactly", () => {
   approximatelyEqual(portrait.width, 300 * (9 / 16));
 });
 
+test("source aspect fitting stays contained across 1080p, 4K, and ultrawide boxes", () => {
+  const sourceAspects = [
+    ["16:9", 16 / 9],
+    ["16:10", 16 / 10],
+    ["21:9", 21 / 9],
+    ["32:9", 32 / 9],
+    ["4:3", 4 / 3],
+    ["portrait", 9 / 16],
+  ];
+  const containers = [
+    ["1080p", 1920, 1080],
+    ["4K", 3840, 2160],
+    ["ultrawide", 3440, 1440],
+    ["super-ultrawide", 5120, 1440],
+  ];
+
+  for (const [containerName, width, height] of containers) {
+    for (const [aspectName, aspectRatio] of sourceAspects) {
+      const fitted = fitAspectRatio(width, height, aspectRatio);
+      const label = `${containerName} ${width}x${height}, source ${aspectName}`;
+      assert.ok(fitted.width <= width + EPSILON, `${label} width`);
+      assert.ok(fitted.height <= height + EPSILON, `${label} height`);
+      approximatelyEqual(fitted.width / fitted.height, aspectRatio, 1e-9);
+      assert.ok(
+        Math.abs(fitted.width - width) <= EPSILON || Math.abs(fitted.height - height) <= EPSILON,
+        `${label} must consume one constraining axis`
+      );
+    }
+  }
+});
+
 test("aspect fitting returns safe zero geometry for unavailable space", () => {
   assert.deepEqual(fitAspectRatio(0, 100, 16 / 9), {
     width: 0,
@@ -313,6 +344,92 @@ test("optimal grids choose expected arrangements for representative shapes", () 
   assert.deepEqual({ columns: portraitThree.columns, rows: portraitThree.rows }, { columns: 1, rows: 3 });
 });
 
+test("uniform per-tile aspect ratios preserve the original grid contract exactly", () => {
+  const containers = [
+    { width: 1920, height: 1080 },
+    { width: 3840, height: 2160 },
+    { width: 3440, height: 1440 },
+    { width: 5120, height: 1440 },
+  ];
+  const aspects = [16 / 9, 16 / 10, 21 / 9, 32 / 9, 4 / 3, 9 / 16];
+
+  for (const container of containers) {
+    for (const aspectRatio of aspects) {
+      const options = { ...container, tileCount: 6, gap: 12, aspectRatio };
+      assert.deepEqual(
+        chooseOptimalGrid({ ...options, aspectRatios: Array(6).fill(aspectRatio) }),
+        chooseOptimalGrid(options),
+        `${container.width}x${container.height}, aspect=${aspectRatio}`
+      );
+    }
+  }
+});
+
+test("mixed source aspects select and expose source-aware tile geometry", () => {
+  const aspectRatios = [32 / 9, 9 / 16];
+  const options = {
+    width: 1920,
+    height: 1080,
+    tileCount: aspectRatios.length,
+    gap: 12,
+    aspectRatios,
+  };
+  const layout = chooseOptimalGrid(options);
+  const uniformFallback = chooseOptimalGrid({
+    width: options.width,
+    height: options.height,
+    tileCount: options.tileCount,
+    gap: options.gap,
+  });
+
+  assert.deepEqual({ columns: uniformFallback.columns, rows: uniformFallback.rows }, { columns: 2, rows: 1 });
+  assert.deepEqual({ columns: layout.columns, rows: layout.rows }, { columns: 1, rows: 2 });
+  assert.deepEqual(layout.aspectRatios, aspectRatios);
+  assert.equal(layout.tileLayouts.length, aspectRatios.length);
+  assert.equal(layout.columnWidths.length, layout.columns);
+  assert.equal(layout.rowHeights.length, layout.rows);
+  assert.ok(layout.totalWidth <= options.width + EPSILON);
+  assert.ok(layout.totalHeight <= options.height + EPSILON);
+
+  layout.tileLayouts.forEach((tile, index) => {
+    approximatelyEqual(tile.width / tile.height, aspectRatios[index], 1e-9);
+    assert.ok(tile.width <= layout.cellWidth + EPSILON);
+    assert.ok(tile.height <= layout.cellHeight + EPSILON);
+    assert.ok(tile.width <= layout.columnWidths[tile.column] + EPSILON);
+    assert.ok(tile.height <= layout.rowHeights[tile.row] + EPSILON);
+  });
+
+  const candidates = listGridCandidates(options);
+  assert.equal(layout.score, Math.max(...candidates.map((candidate) => candidate.score)));
+});
+
+test("mixed source grid selection is deterministic across representative display boxes", () => {
+  const aspectRatios = [16 / 9, 16 / 10, 21 / 9, 32 / 9, 4 / 3, 9 / 16];
+  const containers = [
+    { width: 1920, height: 1080 },
+    { width: 3840, height: 2160 },
+    { width: 3440, height: 1440 },
+    { width: 5120, height: 1440 },
+  ];
+
+  for (const container of containers) {
+    const input = {
+      ...container,
+      tileCount: aspectRatios.length,
+      gap: 12,
+      aspectRatios,
+    };
+    const first = chooseOptimalGrid(input);
+    assert.equal(first.valid, true);
+    assert.equal(first.tileLayouts.length, aspectRatios.length);
+    assert.ok(first.totalWidth <= container.width + EPSILON);
+    assert.ok(first.totalHeight <= container.height + EPSILON);
+    for (let index = 0; index < 25; index += 1) {
+      assert.deepEqual(chooseOptimalGrid(input), first);
+    }
+  }
+});
+
 test("empty optimal grid has a stable zero-sized result", () => {
   assert.deepEqual(chooseOptimalGrid({ width: 1000, height: 600, tileCount: 0 }), {
     valid: true,
@@ -330,9 +447,9 @@ test("empty optimal grid has a stable zero-sized result", () => {
 });
 
 test("grid geometry never exceeds its container across an exhaustive matrix", () => {
-  const widths = [240, 320, 480, 640, 900, 1280, 1920, 2560];
-  const heights = [180, 240, 360, 480, 600, 720, 1080, 1440];
-  const aspects = [4 / 3, 16 / 9, 21 / 9, 9 / 16];
+  const widths = [240, 320, 480, 640, 900, 1280, 1920, 2560, 3440, 3840, 5120];
+  const heights = [180, 240, 360, 480, 600, 720, 1080, 1440, 2160];
+  const aspects = [4 / 3, 16 / 10, 16 / 9, 21 / 9, 32 / 9, 9 / 16];
   const gaps = [0, 6, 12, 24];
 
   for (const width of widths) {

--- a/core/viewer/participants-fullscreen.js
+++ b/core/viewer/participants-fullscreen.js
@@ -3,51 +3,143 @@
    video quality, screen/camera recovery
    ========================================================= */
 
-// Fullscreen video helper — click video to exit, overlay hint shown on enter
+var activeVideoFullscreenSession = null;
+
+function resolveVideoFullscreenHost(videoEl) {
+  if (!videoEl || !videoEl.isConnected) return null;
+  if (typeof videoEl.closest === "function") {
+    var stableHost = videoEl.closest(".tile, .user-avatar");
+    if (stableHost) return stableHost;
+  }
+  return videoEl.parentElement || null;
+}
+
+function captureFullscreenResponsiveState() {
+  var shell = typeof window !== "undefined" ? window.EchoUiShell : null;
+  return shell && typeof shell.captureResponsiveState === "function"
+    ? shell.captureResponsiveState()
+    : null;
+}
+
+function restoreFullscreenResponsiveState(snapshot) {
+  if (!snapshot || typeof window === "undefined") return;
+  var shell = window.EchoUiShell;
+  if (!shell || typeof shell.restoreResponsiveState !== "function") return;
+  var requestFrame = typeof window.requestAnimationFrame === "function"
+    ? window.requestAnimationFrame.bind(window)
+    : function(callback) { return window.setTimeout(callback, 0); };
+  requestFrame(function() {
+    requestFrame(function() {
+      shell.restoreResponsiveState(snapshot);
+    });
+  });
+}
+
+// Fullscreen the existing stable media host. Keeping the live video inside its
+// Stage tile lets subscription reconciliation, diagnostics, and the watchdog
+// continue to find the same node throughout the transition.
 function enterVideoFullscreen(videoEl) {
   if (document.fullscreenElement) {
-    document.exitFullscreen();
-    return;
+    return document.exitFullscreen();
   }
-  // Wrap in a container so we can overlay a hint
-  var wrapper = document.createElement("div");
-  wrapper.className = "fullscreen-video-wrapper";
+  if (activeVideoFullscreenSession) return activeVideoFullscreenSession.promise;
+
+  var host = resolveVideoFullscreenHost(videoEl);
+  if (!host || typeof host.requestFullscreen !== "function") {
+    return Promise.resolve(false);
+  }
+
   var hint = document.createElement("div");
   hint.className = "fullscreen-hint";
-  hint.textContent = "Click or press ESC to exit";
-  wrapper.appendChild(hint);
+  hint.textContent = "Click the video, use Exit fullscreen, or press ESC to exit";
+  host.appendChild(hint);
 
-  // Move video into wrapper temporarily
-  var parent = videoEl.parentNode;
-  var next = videoEl.nextSibling;
-  wrapper.appendChild(videoEl);
-  document.body.appendChild(wrapper);
+  var isolatedMarker = null;
+  if (document.documentElement.dataset.echoIsolatedPreview === "true") {
+    isolatedMarker = document.createElement("div");
+    isolatedMarker.className = "fullscreen-isolated-preview";
+    isolatedMarker.textContent = "Isolated preview · Not Live Echo";
+    host.appendChild(isolatedMarker);
+  }
 
-  // Fade out hint after 2s
-  setTimeout(function() { hint.classList.add("fade-out"); }, 2000);
+  var fullscreenControl = host.querySelector(".tile-fullscreen-btn");
+  var priorControlLabel = fullscreenControl && fullscreenControl.getAttribute("aria-label");
+  var priorControlTitle = fullscreenControl && fullscreenControl.title;
+  var responsiveSnapshot = captureFullscreenResponsiveState();
+  var entered = false;
+  var cleaned = false;
 
-  wrapper.requestFullscreen().then(function() {
-    // Click anywhere on wrapper exits fullscreen
-    wrapper.addEventListener("click", function() {
-      if (document.fullscreenElement) document.exitFullscreen();
-    });
-  }).catch(function() {
-    // Fullscreen denied — restore video
-    parent.insertBefore(videoEl, next);
-    wrapper.remove();
-  });
+  function setControlPresentation(isFullscreen) {
+    if (!fullscreenControl) return;
+    fullscreenControl.setAttribute(
+      "aria-label",
+      isFullscreen ? "Exit shared screen fullscreen" : (priorControlLabel || "Open shared screen fullscreen")
+    );
+    fullscreenControl.title = isFullscreen ? "Exit fullscreen" : (priorControlTitle || "Fullscreen");
+  }
 
-  // When exiting fullscreen, restore video to original location
-  var onFsChange = function() {
-    if (!document.fullscreenElement) {
-      document.removeEventListener("fullscreenchange", onFsChange);
-      if (wrapper.contains(videoEl)) {
-        parent.insertBefore(videoEl, next);
-      }
-      wrapper.remove();
+  function onHostClick(event) {
+    if (document.fullscreenElement !== host) return;
+    var interactive = event.target && typeof event.target.closest === "function"
+      ? event.target.closest("button, input, select, textarea, a[href]")
+      : null;
+    if (interactive) return;
+    event.preventDefault();
+    event.stopPropagation();
+    document.exitFullscreen();
+  }
+
+  function cleanup(restoreResponsiveState) {
+    if (cleaned) return;
+    cleaned = true;
+    document.removeEventListener("fullscreenchange", onFullscreenChange);
+    host.removeEventListener("click", onHostClick, true);
+    host.classList.remove("fullscreen-video-wrapper");
+    hint.remove();
+    if (isolatedMarker) isolatedMarker.remove();
+    setControlPresentation(false);
+    activeVideoFullscreenSession = null;
+    if (restoreResponsiveState) restoreFullscreenResponsiveState(responsiveSnapshot);
+    if (fullscreenControl && fullscreenControl.isConnected) {
+      try { fullscreenControl.focus({ preventScroll: true }); } catch (_focusError) {}
     }
-  };
-  document.addEventListener("fullscreenchange", onFsChange);
+  }
+
+  function onFullscreenChange() {
+    if (document.fullscreenElement === host) {
+      entered = true;
+      setControlPresentation(true);
+      return;
+    }
+    if (entered && !document.fullscreenElement) cleanup(true);
+  }
+
+  host.classList.add("fullscreen-video-wrapper");
+  host.addEventListener("click", onHostClick, true);
+  document.addEventListener("fullscreenchange", onFullscreenChange);
+  setTimeout(function() {
+    if (hint.isConnected) hint.classList.add("fade-out");
+  }, 2400);
+
+  var request = Promise.resolve().then(function() {
+    return host.requestFullscreen();
+  }).then(function() {
+    // Some embedded browser hosts can resolve the request while immediately
+    // declining the top-layer transition. Do not leave fullscreen-only classes
+    // and controls behind when no fullscreen element was established.
+    if (document.fullscreenElement !== host) {
+      cleanup(false);
+      return false;
+    }
+    entered = true;
+    setControlPresentation(true);
+    return true;
+  }).catch(function() {
+    cleanup(false);
+    return false;
+  });
+  activeVideoFullscreenSession = { host: host, promise: request };
+  return request;
 }
 
 // Image lightbox — click chat image to view full-size, click or ESC to close

--- a/core/viewer/participants-grid.js
+++ b/core/viewer/participants-grid.js
@@ -35,6 +35,7 @@ function addScreenTile(label, element, trackSid) {
   }
   ensureVideoPlays(element._lkTrack, element);
   const tile = addTile(label, element);
+  tile.style.setProperty("--screen-source-aspect-ratio", (16 / 9).toFixed(6));
 
   // Poster overlay: hide uninitialized GPU garbage (green/black flash) until first real frame.
   // Uses a dark cover that fades out once the video has decoded data.
@@ -128,10 +129,16 @@ function addScreenTile(label, element, trackSid) {
       const vw = element.videoWidth, vh = element.videoHeight;
       if (vw && vh) {
         const ratio = vw / vh;
+        const publishedRatio = ratio.toFixed(6);
+        const aspectChanged = tile.style.getPropertyValue("--screen-source-aspect-ratio") !== publishedRatio;
         tile.classList.toggle("ultrawide", ratio > 2.0);
         tile.classList.toggle("superwide", ratio > 2.8);
         tile.classList.toggle("portrait", ratio < 1.0);
         tile.dataset.aspectRatio = ratio.toFixed(2);
+        tile.style.setProperty("--screen-source-aspect-ratio", publishedRatio);
+        if (aspectChanged && typeof window._echoRecalcGrid === "function") {
+          window._echoRecalcGrid();
+        }
       }
     };
     element.addEventListener("loadedmetadata", tagAspect);

--- a/core/viewer/screen-video-surface.test.js
+++ b/core/viewer/screen-video-surface.test.js
@@ -17,11 +17,11 @@ test("screen video elements receive the protected surface class", () => {
   assert.match(gridJs, /element\.classList\.add\("screen-video-surface"\)/);
 });
 
-test("protected video surface rules avoid direct filters and clipping", () => {
+test("protected video surface rules avoid filters and rounded clipping", () => {
   const match = css.match(/\.screens-grid \.tile video\.screen-video-surface\s*\{([^}]*)\}/);
   assert.ok(match, "missing .screens-grid .tile video.screen-video-surface rule");
   assert.equal(/filter\s*:/.test(match[1]), false);
   assert.equal(/backdrop-filter\s*:/.test(match[1]), false);
-  assert.equal(/border-radius\s*:/.test(match[1]), false);
+  assert.match(match[1], /border-radius\s*:\s*0\s*;/);
   assert.equal(/box-shadow\s*:/.test(match[1]), false);
 });

--- a/core/viewer/style.css
+++ b/core/viewer/style.css
@@ -977,6 +977,7 @@ video {
   transform: translateZ(0);
   backface-visibility: hidden;
   mix-blend-mode: normal;
+  border-radius: 0;
 }
 
 .screens-grid {
@@ -993,7 +994,7 @@ video {
   max-height: 100%;
   max-width: 100%;
   overflow: visible;
-  aspect-ratio: 16 / 9;
+  aspect-ratio: var(--screen-source-aspect-ratio, 16 / 9);
   justify-self: center;
   align-self: center;
   position: relative;
@@ -1039,6 +1040,12 @@ video {
   grid-column: 1 / -1;
   max-height: none;
   min-height: 0;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  aspect-ratio: auto;
+  justify-self: stretch;
+  align-self: stretch;
   opacity: 1;
 }
 
@@ -2577,21 +2584,81 @@ video {
 }
 
 /* ─── Fullscreen Video ─── */
-.fullscreen-video-wrapper {
-  position: relative;
-  width: 100%;
-  height: 100%;
-  background: #000;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+.fullscreen-video-wrapper:fullscreen {
+  box-sizing: border-box !important;
+  position: relative !important;
+  width: 100vw !important;
+  height: 100vh !important;
+  min-width: 0 !important;
+  min-height: 0 !important;
+  max-width: none !important;
+  max-height: none !important;
+  margin: 0 !important;
+  padding: 0 !important;
+  display: grid !important;
+  grid-template: minmax(0, 1fr) / minmax(0, 1fr) !important;
+  gap: 0 !important;
+  place-items: stretch !important;
+  overflow: hidden !important;
+  aspect-ratio: auto !important;
+  border: 0 !important;
+  border-radius: 0 !important;
+  background: #000 !important;
+  box-shadow: none !important;
   cursor: pointer;
 }
-.fullscreen-video-wrapper video {
-  width: 100%;
-  height: 100%;
-  object-fit: contain !important;
+
+.fullscreen-video-wrapper:fullscreen::after {
+  display: none !important;
 }
+
+.fullscreen-video-wrapper:fullscreen > video {
+  grid-area: 1 / 1 !important;
+  width: 100% !important;
+  height: 100% !important;
+  min-width: 0 !important;
+  min-height: 0 !important;
+  max-width: none !important;
+  max-height: none !important;
+  align-self: stretch !important;
+  justify-self: stretch !important;
+  object-fit: contain !important;
+  border-radius: 0 !important;
+  background: #000 !important;
+  z-index: 1;
+}
+
+.fullscreen-video-wrapper:fullscreen > h3 {
+  position: absolute;
+  top: 16px;
+  left: 16px;
+  z-index: 12;
+  width: max-content;
+  max-width: calc(100% - 92px);
+  pointer-events: none;
+}
+
+.fullscreen-video-wrapper:fullscreen .tile-fullscreen-btn {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  z-index: 14;
+  width: 44px;
+  height: 44px;
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.fullscreen-video-wrapper:fullscreen .tile-fullscreen-btn:focus-visible {
+  outline: 3px solid #f8d58a;
+  outline-offset: 3px;
+}
+
+.fullscreen-video-wrapper:fullscreen .tile-volume-wrap,
+.fullscreen-video-wrapper:fullscreen .tile-overlay {
+  z-index: 12;
+}
+
 .fullscreen-hint {
   position: absolute;
   bottom: 40px;
@@ -2609,6 +2676,28 @@ video {
 }
 .fullscreen-hint.fade-out {
   opacity: 0;
+}
+
+.fullscreen-isolated-preview {
+  position: absolute;
+  top: 18px;
+  left: 50%;
+  z-index: 13;
+  max-width: calc(100% - 220px);
+  padding: 6px 10px;
+  overflow: hidden;
+  color: #fff3c7;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-overflow: ellipsis;
+  text-transform: uppercase;
+  white-space: nowrap;
+  border: 1px solid rgba(248, 213, 138, 0.65);
+  border-radius: 999px;
+  background: rgba(75, 45, 8, 0.9);
+  transform: translateX(-50%);
+  pointer-events: none;
 }
 
 /* ── Bug Report ── */

--- a/core/viewer/ui-shell.js
+++ b/core/viewer/ui-shell.js
@@ -121,6 +121,31 @@
       };
     }
 
+    function isResponsiveMode(mode) {
+      if (policy && typeof policy.isMode === "function") return policy.isMode(mode);
+      return ["mini", "compact", "lounge", "theater"].includes(mode);
+    }
+
+    function captureResponsiveState() {
+      const viewport = readViewport();
+      const mode = isResponsiveMode(previousMode)
+        ? previousMode
+        : isResponsiveMode(rootElement.dataset.uiMode)
+          ? rootElement.dataset.uiMode
+          : null;
+      return Object.freeze({
+        mode,
+        width: viewport.width,
+        height: viewport.height,
+      });
+    }
+
+    function restoreResponsiveState(snapshot) {
+      if (rootElement.dataset.uiShell !== V2_VARIANT) return null;
+      previousMode = snapshot && isResponsiveMode(snapshot.mode) ? snapshot.mode : null;
+      return measureNow();
+    }
+
     function notifyPresentationChange(resolved) {
       const detail = {
         variant: rootElement.dataset.uiShell || LEGACY_VARIANT,
@@ -208,7 +233,9 @@
 
     return Object.freeze({
       applyVariant,
+      captureResponsiveState,
       measureNow,
+      restoreResponsiveState,
       scheduleMeasure,
       start,
       stop,
@@ -239,16 +266,26 @@
     return installedController ? installedController.applyVariant(value, options) : null;
   }
 
+  function captureResponsiveState() {
+    return installedController ? installedController.captureResponsiveState() : null;
+  }
+
+  function restoreResponsiveState(snapshot) {
+    return installedController ? installedController.restoreResponsiveState(snapshot) : null;
+  }
+
   return {
     FLAG_NAME,
     LEGACY_VARIANT,
     V2_VARIANT,
     applyVariant,
+    captureResponsiveState,
     createShellController,
     install,
     normalizeVariant,
     parseFlagValue,
     readQueryOverride,
+    restoreResponsiveState,
     resolveShellVariant,
   };
 });

--- a/core/viewer/ui-shell.test.js
+++ b/core/viewer/ui-shell.test.js
@@ -6,6 +6,7 @@ const {
   parseFlagValue,
   resolveShellVariant,
 } = require("./ui-shell.js");
+const layoutPolicy = require("./layout-policy.js");
 
 function createHarness(policyOverride) {
   const attributes = new Set();
@@ -176,4 +177,30 @@ test("runtime variant changes can persist without rebuilding the controller", ()
   controller.applyVariant("legacy", { persist: true });
   assert.equal(harness.storage.get("echo-ui-shell-v2"), "0");
   assert.equal(harness.listeners.get("resize").length, 1);
+});
+
+test("fullscreen state restoration resumes hysteresis from the prior layout mode", () => {
+  const harness = createHarness(layoutPolicy);
+  const controller = createShellController(harness);
+
+  harness.rootElement.clientWidth = 800;
+  harness.rootElement.clientHeight = 600;
+  controller.start("v2");
+  assert.equal(harness.rootElement.dataset.uiMode, "compact");
+
+  harness.rootElement.clientWidth = 900;
+  controller.measureNow();
+  assert.equal(harness.rootElement.dataset.uiMode, "compact");
+  const beforeFullscreen = controller.captureResponsiveState();
+  assert.deepEqual(beforeFullscreen, { mode: "compact", width: 900, height: 600 });
+
+  harness.rootElement.clientWidth = 1920;
+  harness.rootElement.clientHeight = 1080;
+  controller.measureNow();
+  assert.equal(harness.rootElement.dataset.uiMode, "theater");
+
+  harness.rootElement.clientWidth = 900;
+  harness.rootElement.clientHeight = 600;
+  controller.restoreResponsiveState(beforeFullscreen);
+  assert.equal(harness.rootElement.dataset.uiMode, "compact");
 });

--- a/docs/UI-RESPONSIVE-CONTRACT.md
+++ b/docs/UI-RESPONSIVE-CONTRACT.md
@@ -178,8 +178,11 @@ The screen-grid allocator calculates media tile geometry inside the stage. It
 receives the stage's available rectangle; it must not duplicate shell
 breakpoints or control utility-panel behavior. A single visible share owns the
 full grid independently of the currently decoded media resolution. Two or more
-shares use the canonical grid policy, and every video preserves its source with
-`object-fit: contain`.
+shares use the canonical grid policy. That policy may use each decoded source's
+aspect ratio to choose tracks, but its input rectangle is always the Stage's CSS
+viewport geometry rather than physical display pixels. Every video preserves
+its complete source frame with `object-fit: contain`; letterboxing and
+pillarboxing are preferred to cropping or stretching.
 
 The Camera Lobby uses the same canonical grid policy against the lobby's own
 available rectangle. Resizing may change only grid tracks and tile geometry; it
@@ -403,13 +406,25 @@ The same media element must remain connected to the same track across a resize.
 CSS may change its containing geometry and `object-fit`. The media-grid owner may
 recalculate tile tracks after its container changes size.
 
+Browser fullscreen must target the existing stable media tile (or another
+existing stable media host). It must not reparent, clone, or replace the live
+video. The fullscreen host keeps an explicit, keyboard-reachable exit control,
+preserves source aspect ratio, and restores focus, focused-share state, and the
+pre-fullscreen responsive hysteresis history after exit. Resize and display
+changes while fullscreen may update the temporary presentation, but must not
+leave stale tracks or geometry after exit. The Windows desktop shell inherits
+this HTML fullscreen path through its WebView runtime; responsive code must not
+also invoke an independent native fullscreen toggle.
+
 If an intentional user action hides or stops watching media, that feature's
 existing state machine remains the owner. Responsive code must not impersonate
 that action.
 
 Acceptance tests for the shell must retain references to representative media
-nodes, cross every hysteresis boundary in both directions, and assert object
-identity, track identity, publication state, volume, and selected UI state.
+nodes, cross every hysteresis boundary in both directions, exercise repeated
+fullscreen enter/exit cycles, and assert object identity, track identity,
+publication state, volume, focused-share state, responsive mode restoration,
+and selected UI state.
 
 ## Accessibility and Input Contract
 


### PR DESCRIPTION
## Summary

- keep screen and camera media inside their stable tile/avatar host during browser fullscreen
- make Stage allocation source-aspect-aware across 16:9, 16:10, 21:9, 32:9, 4:3, and portrait media
- preserve responsive mode, media identity, focus, controls, and geometry across fullscreen entry, resize, exit, and retry
- add an isolated dynamic-port preview plus focused Chromium regression coverage and responsive-contract documentation

## Root cause

The old fullscreen helper moved the live `<video>` into a temporary body wrapper and later restored it using a saved sibling. If that transient sibling disappeared while fullscreen, restoration threw and stranded the media outside Stage. Reparenting also made normal subscription reconciliation think the video was missing, allowing duplicate or stale media nodes. Separately, Stage tiles were always allocated as 16:9 even when decoded media had a different aspect ratio, which badly under-used ultrawide and portrait layouts.

## Release impact

Server-served viewer only. No native desktop client source changed and no desktop binary update is required. The Windows WebView2 shell inherits the same served viewer and already maps HTML fullscreen to its native fullscreen state; this change deliberately does not invoke the dormant native fullscreen command.

No production service, client, room, user, SFU, TURN, Spotify integration, hostname, or port was touched.

## Validation

- `tools/verify/quick.sh`: guardrails and syntax checks passed; 277 deterministic JavaScript tests passed; Rust control-plane check passed
- `npm run verify:viewer:layout`: 154/154 Chromium layout tests passed on a dynamically assigned loopback port
- focused `stage.fullscreen.spec.js`: 11/11 passed, covering media ownership, camera fullscreen, rejected requests/retry, disappearing poster siblings, repeated cycles, fullscreen/post-exit resize, mixed 32:9 + portrait Stage geometry, keyboard exit, display scaling, and compact/mini controls
- source/viewer matrix covers 1366x768, 1920x1080, 2560x1440, 3840x2160, 3440x1440, and 5120x1440
- final in-app browser inspection confirmed contained, uncropped media; zero document overflow; stable media identity; working controls; and correct restoration
- generated build/test artifacts and task-owned preview processes were removed after validation
