### PR TITLE
Fix Android Firefox screen receiving

### DIFF
--- a/core/viewer/android-firefox-screen-recovery.test.js
+++ b/core/viewer/android-firefox-screen-recovery.test.js
@@ -1,0 +1,163 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const {
+  attemptAndroidFirefoxScreenSubscriptionReset,
+} = require("./participants-fullscreen.js");
+
+function createGeneration() {
+  const calls = [];
+  const timers = [];
+  const track = {
+    kind: "video",
+    mediaStreamTrack: { readyState: "live", muted: true },
+  };
+  const publication = {
+    isSubscribed: true,
+    track,
+    setSubscribed(value) {
+      calls.push(["setSubscribed", value]);
+      this.isSubscribed = value;
+    },
+  };
+  const tile = {
+    isConnected: true,
+    dataset: { trackSid: "TR_old" },
+  };
+  const meta = { publication, tile, identity: "sam" };
+  const metaBySid = new Map([["TR_old", meta]]);
+  const tileBySid = new Map([["TR_old", tile]]);
+  const recoveryStateBySid = new Map();
+  return {
+    calls,
+    timers,
+    publication,
+    tile,
+    meta,
+    metaBySid,
+    tileBySid,
+    recoveryStateBySid,
+    options: {
+      enabled: true,
+      trackSid: "TR_old",
+      meta,
+      publication,
+      tile,
+      frameAgeMs: 6000,
+      firstLineRecoveryAt: 1000,
+      recoveryStateBySid,
+      getCurrentMeta: (sid) => metaBySid.get(sid),
+      getCurrentTile: (sid) => tileBySid.get(sid),
+      isHidden: () => false,
+      markResubscribeIntent: (sid) => calls.push(["intent", sid]),
+      requestKeyFrame: () => calls.push(["keyframe"]),
+      schedule: (callback, delay) => timers.push({ callback, delay }),
+    },
+  };
+}
+
+test("non-target receiver gates cause zero subscription recovery actions", () => {
+  const negativePlatforms = [
+    "Windows Chrome",
+    "Windows Tauri",
+    "macOS Safari",
+    "macOS Chrome",
+    "Android Chrome",
+    "iOS Safari",
+    "iOS Firefox",
+  ];
+
+  for (const label of negativePlatforms) {
+    const fixture = createGeneration();
+    fixture.options.enabled = false;
+    assert.equal(attemptAndroidFirefoxScreenSubscriptionReset(fixture.options), false, label);
+    assert.deepEqual(fixture.calls, [], label + " must not change a subscription");
+    assert.deepEqual(fixture.timers, [], label + " must not schedule recovery");
+  }
+});
+
+test("stalled Android Firefox screen subscription resets exactly once", () => {
+  const fixture = createGeneration();
+
+  assert.equal(attemptAndroidFirefoxScreenSubscriptionReset(fixture.options), true);
+  assert.deepEqual(fixture.calls, [
+    ["intent", "TR_old"],
+    ["setSubscribed", false],
+  ]);
+  assert.equal(fixture.timers.length, 1);
+  assert.equal(fixture.timers[0].delay, 500);
+
+  assert.equal(attemptAndroidFirefoxScreenSubscriptionReset(fixture.options), false);
+  assert.equal(fixture.timers.length, 1, "the same SID must never start another reset timer");
+
+  fixture.timers[0].callback();
+  assert.deepEqual(fixture.calls, [
+    ["intent", "TR_old"],
+    ["setSubscribed", false],
+    ["setSubscribed", true],
+    ["keyframe"],
+  ]);
+});
+
+test("old-generation reset timer cannot touch a replacement track", () => {
+  const fixture = createGeneration();
+  assert.equal(attemptAndroidFirefoxScreenSubscriptionReset(fixture.options), true);
+
+  const replacementTile = { isConnected: true, dataset: { trackSid: "TR_new" } };
+  const replacementPublication = { isSubscribed: true, track: {} };
+  const replacementMeta = {
+    publication: replacementPublication,
+    tile: replacementTile,
+    identity: "sam",
+  };
+  fixture.metaBySid.delete("TR_old");
+  fixture.tileBySid.delete("TR_old");
+  fixture.metaBySid.set("TR_new", replacementMeta);
+  fixture.tileBySid.set("TR_new", replacementTile);
+
+  fixture.timers[0].callback();
+  assert.deepEqual(fixture.calls, [
+    ["intent", "TR_old"],
+    ["setSubscribed", false],
+  ]);
+  assert.equal(replacementPublication.isSubscribed, true);
+  assert.equal(replacementTile.isConnected, true);
+});
+
+test("same-SID metadata replacement cannot reset the one-shot recovery state", () => {
+  const fixture = createGeneration();
+  assert.equal(attemptAndroidFirefoxScreenSubscriptionReset(fixture.options), true);
+
+  const replacementCalls = [];
+  const replacementTile = { isConnected: true, dataset: { trackSid: "TR_old" } };
+  const replacementPublication = {
+    isSubscribed: true,
+    track: {
+      kind: "video",
+      mediaStreamTrack: { readyState: "live", muted: true },
+    },
+    setSubscribed(value) {
+      replacementCalls.push(value);
+      this.isSubscribed = value;
+    },
+  };
+  const replacementMeta = {
+    publication: replacementPublication,
+    tile: replacementTile,
+    identity: "sam",
+  };
+  fixture.metaBySid.set("TR_old", replacementMeta);
+  fixture.tileBySid.set("TR_old", replacementTile);
+
+  const replacementOptions = {
+    ...fixture.options,
+    meta: replacementMeta,
+    publication: replacementPublication,
+    tile: replacementTile,
+  };
+
+  assert.equal(attemptAndroidFirefoxScreenSubscriptionReset(replacementOptions), false);
+  assert.deepEqual(replacementCalls, []);
+  assert.equal(fixture.timers.length, 1, "same SID must retain its original one-shot timer only");
+  fixture.timers[0].callback();
+  assert.deepEqual(replacementCalls, []);
+});

