### PR TITLE
Recover stalled Android Firefox rooms

### DIFF
--- a/core/viewer/android-firefox-room-disconnect-recovery.test.js
+++ b/core/viewer/android-firefox-room-disconnect-recovery.test.js
@@ -316,7 +316,7 @@ test("production wiring is target-gated and invokes only supported connectToRoom
   );
   assert.match(
     connectSource,
-    /RoomEvent\.Disconnected[\s\S]*?androidFirefoxRoomDisconnectRecovery\?\.handleDisconnected\(\{[\s\S]*?reconnect: function\(\) \{\s+return connectToRoom\(\{[\s\S]*?reuseAdmin: true,[\s\S]*?preserveMicIntent: true/
+    /function reconnectAndroidFirefoxRoom\([\s\S]*?return connectToRoom\(\{[\s\S]*?reuseAdmin: true,[\s\S]*?preserveMicIntent: true[\s\S]*?RoomEvent\.Disconnected[\s\S]*?handleDisconnected\(\{[\s\S]*?reconnect: reconnectAndroidFirefoxRoom/
   );
   assert.match(
     connectSource,
@@ -324,7 +324,7 @@ test("production wiring is target-gated and invokes only supported connectToRoom
   );
   assert.match(
     connectSource,
-    /if \(androidFirefoxRoomDisconnectRecoveryEnabled &&\s+state === "disconnected" &&\s+newRoom !== room\) \{[\s\S]*?return;/
+    /ConnectionStateChanged[\s\S]*?if \(androidFirefoxRoomDisconnectRecoveryEnabled && newRoom !== room\) \{[\s\S]*?return;/
   );
   assert.match(
     connectSource,

--- a/core/viewer/android-firefox-stalled-reconnect-recovery.test.js
+++ b/core/viewer/android-firefox-stalled-reconnect-recovery.test.js
@@ -1,0 +1,354 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const vm = require("node:vm");
+const {
+  createAndroidFirefoxRoomDisconnectRecovery,
+  disconnectAndroidFirefoxRecoverySource,
+  resolvePostConnectMicrophoneBehavior,
+} = require("./room-switch-state.js");
+
+const rnnoiseSource = fs.readFileSync(path.join(__dirname, "rnnoise.js"), "utf8");
+const connectSource = fs.readFileSync(path.join(__dirname, "connect.js"), "utf8");
+
+function loadRealBrowserPredicate() {
+  const context = {
+    navigator: { userAgent: "", platform: "" },
+    echoGet() { return null; },
+    debugLog() {},
+  };
+  vm.createContext(context);
+  vm.runInContext(rnnoiseSource, context, { filename: "rnnoise.js" });
+  return context.isAndroidFirefoxBrowser;
+}
+
+const isAndroidFirefoxBrowser = loadRealBrowserPredicate();
+const androidFirefoxUa =
+  "Mozilla/5.0 (Android 16; Mobile; rv:153.0) Gecko/153.0 Firefox/153.0";
+const disconnectReasons = {
+  1: "CLIENT_INITIATED",
+  3: "SERVER_SHUTDOWN",
+  14: "CONNECTION_TIMEOUT",
+  15: "MEDIA_FAILURE",
+};
+
+function createHarness(options = {}) {
+  const timers = [];
+  const reconnectStates = [];
+  const stalled = [];
+  let nextTimerId = 1;
+  let currentRoom = options.room || { sid: "source-room" };
+  let hidden = options.hidden === true;
+  let online = options.online !== false;
+  let switching = options.switching === true;
+  let reconnectCalls = 0;
+
+  const controller = createAndroidFirefoxRoomDisconnectRecovery({
+    navigatorObject: { userAgent: options.userAgent || androidFirefoxUa },
+    isNativeShell: options.isNativeShell === true,
+    isTargetBrowser: isAndroidFirefoxBrowser,
+    stalledReconnectTimeoutMs: 15000,
+    retryDelaysMs: [500, 2000, 5000],
+    getCurrentRoom() { return currentRoom; },
+    isSwitching() { return switching; },
+    isHidden() { return hidden; },
+    isOnline() { return online; },
+    schedule(callback, delay) {
+      const timer = { id: nextTimerId++, callback, delay, cancelled: false };
+      timers.push(timer);
+      return timer.id;
+    },
+    cancelSchedule(timerId) {
+      const timer = timers.find((candidate) => candidate.id === timerId);
+      if (timer) timer.cancelled = true;
+    },
+    onStalledReconnect(state) { stalled.push(state); },
+  });
+
+  function reconnect(recoveryState) {
+    reconnectCalls += 1;
+    reconnectStates.push(recoveryState);
+    if (typeof options.reconnect === "function") {
+      return options.reconnect({
+        controller,
+        currentRoom,
+        reconnectCalls,
+        recoveryState,
+        setCurrentRoom,
+      });
+    }
+    currentRoom = { sid: "replacement-room-" + reconnectCalls };
+  }
+
+  function arm(micWasEnabled = false) {
+    return controller.handleReconnecting({
+      room: currentRoom,
+      reconnect,
+      micWasEnabled,
+    });
+  }
+
+  function disconnect(reason = 14, micWasEnabled = false) {
+    return controller.handleDisconnected({
+      room: currentRoom,
+      reason,
+      disconnectReasons,
+      reconnect,
+      micWasEnabled,
+    });
+  }
+
+  async function fire(timer, includeCancelled = false) {
+    assert.ok(timer, "expected a timer");
+    if (!includeCancelled) assert.equal(timer.cancelled, false, "timer must still be live");
+    timer.fired = true;
+    await timer.callback();
+  }
+
+  function liveTimers() {
+    return timers.filter((timer) => !timer.cancelled && !timer.fired);
+  }
+
+  function setCurrentRoom(room) { currentRoom = room; }
+
+  return {
+    arm,
+    controller,
+    disconnect,
+    fire,
+    getCurrentRoom: () => currentRoom,
+    getReconnectCalls: () => reconnectCalls,
+    liveTimers,
+    reconnectStates,
+    setCurrentRoom,
+    setHidden(value) { hidden = value; },
+    setOnline(value) { online = value; },
+    setSwitching(value) { switching = value; },
+    stalled,
+    timers,
+  };
+}
+
+test("stalled reconnect watchdog coalesces SDK events and carries first-event mic intent", async () => {
+  const harness = createHarness();
+
+  assert.equal(harness.arm(true), true);
+  assert.equal(harness.arm(false), false, "Room and signal reconnect events must share one watchdog");
+  assert.deepEqual(harness.liveTimers().map((timer) => timer.delay), [15000]);
+  assert.deepEqual(harness.controller.snapshot(), {
+    enabled: true,
+    active: false,
+    watching: true,
+    scheduled: true,
+    waiting: false,
+    stale: false,
+  });
+
+  await harness.fire(harness.liveTimers()[0]);
+  assert.equal(harness.getReconnectCalls(), 0, "watchdog expiry only queues the bounded fresh attempt");
+  assert.deepEqual(harness.liveTimers().map((timer) => timer.delay), [500]);
+  assert.equal(harness.stalled.length, 1);
+
+  await harness.fire(harness.liveTimers()[0]);
+  assert.equal(harness.getReconnectCalls(), 1);
+  assert.equal(harness.reconnectStates[0].micWasEnabled, true);
+  assert.deepEqual(harness.controller.snapshot(), { enabled: true, active: false });
+});
+
+test("current Room success cancels watchdog while stale Room success cannot cancel current generation", async () => {
+  const first = createHarness();
+  assert.equal(first.arm(), true);
+  const cancelledTimer = first.liveTimers()[0];
+  assert.equal(first.controller.handleConnected({ room: first.getCurrentRoom() }), true);
+  assert.equal(cancelledTimer.cancelled, true);
+  await first.fire(cancelledTimer, true);
+  assert.equal(first.getReconnectCalls(), 0);
+
+  const raced = createHarness();
+  const oldRoom = raced.getCurrentRoom();
+  assert.equal(raced.arm(), true);
+  const oldGenerationTimer = raced.liveTimers()[0];
+  const currentRoom = { sid: "new-current-room" };
+  raced.setCurrentRoom(currentRoom);
+  assert.equal(raced.controller.handleConnected({ room: oldRoom }), false);
+  assert.equal(raced.controller.handleReconnecting({
+    room: currentRoom,
+    reconnect: async () => {},
+    micWasEnabled: false,
+  }), true);
+  const currentGenerationTimer = raced.liveTimers().find((timer) => timer !== oldGenerationTimer);
+
+  await raced.fire(oldGenerationTimer, true);
+  assert.equal(currentGenerationTimer.cancelled, false, "late old generation must not clear current watchdog");
+  assert.equal(raced.controller.snapshot().watching, true);
+});
+
+test("a later reconnect episode captures the user's new microphone intent", async () => {
+  const harness = createHarness();
+  const currentRoom = harness.getCurrentRoom();
+
+  assert.equal(harness.arm(true), true);
+  assert.equal(harness.controller.handleConnected({ room: currentRoom }), true);
+  assert.equal(harness.arm(false), true, "second episode must create a new intent snapshot");
+
+  await harness.fire(harness.liveTimers()[0]);
+  await harness.fire(harness.liveTimers()[0]);
+
+  assert.equal(harness.getReconnectCalls(), 1);
+  assert.equal(harness.reconnectStates[0].micWasEnabled, false);
+});
+
+test("hidden or offline stale reconnect defers without consuming a recovery attempt", async () => {
+  const harness = createHarness();
+  assert.equal(harness.arm(true), true);
+  harness.setHidden(true);
+  harness.setOnline(false);
+
+  await harness.fire(harness.liveTimers()[0]);
+  assert.equal(harness.getReconnectCalls(), 0);
+  assert.equal(harness.controller.snapshot().waiting, true);
+  assert.equal(harness.controller.resume(), false);
+
+  harness.setHidden(false);
+  assert.equal(harness.controller.resume(), false, "offline still blocks replacement teardown");
+  harness.setOnline(true);
+  assert.equal(harness.controller.resume(), true);
+  assert.deepEqual(harness.liveTimers().map((timer) => timer.delay), [500]);
+  assert.equal(harness.controller.snapshot().attemptCount, 0);
+
+  await harness.fire(harness.liveTimers()[0]);
+  assert.equal(harness.getReconnectCalls(), 1);
+  assert.equal(harness.reconnectStates[0].micWasEnabled, true);
+});
+
+test("expected leave, terminal disconnect, switch, and explicit cancel synchronously stop watchdog", async () => {
+  const expected = createHarness();
+  assert.equal(expected.arm(), true);
+  const expectedTimer = expected.liveTimers()[0];
+  expected.getCurrentRoom()._echoExpectedDisconnect = true;
+  assert.equal(expected.disconnect(1), false);
+  assert.equal(expectedTimer.cancelled, true);
+  await expected.fire(expectedTimer, true);
+  assert.equal(expected.getReconnectCalls(), 0);
+
+  const terminal = createHarness();
+  assert.equal(terminal.arm(), true);
+  assert.equal(terminal.disconnect(3), false);
+  assert.equal(terminal.liveTimers().length, 0);
+
+  const switching = createHarness();
+  assert.equal(switching.arm(), true);
+  const switchingTimer = switching.liveTimers()[0];
+  switching.setSwitching(true);
+  await switching.fire(switchingTimer);
+  assert.equal(switching.getReconnectCalls(), 0);
+
+  const cancelled = createHarness();
+  assert.equal(cancelled.arm(), true);
+  const cancelledTimer = cancelled.liveTimers()[0];
+  assert.equal(cancelled.controller.cancel({ sid: "not-current" }), false);
+  assert.equal(cancelled.controller.cancel(cancelled.getCurrentRoom()), true);
+  await cancelled.fire(cancelledTimer, true);
+  assert.equal(cancelled.getReconnectCalls(), 0);
+});
+
+test("controlled source CLIENT_INITIATED teardown does not cancel serialized retries", async () => {
+  const harness = createHarness({
+    reconnect({ controller, currentRoom }) {
+      currentRoom._echoRecoveryDisconnect = true;
+      currentRoom._echoExpectedDisconnect = true;
+      assert.equal(controller.handleDisconnected({
+        room: currentRoom,
+        reason: 1,
+        disconnectReasons,
+        reconnect() {},
+      }), false);
+      throw new Error("first fresh candidate failed");
+    },
+  });
+
+  assert.equal(harness.arm(true), true);
+  await harness.fire(harness.liveTimers()[0]);
+  await harness.fire(harness.liveTimers()[0]);
+
+  assert.equal(harness.getReconnectCalls(), 1);
+  assert.deepEqual(harness.liveTimers().map((timer) => timer.delay), [2000]);
+  assert.equal(harness.controller.snapshot().active, true);
+});
+
+test("failed source teardown is retried and successful teardown stays single-flight", async () => {
+  let disconnectCalls = 0;
+  let releaseSecondDisconnect;
+  const secondDisconnect = new Promise((resolve) => { releaseSecondDisconnect = resolve; });
+  const sourceRoom = {
+    disconnect(stopTracks) {
+      disconnectCalls += 1;
+      assert.equal(stopTracks, true);
+      if (disconnectCalls === 1) return Promise.reject(new Error("sendLeave failed"));
+      return secondDisconnect;
+    },
+  };
+
+  await assert.rejects(
+    disconnectAndroidFirefoxRecoverySource(sourceRoom),
+    /sendLeave failed/
+  );
+  assert.equal(sourceRoom._echoRecoveryDisconnectPromise, null);
+  assert.equal(sourceRoom._echoRecoveryDisconnectComplete, undefined);
+
+  const retryOne = disconnectAndroidFirefoxRecoverySource(sourceRoom);
+  const retryTwo = disconnectAndroidFirefoxRecoverySource(sourceRoom);
+  assert.equal(disconnectCalls, 2, "concurrent retry callers must share one teardown");
+  releaseSecondDisconnect();
+  assert.deepEqual(await Promise.all([retryOne, retryTwo]), [true, true]);
+  assert.equal(sourceRoom._echoRecoveryDisconnectComplete, true);
+
+  assert.equal(await disconnectAndroidFirefoxRecoverySource(sourceRoom), false);
+  assert.equal(disconnectCalls, 2, "completed teardown must never run again");
+});
+
+test("real platform gate gives every non-target client zero stalled-reconnect actions", () => {
+  const cases = [
+    ["Windows Chrome", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/153.0 Safari/537.36", false],
+    ["Windows native", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/153.0 Safari/537.36", true],
+    ["Android Firefox native", androidFirefoxUa, true],
+    ["macOS Safari", "Mozilla/5.0 (Macintosh; Intel Mac OS X 15_6) AppleWebKit/605.1.15 Version/19.0 Safari/605.1.15", false],
+    ["Android Chrome", "Mozilla/5.0 (Linux; Android 16) AppleWebKit/537.36 Chrome/153.0 Mobile Safari/537.36", false],
+    ["iOS Safari", "Mozilla/5.0 (iPhone; CPU iPhone OS 19_6 like Mac OS X) AppleWebKit/605.1.15 Mobile/15E148 Safari/604.1", false],
+  ];
+
+  for (const [name, userAgent, isNativeShell] of cases) {
+    const harness = createHarness({ userAgent, isNativeShell });
+    assert.equal(harness.controller.isEnabled(), false, name);
+    assert.equal(harness.arm(), false, name);
+    assert.equal(harness.controller.resume(), false, name);
+    assert.equal(harness.liveTimers().length, 0, name);
+    assert.equal(harness.getReconnectCalls(), 0, name);
+  }
+});
+
+test("mic preservation policy remains recovery-only and production wiring tears down before fresh connect", () => {
+  assert.deepEqual(resolvePostConnectMicrophoneBehavior({
+    reuseAdmin: true,
+    preserveMicIntent: true,
+    micWasEnabled: false,
+  }), { restoreMic: false, preserveMutedMic: true });
+  assert.deepEqual(resolvePostConnectMicrophoneBehavior({
+    reuseAdmin: true,
+    preserveMicIntent: true,
+    micWasEnabled: true,
+  }), { restoreMic: true, preserveMutedMic: false });
+
+  assert.match(connectSource, /androidFirefoxRoomDisconnectRecoveryEnabled = typeof isAndroidFirefoxBrowser/);
+  assert.match(connectSource, /if \(state === "reconnecting"\)[\s\S]*?else if \(androidFirefoxRoomDisconnectRecoveryEnabled && state === "signalReconnecting"\)/);
+  assert.match(connectSource, /RoomEvent\.SignalReconnecting[\s\S]*?watchAndroidFirefoxRoomReconnect\(\)/);
+  assert.match(connectSource, /RoomEvent\.SignalReconnected[\s\S]*?handleConnected\(\{ room: newRoom \}\)/);
+  assert.match(connectSource, /handleConnected\(\{ room: newRoom \}\);\s+resetAndroidFirefoxRecoveryMicIntent\(\)/);
+  assert.match(connectSource, /handleReconnecting\(\{[\s\S]*?micWasEnabled: captureAndroidFirefoxRecoveryMicIntent\(\)/);
+  assert.match(connectSource, /disconnectAndroidFirefoxRecoverySource[\s\S]*?await disconnectRecoverySource\(androidFirefoxRecoverySourceRoom\)/);
+  assert.match(connectSource, /await disconnectRecoverySource\(androidFirefoxRecoverySourceRoom\)[\s\S]*?await newRoom\.connect/);
+  assert.match(connectSource, /reuseAdmin: true,[\s\S]*?preserveMicIntent: true,[\s\S]*?androidFirefoxRecoverySourceRoom: newRoom/);
+  assert.match(connectSource, /ignoreAndroidFirefoxStaleRoomEvent\("local track unpublished"\)/);
+  assert.match(connectSource, /androidFirefoxRoomDisconnectRecovery\?\.cancel\(room\);[\s\S]*?connectSequence \+= 1;[\s\S]*?room\._echoExpectedDisconnect = true/);
+});

--- a/core/viewer/connect.js
+++ b/core/viewer/connect.js
@@ -118,6 +118,11 @@ if (androidFirefoxRoomDisconnectRecoveryEnabled &&
       onExhausted: function(state) {
         debugLog("[android-firefox-room-recovery] exhausted after " + state.attempts + " attempts");
       },
+      onStalledReconnect: function(state) {
+        debugLog("[android-firefox-room-recovery] SDK reconnect still stalled after " +
+          state.timeoutMs + "ms; starting fresh Room recovery");
+        setStatus("Refreshing stalled Android Firefox session...", true);
+      },
     });
 
   document.addEventListener("visibilitychange", function() {
@@ -174,6 +179,10 @@ async function switchRoom(roomId) {
     currentRoomName = roomId;
   }
 
+  if (androidFirefoxRoomDisconnectRecoveryEnabled) {
+    androidFirefoxRoomDisconnectRecovery?.cancel(room);
+    connectSequence += 1;
+  }
   switchingRoom = true;
   _isRoomSwitch = true;
   // Freeze local publish intent until the new room is connected. This keeps a
@@ -312,11 +321,19 @@ async function connectToRoom({
   name,
   reuseAdmin,
   preserveMicIntent,
+  androidFirefoxRecoverySourceRoom,
+  androidFirefoxPreservedMicEnabled,
 }) {
+  const controlledAndroidFirefoxReplacement = androidFirefoxRoomDisconnectRecoveryEnabled &&
+    !!androidFirefoxRecoverySourceRoom &&
+    androidFirefoxRecoverySourceRoom === room;
   // A newly connected LiveKit participant has no publications yet. Preserve
   // the user's pre-switch intent separately so authoritative reconciliation
   // can report the new room truth without cancelling mic restoration.
-  const micWasEnabledBeforeConnect = desiredMicEnabledForRoomSwitch() === true;
+  const micWasEnabledBeforeConnect = controlledAndroidFirefoxReplacement &&
+    typeof androidFirefoxPreservedMicEnabled === "boolean"
+    ? androidFirefoxPreservedMicEnabled
+    : desiredMicEnabledForRoomSwitch() === true;
   const postConnectMicBehavior = window.EchoRoomSwitchState?.resolvePostConnectMicrophoneBehavior
     ? window.EchoRoomSwitchState.resolvePostConnectMicrophoneBehavior({
         reuseAdmin: reuseAdmin === true,
@@ -331,6 +348,24 @@ async function connectToRoom({
       };
   const restoreMicAfterConnect = postConnectMicBehavior.restoreMic;
   const preserveDisabledMicAfterConnect = postConnectMicBehavior.preserveMutedMic;
+  var controlledReplacementSequence = null;
+  if (controlledAndroidFirefoxReplacement) {
+    // Stop LiveKit's stale same-identity resume loop before opening a fresh
+    // Room. The marker suppresses teardown events from mutating current UI or
+    // cancelling the serialized recovery controller.
+    controlledReplacementSequence = ++connectSequence;
+    var disconnectRecoverySource = window.EchoRoomSwitchState?.disconnectAndroidFirefoxRecoverySource;
+    if (typeof disconnectRecoverySource !== "function") {
+      throw new Error("Android Firefox recovery teardown helper is unavailable");
+    }
+    await disconnectRecoverySource(androidFirefoxRecoverySourceRoom);
+    if (controlledReplacementSequence !== connectSequence ||
+        androidFirefoxRecoverySourceRoom !== room ||
+        switchingRoom ||
+        _isRoomSwitch) {
+      return;
+    }
+  }
   if (!controlUrl || !sfuUrl) {
     setStatus("Enter control URL and SFU URL.", true);
     return;
@@ -353,7 +388,9 @@ async function connectToRoom({
   } catch {}
 
   setStatus("Requesting token...");
-  const seq = ++connectSequence;
+  const seq = controlledReplacementSequence == null
+    ? ++connectSequence
+    : controlledReplacementSequence;
   if (!reuseAdmin) {
     // First connect: ensure room exists (not needed for subsequent switches of fixed rooms)
     await ensureRoomExists(controlUrl, adminToken, roomId);
@@ -641,20 +678,86 @@ async function connectToRoom({
       newRoom.startAudio().catch(() => {});
     }
   } catch {}
+  var androidFirefoxRecoveryMicWasEnabled = null;
+  function captureAndroidFirefoxRecoveryMicIntent() {
+    if (typeof androidFirefoxRecoveryMicWasEnabled !== "boolean") {
+      androidFirefoxRecoveryMicWasEnabled = desiredMicEnabledForRoomSwitch() === true;
+    }
+    return androidFirefoxRecoveryMicWasEnabled;
+  }
+  function resetAndroidFirefoxRecoveryMicIntent() {
+    androidFirefoxRecoveryMicWasEnabled = null;
+  }
+  function reconnectAndroidFirefoxRoom(recoveryState) {
+    var preservedMicEnabled = typeof recoveryState?.micWasEnabled === "boolean"
+      ? recoveryState.micWasEnabled
+      : captureAndroidFirefoxRecoveryMicIntent();
+    return connectToRoom({
+      controlUrl: controlUrl,
+      sfuUrl: sfuUrl,
+      roomId: roomId,
+      identity: identity,
+      name: name,
+      reuseAdmin: true,
+      preserveMicIntent: true,
+      androidFirefoxRecoverySourceRoom: newRoom,
+      androidFirefoxPreservedMicEnabled: preservedMicEnabled,
+    });
+  }
+  function watchAndroidFirefoxRoomReconnect() {
+    if (!androidFirefoxRoomDisconnectRecoveryEnabled) return;
+    var accepted = androidFirefoxRoomDisconnectRecovery?.handleReconnecting({
+      room: newRoom,
+      reconnect: reconnectAndroidFirefoxRoom,
+      micWasEnabled: captureAndroidFirefoxRecoveryMicIntent(),
+    });
+    if (accepted) {
+      debugLog("[android-firefox-room-recovery] watching SDK reconnect for a stall");
+    }
+  }
+  function scheduleReconnectFlagSafetyReset() {
+    setTimeout(() => {
+      if (androidFirefoxRoomDisconnectRecoveryEnabled &&
+          (newRoom !== room || newRoom._echoRecoveryDisconnect === true)) {
+        return;
+      }
+      if (_isReconnecting) {
+        _isReconnecting = false;
+        debugLog("[reconnect] safety timeout — resetting reconnecting flag");
+      }
+    }, 10000);
+  }
+  function ignoreAndroidFirefoxStaleRoomEvent(eventName) {
+    if (!androidFirefoxRoomDisconnectRecoveryEnabled ||
+        (newRoom === room && newRoom._echoRecoveryDisconnect !== true)) {
+      return false;
+    }
+    debugLog("[android-firefox-room-recovery] ignored stale/controlled Room " + eventName);
+    return true;
+  }
   if (LK.RoomEvent?.ConnectionStateChanged) {
     newRoom.on(LK.RoomEvent.ConnectionStateChanged, (state) => {
       if (!state) return;
+      if (androidFirefoxRoomDisconnectRecoveryEnabled && newRoom !== room) {
+        debugLog("[android-firefox-room-recovery] ignored stale Room " + state + " state");
+        return;
+      }
       if (androidFirefoxRoomDisconnectRecoveryEnabled &&
-          state === "disconnected" &&
-          newRoom !== room) {
-        debugLog("[android-firefox-room-recovery] ignored stale Room disconnected state");
+          newRoom._echoRecoveryDisconnect === true) {
+        debugLog("[android-firefox-room-recovery] ignored controlled old Room " + state + " state");
         return;
       }
       debugLog("[connection] state changed: " + state);
       if (state === "reconnecting") {
         _isReconnecting = true;
+        if (androidFirefoxRoomDisconnectRecoveryEnabled) watchAndroidFirefoxRoomReconnect();
+      } else if (androidFirefoxRoomDisconnectRecoveryEnabled && state === "signalReconnecting") {
+        _isReconnecting = true;
+        watchAndroidFirefoxRoomReconnect();
       } else if (state === "connected") {
         _isReconnecting = false;
+        androidFirefoxRoomDisconnectRecovery?.handleConnected({ room: newRoom });
+        resetAndroidFirefoxRecoveryMicIntent();
       }
       if (state === "disconnected") {
         _isReconnecting = false;
@@ -671,6 +774,14 @@ async function connectToRoom({
   }
   if (LK.RoomEvent?.Disconnected) {
     newRoom.on(LK.RoomEvent.Disconnected, (reason) => {
+      if (androidFirefoxRoomDisconnectRecoveryEnabled &&
+          newRoom._echoRecoveryDisconnect === true) {
+        if (typeof stopInboundScreenStatsMonitor === "function") {
+          stopInboundScreenStatsMonitor();
+        }
+        debugLog("[android-firefox-room-recovery] ignored controlled source Room disconnect");
+        return;
+      }
       // Failed reconnect candidates also emit Disconnected. On Android Firefox,
       // ignore those stale Room instances before they overwrite the active
       // session status or stop its stats monitor. Other platforms retain the
@@ -697,17 +808,8 @@ async function connectToRoom({
         room: newRoom,
         reason: reason,
         disconnectReasons: LK.DisconnectReason,
-        reconnect: function() {
-          return connectToRoom({
-            controlUrl: controlUrl,
-            sfuUrl: sfuUrl,
-            roomId: roomId,
-            identity: identity,
-            name: name,
-            reuseAdmin: true,
-            preserveMicIntent: true,
-          });
-        },
+        reconnect: reconnectAndroidFirefoxRoom,
+        micWasEnabled: captureAndroidFirefoxRecoveryMicIntent(),
       });
       if (recoveryAccepted) {
         setStatus("Reconnecting Android Firefox session...", true);
@@ -716,17 +818,30 @@ async function connectToRoom({
   }
   if (LK.RoomEvent?.SignalReconnecting) {
     newRoom.on(LK.RoomEvent.SignalReconnecting, () => {
+      if (androidFirefoxRoomDisconnectRecoveryEnabled &&
+          (newRoom !== room || newRoom._echoRecoveryDisconnect === true)) {
+        debugLog("[android-firefox-room-recovery] ignored stale Room signal reconnecting");
+        return;
+      }
       _isReconnecting = true;
+      watchAndroidFirefoxRoomReconnect();
       setStatus("Signal reconnecting...", true);
       recordActiveRoomDiagnostic(newRoom, () => logEvent("signal-reconnecting", ""));
       debugLog("[reconnect] signal reconnecting — suppressing chimes and delaying cleanup");
       // Safety: auto-reset after 10s if reconnection stalls
-      setTimeout(() => { if (_isReconnecting) { _isReconnecting = false; debugLog("[reconnect] safety timeout — resetting reconnecting flag"); } }, 10000);
+      scheduleReconnectFlagSafetyReset();
     });
   }
   if (LK.RoomEvent?.SignalReconnected) {
     newRoom.on(LK.RoomEvent.SignalReconnected, () => {
+      if (androidFirefoxRoomDisconnectRecoveryEnabled &&
+          (newRoom !== room || newRoom._echoRecoveryDisconnect === true)) {
+        debugLog("[android-firefox-room-recovery] ignored stale Room signal reconnected");
+        return;
+      }
       _isReconnecting = false;
+      androidFirefoxRoomDisconnectRecovery?.handleConnected({ room: newRoom });
+      resetAndroidFirefoxRecoveryMicIntent();
       setStatus("Signal reconnected");
       recordActiveRoomDiagnostic(newRoom, () => logEvent("signal-reconnected", ""));
       debugLog("[reconnect] signal reconnected — cancelling pending disconnects");
@@ -754,16 +869,29 @@ async function connectToRoom({
   // Room-level reconnecting/reconnected (covers media reconnection too)
   if (LK.RoomEvent?.Reconnecting) {
     newRoom.on(LK.RoomEvent.Reconnecting, () => {
+      if (androidFirefoxRoomDisconnectRecoveryEnabled &&
+          (newRoom !== room || newRoom._echoRecoveryDisconnect === true)) {
+        debugLog("[android-firefox-room-recovery] ignored stale Room reconnecting event");
+        return;
+      }
       _isReconnecting = true;
+      watchAndroidFirefoxRoomReconnect();
       setStatus("Reconnecting...", true);
       recordActiveRoomDiagnostic(newRoom, () => logEvent("reconnecting", ""));
       debugLog("[reconnect] room reconnecting — suppressing chimes and delaying cleanup");
-      setTimeout(() => { if (_isReconnecting) { _isReconnecting = false; debugLog("[reconnect] safety timeout — resetting reconnecting flag"); } }, 10000);
+      scheduleReconnectFlagSafetyReset();
     });
   }
   if (LK.RoomEvent?.Reconnected) {
     newRoom.on(LK.RoomEvent.Reconnected, () => {
+      if (androidFirefoxRoomDisconnectRecoveryEnabled &&
+          (newRoom !== room || newRoom._echoRecoveryDisconnect === true)) {
+        debugLog("[android-firefox-room-recovery] ignored stale Room reconnected event");
+        return;
+      }
       _isReconnecting = false;
+      androidFirefoxRoomDisconnectRecovery?.handleConnected({ room: newRoom });
+      resetAndroidFirefoxRecoveryMicIntent();
       setStatus("Reconnected");
       recordActiveRoomDiagnostic(newRoom, () => logEvent("reconnected", ""));
       debugLog("[reconnect] room reconnected — cancelling pending disconnects");
@@ -789,6 +917,15 @@ async function connectToRoom({
   }
   if (LK.RoomEvent?.ConnectionError) {
     newRoom.on(LK.RoomEvent.ConnectionError, (err) => {
+      if (androidFirefoxRoomDisconnectRecoveryEnabled && newRoom !== room) {
+        debugLog("[android-firefox-room-recovery] ignored stale Room connection error");
+        return;
+      }
+      if (androidFirefoxRoomDisconnectRecoveryEnabled &&
+          newRoom._echoRecoveryDisconnect === true) {
+        debugLog("[android-firefox-room-recovery] ignored controlled source Room connection error");
+        return;
+      }
       const detail = err?.message || String(err || "unknown");
       recordActiveRoomDiagnostic(newRoom, () => {
         window.EchoWebDiagnosticsRuntime?.recordConnectionState?.("error", err?.name);
@@ -799,6 +936,7 @@ async function connectToRoom({
   const localIdentity = identity;
   ensureParticipantCard({ identity: localIdentity, name }, true);
   newRoom.on(LK.RoomEvent.TrackSubscribed, (track, publication, participant) => {
+    if (ignoreAndroidFirefoxStaleRoomEvent("track subscribed")) return;
     // DEBUG: log ALL track subscriptions
     console.log('[TRACK-SUB] ' + (participant?.identity || '?') + ' kind=' + track.kind + ' source=' + (publication?.source || track?.source));
     // $screen companions publish as Camera for SFU optimization — patch to ScreenShare
@@ -846,6 +984,7 @@ async function connectToRoom({
   });
   if (LK.RoomEvent?.TrackSubscriptionFailed) {
     newRoom.on(LK.RoomEvent.TrackSubscriptionFailed, (publication, participant, err) => {
+      if (ignoreAndroidFirefoxStaleRoomEvent("track subscription failed")) return;
       const detail = err?.message || String(err || "track subscription failed");
       setStatus(`Track subscription failed: ${detail}`, true);
       debugLog(`track subscription failed ${participant?.identity || "unknown"} ${detail}`);
@@ -868,6 +1007,7 @@ async function connectToRoom({
   }
   if (LK.RoomEvent?.TrackPublished) {
     newRoom.on(LK.RoomEvent.TrackPublished, (publication, participant) => {
+      if (ignoreAndroidFirefoxStaleRoomEvent("track published")) return;
       // $screen companions publish as Camera for SFU optimization — patch to ScreenShare
       patchScreenCompanionSource(publication, publication?.track, participant);
       var pubSource = getTrackSource(publication, publication?.track);
@@ -926,6 +1066,7 @@ async function connectToRoom({
     });
   }
   newRoom.on(LK.RoomEvent.TrackUnsubscribed, (track, publication, participant) => {
+    if (ignoreAndroidFirefoxStaleRoomEvent("track unsubscribed")) return;
     handleTrackUnsubscribed(track, publication, participant);
   });
   // Remote TrackUnpublished — fires AFTER the publication is removed from the
@@ -934,6 +1075,7 @@ async function connectToRoom({
   // This handler catches screen share tiles and camera cards that got stuck.
   if (LK.RoomEvent?.TrackUnpublished) {
     newRoom.on(LK.RoomEvent.TrackUnpublished, (publication, participant) => {
+      if (ignoreAndroidFirefoxStaleRoomEvent("track unpublished")) return;
       if (!publication || !participant) return;
       // $screen companions publish as Camera for SFU optimization — patch to ScreenShare
       patchScreenCompanionSource(publication, publication?.track, participant);
@@ -1015,6 +1157,7 @@ async function connectToRoom({
     });
   }
   newRoom.on(LK.RoomEvent.ParticipantConnected, (participant) => {
+    if (ignoreAndroidFirefoxStaleRoomEvent("participant connected")) return;
     console.log('[PARTICIPANT] connected: ' + participant.identity);
     if (participant.identity.endsWith('$screen')) {
       debugLog('[screen-merge] $screen companion joined: ' + participant.identity);
@@ -1102,6 +1245,7 @@ async function connectToRoom({
   });
   if (LK.RoomEvent?.ParticipantNameChanged) {
     newRoom.on(LK.RoomEvent.ParticipantNameChanged, (participant) => {
+      if (ignoreAndroidFirefoxStaleRoomEvent("participant name changed")) return;
       const cardRef = participantCards.get(participant.identity);
       if (!cardRef) return;
       const label = participant.name || "Guest";
@@ -1113,6 +1257,7 @@ async function connectToRoom({
     });
   }
   newRoom.on(LK.RoomEvent.ParticipantDisconnected, (participant) => {
+    if (ignoreAndroidFirefoxStaleRoomEvent("participant disconnected")) return;
     const key = participant.identity;
     debugLog(`participant disconnected ${participant.identity} (reconnecting=${_isReconnecting})`);
 
@@ -1208,6 +1353,7 @@ async function connectToRoom({
   });
   if (LK.RoomEvent?.TrackMuted) {
     newRoom.on(LK.RoomEvent.TrackMuted, (publication, participant) => {
+      if (ignoreAndroidFirefoxStaleRoomEvent("track muted")) return;
       if (!participant) return;
       const source = publication?.source;
       if (publication?.kind === LK.Track.Kind.Audio && source === LK.Track.Source.Microphone) {
@@ -1230,6 +1376,7 @@ async function connectToRoom({
   }
   if (LK.RoomEvent?.TrackUnmuted) {
     newRoom.on(LK.RoomEvent.TrackUnmuted, (publication, participant) => {
+      if (ignoreAndroidFirefoxStaleRoomEvent("track unmuted")) return;
       if (!participant) return;
       const source = publication?.source;
       if (publication?.kind === LK.Track.Kind.Audio && source === LK.Track.Source.Microphone) {
@@ -1254,6 +1401,7 @@ async function connectToRoom({
   }
   if (LK.RoomEvent?.ActiveSpeakers) {
     newRoom.on(LK.RoomEvent.ActiveSpeakers, (speakers) => {
+      if (ignoreAndroidFirefoxStaleRoomEvent("active speakers")) return;
       activeSpeakerIds = new Set(speakers.map((p) => p.identity));
       lastActiveSpeakerEvent = performance.now();
       updateActiveSpeakerUi();
@@ -1261,6 +1409,7 @@ async function connectToRoom({
   }
   if (LK.RoomEvent?.DataReceived) {
     newRoom.on(LK.RoomEvent.DataReceived, (payload, participant) => {
+      if (ignoreAndroidFirefoxStaleRoomEvent("data received")) return;
       try {
         const text = new TextDecoder().decode(payload);
         const msg = JSON.parse(text);
@@ -1355,6 +1504,7 @@ async function connectToRoom({
   }
   if (LK.RoomEvent?.LocalTrackPublished) {
     newRoom.on(LK.RoomEvent.LocalTrackPublished, (publication) => {
+      if (ignoreAndroidFirefoxStaleRoomEvent("local track published")) return;
       const local = room.localParticipant;
       if (!local || !publication) return;
       updatePublisherMicrophoneState(publication, local, true);
@@ -1391,6 +1541,7 @@ async function connectToRoom({
   }
   if (LK.RoomEvent?.LocalTrackUnpublished) {
     newRoom.on(LK.RoomEvent.LocalTrackUnpublished, (publication) => {
+      if (ignoreAndroidFirefoxStaleRoomEvent("local track unpublished")) return;
       const localParticipant = room?.localParticipant;
       if (localParticipant) updatePublisherMicrophoneState(publication, localParticipant, false);
       const source = publication.source;
@@ -1460,7 +1611,7 @@ async function connectToRoom({
   // New room is connected — NOW disconnect old room and swap
   if (hadOldRoom && oldRoom) {
     oldRoom._echoExpectedDisconnect = true;
-    oldRoom.disconnect();
+    if (oldRoom._echoRecoveryDisconnect !== true) oldRoom.disconnect();
     clearMedia();
     clearSoundboardState();
     hiddenScreens.clear();
@@ -1866,6 +2017,7 @@ async function connect() {
 
 async function disconnect() {
   if (!room) return;
+  androidFirefoxRoomDisconnectRecovery?.cancel(room);
   // Invalidate any in-flight connect/switch attempts (#67)
   connectSequence++;
   sendLeaveNotification();

--- a/core/viewer/room-switch-state.js
+++ b/core/viewer/room-switch-state.js
@@ -148,11 +148,47 @@
     };
   }
 
+  async function disconnectAndroidFirefoxRecoverySource(sourceRoom) {
+    if (!sourceRoom || typeof sourceRoom.disconnect !== "function") {
+      throw new Error("Android Firefox recovery source Room is unavailable");
+    }
+
+    sourceRoom._echoRecoveryDisconnect = true;
+    sourceRoom._echoExpectedDisconnect = true;
+    if (sourceRoom._echoRecoveryDisconnectComplete === true) return false;
+
+    let disconnectPromise = sourceRoom._echoRecoveryDisconnectPromise;
+    if (!disconnectPromise) {
+      disconnectPromise = (async function() {
+        await sourceRoom.disconnect(true);
+        sourceRoom._echoRecoveryDisconnectComplete = true;
+        return true;
+      })();
+      sourceRoom._echoRecoveryDisconnectPromise = disconnectPromise;
+    }
+
+    try {
+      return await disconnectPromise;
+    } catch (error) {
+      // A failed sendLeave/engine close must not poison every bounded retry.
+      // Keep concurrent callers on one promise, then let the next attempt
+      // create a fresh teardown promise for the same source Room.
+      if (sourceRoom._echoRecoveryDisconnectPromise === disconnectPromise) {
+        sourceRoom._echoRecoveryDisconnectPromise = null;
+      }
+      throw error;
+    }
+  }
+
   function createAndroidFirefoxRoomDisconnectRecovery(options) {
     const opts = options || {};
     const retryDelaysMs = Array.isArray(opts.retryDelaysMs)
       ? opts.retryDelaysMs.filter((delay) => Number.isFinite(delay) && delay >= 0)
       : [500, 2000, 5000];
+    const stalledReconnectTimeoutMs = Number.isFinite(opts.stalledReconnectTimeoutMs) &&
+      opts.stalledReconnectTimeoutMs >= 0
+      ? opts.stalledReconnectTimeoutMs
+      : 15000;
     const schedule = typeof opts.schedule === "function" ? opts.schedule : setTimeout;
     const cancelSchedule = typeof opts.cancelSchedule === "function" ? opts.cancelSchedule : clearTimeout;
     const getCurrentRoom = typeof opts.getCurrentRoom === "function" ? opts.getCurrentRoom : () => null;
@@ -164,6 +200,7 @@
 
     let nextGeneration = 0;
     let activeRecovery = null;
+    let activeReconnectWatch = null;
 
     function disconnectReasonName(reason, disconnectReasons) {
       if (typeof reason === "string") return reason.toUpperCase();
@@ -196,13 +233,34 @@
       return true;
     }
 
-    function isCurrentRecovery(recovery) {
+    function clearReconnectWatch(expectedWatch) {
+      if (!activeReconnectWatch || (expectedWatch && activeReconnectWatch !== expectedWatch)) return false;
+      if (activeReconnectWatch.timerId != null) {
+        cancelSchedule(activeReconnectWatch.timerId);
+      }
+      activeReconnectWatch = null;
+      return true;
+    }
+
+    function isEligibleCurrentRoom(candidateRoom) {
       return enabled &&
-        !!recovery &&
-        activeRecovery === recovery &&
-        recovery.room === getCurrentRoom() &&
-        recovery.room?._echoExpectedDisconnect !== true &&
+        !!candidateRoom &&
+        candidateRoom === getCurrentRoom() &&
+        (candidateRoom._echoExpectedDisconnect !== true ||
+          candidateRoom._echoRecoveryDisconnect === true) &&
         isSwitching() !== true;
+    }
+
+    function isCurrentRecovery(recovery) {
+      return !!recovery &&
+        activeRecovery === recovery &&
+        isEligibleCurrentRoom(recovery.room);
+    }
+
+    function isCurrentReconnectWatch(watch) {
+      return !!watch &&
+        activeReconnectWatch === watch &&
+        isEligibleCurrentRoom(watch.room);
     }
 
     function queueNextAttempt(recovery) {
@@ -256,7 +314,10 @@
 
       let failed = false;
       try {
-        await recovery.reconnect();
+        await recovery.reconnect({
+          room: recovery.room,
+          micWasEnabled: recovery.micWasEnabled,
+        });
       } catch (error) {
         failed = true;
         if (typeof opts.onAttemptFailed === "function") {
@@ -277,27 +338,21 @@
       return queueNextAttempt(recovery);
     }
 
-    function handleDisconnected(event) {
-      const detail = event || {};
-      const candidateRoom = detail.room;
-      if (!enabled || !candidateRoom || candidateRoom !== getCurrentRoom()) return false;
-
-      if (candidateRoom._echoExpectedDisconnect === true ||
-          isSwitching() === true ||
-          isTerminalDisconnectReason(detail.reason, detail.disconnectReasons)) {
-        if (activeRecovery?.room === candidateRoom) clearActiveRecovery(activeRecovery);
-        return false;
-      }
-      if (typeof detail.reconnect !== "function") return false;
+    function beginRecovery(candidateRoom, reconnect, micWasEnabled) {
+      if (!isEligibleCurrentRoom(candidateRoom) || typeof reconnect !== "function") return false;
 
       if (activeRecovery) {
         if (activeRecovery.room === candidateRoom) return false;
         clearActiveRecovery(activeRecovery);
       }
+      if (activeReconnectWatch?.room === candidateRoom) {
+        clearReconnectWatch(activeReconnectWatch);
+      }
 
       const recovery = {
         room: candidateRoom,
-        reconnect: detail.reconnect,
+        reconnect,
+        micWasEnabled: typeof micWasEnabled === "boolean" ? micWasEnabled : null,
         generation: ++nextGeneration,
         nextAttemptIndex: 0,
         timerId: null,
@@ -310,19 +365,133 @@
       return true;
     }
 
+    function activateReconnectWatch(watch, generation) {
+      if (!isCurrentReconnectWatch(watch) || watch.generation !== generation) {
+        clearReconnectWatch(watch);
+        return false;
+      }
+      watch.stale = true;
+      if (isHidden() === true || isOnline() !== true) {
+        watch.waiting = true;
+        return false;
+      }
+
+      const candidateRoom = watch.room;
+      const reconnect = watch.reconnect;
+      const micWasEnabled = watch.micWasEnabled;
+      clearReconnectWatch(watch);
+      if (typeof opts.onStalledReconnect === "function") {
+        opts.onStalledReconnect({ room: candidateRoom, timeoutMs: stalledReconnectTimeoutMs });
+      }
+      return beginRecovery(candidateRoom, reconnect, micWasEnabled);
+    }
+
+    function handleReconnecting(event) {
+      const detail = event || {};
+      const candidateRoom = detail.room;
+      if (!isEligibleCurrentRoom(candidateRoom) || typeof detail.reconnect !== "function") {
+        if (activeReconnectWatch?.room === candidateRoom) {
+          clearReconnectWatch(activeReconnectWatch);
+        }
+        return false;
+      }
+      if (activeRecovery?.room === candidateRoom || activeReconnectWatch?.room === candidateRoom) {
+        return false;
+      }
+      if (activeReconnectWatch) clearReconnectWatch(activeReconnectWatch);
+
+      const watch = {
+        room: candidateRoom,
+        reconnect: detail.reconnect,
+        micWasEnabled: typeof detail.micWasEnabled === "boolean" ? detail.micWasEnabled : null,
+        generation: ++nextGeneration,
+        timerId: null,
+        stale: false,
+        waiting: false,
+      };
+      activeReconnectWatch = watch;
+      const generation = watch.generation;
+      watch.timerId = schedule(function () {
+        watch.timerId = null;
+        return activateReconnectWatch(watch, generation);
+      }, stalledReconnectTimeoutMs);
+      return true;
+    }
+
+    function handleConnected(event) {
+      const candidateRoom = event?.room;
+      if (!enabled || !candidateRoom || candidateRoom !== getCurrentRoom()) return false;
+
+      let cancelled = false;
+      if (activeReconnectWatch?.room === candidateRoom) {
+        cancelled = clearReconnectWatch(activeReconnectWatch) || cancelled;
+      }
+      if (activeRecovery?.room === candidateRoom) {
+        cancelled = clearActiveRecovery(activeRecovery) || cancelled;
+      }
+      return cancelled;
+    }
+
+    function handleDisconnected(event) {
+      const detail = event || {};
+      const candidateRoom = detail.room;
+      if (!enabled || !candidateRoom || candidateRoom !== getCurrentRoom()) return false;
+
+      // A stale-reconnect recovery deliberately disconnects its source Room
+      // before opening the same identity again. Its CLIENT_INITIATED event is
+      // teardown confirmation, not a request to cancel the serialized recovery.
+      if (candidateRoom._echoRecoveryDisconnect === true) return false;
+
+      if (candidateRoom._echoExpectedDisconnect === true ||
+          isSwitching() === true ||
+          isTerminalDisconnectReason(detail.reason, detail.disconnectReasons)) {
+        if (activeRecovery?.room === candidateRoom) clearActiveRecovery(activeRecovery);
+        if (activeReconnectWatch?.room === candidateRoom) clearReconnectWatch(activeReconnectWatch);
+        return false;
+      }
+      if (typeof detail.reconnect !== "function") return false;
+
+      if (activeRecovery) {
+        if (activeRecovery.room === candidateRoom) return false;
+        clearActiveRecovery(activeRecovery);
+      }
+      if (activeReconnectWatch?.room === candidateRoom) clearReconnectWatch(activeReconnectWatch);
+      return beginRecovery(candidateRoom, detail.reconnect, detail.micWasEnabled);
+    }
+
     function resume() {
+      const watch = activeReconnectWatch;
+      if (watch?.stale && watch.timerId == null) {
+        return activateReconnectWatch(watch, watch.generation);
+      }
       const recovery = activeRecovery;
       if (!recovery || recovery.exhausted || recovery.inFlight || recovery.timerId != null) return false;
       return queueNextAttempt(recovery);
     }
 
     function cancel(candidateRoom) {
-      if (candidateRoom && activeRecovery?.room !== candidateRoom) return false;
-      return clearActiveRecovery(activeRecovery);
+      let cancelled = false;
+      if (!candidateRoom || activeReconnectWatch?.room === candidateRoom) {
+        cancelled = clearReconnectWatch(activeReconnectWatch) || cancelled;
+      }
+      if (!candidateRoom || activeRecovery?.room === candidateRoom) {
+        cancelled = clearActiveRecovery(activeRecovery) || cancelled;
+      }
+      return cancelled;
     }
 
     function snapshot() {
-      if (!activeRecovery) return { enabled, active: false };
+      if (!activeRecovery) {
+        if (!activeReconnectWatch) return { enabled, active: false };
+        return {
+          enabled,
+          active: false,
+          watching: true,
+          scheduled: activeReconnectWatch.timerId != null,
+          waiting: activeReconnectWatch.waiting,
+          stale: activeReconnectWatch.stale,
+        };
+      }
       return {
         enabled,
         active: true,
@@ -336,7 +505,9 @@
 
     return {
       cancel,
+      handleConnected,
       handleDisconnected,
+      handleReconnecting,
       isEnabled: () => enabled,
       resume,
       snapshot,
@@ -347,6 +518,7 @@
     commitConnectedAccessToken,
     createAndroidFirefoxRoomDisconnectRecovery,
     createRoomSwitchState,
+    disconnectAndroidFirefoxRecoverySource,
     resolvePostConnectMicrophoneBehavior,
   };
 });


### PR DESCRIPTION
## What changed

- Arm a 15-second watchdog for Android Firefox Room states that remain `signalReconnecting`/`reconnecting`.
- Stop the stale Room exactly once with the public LiveKit `disconnect(true)` API before opening a fresh same-identity Room.
- Preserve phone microphone intent, defer while hidden/offline, serialize bounded retries, and cancel on leave, room switch, or normal recovery.
- Suppress late lifecycle/media events from stale recovery Rooms.
- Retry a rejected teardown promise without allowing concurrent duplicate teardown.

## Why

Production evidence showed the Android Firefox phone's LiveKit participant was removed after a DTLS/peer-connection timeout, while the SDK remained stuck trying to resume the dead SID. Control presence stayed online but the phone had no LiveKit participant or inbound media. The prior final-`Disconnected` recovery never ran because Firefox never reached that event.

## Impact

Viewer-only and strictly gated to non-native Android Firefox. Windows, macOS, Tauri/native, Android Chrome, and iOS take no recovery actions and retain existing screen-sharing behavior.

## Validation

- `npm run verify:quick` — 301/301 viewer tests pass.
- Focused Android Firefox/room-switch matrix — 37/37 pass.
- `git diff --check` passes.
- Independent adversarial review found no release blockers.
