### PR TITLE
Recover stalled Android Firefox screen media

### DIFF
--- a/core/viewer/android-firefox-screen-recovery.test.js
+++ b/core/viewer/android-firefox-screen-recovery.test.js
@@ -1,6 +1,7 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
 const {
+  attemptAndroidFirefoxConnectedMediaRelayRecovery,
   attemptAndroidFirefoxScreenSubscriptionReset,
 } = require("./participants-fullscreen.js");
 
@@ -44,6 +45,7 @@ function createGeneration() {
       tile,
       frameAgeMs: 6000,
       firstLineRecoveryAt: 1000,
+      nowMs: 10000,
       recoveryStateBySid,
       getCurrentMeta: (sid) => metaBySid.get(sid),
       getCurrentTile: (sid) => tileBySid.get(sid),
@@ -52,6 +54,17 @@ function createGeneration() {
       requestKeyFrame: () => calls.push(["keyframe"]),
       schedule: (callback, delay) => timers.push({ callback, delay }),
     },
+  };
+}
+
+function relayOptions(fixture, overrides = {}) {
+  return {
+    ...fixture.options,
+    roomConnected: true,
+    nowMs: 16000,
+    resetGraceMs: 6000,
+    recover: () => true,
+    ...overrides,
   };
 }
 
@@ -160,4 +173,181 @@ test("same-SID metadata replacement cannot reset the one-shot recovery state", (
   assert.equal(fixture.timers.length, 1, "same SID must retain its original one-shot timer only");
   fixture.timers[0].callback();
   assert.deepEqual(replacementCalls, []);
+});
+
+test("connected Android Firefox media stall escalates only after the SID reset grace period", () => {
+  const fixture = createGeneration();
+  const recoveries = [];
+  let onValidated = null;
+
+  assert.equal(attemptAndroidFirefoxScreenSubscriptionReset(fixture.options), true);
+  fixture.timers[0].callback();
+  assert.deepEqual(fixture.recoveryStateBySid.get("TR_old"), {
+    subscriptionResetAttempted: true,
+    subscriptionResetAt: 10000,
+  });
+
+  assert.equal(attemptAndroidFirefoxConnectedMediaRelayRecovery(relayOptions(fixture, {
+    nowMs: 15999,
+    recover: (detail) => {
+      recoveries.push({
+        trackSid: detail.trackSid,
+        identity: detail.identity,
+        isStillStalled: detail.isStillStalled(),
+      });
+      return true;
+    },
+  })), false, "the per-track reset gets its complete grace period");
+  assert.deepEqual(recoveries, []);
+
+  assert.equal(attemptAndroidFirefoxConnectedMediaRelayRecovery(relayOptions(fixture, {
+    recover: (detail) => {
+      recoveries.push({
+        trackSid: detail.trackSid,
+        identity: detail.identity,
+        isStillStalled: detail.isStillStalled(),
+      });
+      onValidated = detail.onValidated;
+      return true;
+    },
+  })), true);
+  assert.deepEqual(recoveries, [{
+    trackSid: "TR_old",
+    identity: "sam",
+    isStillStalled: true,
+  }]);
+  assert.deepEqual(fixture.recoveryStateBySid.get("TR_old"), {
+    subscriptionResetAttempted: true,
+    subscriptionResetAt: 10000,
+  }, "queue acceptance alone must not consume the fallback");
+  assert.equal(onValidated(), true);
+  assert.deepEqual(fixture.recoveryStateBySid.get("TR_old"), {
+    subscriptionResetAttempted: true,
+    subscriptionResetAt: 10000,
+    relayRecoveryAttempted: true,
+    relayRecoveryAt: 16000,
+  });
+  assert.equal(attemptAndroidFirefoxConnectedMediaRelayRecovery(relayOptions(fixture)), false,
+    "one SID generation cannot trigger a Room loop");
+});
+
+test("relay recovery requires the exact connected live-muted stalled generation", () => {
+  const cases = [
+    ["target gate", (fixture, options) => { options.enabled = false; }],
+    ["connected Room", (fixture, options) => { options.roomConnected = false; }],
+    ["stale frames", (fixture, options) => { options.frameAgeMs = 3000; }],
+    ["active subscription", (fixture) => { fixture.publication.isSubscribed = false; }],
+    ["live track", (fixture) => { fixture.publication.track.mediaStreamTrack.readyState = "ended"; }],
+    ["muted track", (fixture) => { fixture.publication.track.mediaStreamTrack.muted = false; }],
+    ["watched identity", (fixture, options) => { options.isHidden = () => true; }],
+    ["current tile", (fixture) => { fixture.tileBySid.delete("TR_old"); }],
+    ["current metadata", (fixture) => { fixture.metaBySid.delete("TR_old"); }],
+  ];
+
+  for (const [label, mutate] of cases) {
+    const fixture = createGeneration();
+    assert.equal(attemptAndroidFirefoxScreenSubscriptionReset(fixture.options), true, label);
+    fixture.timers[0].callback();
+    let recoveryCalls = 0;
+    const options = relayOptions(fixture, { recover: () => { recoveryCalls += 1; return true; } });
+    mutate(fixture, options);
+    assert.equal(attemptAndroidFirefoxConnectedMediaRelayRecovery(options), false, label);
+    assert.equal(recoveryCalls, 0, label + " must not replace the Room");
+  }
+});
+
+test("rejected or JIT-cancelled relay handoff is retryable while a validated handoff is one-shot", () => {
+  const fixture = createGeneration();
+  assert.equal(attemptAndroidFirefoxScreenSubscriptionReset(fixture.options), true);
+  fixture.timers[0].callback();
+
+  assert.equal(attemptAndroidFirefoxConnectedMediaRelayRecovery(relayOptions(fixture, {
+    recover: () => false,
+  })), false);
+  assert.equal(fixture.recoveryStateBySid.get("TR_old").relayRecoveryAttempted, undefined);
+
+  let cancelledDetail = null;
+  assert.equal(attemptAndroidFirefoxConnectedMediaRelayRecovery(relayOptions(fixture, {
+    recover: (detail) => { cancelledDetail = detail; return true; },
+  })), true);
+  assert.equal(fixture.recoveryStateBySid.get("TR_old").relayRecoveryAttempted, undefined,
+    "an accepted timer may still be cancelled by the JIT predicate");
+
+  let validatedDetail = null;
+  assert.equal(attemptAndroidFirefoxConnectedMediaRelayRecovery(relayOptions(fixture, {
+    recover: (detail) => { validatedDetail = detail; return true; },
+  })), true, "the same SID remains retryable after cancellation");
+  assert.equal(validatedDetail.onValidated(), true);
+  assert.equal(fixture.recoveryStateBySid.get("TR_old").relayRecoveryAttempted, true);
+  assert.equal(cancelledDetail.onValidated(), false,
+    "a stale accepted callback cannot reserve an already-used generation");
+  assert.equal(attemptAndroidFirefoxConnectedMediaRelayRecovery(relayOptions(fixture)), false);
+});
+
+test("relay handoff carries a dynamic exact-generation stall predicate", () => {
+  const fixture = createGeneration();
+  assert.equal(attemptAndroidFirefoxScreenSubscriptionReset(fixture.options), true);
+  fixture.timers[0].callback();
+  let connected = true;
+  let frameAgeMs = 6000;
+  let isStillStalled = null;
+  const options = relayOptions(fixture, {
+    isRoomConnected: () => connected,
+    getFrameAgeMs: () => frameAgeMs,
+    recover(detail) {
+      isStillStalled = detail.isStillStalled;
+      return true;
+    },
+  });
+
+  assert.equal(attemptAndroidFirefoxConnectedMediaRelayRecovery(options), true);
+  assert.equal(isStillStalled(), true);
+
+  frameAgeMs = 0;
+  assert.equal(isStillStalled(), false, "presented frames resumed");
+  frameAgeMs = 6000;
+  connected = false;
+  assert.equal(isStillStalled(), false, "source Room changed or disconnected");
+  connected = true;
+  fixture.publication.track.mediaStreamTrack.muted = false;
+  assert.equal(isStillStalled(), false, "track unmuted");
+  fixture.publication.track.mediaStreamTrack.muted = true;
+  fixture.publication.isSubscribed = false;
+  assert.equal(isStillStalled(), false, "subscription ended");
+  fixture.publication.isSubscribed = true;
+  options.isHidden = () => true;
+  assert.equal(isStillStalled(), false, "screen became hidden");
+  options.isHidden = () => false;
+  fixture.metaBySid.delete("TR_old");
+  assert.equal(isStillStalled(), false, "metadata generation changed");
+});
+
+test("same-SID subscribed replacement inherits the bounded relay escalation state", () => {
+  const fixture = createGeneration();
+  assert.equal(attemptAndroidFirefoxScreenSubscriptionReset(fixture.options), true);
+  fixture.timers[0].callback();
+
+  const replacementTile = { isConnected: true, dataset: { trackSid: "TR_old" } };
+  const replacementPublication = {
+    isSubscribed: true,
+    track: { kind: "video", mediaStreamTrack: { readyState: "live", muted: true } },
+  };
+  const replacementMeta = {
+    publication: replacementPublication,
+    tile: replacementTile,
+    identity: "sam",
+  };
+  fixture.metaBySid.set("TR_old", replacementMeta);
+  fixture.tileBySid.set("TR_old", replacementTile);
+
+  let onValidated = null;
+  const replacementOptions = relayOptions(fixture, {
+    meta: replacementMeta,
+    publication: replacementPublication,
+    tile: replacementTile,
+    recover: (detail) => { onValidated = detail.onValidated; return true; },
+  });
+  assert.equal(attemptAndroidFirefoxConnectedMediaRelayRecovery(replacementOptions), true);
+  assert.equal(onValidated(), true);
+  assert.equal(attemptAndroidFirefoxConnectedMediaRelayRecovery(replacementOptions), false);
 });

