### PR TITLE
fix(viewer): recover Android Firefox room disconnects

### DIFF
--- a/core/viewer/android-firefox-room-disconnect-recovery.test.js
+++ b/core/viewer/android-firefox-room-disconnect-recovery.test.js
@@ -1,0 +1,333 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const vm = require("node:vm");
+const {
+  createAndroidFirefoxRoomDisconnectRecovery,
+  resolvePostConnectMicrophoneBehavior,
+} = require("./room-switch-state.js");
+
+const rnnoiseSource = fs.readFileSync(path.join(__dirname, "rnnoise.js"), "utf8");
+const connectSource = fs.readFileSync(path.join(__dirname, "connect.js"), "utf8");
+
+const disconnectReasons = {
+  0: "UNKNOWN_REASON",
+  1: "CLIENT_INITIATED",
+  2: "DUPLICATE_IDENTITY",
+  3: "SERVER_SHUTDOWN",
+  4: "PARTICIPANT_REMOVED",
+  5: "ROOM_DELETED",
+  6: "STATE_MISMATCH",
+  7: "JOIN_FAILURE",
+  8: "MIGRATION",
+  9: "SIGNAL_CLOSE",
+  10: "ROOM_CLOSED",
+  11: "USER_UNAVAILABLE",
+  12: "USER_REJECTED",
+  13: "SIP_TRUNK_FAILURE",
+  14: "CONNECTION_TIMEOUT",
+  15: "MEDIA_FAILURE",
+};
+
+function loadRealBrowserPredicate() {
+  const context = {
+    navigator: { userAgent: "", platform: "" },
+    echoGet() { return null; },
+    debugLog() {},
+  };
+  vm.createContext(context);
+  vm.runInContext(rnnoiseSource, context, { filename: "rnnoise.js" });
+  return context.isAndroidFirefoxBrowser;
+}
+
+const isAndroidFirefoxBrowser = loadRealBrowserPredicate();
+
+function createHarness(options = {}) {
+  const timers = [];
+  const attempts = [];
+  let nextTimerId = 1;
+  let currentRoom = options.room || { sid: "old-room" };
+  let hidden = options.hidden === true;
+  let online = options.online !== false;
+  let switching = options.switching === true;
+  let reconnectCalls = 0;
+
+  const controller = createAndroidFirefoxRoomDisconnectRecovery({
+    navigatorObject: { userAgent: options.userAgent || "" },
+    isNativeShell: options.isNativeShell === true,
+    isTargetBrowser: isAndroidFirefoxBrowser,
+    retryDelaysMs: options.retryDelaysMs || [500, 2000, 5000],
+    getCurrentRoom() { return currentRoom; },
+    isSwitching() { return switching; },
+    isHidden() { return hidden; },
+    isOnline() { return online; },
+    schedule(callback, delay) {
+      const timer = { id: nextTimerId++, callback, delay, cancelled: false };
+      timers.push(timer);
+      return timer.id;
+    },
+    cancelSchedule(timerId) {
+      const timer = timers.find((candidate) => candidate.id === timerId);
+      if (timer) timer.cancelled = true;
+    },
+    onAttempt(state) { attempts.push(state.attempt); },
+  });
+
+  async function fireNextTimer() {
+    const timer = timers.find((candidate) => !candidate.cancelled);
+    assert.ok(timer, "expected a pending timer");
+    timers.splice(timers.indexOf(timer), 1);
+    await timer.callback();
+    return timer;
+  }
+
+  function liveTimers() {
+    return timers.filter((timer) => !timer.cancelled);
+  }
+
+  function disconnect(reason = 14, reconnectBehavior) {
+    return controller.handleDisconnected({
+      room: currentRoom,
+      reason,
+      disconnectReasons,
+      reconnect: async function() {
+        reconnectCalls += 1;
+        if (reconnectBehavior) return reconnectBehavior({ reconnectCalls, setCurrentRoom });
+        currentRoom = { sid: "replacement-room-" + reconnectCalls };
+      },
+    });
+  }
+
+  function setCurrentRoom(nextRoom) { currentRoom = nextRoom; }
+
+  return {
+    attempts,
+    controller,
+    disconnect,
+    fireNextTimer,
+    getCurrentRoom: () => currentRoom,
+    getReconnectCalls: () => reconnectCalls,
+    liveTimers,
+    setCurrentRoom,
+    setHidden(value) { hidden = value; },
+    setOnline(value) { online = value; },
+    setSwitching(value) { switching = value; },
+  };
+}
+
+const androidFirefoxUa =
+  "Mozilla/5.0 (Android 16; Mobile; rv:153.0) Gecko/153.0 Firefox/153.0";
+
+test("real browser predicate gives every PC, Mac, native, Chrome, and iOS client zero recovery actions", () => {
+  const cases = [
+    {
+      name: "Windows Chrome",
+      userAgent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/153.0.0.0 Safari/537.36",
+    },
+    {
+      name: "Windows Tauri",
+      userAgent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/153.0.0.0 Safari/537.36",
+      isNativeShell: true,
+    },
+    {
+      name: "Android Firefox native shell",
+      userAgent: androidFirefoxUa,
+      isNativeShell: true,
+    },
+    {
+      name: "macOS Safari",
+      userAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 15_6) AppleWebKit/605.1.15 Version/19.0 Safari/605.1.15",
+    },
+    {
+      name: "macOS Chrome",
+      userAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 15_6) AppleWebKit/537.36 Chrome/153.0.0.0 Safari/537.36",
+    },
+    {
+      name: "Android Chrome",
+      userAgent: "Mozilla/5.0 (Linux; Android 16; Pixel 10 Pro) AppleWebKit/537.36 Chrome/153.0.0.0 Mobile Safari/537.36",
+    },
+    {
+      name: "iOS Safari",
+      userAgent: "Mozilla/5.0 (iPhone; CPU iPhone OS 19_6 like Mac OS X) AppleWebKit/605.1.15 Version/19.0 Mobile/15E148 Safari/604.1",
+    },
+    {
+      name: "iOS Firefox",
+      userAgent: "Mozilla/5.0 (iPhone; CPU iPhone OS 19_6 like Mac OS X) AppleWebKit/605.1.15 FxiOS/153.0 Mobile/15E148 Safari/605.1.15",
+    },
+  ];
+
+  for (const testCase of cases) {
+    const harness = createHarness(testCase);
+    assert.equal(harness.controller.isEnabled(), false, testCase.name);
+    assert.equal(harness.disconnect(), false, testCase.name);
+    assert.equal(harness.controller.resume(), false, testCase.name);
+    assert.equal(harness.liveTimers().length, 0, testCase.name);
+    assert.equal(harness.getReconnectCalls(), 0, testCase.name);
+  }
+});
+
+test("Android Firefox unexpected disconnect is coalesced and reconnects through one scheduled action", async () => {
+  const harness = createHarness({ userAgent: androidFirefoxUa });
+
+  assert.equal(harness.controller.isEnabled(), true);
+  assert.equal(harness.disconnect(), true);
+  assert.equal(harness.disconnect(), false, "duplicate disconnect must coalesce");
+  assert.deepEqual(harness.liveTimers().map((timer) => timer.delay), [500]);
+
+  await harness.fireNextTimer();
+
+  assert.equal(harness.getReconnectCalls(), 1);
+  assert.deepEqual(harness.attempts, [1]);
+  assert.deepEqual(harness.controller.snapshot(), { enabled: true, active: false });
+});
+
+test("brief duplicate-identity race retries with bounded deterministic backoff", async () => {
+  const harness = createHarness({ userAgent: androidFirefoxUa });
+  const reconnect = ({ reconnectCalls, setCurrentRoom }) => {
+    if (reconnectCalls < 3) throw new Error("duplicate identity still draining");
+    setCurrentRoom({ sid: "reconnected-room" });
+  };
+
+  assert.equal(harness.disconnect(14, reconnect), true);
+  assert.deepEqual(harness.liveTimers().map((timer) => timer.delay), [500]);
+  await harness.fireNextTimer();
+  assert.deepEqual(harness.liveTimers().map((timer) => timer.delay), [2000]);
+  await harness.fireNextTimer();
+  assert.deepEqual(harness.liveTimers().map((timer) => timer.delay), [5000]);
+  await harness.fireNextTimer();
+
+  assert.equal(harness.getReconnectCalls(), 3);
+  assert.deepEqual(harness.attempts, [1, 2, 3]);
+  assert.deepEqual(harness.controller.snapshot(), { enabled: true, active: false });
+});
+
+test("failed recovery exhausts its bounded retry budget and cannot be restarted by duplicate events", async () => {
+  const harness = createHarness({ userAgent: androidFirefoxUa });
+  const fail = () => { throw new Error("still disconnected"); };
+
+  assert.equal(harness.disconnect(15, fail), true);
+  await harness.fireNextTimer();
+  await harness.fireNextTimer();
+  await harness.fireNextTimer();
+
+  assert.equal(harness.getReconnectCalls(), 3);
+  assert.equal(harness.liveTimers().length, 0);
+  assert.equal(harness.controller.snapshot().exhausted, true);
+  assert.equal(harness.disconnect(15, fail), false);
+  assert.equal(harness.liveTimers().length, 0);
+});
+
+test("hidden and offline Android Firefox recovery defers until both conditions clear", async () => {
+  const harness = createHarness({ userAgent: androidFirefoxUa, hidden: true, online: false });
+
+  assert.equal(harness.disconnect(), true);
+  assert.equal(harness.liveTimers().length, 0);
+  assert.equal(harness.controller.snapshot().waiting, true);
+  assert.equal(harness.controller.resume(), false);
+
+  harness.setHidden(false);
+  assert.equal(harness.controller.resume(), false, "offline state must continue deferring");
+  harness.setOnline(true);
+  assert.equal(harness.controller.resume(), true);
+  assert.deepEqual(harness.liveTimers().map((timer) => timer.delay), [500]);
+
+  await harness.fireNextTimer();
+  assert.equal(harness.getReconnectCalls(), 1);
+});
+
+test("expected, switching, stale, user, and server removals never schedule reconnect", () => {
+  const terminalReasons = [1, 2, 3, 4, 5, 7, 10, 11, 12, 13];
+  for (const reason of terminalReasons) {
+    const harness = createHarness({ userAgent: androidFirefoxUa });
+    assert.equal(harness.disconnect(reason), false, disconnectReasons[reason]);
+    assert.equal(harness.liveTimers().length, 0, disconnectReasons[reason]);
+    assert.equal(harness.getReconnectCalls(), 0, disconnectReasons[reason]);
+  }
+
+  const expected = createHarness({
+    userAgent: androidFirefoxUa,
+    room: { sid: "expected", _echoExpectedDisconnect: true },
+  });
+  assert.equal(expected.disconnect(), false);
+  assert.equal(expected.liveTimers().length, 0);
+
+  const switching = createHarness({ userAgent: androidFirefoxUa, switching: true });
+  assert.equal(switching.disconnect(), false);
+  assert.equal(switching.liveTimers().length, 0);
+
+  const stale = createHarness({ userAgent: androidFirefoxUa });
+  const staleRoom = stale.getCurrentRoom();
+  stale.setCurrentRoom({ sid: "new-current-room" });
+  assert.equal(stale.controller.handleDisconnected({
+    room: staleRoom,
+    reason: 14,
+    disconnectReasons,
+    reconnect() { throw new Error("must not run"); },
+  }), false);
+  assert.equal(stale.liveTimers().length, 0);
+});
+
+test("generation guard cancels a pending retry after another room becomes current", async () => {
+  const harness = createHarness({ userAgent: androidFirefoxUa });
+  assert.equal(harness.disconnect(), true);
+  harness.setCurrentRoom({ sid: "newer-room" });
+
+  await harness.fireNextTimer();
+
+  assert.equal(harness.getReconnectCalls(), 0);
+  assert.deepEqual(harness.controller.snapshot(), { enabled: true, active: false });
+});
+
+test("Android Firefox reconnect preserves muted mic and restores an enabled mic", () => {
+  assert.deepEqual(resolvePostConnectMicrophoneBehavior({
+    reuseAdmin: true,
+    preserveMicIntent: true,
+    micWasEnabled: false,
+  }), {
+    restoreMic: false,
+    preserveMutedMic: true,
+  });
+  assert.deepEqual(resolvePostConnectMicrophoneBehavior({
+    reuseAdmin: true,
+    preserveMicIntent: true,
+    micWasEnabled: true,
+  }), {
+    restoreMic: true,
+    preserveMutedMic: false,
+  });
+
+  // Existing generic switch behavior remains unchanged when the target-only
+  // preservation option is absent.
+  assert.deepEqual(resolvePostConnectMicrophoneBehavior({
+    reuseAdmin: true,
+    preserveMicIntent: false,
+    micWasEnabled: false,
+  }), {
+    restoreMic: false,
+    preserveMutedMic: false,
+  });
+});
+
+test("production wiring is target-gated and invokes only supported connectToRoom reuse path", () => {
+  assert.match(
+    connectSource,
+    /androidFirefoxRoomDisconnectRecoveryEnabled = typeof isAndroidFirefoxBrowser === "function" &&\s+isAndroidFirefoxBrowser\(navigator, window\.__ECHO_NATIVE__ === true\)/
+  );
+  assert.match(
+    connectSource,
+    /RoomEvent\.Disconnected[\s\S]*?androidFirefoxRoomDisconnectRecovery\?\.handleDisconnected\(\{[\s\S]*?reconnect: function\(\) \{\s+return connectToRoom\(\{[\s\S]*?reuseAdmin: true,[\s\S]*?preserveMicIntent: true/
+  );
+  assert.match(
+    connectSource,
+    /if \(androidFirefoxRoomDisconnectRecoveryEnabled && newRoom !== room\) \{[\s\S]*?return;/
+  );
+  assert.match(
+    connectSource,
+    /if \(androidFirefoxRoomDisconnectRecoveryEnabled &&\s+state === "disconnected" &&\s+newRoom !== room\) \{[\s\S]*?return;/
+  );
+  assert.match(
+    connectSource,
+    /if \(restoreMicAfterConnect\)[\s\S]*?else if \(preserveDisabledMicAfterConnect\)[\s\S]*?syncDesiredMicToActual\(false\)[\s\S]*?else \{/
+  );
+});

--- a/core/viewer/connect.js
+++ b/core/viewer/connect.js
@@ -91,6 +91,43 @@ document.addEventListener(
 let switchingRoom = false;
 let connectSequence = 0;
 
+var androidFirefoxRoomDisconnectRecovery = null;
+var androidFirefoxRoomDisconnectRecoveryEnabled = typeof isAndroidFirefoxBrowser === "function" &&
+  isAndroidFirefoxBrowser(navigator, window.__ECHO_NATIVE__ === true);
+if (androidFirefoxRoomDisconnectRecoveryEnabled &&
+    window.EchoRoomSwitchState?.createAndroidFirefoxRoomDisconnectRecovery) {
+  androidFirefoxRoomDisconnectRecovery =
+    window.EchoRoomSwitchState.createAndroidFirefoxRoomDisconnectRecovery({
+      navigatorObject: navigator,
+      isNativeShell: window.__ECHO_NATIVE__ === true,
+      isTargetBrowser: isAndroidFirefoxBrowser,
+      getCurrentRoom: function() { return room; },
+      isSwitching: function() { return switchingRoom || _isRoomSwitch; },
+      isHidden: function() { return document.hidden === true; },
+      isOnline: function() { return navigator.onLine !== false; },
+      schedule: setTimeout,
+      cancelSchedule: clearTimeout,
+      onAttempt: function(state) {
+        debugLog("[android-firefox-room-recovery] reconnect attempt " +
+          state.attempt + "/" + state.maxAttempts);
+      },
+      onAttemptFailed: function(state) {
+        debugLog("[android-firefox-room-recovery] reconnect attempt " +
+          state.attempt + " failed: " + (state.error?.message || state.error));
+      },
+      onExhausted: function(state) {
+        debugLog("[android-firefox-room-recovery] exhausted after " + state.attempts + " attempts");
+      },
+    });
+
+  document.addEventListener("visibilitychange", function() {
+    if (document.hidden !== true) androidFirefoxRoomDisconnectRecovery?.resume();
+  });
+  window.addEventListener("online", function() {
+    androidFirefoxRoomDisconnectRecovery?.resume();
+  });
+}
+
 function recordActiveRoomDiagnostic(candidateRoom, recorder) {
   if (!candidateRoom ||
       candidateRoom !== room ||
@@ -267,11 +304,33 @@ function reconcileLocalPublishIndicators(reason) {
   }
 }
 
-async function connectToRoom({ controlUrl, sfuUrl, roomId, identity, name, reuseAdmin }) {
+async function connectToRoom({
+  controlUrl,
+  sfuUrl,
+  roomId,
+  identity,
+  name,
+  reuseAdmin,
+  preserveMicIntent,
+}) {
   // A newly connected LiveKit participant has no publications yet. Preserve
   // the user's pre-switch intent separately so authoritative reconciliation
   // can report the new room truth without cancelling mic restoration.
-  const restoreMicAfterConnect = !!(reuseAdmin && desiredMicEnabledForRoomSwitch());
+  const micWasEnabledBeforeConnect = desiredMicEnabledForRoomSwitch() === true;
+  const postConnectMicBehavior = window.EchoRoomSwitchState?.resolvePostConnectMicrophoneBehavior
+    ? window.EchoRoomSwitchState.resolvePostConnectMicrophoneBehavior({
+        reuseAdmin: reuseAdmin === true,
+        preserveMicIntent: preserveMicIntent === true,
+        micWasEnabled: micWasEnabledBeforeConnect,
+      })
+    : {
+        restoreMic: reuseAdmin === true && micWasEnabledBeforeConnect,
+        preserveMutedMic: reuseAdmin === true &&
+          preserveMicIntent === true &&
+          !micWasEnabledBeforeConnect,
+      };
+  const restoreMicAfterConnect = postConnectMicBehavior.restoreMic;
+  const preserveDisabledMicAfterConnect = postConnectMicBehavior.preserveMutedMic;
   if (!controlUrl || !sfuUrl) {
     setStatus("Enter control URL and SFU URL.", true);
     return;
@@ -585,6 +644,12 @@ async function connectToRoom({ controlUrl, sfuUrl, roomId, identity, name, reuse
   if (LK.RoomEvent?.ConnectionStateChanged) {
     newRoom.on(LK.RoomEvent.ConnectionStateChanged, (state) => {
       if (!state) return;
+      if (androidFirefoxRoomDisconnectRecoveryEnabled &&
+          state === "disconnected" &&
+          newRoom !== room) {
+        debugLog("[android-firefox-room-recovery] ignored stale Room disconnected state");
+        return;
+      }
       debugLog("[connection] state changed: " + state);
       if (state === "reconnecting") {
         _isReconnecting = true;
@@ -606,6 +671,14 @@ async function connectToRoom({ controlUrl, sfuUrl, roomId, identity, name, reuse
   }
   if (LK.RoomEvent?.Disconnected) {
     newRoom.on(LK.RoomEvent.Disconnected, (reason) => {
+      // Failed reconnect candidates also emit Disconnected. On Android Firefox,
+      // ignore those stale Room instances before they overwrite the active
+      // session status or stop its stats monitor. Other platforms retain the
+      // existing handler behavior.
+      if (androidFirefoxRoomDisconnectRecoveryEnabled && newRoom !== room) {
+        debugLog("[android-firefox-room-recovery] ignored stale Room disconnect");
+        return;
+      }
       const detail = describeDisconnectReason(reason, LK);
       setStatus(`Disconnected: ${detail}`, true);
       if (!_isRoomSwitch) {
@@ -619,6 +692,25 @@ async function connectToRoom({ controlUrl, sfuUrl, roomId, identity, name, reuse
       // a plain disconnect (network drop, server kick) needs an explicit stop.
       if (typeof stopInboundScreenStatsMonitor === "function") {
         stopInboundScreenStatsMonitor();
+      }
+      var recoveryAccepted = androidFirefoxRoomDisconnectRecovery?.handleDisconnected({
+        room: newRoom,
+        reason: reason,
+        disconnectReasons: LK.DisconnectReason,
+        reconnect: function() {
+          return connectToRoom({
+            controlUrl: controlUrl,
+            sfuUrl: sfuUrl,
+            roomId: roomId,
+            identity: identity,
+            name: name,
+            reuseAdmin: true,
+            preserveMicIntent: true,
+          });
+        },
+      });
+      if (recoveryAccepted) {
+        setStatus("Reconnecting Android Firefox session...", true);
       }
     });
   }
@@ -1416,6 +1508,13 @@ async function connectToRoom({ controlUrl, sfuUrl, roomId, identity, name, reuse
     toggleMicOn(true).catch((err) => {
       debugLog("[mic] room-switch re-enable failed: " + (err.message || err));
     });
+  } else if (preserveDisabledMicAfterConnect) {
+    // Android Firefox transport recovery must not turn on a mic the user had
+    // muted. Generic room switches and first-connect behavior stay unchanged.
+    micEnabled = false;
+    syncDesiredMicToActual(false);
+    renderPublishButtons();
+    debugLog("[android-firefox-room-recovery] preserved muted microphone");
   } else {
     // First connect: go through full permission flow
     ensureDevicePermissions().then(() => refreshDevices()).then(() => {

--- a/core/viewer/room-switch-state.js
+++ b/core/viewer/room-switch-state.js
@@ -137,8 +137,216 @@
     return accessToken;
   }
 
+  function resolvePostConnectMicrophoneBehavior(options) {
+    const opts = options || {};
+    const restoreMic = opts.reuseAdmin === true && opts.micWasEnabled === true;
+    return {
+      restoreMic,
+      preserveMutedMic: opts.reuseAdmin === true &&
+        opts.preserveMicIntent === true &&
+        !restoreMic,
+    };
+  }
+
+  function createAndroidFirefoxRoomDisconnectRecovery(options) {
+    const opts = options || {};
+    const retryDelaysMs = Array.isArray(opts.retryDelaysMs)
+      ? opts.retryDelaysMs.filter((delay) => Number.isFinite(delay) && delay >= 0)
+      : [500, 2000, 5000];
+    const schedule = typeof opts.schedule === "function" ? opts.schedule : setTimeout;
+    const cancelSchedule = typeof opts.cancelSchedule === "function" ? opts.cancelSchedule : clearTimeout;
+    const getCurrentRoom = typeof opts.getCurrentRoom === "function" ? opts.getCurrentRoom : () => null;
+    const isSwitching = typeof opts.isSwitching === "function" ? opts.isSwitching : () => false;
+    const isHidden = typeof opts.isHidden === "function" ? opts.isHidden : () => false;
+    const isOnline = typeof opts.isOnline === "function" ? opts.isOnline : () => true;
+    const enabled = typeof opts.isTargetBrowser === "function" &&
+      opts.isTargetBrowser(opts.navigatorObject || null, opts.isNativeShell === true) === true;
+
+    let nextGeneration = 0;
+    let activeRecovery = null;
+
+    function disconnectReasonName(reason, disconnectReasons) {
+      if (typeof reason === "string") return reason.toUpperCase();
+      if (typeof reason === "number" && disconnectReasons && typeof disconnectReasons[reason] === "string") {
+        return disconnectReasons[reason].toUpperCase();
+      }
+      return reason == null ? "UNKNOWN_REASON" : "UNRECOGNIZED_REASON";
+    }
+
+    function isTerminalDisconnectReason(reason, disconnectReasons) {
+      const name = disconnectReasonName(reason, disconnectReasons);
+      return name === "CLIENT_INITIATED" ||
+        name === "DUPLICATE_IDENTITY" ||
+        name === "SERVER_SHUTDOWN" ||
+        name === "PARTICIPANT_REMOVED" ||
+        name === "ROOM_DELETED" ||
+        name === "JOIN_FAILURE" ||
+        name === "ROOM_CLOSED" ||
+        name === "USER_UNAVAILABLE" ||
+        name === "USER_REJECTED" ||
+        name === "SIP_TRUNK_FAILURE";
+    }
+
+    function clearActiveRecovery(expectedRecovery) {
+      if (!activeRecovery || (expectedRecovery && activeRecovery !== expectedRecovery)) return false;
+      if (activeRecovery.timerId != null) {
+        cancelSchedule(activeRecovery.timerId);
+      }
+      activeRecovery = null;
+      return true;
+    }
+
+    function isCurrentRecovery(recovery) {
+      return enabled &&
+        !!recovery &&
+        activeRecovery === recovery &&
+        recovery.room === getCurrentRoom() &&
+        recovery.room?._echoExpectedDisconnect !== true &&
+        isSwitching() !== true;
+    }
+
+    function queueNextAttempt(recovery) {
+      if (!isCurrentRecovery(recovery)) {
+        clearActiveRecovery(recovery);
+        return false;
+      }
+      if (recovery.nextAttemptIndex >= retryDelaysMs.length) {
+        recovery.exhausted = true;
+        recovery.waiting = false;
+        if (typeof opts.onExhausted === "function") {
+          opts.onExhausted({ room: recovery.room, attempts: recovery.nextAttemptIndex });
+        }
+        return false;
+      }
+      if (isHidden() === true || isOnline() !== true) {
+        recovery.waiting = true;
+        return false;
+      }
+
+      recovery.waiting = false;
+      const generation = recovery.generation;
+      const delayMs = retryDelaysMs[recovery.nextAttemptIndex];
+      recovery.timerId = schedule(function () {
+        recovery.timerId = null;
+        return runAttempt(recovery, generation);
+      }, delayMs);
+      return true;
+    }
+
+    async function runAttempt(recovery, generation) {
+      if (!isCurrentRecovery(recovery) || recovery.generation !== generation) {
+        clearActiveRecovery(recovery);
+        return false;
+      }
+      if (isHidden() === true || isOnline() !== true) {
+        recovery.waiting = true;
+        return false;
+      }
+
+      const attemptIndex = recovery.nextAttemptIndex;
+      recovery.nextAttemptIndex += 1;
+      recovery.inFlight = true;
+      if (typeof opts.onAttempt === "function") {
+        opts.onAttempt({
+          room: recovery.room,
+          attempt: attemptIndex + 1,
+          maxAttempts: retryDelaysMs.length,
+        });
+      }
+
+      let failed = false;
+      try {
+        await recovery.reconnect();
+      } catch (error) {
+        failed = true;
+        if (typeof opts.onAttemptFailed === "function") {
+          opts.onAttemptFailed({ room: recovery.room, attempt: attemptIndex + 1, error });
+        }
+      }
+
+      if (activeRecovery !== recovery || recovery.generation !== generation) return false;
+      recovery.inFlight = false;
+      if (!failed && getCurrentRoom() !== recovery.room) {
+        clearActiveRecovery(recovery);
+        return true;
+      }
+      if (!isCurrentRecovery(recovery)) {
+        clearActiveRecovery(recovery);
+        return false;
+      }
+      return queueNextAttempt(recovery);
+    }
+
+    function handleDisconnected(event) {
+      const detail = event || {};
+      const candidateRoom = detail.room;
+      if (!enabled || !candidateRoom || candidateRoom !== getCurrentRoom()) return false;
+
+      if (candidateRoom._echoExpectedDisconnect === true ||
+          isSwitching() === true ||
+          isTerminalDisconnectReason(detail.reason, detail.disconnectReasons)) {
+        if (activeRecovery?.room === candidateRoom) clearActiveRecovery(activeRecovery);
+        return false;
+      }
+      if (typeof detail.reconnect !== "function") return false;
+
+      if (activeRecovery) {
+        if (activeRecovery.room === candidateRoom) return false;
+        clearActiveRecovery(activeRecovery);
+      }
+
+      const recovery = {
+        room: candidateRoom,
+        reconnect: detail.reconnect,
+        generation: ++nextGeneration,
+        nextAttemptIndex: 0,
+        timerId: null,
+        inFlight: false,
+        waiting: false,
+        exhausted: false,
+      };
+      activeRecovery = recovery;
+      queueNextAttempt(recovery);
+      return true;
+    }
+
+    function resume() {
+      const recovery = activeRecovery;
+      if (!recovery || recovery.exhausted || recovery.inFlight || recovery.timerId != null) return false;
+      return queueNextAttempt(recovery);
+    }
+
+    function cancel(candidateRoom) {
+      if (candidateRoom && activeRecovery?.room !== candidateRoom) return false;
+      return clearActiveRecovery(activeRecovery);
+    }
+
+    function snapshot() {
+      if (!activeRecovery) return { enabled, active: false };
+      return {
+        enabled,
+        active: true,
+        attemptCount: activeRecovery.nextAttemptIndex,
+        scheduled: activeRecovery.timerId != null,
+        inFlight: activeRecovery.inFlight,
+        waiting: activeRecovery.waiting,
+        exhausted: activeRecovery.exhausted,
+      };
+    }
+
+    return {
+      cancel,
+      handleDisconnected,
+      isEnabled: () => enabled,
+      resume,
+      snapshot,
+    };
+  }
+
   return {
     commitConnectedAccessToken,
+    createAndroidFirefoxRoomDisconnectRecovery,
     createRoomSwitchState,
+    resolvePostConnectMicrophoneBehavior,
   };
 });


### PR DESCRIPTION
## Summary

- recover only non-native Android Firefox after a final unexpected current-Room disconnect
- reconnect through Echo's supported `connectToRoom` path with coalesced 500ms / 2s / 5s retries
- preserve muted/unmuted microphone intent and guard stale Room events
- leave Windows, macOS, Tauri/WebView2, Android Chrome, iOS, control, SFU, and native capture unchanged

## Evidence

The live phone session initially decoded the screen, then its signaling socket closed and LiveKit ended the entire participant with `PEER_CONNECTION_DISCONNECTED` plus publisher/subscriber DTLS timeouts. The Windows publisher and desktop receiver remained healthy at 28–29 FPS with advancing decoded/presented counters.

## Verification

- `npm run verify:quick` — 292/292 tests pass
- real UA/native negative matrix proves zero recovery actions on Windows Chrome/Tauri, macOS Safari/Chrome, Android Chrome/native shells, and iOS
- deterministic coverage for coalescing, bounded retries, stale generations, terminal disconnect reasons, hidden/offline deferral, stale Room events, and mic state
- `git diff --check`

## Release boundary

Server-served viewer only. No desktop binary, control, SFU, TURN, or capture changes. Production acceptance must keep Android Firefox streaming for more than 3 minutes and verify a visible screen-source content change while desktop remains healthy.