--- a/core/viewer/connect.js
+++ b/core/viewer/connect.js
@@ -315,7 +315,9 @@ async function connectToRoom({ controlUrl, sfuUrl, roomId, identity, name, reuse
   // Chrome BWE starts at ~300kbps and probes up. If the SFU answer caps bandwidth
   // (b=AS or b=TIAS), Chrome never probes higher. We munge BOTH local and remote
   // descriptions to set 8Mbps bandwidth and add x-google bitrate hints.
-  if (!window._sdpMungingInstalled) {
+  var _skipAndroidFirefoxRtcOverrides = typeof isAndroidFirefoxBrowser === "function" &&
+    isAndroidFirefoxBrowser(navigator, window.__ECHO_NATIVE__ === true);
+  if (!_skipAndroidFirefoxRtcOverrides && !window._sdpMungingInstalled) {
     window._sdpMungingInstalled = true;
 
     function _mungeSDPBandwidth(sdp) {
@@ -520,6 +522,8 @@ async function connectToRoom({ controlUrl, sfuUrl, roomId, identity, name, reuse
     };
 
     debugLog("SDP + transceiver + setParameters overrides installed (H264 High 5.1, simulcast 3-layer, 20Mbps aggregate)");
+  } else if (_skipAndroidFirefoxRtcOverrides) {
+    debugLog("[SDP] custom WebRTC overrides skipped for Android Firefox");
   }
 
   const LK = getLiveKitClient();

--- a/core/viewer/index.html
+++ b/core/viewer/index.html
@@ -792,7 +792,7 @@
     <script src="display-status.js?v=0.6.10-local.1.1776128211"></script>
     <script src="native-presenter.js?v=0.6.11.1777921630"></script>
     <script src="identity.js?v=0.6.11.1777930912"></script>
-    <script src="rnnoise.js?v=0.6.11.1777930912"></script>
+    <script src="rnnoise.js?v=0.6.34.1786386773"></script>
     <script src="chimes.js?v=0.6.11.1777930912"></script>
     <script src="room-status.js?v=0.6.11.1777930912"></script>
     <script src="auth.js?v=0.6.11.1777930912"></script>
@@ -806,17 +806,17 @@
     <script src="screen-share-quality.js?v=0.6.11.1777930912"></script>
     <script src="screen-share-adaptive.js?v=0.6.11.1777930912"></script>
     <script src="screen-share-native.js?v=0.6.11.1777930912"></script>
-    <script src="participants-grid.js?v=0.6.34.1786210901"></script>
+    <script src="participants-grid.js?v=0.6.34.1786386773"></script>
     <script src="grid-layout.js?v=0.6.34.1786210901"></script>
     <script src="camera-lobby-layout.js?v=0.6.11.1777930912"></script>
     <script src="participants-avatar.js?v=0.6.11.1777930912"></script>
-    <script src="participants-fullscreen.js?v=0.6.34.1786210901"></script>
+    <script src="participants-fullscreen.js?v=0.6.34.1786386773"></script>
     <script src="participants.js?v=0.6.11.1777930912"></script>
     <script src="audio-routing.js?v=0.6.11.1777930912"></script>
     <script src="media-controls.js?v=0.6.11.1777930912"></script>
     <script src="admin-history.js?v=0.6.34.1785470400"></script>
     <script src="admin.js?v=0.6.34.1785470400"></script>
-    <script src="connect.js?v=0.6.11.1777930912"></script>
+    <script src="connect.js?v=0.6.34.1786386773"></script>
     <script src="app.js?v=0.6.11.1777930912"></script>
     <script src="capture-picker.js?v=0.6.11.1777930912"></script>
     <script src="jam-visualizer.js?v=0.6.34.1785384000"></script>

--- a/core/viewer/participants-fullscreen.js
+++ b/core/viewer/participants-fullscreen.js
@@ -4,6 +4,64 @@
    ========================================================= */
 
 var activeVideoFullscreenSession = null;
+var androidFirefoxScreenRecoveryBySid = new Map();
+
+function isCurrentScreenRecoveryGeneration(options) {
+  if (!options || !options.trackSid || !options.meta || !options.publication || !options.tile) return false;
+  if (!options.tile.isConnected) return false;
+  if (options.tile.dataset?.trackSid !== options.trackSid) return false;
+  if (options.meta.publication !== options.publication || options.meta.tile !== options.tile) return false;
+  if (options.getCurrentMeta(options.trackSid) !== options.meta) return false;
+  if (options.getCurrentTile(options.trackSid) !== options.tile) return false;
+  if (options.isHidden && options.isHidden(options.meta.identity)) return false;
+  return true;
+}
+
+function attemptAndroidFirefoxScreenSubscriptionReset(options) {
+  if (!options || options.enabled !== true) return false;
+  var meta = options.meta;
+  var publication = options.publication;
+  var trackSid = options.trackSid;
+  var tile = options.tile;
+  if (!isCurrentScreenRecoveryGeneration(options)) return false;
+  if (!options.recoveryStateBySid) return false;
+  var recoveryState = options.recoveryStateBySid.get(trackSid);
+  if (recoveryState?.subscriptionResetAttempted === true) return false;
+  if (publication.isSubscribed !== true || typeof publication.setSubscribed !== "function") return false;
+  var mediaTrack = publication.track?.mediaStreamTrack;
+  if (!mediaTrack || mediaTrack.readyState !== "live" || mediaTrack.muted !== true) return false;
+  if (!(options.frameAgeMs > 3000) || !(options.firstLineRecoveryAt > 0)) return false;
+
+  // Mark before touching the subscription. TrackUnsubscribed can arrive
+  // synchronously. SID-scoped state survives same-SID metadata replacement,
+  // so this recovery cannot turn into a reset loop.
+  options.recoveryStateBySid.set(trackSid, { subscriptionResetAttempted: true });
+  if (typeof options.markResubscribeIntent === "function") {
+    options.markResubscribeIntent(trackSid);
+  }
+  if (typeof options.log === "function") {
+    options.log("[android-firefox-recovery] resetting stalled screen subscription sid=" + trackSid);
+  }
+  var originalTrack = publication.track;
+  publication.setSubscribed(false);
+
+  options.schedule(function() {
+    var currentOptions = Object.assign({}, options, {
+      meta: meta,
+      publication: publication,
+      tile: tile,
+    });
+    if (!isCurrentScreenRecoveryGeneration(currentOptions)) return;
+    publication.setSubscribed(true);
+    if (typeof options.requestKeyFrame === "function") {
+      options.requestKeyFrame(publication, publication.track || originalTrack);
+    }
+    if (typeof options.log === "function") {
+      options.log("[android-firefox-recovery] restored screen subscription sid=" + trackSid);
+    }
+  }, options.resetDelayMs == null ? 500 : options.resetDelayMs);
+  return true;
+}
 
 function resolveVideoFullscreenHost(videoEl) {
   if (!videoEl || !videoEl.isConnected) return null;
@@ -197,6 +255,7 @@ function registerScreenTrack(trackSid, publication, tile, identity) {
 
 function unregisterScreenTrack(trackSid) {
   if (!trackSid) return;
+  androidFirefoxScreenRecoveryBySid.delete(trackSid);
   if (typeof stopNativePresenterForTrack === "function") {
     stopNativePresenterForTrack(trackSid).catch(function(e) {
       debugLog("[native-presenter] unregister stop failed: " + (e && e.message ? e.message : e));
@@ -244,6 +303,41 @@ function startScreenWatchdog() {
       // New tiles need time to receive first frames before recovery kicks in.
       var tileAge = now - (meta.createdAt || 0);
       if (tileAge < 8000) return;
+      const stalled = age > 3000;
+
+      // Firefox on Android can negotiate successfully, decode a handful of
+      // frames, then leave every remote MediaStreamTrack live-but-muted. Give
+      // the normal keyframe/reattach recovery one full watchdog pass first,
+      // then perform one exact-SID subscription reset. No other browser or the
+      // native desktop shell can enter this path.
+      var androidFirefoxRecoveryEnabled = typeof isAndroidFirefoxBrowser === "function" &&
+        isAndroidFirefoxBrowser(
+          typeof navigator === "object" ? navigator : null,
+          typeof window === "object" && window.__ECHO_NATIVE__ === true
+        );
+      var localScreenIdentity = room?.localParticipant?.identity || null;
+      var isRemoteScreen = !!meta.identity && meta.identity !== localScreenIdentity;
+      if (androidFirefoxRecoveryEnabled && isRemoteScreen && stalled &&
+          meta.lastFix > 0 && now - meta.lastFix >= 2500) {
+        var resetScheduled = attemptAndroidFirefoxScreenSubscriptionReset({
+          enabled: true,
+          trackSid: trackSid,
+          meta: meta,
+          publication: publication,
+          tile: tile,
+          frameAgeMs: age,
+          firstLineRecoveryAt: meta.lastFix,
+          recoveryStateBySid: androidFirefoxScreenRecoveryBySid,
+          getCurrentMeta: function(sid) { return screenTrackMeta.get(sid); },
+          getCurrentTile: function(sid) { return screenTileBySid.get(sid); },
+          isHidden: function(identity) { return hiddenScreens.has(identity); },
+          markResubscribeIntent: markResubscribeIntent,
+          requestKeyFrame: requestVideoKeyFrame,
+          schedule: setTimeout,
+          log: debugLog,
+        });
+        if (resetScheduled) return;
+      }
       if (isBlack && blackFor > 3000 && track) {
         if (!meta.lastSwap || now - meta.lastSwap > 10000) {
           meta.lastSwap = now;
@@ -265,7 +359,6 @@ function startScreenWatchdog() {
       }
       // Give new tracks time to settle before trying aggressive recovery.
       if (!isBlack && sinceFirstFrame > 0 && sinceFirstFrame < 5000 && age < 5000) return;
-      const stalled = age > 3000;
       if (!stalled) return;
       const minFixInterval = meta.lastFix ? (isBlack ? 8000 : 15000) : (isBlack ? 4000 : 6000);
       if (now - (meta.lastFix || 0) < minFixInterval) return;
@@ -664,8 +757,10 @@ function attachVideoDiagnostics(track, element, overlay) {
 
 if (typeof module === "object" && module.exports) {
   module.exports = {
+    attemptAndroidFirefoxScreenSubscriptionReset,
     createVideoFrameRateTracker,
     getVideoPresentationSnapshot,
+    isCurrentScreenRecoveryGeneration,
   };
 }
 

--- a/core/viewer/participants-grid.js
+++ b/core/viewer/participants-grid.js
@@ -181,6 +181,7 @@ function clearMedia() {
   screenTileBySid.clear();
   screenTileByIdentity.clear();
   screenTrackMeta.clear();
+  androidFirefoxScreenRecoveryBySid.clear();
   screenRecoveryAttempts.clear();
   screenResubscribeIntent.clear();
   stopInboundScreenStatsMonitor();

--- a/core/viewer/rnnoise.js
+++ b/core/viewer/rnnoise.js
@@ -4,6 +4,16 @@
 
 // Mobile device detection — variable declared in state.js, assigned here
 var _isMobileDevice = /Android|iPhone|iPad|iPod|Mobile/i.test(navigator.userAgent);
+
+// Firefox on Android needs LiveKit's unmodified SDP negotiation. Keep this
+// predicate narrow so every desktop/native client and other mobile browser
+// retains the existing custom WebRTC overrides.
+function isAndroidFirefoxBrowser(navigatorObject, isNativeShell) {
+  if (isNativeShell) return false;
+  var ua = String(navigatorObject && navigatorObject.userAgent || "");
+  return /Android/i.test(ua) && /Firefox\/\d/i.test(ua);
+}
+
 var _isMacOSDevice = (function() {
   try {
     var uaPlatform = navigator.userAgentData && navigator.userAgentData.platform;

--- a/core/viewer/rnnoise.test.js
+++ b/core/viewer/rnnoise.test.js
@@ -5,6 +5,7 @@ const path = require("node:path");
 const vm = require("node:vm");
 
 const source = fs.readFileSync(path.join(__dirname, "rnnoise.js"), "utf8");
+const connectSource = fs.readFileSync(path.join(__dirname, "connect.js"), "utf8");
 
 function loadRnnoise(options = {}) {
   const logs = [];
@@ -68,6 +69,72 @@ test("Windows keeps the existing RNNoise default and saved preference", () => {
   assert.equal(defaultOn.enabled, true);
   assert.equal(savedOff.blocked, false);
   assert.equal(savedOff.enabled, false);
+});
+
+test("Android Firefox 153 is the only browser that bypasses custom RTC overrides", () => {
+  const loaded = loadRnnoise();
+  const isTarget = loaded.context.isAndroidFirefoxBrowser;
+  const cases = [
+    {
+      name: "Android Firefox 153",
+      expected: true,
+      navigator: {
+        userAgent: "Mozilla/5.0 (Android 16; Mobile; rv:153.0) Gecko/153.0 Firefox/153.0",
+      },
+    },
+    {
+      name: "Android Chrome 153",
+      expected: false,
+      navigator: {
+        userAgent: "Mozilla/5.0 (Linux; Android 16; Pixel 10 Pro) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/153.0.0.0 Mobile Safari/537.36",
+      },
+    },
+    {
+      name: "iOS Safari",
+      expected: false,
+      navigator: {
+        userAgent: "Mozilla/5.0 (iPhone; CPU iPhone OS 19_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/19.0 Mobile/15E148 Safari/604.1",
+      },
+    },
+    {
+      name: "Windows Chrome",
+      expected: false,
+      navigator: {
+        userAgent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/153.0.0.0 Safari/537.36",
+      },
+    },
+    {
+      name: "macOS Safari",
+      expected: false,
+      navigator: {
+        userAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 15_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/19.0 Safari/605.1.15",
+      },
+    },
+    {
+      name: "macOS Chrome",
+      expected: false,
+      navigator: {
+        userAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 15_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/153.0.0.0 Safari/537.36",
+      },
+    },
+  ];
+
+  for (const testCase of cases) {
+    assert.equal(isTarget(testCase.navigator, false), testCase.expected, testCase.name);
+  }
+  assert.equal(isTarget(cases[3].navigator, true), false, "Windows Tauri");
+  assert.equal(isTarget(cases[0].navigator, true), false, "native shells never bypass overrides");
+});
+
+test("connect gates the complete custom RTC override installer with the Android Firefox predicate", () => {
+  assert.match(
+    connectSource,
+    /isAndroidFirefoxBrowser\(navigator, window\.__ECHO_NATIVE__ === true\)/
+  );
+  assert.match(
+    connectSource,
+    /if \(!_skipAndroidFirefoxRtcOverrides && !window\._sdpMungingInstalled\) \{/
+  );
 });
 
 test("macOS enable request exits before touching room or media state", async () => {


### PR DESCRIPTION
## Summary

- bypass Echo's custom H264/SDP overrides only for non-native Android Firefox so LiveKit can use its native receiver negotiation
- add one exact-track, one-shot subscription reset after Android Firefox reports a sustained live-but-muted screen track and the existing recovery pass has failed
- guard delayed recovery against replaced tracks, hidden shares, and stale tile generations
- add explicit negative coverage proving Windows Chrome, Windows Tauri, macOS Safari/Chrome, Android Chrome, and iOS do not enter the new path

## Incident evidence

The Windows publisher and a desktop subscriber remained healthy at roughly 30 FPS with advancing encoded/decoded/presented frames. A clean Android Firefox 153 phone session instead reported all remote MediaStreamTracks as live/muted and no inbound media after negotiation, including after a forced room/share reload.

## Verification

- `npm run verify:quick`
- 283/283 viewer tests passed
- repository guardrails passed
- adversarial race/platform review found no blockers
- no builds, installs, desktop-client changes, control/SFU/TURN changes, or build artifacts

## Release impact

- [x] Server-only viewer update
- [ ] Desktop binary required
- [ ] Both

Windows and macOS browser/native behavior remains on the existing code path. Final effectiveness acceptance requires a fresh Android Firefox phone join after guarded viewer deployment.