--- a/core/viewer/android-firefox-stalled-reconnect-recovery.test.js
+++ b/core/viewer/android-firefox-stalled-reconnect-recovery.test.js
@@ -37,12 +37,15 @@ function createHarness(options = {}) {
   const timers = [];
   const reconnectStates = [];
   const stalled = [];
+  const connectedMediaStalls = [];
   let nextTimerId = 1;
   let currentRoom = options.room || { sid: "source-room" };
   let hidden = options.hidden === true;
   let online = options.online !== false;
   let switching = options.switching === true;
+  let mediaStalled = options.mediaStalled !== false;
   let reconnectCalls = 0;
+  let validatedMediaStalls = 0;
 
   const controller = createAndroidFirefoxRoomDisconnectRecovery({
     navigatorObject: { userAgent: options.userAgent || androidFirefoxUa },
@@ -64,6 +67,12 @@ function createHarness(options = {}) {
       if (timer) timer.cancelled = true;
     },
     onStalledReconnect(state) { stalled.push(state); },
+    onConnectedMediaStall(state) {
+      connectedMediaStalls.push(state);
+      if (typeof options.onConnectedMediaStall === "function") {
+        options.onConnectedMediaStall({ controller, state });
+      }
+    },
   });
 
   function reconnect(recoveryState) {
@@ -99,6 +108,27 @@ function createHarness(options = {}) {
     });
   }
 
