### PR TITLE
fix(viewer): bound Android Firefox teardown recovery

### DIFF
--- a/core/viewer/android-firefox-stalled-reconnect-recovery.test.js
+++ b/core/viewer/android-firefox-stalled-reconnect-recovery.test.js
@@ -308,6 +308,151 @@ test("failed source teardown is retried and successful teardown stays single-fli
   assert.equal(disconnectCalls, 2, "completed teardown must never run again");
 });
 
+test("falsy source teardown rejection clears the cached attempt and permits a successful retry", async () => {
+  let disconnectCalls = 0;
+  const sourceRoom = {
+    disconnect() {
+      disconnectCalls += 1;
+      if (disconnectCalls === 1) return Promise.reject(undefined);
+      return Promise.resolve();
+    },
+  };
+
+  let rejected = false;
+  try {
+    await disconnectAndroidFirefoxRecoverySource(sourceRoom);
+  } catch (error) {
+    rejected = true;
+    assert.equal(error, undefined);
+  }
+  assert.equal(rejected, true);
+  assert.equal(sourceRoom._echoRecoveryDisconnectPromise, null);
+  assert.equal(sourceRoom._echoRecoveryDisconnectComplete, undefined);
+
+  assert.equal(await disconnectAndroidFirefoxRecoverySource(sourceRoom), true);
+  assert.equal(disconnectCalls, 2);
+  assert.equal(sourceRoom._echoRecoveryDisconnectComplete, true);
+});
+
+test("never-settling source teardown releases once at its deadline and remains single-flight", async () => {
+  const timers = [];
+  let disconnectCalls = 0;
+  const sourceRoom = {
+    disconnect(stopTracks) {
+      disconnectCalls += 1;
+      assert.equal(stopTracks, true);
+      return new Promise(() => {});
+    },
+  };
+  const options = {
+    timeoutMs: 1500,
+    schedule(callback, delay) {
+      const timer = { callback, delay, cancelled: false };
+      timers.push(timer);
+      return timer;
+    },
+    cancelSchedule(timer) { timer.cancelled = true; },
+  };
+
+  const first = disconnectAndroidFirefoxRecoverySource(sourceRoom, options);
+  const concurrent = disconnectAndroidFirefoxRecoverySource(sourceRoom, options);
+  await Promise.resolve();
+
+  assert.equal(disconnectCalls, 1, "concurrent callers must share the wedged teardown");
+  assert.equal(timers.length, 1, "the shared teardown must own one deadline");
+  assert.equal(timers[0].delay, 1500);
+  timers[0].callback();
+
+  assert.deepEqual(await Promise.all([first, concurrent]), [true, true]);
+  assert.equal(sourceRoom._echoRecoveryDisconnectReleased, true);
+  assert.equal(sourceRoom._echoRecoveryDisconnectTimedOut, true);
+  assert.equal(sourceRoom._echoRecoveryDisconnectComplete, undefined);
+  assert.equal(await disconnectAndroidFirefoxRecoverySource(sourceRoom, options), false);
+  assert.equal(disconnectCalls, 1, "released teardown must not start again");
+});
+
+test("controller cannot overlap fresh connects while a wedged teardown waits for its deadline", async () => {
+  const teardownTimers = [];
+  let disconnectCalls = 0;
+  let replacementStarts = 0;
+  const teardownOptions = {
+    timeoutMs: 1500,
+    schedule(callback, delay) {
+      const timer = { callback, delay, cancelled: false };
+      teardownTimers.push(timer);
+      return timer;
+    },
+    cancelSchedule(timer) { timer.cancelled = true; },
+  };
+  const harness = createHarness({
+    reconnect({ currentRoom, setCurrentRoom }) {
+      replacementStarts += 1;
+      currentRoom.disconnect = function(stopTracks) {
+        disconnectCalls += 1;
+        assert.equal(stopTracks, true);
+        return new Promise(() => {});
+      };
+      return disconnectAndroidFirefoxRecoverySource(currentRoom, teardownOptions)
+        .then(function() {
+          setCurrentRoom({ sid: "replacement-room" });
+        });
+    },
+  });
+
+  assert.equal(harness.arm(true), true);
+  await harness.fire(harness.liveTimers()[0]);
+  const attempt = harness.fire(harness.liveTimers()[0]);
+  await Promise.resolve();
+
+  assert.equal(replacementStarts, 1);
+  assert.equal(disconnectCalls, 1);
+  assert.equal(harness.arm(false), false, "duplicate reconnect events must not start another fresh connect");
+  assert.equal(harness.controller.snapshot().inFlight, true);
+  assert.equal(teardownTimers.length, 1);
+  assert.equal(teardownTimers[0].delay, 1500);
+
+  teardownTimers[0].callback();
+  await attempt;
+  assert.equal(replacementStarts, 1);
+  assert.equal(disconnectCalls, 1);
+  assert.equal(harness.getCurrentRoom().sid, "replacement-room");
+  assert.deepEqual(harness.controller.snapshot(), { enabled: true, active: false });
+});
+
+test("late source teardown completion cannot restart or overwrite a released handoff", async () => {
+  const timers = [];
+  let disconnectCalls = 0;
+  let finishDisconnect;
+  const sourceRoom = {
+    disconnect() {
+      disconnectCalls += 1;
+      return new Promise((resolve) => { finishDisconnect = resolve; });
+    },
+  };
+  const options = {
+    timeoutMs: 1500,
+    schedule(callback) {
+      const timer = { callback, cancelled: false };
+      timers.push(timer);
+      return timer;
+    },
+    cancelSchedule(timer) { timer.cancelled = true; },
+  };
+
+  const teardown = disconnectAndroidFirefoxRecoverySource(sourceRoom, options);
+  await Promise.resolve();
+  timers[0].callback();
+  assert.equal(await teardown, true);
+  assert.equal(sourceRoom._echoRecoveryDisconnectReleased, true);
+
+  finishDisconnect();
+  await Promise.resolve();
+  await Promise.resolve();
+  assert.equal(sourceRoom._echoRecoveryDisconnectComplete, true);
+  assert.equal(await disconnectAndroidFirefoxRecoverySource(sourceRoom, options), false);
+  assert.equal(disconnectCalls, 1);
+});
+
 test("real platform gate gives every non-target client zero stalled-reconnect actions", () => {
   const cases = [
     ["Windows Chrome", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/153.0 Safari/537.36", false],
@@ -348,6 +493,8 @@ test("mic preservation policy remains recovery-only and production wiring tears 
   assert.match(connectSource, /handleReconnecting\(\{[\s\S]*?micWasEnabled: captureAndroidFirefoxRecoveryMicIntent\(\)/);
   assert.match(connectSource, /disconnectAndroidFirefoxRecoverySource[\s\S]*?await disconnectRecoverySource\(androidFirefoxRecoverySourceRoom\)/);
   assert.match(connectSource, /await disconnectRecoverySource\(androidFirefoxRecoverySourceRoom\)[\s\S]*?await newRoom\.connect/);
+  assert.match(connectSource, /_echoRecoveryDisconnectTimedOut === true[\s\S]*?continuing fresh handoff/);
+  assert.match(connectSource, /newRoom\._echoRecoveryDisconnect === true\)[\s\S]*?if \(newRoom === room && typeof stopInboundScreenStatsMonitor/);
   assert.match(connectSource, /reuseAdmin: true,[\s\S]*?preserveMicIntent: true,[\s\S]*?androidFirefoxRecoverySourceRoom: newRoom/);
   assert.match(connectSource, /ignoreAndroidFirefoxStaleRoomEvent\("local track unpublished"\)/);
   assert.match(connectSource, /androidFirefoxRoomDisconnectRecovery\?\.cancel\(room\);[\s\S]*?connectSequence \+= 1;[\s\S]*?room\._echoExpectedDisconnect = true/);

--- a/core/viewer/connect.js
+++ b/core/viewer/connect.js
@@ -359,6 +359,9 @@ async function connectToRoom({
       throw new Error("Android Firefox recovery teardown helper is unavailable");
     }
     await disconnectRecoverySource(androidFirefoxRecoverySourceRoom);
+    if (androidFirefoxRecoverySourceRoom._echoRecoveryDisconnectTimedOut === true) {
+      debugLog("[android-firefox-room-recovery] source Room teardown exceeded 1500ms; continuing fresh handoff");
+    }
     if (controlledReplacementSequence !== connectSequence ||
         androidFirefoxRecoverySourceRoom !== room ||
         switchingRoom ||
@@ -776,7 +779,7 @@ async function connectToRoom({
     newRoom.on(LK.RoomEvent.Disconnected, (reason) => {
       if (androidFirefoxRoomDisconnectRecoveryEnabled &&
           newRoom._echoRecoveryDisconnect === true) {
-        if (typeof stopInboundScreenStatsMonitor === "function") {
+        if (newRoom === room && typeof stopInboundScreenStatsMonitor === "function") {
           stopInboundScreenStatsMonitor();
         }
         debugLog("[android-firefox-room-recovery] ignored controlled source Room disconnect");

--- a/core/viewer/room-switch-state.js
+++ b/core/viewer/room-switch-state.js
@@ -148,20 +148,60 @@
     };
   }
 
-  async function disconnectAndroidFirefoxRecoverySource(sourceRoom) {
+  async function disconnectAndroidFirefoxRecoverySource(sourceRoom, options) {
     if (!sourceRoom || typeof sourceRoom.disconnect !== "function") {
       throw new Error("Android Firefox recovery source Room is unavailable");
     }
 
+    const opts = options || {};
+    const timeoutMs = Number.isFinite(opts.timeoutMs) && opts.timeoutMs >= 0
+      ? opts.timeoutMs
+      : 1500;
+    const schedule = typeof opts.schedule === "function" ? opts.schedule : setTimeout;
+    const cancelSchedule = typeof opts.cancelSchedule === "function" ? opts.cancelSchedule : clearTimeout;
+
     sourceRoom._echoRecoveryDisconnect = true;
     sourceRoom._echoExpectedDisconnect = true;
-    if (sourceRoom._echoRecoveryDisconnectComplete === true) return false;
+    if (sourceRoom._echoRecoveryDisconnectComplete === true ||
+        sourceRoom._echoRecoveryDisconnectReleased === true) {
+      return false;
+    }
 
     let disconnectPromise = sourceRoom._echoRecoveryDisconnectPromise;
     if (!disconnectPromise) {
       disconnectPromise = (async function() {
-        await sourceRoom.disconnect(true);
-        sourceRoom._echoRecoveryDisconnectComplete = true;
+        let timeoutId = null;
+        const disconnectOutcome = (async function() {
+          await sourceRoom.disconnect(true);
+          sourceRoom._echoRecoveryDisconnectComplete = true;
+          return { completed: true };
+        })()
+          .then(undefined, function(error) {
+            // Convert a late rejection into data so a teardown that rejects
+            // after the deadline cannot become an unhandled Promise.
+            return { completed: false, rejected: true, error: error };
+          });
+        const deadline = new Promise(function(resolve) {
+          timeoutId = schedule(function() {
+            resolve({ completed: false, timedOut: true });
+          }, timeoutMs);
+        });
+
+        let outcome;
+        try {
+          outcome = await Promise.race([disconnectOutcome, deadline]);
+        } finally {
+          if (timeoutId != null) cancelSchedule(timeoutId);
+        }
+        if (outcome?.rejected === true) throw outcome.error;
+        if (outcome?.timedOut) {
+          // LiveKit can send CLIENT_REQUEST_LEAVE and then remain pending while
+          // closing a wedged Android Firefox engine. Release the serialized
+          // handoff after a short deadline; the old Room stays marked so its
+          // late events cannot mutate the replacement session.
+          sourceRoom._echoRecoveryDisconnectReleased = true;
+          sourceRoom._echoRecoveryDisconnectTimedOut = true;
+        }
         return true;
       })();
       sourceRoom._echoRecoveryDisconnectPromise = disconnectPromise;


### PR DESCRIPTION
## Summary
- release a wedged Android Firefox Room teardown after 1.5 seconds so the serialized fresh-room recovery can continue
- keep the source teardown single-flight and safely observe late completion or rejection
- prevent late controlled old-room disconnect events from stopping the replacement phone stats monitor

## Scope
- viewer-only
- exact non-native Android Firefox recovery path only
- no PC, Mac, native client, capture, SFU, TURN, or control behavior changes

## Verification
- `npm run verify:quick` (305/305 viewer tests)
- focused Android Firefox recovery matrix (22/22)
- `git diff --check`
- independent adversarial review: GO

## Live evidence
Production #236 fired its 15-second watchdog and sent CLIENT_REQUEST_LEAVE, but LiveKit's `Room.disconnect(true)` never settled, so no replacement token or SFU request followed. This patch bounds that exact handoff.