+  function connectedMediaStall(options = {}) {
+    return controller.handleConnectedMediaStall({
+      room: currentRoom,
+      trackSid: options.trackSid || "TR_screen",
+      alreadyUsingRelay: options.alreadyUsingRelay === true,
+      isStillStalled: typeof options.isStillStalled === "function"
+        ? options.isStillStalled
+        : () => mediaStalled,
+      onValidated: typeof options.onValidated === "function"
+        ? options.onValidated
+        : () => {
+            validatedMediaStalls += 1;
+            return true;
+          },
+      micWasEnabled: options.micWasEnabled === true,
+      reconnect(recoveryState) {
+        return reconnect({ ...recoveryState, forceRelay: true });
+      },
+    });
+  }
+
   async function fire(timer, includeCancelled = false) {
     assert.ok(timer, "expected a timer");
     if (!includeCancelled) assert.equal(timer.cancelled, false, "timer must still be live");
@@ -114,15 +144,19 @@ function createHarness(options = {}) {
 
   return {
     arm,
+    connectedMediaStall,
+    connectedMediaStalls,
     controller,
     disconnect,
     fire,
     getCurrentRoom: () => currentRoom,
     getReconnectCalls: () => reconnectCalls,
+    getValidatedMediaStalls: () => validatedMediaStalls,
     liveTimers,
     reconnectStates,
     setCurrentRoom,
     setHidden(value) { hidden = value; },
+    setMediaStalled(value) { mediaStalled = value; },
     setOnline(value) { online = value; },
     setSwitching(value) { switching = value; },
     stalled,
@@ -453,6 +487,304 @@ test("late source teardown completion cannot restart or overwrite a released han
   assert.equal(disconnectCalls, 1);
 });
 
+test("connected media stall starts one relay fallback and preserves microphone intent", async () => {
+  const harness = createHarness();
+  const sourceRoom = harness.getCurrentRoom();
+
+  assert.equal(harness.connectedMediaStall({ trackSid: "TR_stalled", micWasEnabled: true }), true);
+  assert.equal(harness.connectedMediaStall({ trackSid: "TR_stalled", micWasEnabled: false }), false,
+    "duplicate watchdog ticks must coalesce on the same source Room");
+  assert.equal(harness.controller.handleConnected({ room: sourceRoom }), false,
+    "redundant connected events cannot substitute for media recovery");
+  assert.deepEqual(harness.liveTimers().map((timer) => timer.delay), [500]);
+  assert.deepEqual(harness.connectedMediaStalls, [],
+    "diagnostics must wait for the just-in-time media validation");
+
+  await harness.fire(harness.liveTimers()[0]);
+  assert.equal(harness.getValidatedMediaStalls(), 1);
+  assert.deepEqual(harness.connectedMediaStalls, [{ room: sourceRoom, trackSid: "TR_stalled" }]);
+  assert.equal(harness.getReconnectCalls(), 1);
+  assert.deepEqual(harness.reconnectStates, [{
+    room: sourceRoom,
+    micWasEnabled: true,
+    forceRelay: true,
+  }]);
+  assert.notEqual(harness.getCurrentRoom(), sourceRoom);
+  assert.deepEqual(harness.controller.snapshot(), { enabled: true, active: false });
+});
+
+test("an existing signaling watch rejects a later connected-media recovery claim", async () => {
+  const harness = createHarness();
+  const sourceRoom = harness.getCurrentRoom();
+  assert.equal(harness.arm(true), true);
+  const signalingTimer = harness.liveTimers()[0];
+
+  assert.equal(harness.connectedMediaStall({ micWasEnabled: false }), false);
+  assert.equal(signalingTimer.cancelled, false);
+  assert.deepEqual(harness.liveTimers().map((timer) => timer.delay), [15000]);
+  assert.deepEqual(harness.connectedMediaStalls, []);
+
+  await harness.fire(signalingTimer);
+  await harness.fire(harness.liveTimers()[0]);
+  assert.deepEqual(harness.reconnectStates, [{
+    room: sourceRoom,
+    micWasEnabled: true,
+  }], "the first signaling event retains recovery ownership and mic intent");
+});
+
+test("cancelled media validation leaves the same SID eligible for one real relay handoff", async () => {
+  const harness = createHarness();
+  const sourceRoom = harness.getCurrentRoom();
+
+  assert.equal(harness.connectedMediaStall({ trackSid: "TR_same", micWasEnabled: false }), true);
+  const timer = harness.liveTimers()[0];
+  harness.setMediaStalled(false);
+  await harness.fire(timer);
+
+  assert.equal(harness.getReconnectCalls(), 0);
+  assert.equal(harness.getValidatedMediaStalls(), 0,
+    "a recovered stream must not consume its relay fallback");
+  assert.deepEqual(harness.controller.snapshot(), { enabled: true, active: false });
+
+  harness.setMediaStalled(true);
+  assert.equal(harness.connectedMediaStall({ trackSid: "TR_same", micWasEnabled: true }), true,
+    "the same SID may schedule again with the user's fresh mic intent");
+  await harness.fire(harness.liveTimers()[0]);
+  assert.equal(harness.getValidatedMediaStalls(), 1);
+  assert.equal(harness.getReconnectCalls(), 1,
+    "only the validated stall may start the relay Room");
+  assert.deepEqual(harness.reconnectStates, [{
+    room: sourceRoom,
+    micWasEnabled: true,
+    forceRelay: true,
+  }], "a cancelled attempt cannot cache the old muted intent for the same-SID rearm");
+});
+
+test("Room and signal reconnect ordering supersedes an uncommitted media timer", async () => {
+  const eventOrders = [
+    ["Reconnecting", "SignalReconnecting"],
+    ["SignalReconnecting", "Reconnecting"],
+  ];
+
+  for (const [firstEvent, duplicateEvent] of eventOrders) {
+    const harness = createHarness();
+    const sourceRoom = harness.getCurrentRoom();
+    assert.equal(harness.connectedMediaStall({ micWasEnabled: true }), true, firstEvent);
+    const mediaTimer = harness.liveTimers()[0];
+
+    assert.equal(harness.arm(false), true, firstEvent + " must take ownership");
+    assert.equal(mediaTimer.cancelled, true, firstEvent + " must cancel the media timer");
+    assert.equal(harness.arm(false), false, duplicateEvent + " must coalesce");
+    assert.deepEqual(harness.liveTimers().map((timer) => timer.delay), [15000], firstEvent);
+
+    await harness.fire(mediaTimer, true);
+    assert.equal(harness.getValidatedMediaStalls(), 0, firstEvent);
+    assert.equal(harness.getReconnectCalls(), 0, firstEvent);
+
+    await harness.fire(harness.liveTimers()[0]);
+    assert.deepEqual(harness.liveTimers().map((timer) => timer.delay), [500], firstEvent);
+    await harness.fire(harness.liveTimers()[0]);
+    assert.deepEqual(harness.reconnectStates, [{
+      room: sourceRoom,
+      micWasEnabled: true,
+    }], firstEvent + " must preserve the media recovery's first mic intent");
+    assert.equal(harness.getReconnectCalls(), 1, firstEvent);
+  }
+});
+
+test("connected return cancels the reconnect watch that superseded a media timer", async () => {
+  const harness = createHarness();
+  const sourceRoom = harness.getCurrentRoom();
+  assert.equal(harness.connectedMediaStall({ micWasEnabled: true }), true);
+  const mediaTimer = harness.liveTimers()[0];
+  assert.equal(harness.arm(false), true);
+  const reconnectTimer = harness.liveTimers()[0];
+
+  assert.equal(harness.controller.handleConnected({ room: sourceRoom }), true);
+  assert.equal(mediaTimer.cancelled, true);
+  assert.equal(reconnectTimer.cancelled, true);
+  await harness.fire(mediaTimer, true);
+  await harness.fire(reconnectTimer, true);
+
+  assert.equal(harness.getValidatedMediaStalls(), 0);
+  assert.equal(harness.getReconnectCalls(), 0);
+  assert.deepEqual(harness.controller.snapshot(), { enabled: true, active: false });
+});
+
+test("direct nonterminal disconnect supersedes an uncommitted media timer", async () => {
+  const harness = createHarness();
+  const sourceRoom = harness.getCurrentRoom();
+  assert.equal(harness.connectedMediaStall({ micWasEnabled: true }), true);
+  const mediaTimer = harness.liveTimers()[0];
+
+  assert.equal(harness.disconnect(14, false), true);
+  assert.equal(mediaTimer.cancelled, true);
+  assert.deepEqual(harness.liveTimers().map((timer) => timer.delay), [500]);
+  await harness.fire(mediaTimer, true);
+  assert.equal(harness.getValidatedMediaStalls(), 0);
+  assert.equal(harness.getReconnectCalls(), 0);
+
+  await harness.fire(harness.liveTimers()[0]);
+  assert.deepEqual(harness.reconnectStates, [{
+    room: sourceRoom,
+    micWasEnabled: true,
+  }], "direct disconnect must retain the media recovery's first mic intent");
+  assert.equal(harness.getReconnectCalls(), 1);
+});
+
+test("signaling and direct disconnect cannot supersede committed or in-flight media recovery", async () => {
+  let committedSignalAccepted = null;
+  let committedDisconnectAccepted = null;
+  const committed = createHarness({
+    onConnectedMediaStall({ controller, state }) {
+      committedSignalAccepted = controller.handleReconnecting({
+        room: state.room,
+        reconnect: async () => {},
+        micWasEnabled: false,
+      });
+      committedDisconnectAccepted = controller.handleDisconnected({
+        room: state.room,
+        reason: 14,
+        disconnectReasons,
+        reconnect: async () => {},
+        micWasEnabled: false,
+      });
+    },
+  });
+  assert.equal(committed.connectedMediaStall({ micWasEnabled: true }), true);
+  await committed.fire(committed.liveTimers()[0]);
+  assert.equal(committedSignalAccepted, false,
+    "eligibility commit must make the serialized relay handoff authoritative");
+  assert.equal(committedDisconnectAccepted, false,
+    "a direct disconnect cannot replace an eligibility-committed handoff");
+  assert.equal(committed.getReconnectCalls(), 1);
+
+  let releaseAttempt = null;
+  const inFlight = createHarness({
+    reconnect({ setCurrentRoom }) {
+      return new Promise((resolve) => {
+        releaseAttempt = () => {
+          setCurrentRoom({ sid: "replacement-room" });
+          resolve();
+        };
+      });
+    },
+  });
+  assert.equal(inFlight.connectedMediaStall({ micWasEnabled: true }), true);
+  const attempt = inFlight.fire(inFlight.liveTimers()[0]);
+  await Promise.resolve();
+  assert.equal(inFlight.controller.snapshot().inFlight, true);
+  assert.equal(inFlight.arm(false), false,
+    "an in-flight relay handoff cannot be replaced by a second recovery owner");
+  assert.equal(inFlight.disconnect(14, false), false,
+    "direct disconnect cannot replace an in-flight relay handoff");
+  assert.deepEqual(inFlight.liveTimers(), []);
+  releaseAttempt();
+  await attempt;
+  assert.equal(inFlight.getReconnectCalls(), 1);
+  assert.deepEqual(inFlight.controller.snapshot(), { enabled: true, active: false });
+});
+
+test("expected and terminal disconnect still cancel pending media recovery without replacement", async () => {
+  const cases = [
+    ["expected leave", (harness) => { harness.getCurrentRoom()._echoExpectedDisconnect = true; }, 1],
+    ["terminal disconnect", () => {}, 3],
+  ];
+
+  for (const [label, prepare, reason] of cases) {
+    const harness = createHarness();
+    assert.equal(harness.connectedMediaStall({ micWasEnabled: true }), true, label);
+    const mediaTimer = harness.liveTimers()[0];
+    prepare(harness);
+    assert.equal(harness.disconnect(reason, false), false, label);
+    assert.equal(mediaTimer.cancelled, true, label);
+    assert.deepEqual(harness.liveTimers(), [], label);
+    await harness.fire(mediaTimer, true);
+    assert.equal(harness.getValidatedMediaStalls(), 0, label);
+    assert.equal(harness.getReconnectCalls(), 0, label);
+    assert.deepEqual(harness.controller.snapshot(), { enabled: true, active: false }, label);
+  }
+});
+
+test("hidden or offline deferral revalidates recovered media before resuming", async () => {
+  for (const condition of ["hidden", "offline"]) {
+    const harness = createHarness();
+    assert.equal(harness.connectedMediaStall(), true, condition);
+    const timer = harness.liveTimers()[0];
+    if (condition === "hidden") harness.setHidden(true);
+    else harness.setOnline(false);
+    await harness.fire(timer);
+    assert.equal(harness.getReconnectCalls(), 0, condition);
+    assert.equal(harness.getValidatedMediaStalls(), 0, condition);
+    assert.equal(harness.controller.snapshot().waiting, true, condition);
+
+    harness.setMediaStalled(false);
+    if (condition === "hidden") harness.setHidden(false);
+    else harness.setOnline(true);
+    assert.equal(harness.controller.resume(), true, condition);
+    await harness.fire(harness.liveTimers()[0]);
+    assert.equal(harness.getReconnectCalls(), 0, condition);
+    assert.equal(harness.getValidatedMediaStalls(), 0, condition);
+    assert.deepEqual(harness.controller.snapshot(), { enabled: true, active: false }, condition);
+  }
+});
+
+test("switch, leave, and stale Room invalidate a scheduled connected-media handoff", async () => {
+  const cases = [
+    ["switch", (harness) => harness.setSwitching(true)],
+    ["leave", (harness) => { harness.getCurrentRoom()._echoExpectedDisconnect = true; }],
+    ["stale Room", (harness) => harness.setCurrentRoom({ sid: "other-room" })],
+  ];
+
+  for (const [label, invalidate] of cases) {
+    const harness = createHarness();
+    assert.equal(harness.connectedMediaStall(), true, label);
+    const timer = harness.liveTimers()[0];
+    invalidate(harness);
+    await harness.fire(timer);
+    assert.equal(harness.getReconnectCalls(), 0, label);
+    assert.equal(harness.getValidatedMediaStalls(), 0, label);
+    assert.deepEqual(harness.controller.snapshot(), { enabled: true, active: false }, label);
+  }
+});
+
+test("relay-forced Room cannot trigger another connected-media fallback", () => {
+  const harness = createHarness();
+
+  assert.equal(harness.connectedMediaStall({ alreadyUsingRelay: true }), false);
+  assert.deepEqual(harness.liveTimers(), []);
+  assert.deepEqual(harness.connectedMediaStalls, []);
+  assert.equal(harness.getReconnectCalls(), 0);
+});
+
+test("connected-media fallback honors switch, visibility, and network guards", () => {
+  const switching = createHarness({ switching: true });
+  assert.equal(switching.connectedMediaStall(), false);
+  assert.deepEqual(switching.liveTimers(), []);
+
+  const hidden = createHarness({ hidden: true });
+  assert.equal(hidden.connectedMediaStall(), true);
+  assert.deepEqual(hidden.controller.snapshot(), {
+    enabled: true,
+    active: true,
+    attemptCount: 0,
+    scheduled: false,
+    inFlight: false,
+    waiting: true,
+    exhausted: false,
+  });
+  hidden.setHidden(false);
+  assert.equal(hidden.controller.resume(), true);
+  assert.deepEqual(hidden.liveTimers().map((timer) => timer.delay), [500]);
+
+  const offline = createHarness({ online: false });
+  assert.equal(offline.connectedMediaStall(), true);
+  assert.deepEqual(offline.liveTimers(), []);
+  offline.setOnline(true);
+  assert.equal(offline.controller.resume(), true);
+  assert.deepEqual(offline.liveTimers().map((timer) => timer.delay), [500]);
+});
+
 test("real platform gate gives every non-target client zero stalled-reconnect actions", () => {
   const cases = [
     ["Windows Chrome", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/153.0 Safari/537.36", false],
@@ -467,6 +799,7 @@ test("real platform gate gives every non-target client zero stalled-reconnect ac
     const harness = createHarness({ userAgent, isNativeShell });
     assert.equal(harness.controller.isEnabled(), false, name);
     assert.equal(harness.arm(), false, name);
+    assert.equal(harness.connectedMediaStall(), false, name);
     assert.equal(harness.controller.resume(), false, name);
     assert.equal(harness.liveTimers().length, 0, name);
     assert.equal(harness.getReconnectCalls(), 0, name);
@@ -496,6 +829,12 @@ test("mic preservation policy remains recovery-only and production wiring tears 
   assert.match(connectSource, /_echoRecoveryDisconnectTimedOut === true[\s\S]*?continuing fresh handoff/);
   assert.match(connectSource, /newRoom\._echoRecoveryDisconnect === true\)[\s\S]*?if \(newRoom === room && typeof stopInboundScreenStatsMonitor/);
   assert.match(connectSource, /reuseAdmin: true,[\s\S]*?preserveMicIntent: true,[\s\S]*?androidFirefoxRecoverySourceRoom: newRoom/);
+  assert.match(connectSource, /forceAndroidFirefoxRelay = controlledAndroidFirefoxReplacement &&\s+androidFirefoxForceRelay === true/);
+  assert.match(connectSource, /_echoAndroidFirefoxConnectedMediaRelayRecovery = function[\s\S]*?handleConnectedMediaStall\(\{[\s\S]*?alreadyUsingRelay:[\s\S]*?forceRelay: true/);
+  assert.match(connectSource, /handleConnectedMediaStall\(\{[\s\S]*?isStillStalled: detail\?\.isStillStalled,[\s\S]*?onValidated: detail\?\.onValidated/);
+  assert.match(connectSource, /handleConnectedMediaStall\(\{[\s\S]*?micWasEnabled: desiredMicEnabledForRoomSwitch\(\) === true/);
+  assert.match(connectSource, /if \(forceAndroidFirefoxRelay\) \{\s+rtcConfig\.iceTransportPolicy = "relay"/);
+  assert.match(connectSource, /androidFirefoxForceRelay: recoveryState\?\.forceRelay === true/);
   assert.match(connectSource, /ignoreAndroidFirefoxStaleRoomEvent\("local track unpublished"\)/);
   assert.match(connectSource, /androidFirefoxRoomDisconnectRecovery\?\.cancel\(room\);[\s\S]*?connectSequence \+= 1;[\s\S]*?room\._echoExpectedDisconnect = true/);
 });

--- a/core/viewer/connect.js
+++ b/core/viewer/connect.js
@@ -123,6 +123,15 @@ if (androidFirefoxRoomDisconnectRecoveryEnabled &&
           state.timeoutMs + "ms; starting fresh Room recovery");
         setStatus("Refreshing stalled Android Firefox session...", true);
       },
+      onConnectedMediaStall: function(state) {
+        debugLog("[android-firefox-room-recovery] connected media remained stalled; " +
+          "forcing relay Room sid=" + (state.trackSid || "unknown"));
+        if (typeof reportWatchDebug === "function") {
+          reportWatchDebug("android-firefox connected-media-stall action=relay-room sid=" +
+            (state.trackSid || "unknown"));
+        }
+        setStatus("Refreshing Android Firefox media over relay...", true);
+      },
     });
 
   document.addEventListener("visibilitychange", function() {
@@ -131,6 +140,13 @@ if (androidFirefoxRoomDisconnectRecoveryEnabled &&
   window.addEventListener("online", function() {
     androidFirefoxRoomDisconnectRecovery?.resume();
   });
+}
+
+function requestAndroidFirefoxConnectedMediaRelayRecovery(detail) {
+  if (!androidFirefoxRoomDisconnectRecoveryEnabled || !room) return false;
+  var recover = room._echoAndroidFirefoxConnectedMediaRelayRecovery;
+  if (typeof recover !== "function") return false;
+  return recover(detail || {}) === true;
 }
 
 function recordActiveRoomDiagnostic(candidateRoom, recorder) {
@@ -323,10 +339,13 @@ async function connectToRoom({
   preserveMicIntent,
   androidFirefoxRecoverySourceRoom,
   androidFirefoxPreservedMicEnabled,
+  androidFirefoxForceRelay,
 }) {
   const controlledAndroidFirefoxReplacement = androidFirefoxRoomDisconnectRecoveryEnabled &&
     !!androidFirefoxRecoverySourceRoom &&
     androidFirefoxRecoverySourceRoom === room;
+  const forceAndroidFirefoxRelay = controlledAndroidFirefoxReplacement &&
+    androidFirefoxForceRelay === true;
   // A newly connected LiveKit participant has no publications yet. Preserve
   // the user's pre-switch intent separately so authoritative reconciliation
   // can report the new room truth without cancelling mic restoration.
@@ -705,7 +724,27 @@ async function connectToRoom({
       preserveMicIntent: true,
       androidFirefoxRecoverySourceRoom: newRoom,
       androidFirefoxPreservedMicEnabled: preservedMicEnabled,
+      androidFirefoxForceRelay: recoveryState?.forceRelay === true,
     });
+  }
+  if (androidFirefoxRoomDisconnectRecoveryEnabled) {
+    newRoom._echoAndroidFirefoxRelayForced = forceAndroidFirefoxRelay;
+    newRoom._echoAndroidFirefoxConnectedMediaRelayRecovery = function(detail) {
+      if (newRoom !== room || String(newRoom.state || "").toLowerCase() !== "connected") {
+        return false;
+      }
+      return androidFirefoxRoomDisconnectRecovery?.handleConnectedMediaStall({
+        room: newRoom,
+        trackSid: detail?.trackSid || null,
+        alreadyUsingRelay: newRoom._echoAndroidFirefoxRelayForced === true,
+        isStillStalled: detail?.isStillStalled,
+        onValidated: detail?.onValidated,
+        micWasEnabled: desiredMicEnabledForRoomSwitch() === true,
+        reconnect: function(recoveryState) {
+          return reconnectAndroidFirefoxRoom(Object.assign({}, recoveryState, { forceRelay: true }));
+        },
+      }) === true;
+    };
   }
   function watchAndroidFirefoxRoomReconnect() {
     if (!androidFirefoxRoomDisconnectRecoveryEnabled) return;
@@ -1601,9 +1640,14 @@ async function connectToRoom({
     debugLog("[ice] failed to fetch ICE config, using STUN-only fallback");
   }
 
+  var rtcConfig = { iceServers: iceServers };
+  if (forceAndroidFirefoxRelay) {
+    rtcConfig.iceTransportPolicy = "relay";
+    debugLog("[android-firefox-room-recovery] forcing TURN relay for connected-media recovery");
+  }
   await newRoom.connect(sfuUrl, accessToken, {
     autoSubscribe: true,
-    rtcConfig: { iceServers: iceServers },
+    rtcConfig: rtcConfig,
   });
   if (seq !== connectSequence) {
     newRoom._echoExpectedDisconnect = true;

--- a/core/viewer/participants-fullscreen.js
+++ b/core/viewer/participants-fullscreen.js
@@ -35,7 +35,15 @@ function attemptAndroidFirefoxScreenSubscriptionReset(options) {
   // Mark before touching the subscription. TrackUnsubscribed can arrive
   // synchronously. SID-scoped state survives same-SID metadata replacement,
   // so this recovery cannot turn into a reset loop.
-  options.recoveryStateBySid.set(trackSid, { subscriptionResetAttempted: true });
+  var resetAtMs = Number.isFinite(options.nowMs)
+    ? options.nowMs
+    : (typeof performance === "object" && typeof performance.now === "function"
+        ? performance.now()
+        : Date.now());
+  options.recoveryStateBySid.set(trackSid, {
+    subscriptionResetAttempted: true,
+    subscriptionResetAt: resetAtMs,
+  });
   if (typeof options.markResubscribeIntent === "function") {
     options.markResubscribeIntent(trackSid);
   }
@@ -60,6 +68,91 @@ function attemptAndroidFirefoxScreenSubscriptionReset(options) {
       options.log("[android-firefox-recovery] restored screen subscription sid=" + trackSid);
     }
   }, options.resetDelayMs == null ? 500 : options.resetDelayMs);
+  return true;
+}
+
+function isAndroidFirefoxConnectedMediaStallCurrent(options) {
+  if (!options || options.enabled !== true) return false;
+  var roomConnected = options.roomConnected === true;
+  if (typeof options.isRoomConnected === "function") {
+    try {
+      roomConnected = options.isRoomConnected() === true;
+    } catch (_error) {
+      roomConnected = false;
+    }
+  }
+  if (!roomConnected) return false;
+  if (!isCurrentScreenRecoveryGeneration(options)) return false;
+  if (options.publication.isSubscribed !== true) return false;
+
+  var frameAgeMs = options.frameAgeMs;
+  if (typeof options.getFrameAgeMs === "function") {
+    try {
+      frameAgeMs = options.getFrameAgeMs();
+    } catch (_error) {
+      return false;
+    }
+  }
+  if (!(frameAgeMs > 3000)) return false;
+
+  var mediaTrack = options.publication.track?.mediaStreamTrack;
+  return !!mediaTrack && mediaTrack.readyState === "live" && mediaTrack.muted === true;
+}
+
+function attemptAndroidFirefoxConnectedMediaRelayRecovery(options) {
+  if (!isAndroidFirefoxConnectedMediaStallCurrent(options)) return false;
+  if (!options.recoveryStateBySid || typeof options.recover !== "function") return false;
+
+  var recoveryState = options.recoveryStateBySid.get(options.trackSid);
+  if (!recoveryState || recoveryState.subscriptionResetAttempted !== true ||
+      recoveryState.relayRecoveryAttempted === true) {
+    return false;
+  }
+  var resetAtMs = recoveryState.subscriptionResetAt;
+  var nowMs = Number.isFinite(options.nowMs)
+    ? options.nowMs
+    : (typeof performance === "object" && typeof performance.now === "function"
+        ? performance.now()
+        : Date.now());
+  var graceMs = Number.isFinite(options.resetGraceMs) && options.resetGraceMs >= 0
+    ? options.resetGraceMs
+    : 6000;
+  if (!Number.isFinite(resetAtMs) || nowMs - resetAtMs < graceMs) return false;
+
+  var accepted = options.recover({
+    trackSid: options.trackSid,
+    identity: options.meta.identity || "",
+    isStillStalled: function() {
+      return isAndroidFirefoxConnectedMediaStallCurrent(options);
+    },
+    onValidated: function() {
+      if (!isAndroidFirefoxConnectedMediaStallCurrent(options)) return false;
+      var currentRecoveryState = options.recoveryStateBySid.get(options.trackSid);
+      if (!currentRecoveryState || currentRecoveryState.subscriptionResetAttempted !== true ||
+          currentRecoveryState.relayRecoveryAttempted === true) {
+        return false;
+      }
+      var validatedAtMs;
+      if (typeof options.getNowMs === "function") {
+        try {
+          validatedAtMs = options.getNowMs();
+        } catch (_error) {
+          return false;
+        }
+      }
+      if (!Number.isFinite(validatedAtMs)) validatedAtMs = nowMs;
+      options.recoveryStateBySid.set(options.trackSid, Object.assign({}, currentRecoveryState, {
+        relayRecoveryAttempted: true,
+        relayRecoveryAt: validatedAtMs,
+      }));
+      if (typeof options.log === "function") {
+        options.log("[android-firefox-recovery] escalating connected media stall to relay Room sid=" +
+          options.trackSid);
+      }
+      return true;
+    },
+  }) === true;
+  if (!accepted) return false;
   return true;
 }
 
@@ -327,6 +420,7 @@ function startScreenWatchdog() {
           tile: tile,
           frameAgeMs: age,
           firstLineRecoveryAt: meta.lastFix,
+          nowMs: now,
           recoveryStateBySid: androidFirefoxScreenRecoveryBySid,
           getCurrentMeta: function(sid) { return screenTrackMeta.get(sid); },
           getCurrentTile: function(sid) { return screenTileBySid.get(sid); },
@@ -337,6 +431,44 @@ function startScreenWatchdog() {
           log: debugLog,
         });
         if (resetScheduled) return;
+
+        var connectedMediaRecoveryRoom = room;
+        var relayRecoveryAccepted = attemptAndroidFirefoxConnectedMediaRelayRecovery({
+          enabled: true,
+          roomConnected: String(connectedMediaRecoveryRoom?.state || "").toLowerCase() === "connected",
+          isRoomConnected: function() {
+            return room === connectedMediaRecoveryRoom &&
+              String(connectedMediaRecoveryRoom?.state || "").toLowerCase() === "connected";
+          },
+          trackSid: trackSid,
+          meta: meta,
+          publication: publication,
+          tile: tile,
+          frameAgeMs: age,
+          getFrameAgeMs: function() {
+            var currentMeta = screenTrackMeta.get(trackSid);
+            var currentTile = screenTileBySid.get(trackSid);
+            var currentVideo = currentTile?.querySelector("video");
+            if (!currentMeta || !currentTile || !currentVideo ||
+                currentVideo._lkTrack !== currentMeta.publication?.track) {
+              return null;
+            }
+            return performance.now() - (currentVideo._lastFrameTs || 0);
+          },
+          nowMs: now,
+          getNowMs: function() { return performance.now(); },
+          resetGraceMs: 6000,
+          recoveryStateBySid: androidFirefoxScreenRecoveryBySid,
+          getCurrentMeta: function(sid) { return screenTrackMeta.get(sid); },
+          getCurrentTile: function(sid) { return screenTileBySid.get(sid); },
+          isHidden: function(identity) { return hiddenScreens.has(identity); },
+          recover: function(detail) {
+            if (typeof requestAndroidFirefoxConnectedMediaRelayRecovery !== "function") return false;
+            return requestAndroidFirefoxConnectedMediaRelayRecovery(detail);
+          },
+          log: debugLog,
+        });
+        if (relayRecoveryAccepted) return;
       }
       if (isBlack && blackFor > 3000 && track) {
         if (!meta.lastSwap || now - meta.lastSwap > 10000) {
@@ -758,8 +890,10 @@ function attachVideoDiagnostics(track, element, overlay) {
 if (typeof module === "object" && module.exports) {
   module.exports = {
     attemptAndroidFirefoxScreenSubscriptionReset,
+    attemptAndroidFirefoxConnectedMediaRelayRecovery,
     createVideoFrameRateTracker,
     getVideoPresentationSnapshot,
+    isAndroidFirefoxConnectedMediaStallCurrent,
     isCurrentScreenRecoveryGeneration,
   };
 }

--- a/core/viewer/room-switch-state.js
+++ b/core/viewer/room-switch-state.js
@@ -340,6 +340,36 @@
         recovery.waiting = true;
         return false;
       }
+      if (recovery.eligibilityValidated !== true && typeof recovery.isStillEligible === "function") {
+        let stillEligible = false;
+        try {
+          stillEligible = recovery.isStillEligible({ room: recovery.room }) === true;
+        } catch (_error) {
+          stillEligible = false;
+        }
+        if (!stillEligible) {
+          clearActiveRecovery(recovery);
+          return false;
+        }
+        let validationCommitted = false;
+        try {
+          validationCommitted = recovery.onEligibilityValidated({ room: recovery.room }) === true;
+        } catch (_error) {
+          validationCommitted = false;
+        }
+        if (!validationCommitted) {
+          clearActiveRecovery(recovery);
+          return false;
+        }
+        recovery.eligibilityValidated = true;
+        if (recovery.kind === "connected-media" &&
+            typeof opts.onConnectedMediaStall === "function") {
+          opts.onConnectedMediaStall({
+            room: recovery.room,
+            trackSid: recovery.trackSid || null,
+          });
+        }
+      }
 
       const attemptIndex = recovery.nextAttemptIndex;
       recovery.nextAttemptIndex += 1;
@@ -378,8 +408,9 @@
       return queueNextAttempt(recovery);
     }
 
-    function beginRecovery(candidateRoom, reconnect, micWasEnabled) {
+    function beginRecovery(candidateRoom, reconnect, micWasEnabled, recoveryOptions) {
       if (!isEligibleCurrentRoom(candidateRoom) || typeof reconnect !== "function") return false;
+      const recoveryOpts = recoveryOptions || {};
 
       if (activeRecovery) {
         if (activeRecovery.room === candidateRoom) return false;
@@ -399,6 +430,15 @@
         inFlight: false,
         waiting: false,
         exhausted: false,
+        isStillEligible: typeof recoveryOpts.isStillEligible === "function"
+          ? recoveryOpts.isStillEligible
+          : null,
+        onEligibilityValidated: typeof recoveryOpts.onEligibilityValidated === "function"
+          ? recoveryOpts.onEligibilityValidated
+          : null,
+        kind: recoveryOpts.kind || null,
+        trackSid: recoveryOpts.trackSid || null,
+        eligibilityValidated: false,
       };
       activeRecovery = recovery;
       queueNextAttempt(recovery);
@@ -435,7 +475,24 @@
         }
         return false;
       }
-      if (activeRecovery?.room === candidateRoom || activeReconnectWatch?.room === candidateRoom) {
+      let micWasEnabled = typeof detail.micWasEnabled === "boolean" ? detail.micWasEnabled : null;
+      if (activeRecovery?.room === candidateRoom) {
+        const pendingRecovery = activeRecovery;
+        const maySupersedeConnectedMedia = pendingRecovery.kind === "connected-media" &&
+          pendingRecovery.eligibilityValidated !== true &&
+          pendingRecovery.inFlight !== true;
+        if (!maySupersedeConnectedMedia) return false;
+
+        // Signaling loss is now the authoritative failure. Cancel the still-
+        // uncommitted media timer and let the normal reconnect watchdog own the
+        // Room, while retaining the microphone intent captured by the first
+        // recovery signal.
+        if (typeof pendingRecovery.micWasEnabled === "boolean") {
+          micWasEnabled = pendingRecovery.micWasEnabled;
+        }
+        clearActiveRecovery(pendingRecovery);
+      }
+      if (activeReconnectWatch?.room === candidateRoom) {
         return false;
       }
       if (activeReconnectWatch) clearReconnectWatch(activeReconnectWatch);
@@ -443,7 +500,7 @@
       const watch = {
         room: candidateRoom,
         reconnect: detail.reconnect,
-        micWasEnabled: typeof detail.micWasEnabled === "boolean" ? detail.micWasEnabled : null,
+        micWasEnabled,
         generation: ++nextGeneration,
         timerId: null,
         stale: false,
@@ -466,10 +523,44 @@
       if (activeReconnectWatch?.room === candidateRoom) {
         cancelled = clearReconnectWatch(activeReconnectWatch) || cancelled;
       }
-      if (activeRecovery?.room === candidateRoom) {
+      // A connected-state event proves an SDK reconnect recovered, but it does
+      // not prove that an already-connected Room resumed media. Let the latter
+      // reach its exact just-in-time media predicate instead of cancelling it
+      // on a redundant connection event.
+      if (activeRecovery?.room === candidateRoom &&
+          typeof activeRecovery.isStillEligible !== "function") {
         cancelled = clearActiveRecovery(activeRecovery) || cancelled;
       }
       return cancelled;
+    }
+
+    function handleConnectedMediaStall(event) {
+      const detail = event || {};
+      const candidateRoom = detail.room;
+      if (!isEligibleCurrentRoom(candidateRoom) || typeof detail.reconnect !== "function") {
+        return false;
+      }
+      // A relay-forced replacement is the final bounded fallback for this Room
+      // generation. If it also stalls, leave the session stable for diagnosis
+      // instead of cycling Rooms indefinitely.
+      if (detail.alreadyUsingRelay === true) return false;
+      if (typeof detail.isStillStalled !== "function") return false;
+      if (typeof detail.onValidated !== "function") return false;
+      if (activeRecovery?.room === candidateRoom) return false;
+      if (activeReconnectWatch?.room === candidateRoom) return false;
+
+      const accepted = beginRecovery(
+        candidateRoom,
+        detail.reconnect,
+        detail.micWasEnabled,
+        {
+          isStillEligible: detail.isStillStalled,
+          onEligibilityValidated: detail.onValidated,
+          kind: "connected-media",
+          trackSid: detail.trackSid || null,
+        }
+      );
+      return accepted;
     }
 
     function handleDisconnected(event) {
@@ -491,12 +582,24 @@
       }
       if (typeof detail.reconnect !== "function") return false;
 
+      let micWasEnabled = typeof detail.micWasEnabled === "boolean" ? detail.micWasEnabled : null;
       if (activeRecovery) {
-        if (activeRecovery.room === candidateRoom) return false;
-        clearActiveRecovery(activeRecovery);
+        if (activeRecovery.room === candidateRoom) {
+          const pendingRecovery = activeRecovery;
+          const maySupersedeConnectedMedia = pendingRecovery.kind === "connected-media" &&
+            pendingRecovery.eligibilityValidated !== true &&
+            pendingRecovery.inFlight !== true;
+          if (!maySupersedeConnectedMedia) return false;
+          if (typeof pendingRecovery.micWasEnabled === "boolean") {
+            micWasEnabled = pendingRecovery.micWasEnabled;
+          }
+          clearActiveRecovery(pendingRecovery);
+        } else {
+          clearActiveRecovery(activeRecovery);
+        }
       }
       if (activeReconnectWatch?.room === candidateRoom) clearReconnectWatch(activeReconnectWatch);
-      return beginRecovery(candidateRoom, detail.reconnect, detail.micWasEnabled);
+      return beginRecovery(candidateRoom, detail.reconnect, micWasEnabled);
     }
 
     function resume() {
@@ -546,6 +649,7 @@
     return {
       cancel,
       handleConnected,
+      handleConnectedMediaStall,
       handleDisconnected,
       handleReconnecting,
       isEnabled: () => enabled,


### PR DESCRIPTION
## Summary
- detect the Android Firefox connected-media stall after the existing exact-track subscription reset
- replace only the affected Android Firefox Room with one relay-forced recovery Room after exact just-in-time state validation
- preserve microphone intent and serialize recovery ownership across reconnect, disconnect, leave, visibility, and room-switch races

## Release impact
- Server-served viewer only
- No Windows desktop binary, native capture, control, SFU, TURN, PC, or Mac behavior change

## Verification
- npm run verify:quick (322/322 viewer tests)
- git diff --check
- two independent adversarial reviews: GO

## Live acceptance gate
This is a bounded production candidate. Final acceptance requires Android Firefox to show a relay-selected connection with advancing decoded/presented frames through a screen-content change and a close/reopen/rejoin cycle. Desktop screen publishing and receiving must remain healthy throughout.