### PR TITLE
Fix Android Firefox presentation stalls

### DIFF
--- a/core/viewer/android-firefox-presentation-stall.test.js
+++ b/core/viewer/android-firefox-presentation-stall.test.js
@@ -1,0 +1,559 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const vm = require("node:vm");
+
+const {
+  getAndroidFirefoxPresentationRecoveryAction,
+  isAndroidFirefoxPresentationRelayAction,
+  markAndroidFirefoxPresentationRecoveryAction,
+} = require("./participants-fullscreen.js");
+const {
+  getAndroidFirefoxStatsSingleFlight,
+  isInboundScreenStatsPollCurrent,
+  resolveInboundScreenStatsMonitorBinding,
+  resolveSelectedIceCandidatePair,
+} = require("./screen-share-adaptive.js");
+
+const viewerDir = __dirname;
+const rnnoiseSource = fs.readFileSync(path.join(viewerDir, "rnnoise.js"), "utf8");
+function loadRealBrowserPredicate() {
+  const context = {
+    navigator: { userAgent: "", platform: "" },
+    echoGet() { return null; },
+    debugLog() {},
+  };
+  vm.createContext(context);
+  vm.runInContext(rnnoiseSource, context, { filename: "rnnoise.js" });
+  return context.isAndroidFirefoxBrowser;
+}
+const isAndroidFirefoxBrowser = loadRealBrowserPredicate();
+global.isAndroidFirefoxBrowser = isAndroidFirefoxBrowser;
+const {
+  containAndroidFirefoxScreenTileClick,
+  containAndroidFirefoxUtilityScrimClick,
+  isPointInsideVisibleRemoteScreenPresentation,
+  shouldSuppressAndroidFirefoxScreenPresentationInteractions,
+} = require("./participants-grid.js");
+
+test("presentation recovery is sink, subscription, relay and rearms only after sustained progress", () => {
+  const states = new Map();
+  const base = {
+    enabled: true,
+    current: true,
+    trackSid: "TR_screen",
+    recoveryStateBySid: states,
+  };
+
+  assert.equal(getAndroidFirefoxPresentationRecoveryAction({
+    ...base, nowMs: 1000, presentedFrameTs: 1000,
+  }), "progress");
+  assert.equal(getAndroidFirefoxPresentationRecoveryAction({
+    ...base, nowMs: 10000, presentedFrameTs: 1000,
+  }), "none");
+  assert.equal(getAndroidFirefoxPresentationRecoveryAction({
+    ...base, nowMs: 13000, presentedFrameTs: 1000,
+  }), "sink");
+  assert.equal(markAndroidFirefoxPresentationRecoveryAction({
+    ...base, nowMs: 13000, presentedFrameTs: 1000,
+  }, "sink"), true);
+  assert.equal(getAndroidFirefoxPresentationRecoveryAction({
+    ...base, nowMs: 16000, presentedFrameTs: 0,
+  }), "none");
+  assert.equal(getAndroidFirefoxPresentationRecoveryAction({
+    ...base, nowMs: 19000, presentedFrameTs: 0,
+  }), "subscription");
+  states.set("TR_screen", {
+    ...states.get("TR_screen"),
+    subscriptionResetAttempted: true,
+    subscriptionResetAt: 19000,
+    subscriptionResetKind: "presentation",
+  });
+  assert.equal(markAndroidFirefoxPresentationRecoveryAction({
+    ...base, nowMs: 19000, presentedFrameTs: 0,
+  }, "subscription"), true);
+  assert.equal(getAndroidFirefoxPresentationRecoveryAction({
+    ...base, nowMs: 22000, presentedFrameTs: 0,
+  }), "none");
+  assert.equal(getAndroidFirefoxPresentationRecoveryAction({
+    ...base, nowMs: 25000, presentedFrameTs: 0,
+  }), "relay");
+
+  assert.equal(getAndroidFirefoxPresentationRecoveryAction({
+    ...base, nowMs: 26000, presentedFrameTs: 26000,
+  }), "progress");
+  let recovered = states.get("TR_screen");
+  assert.equal(recovered.presentationSinkResetAttempted, true,
+    "one intermittent frame must not rearm the SID");
+  assert.equal(recovered.presentationRearmProgressTicks, 1);
+
+  assert.equal(getAndroidFirefoxPresentationRecoveryAction({
+    ...base, nowMs: 29000, presentedFrameTs: 26000,
+  }), "none");
+  recovered = states.get("TR_screen");
+  assert.equal(recovered.presentationRearmProgressTicks, undefined,
+    "a no-progress watchdog tick breaks the recovery streak");
+
+  assert.equal(getAndroidFirefoxPresentationRecoveryAction({
+    ...base, nowMs: 30000, presentedFrameTs: 30000,
+  }), "progress");
+  assert.equal(getAndroidFirefoxPresentationRecoveryAction({
+    ...base, nowMs: 33000, presentedFrameTs: 33000,
+  }), "progress");
+  recovered = states.get("TR_screen");
+  assert.equal(recovered.presentationSinkResetAttempted, undefined);
+  assert.equal(recovered.presentationSubscriptionResetAttempted, undefined);
+  assert.equal(recovered.subscriptionResetAttempted, undefined);
+
+  assert.equal(getAndroidFirefoxPresentationRecoveryAction({
+    ...base, nowMs: 42000, presentedFrameTs: 33000,
+  }), "none");
+  assert.equal(getAndroidFirefoxPresentationRecoveryAction({
+    ...base, nowMs: 48000, presentedFrameTs: 33000,
+  }), "sink");
+});
+
+test("six-second watchdog jitter retains the first stale observation", () => {
+  const states = new Map([["TR_jitter", { lastPresentedFrameTs: 1000 }]]);
+  const base = {
+    enabled: true,
+    current: true,
+    trackSid: "TR_jitter",
+    presentedFrameTs: 1000,
+    recoveryStateBySid: states,
+  };
+  assert.equal(getAndroidFirefoxPresentationRecoveryAction({ ...base, nowMs: 10000 }), "none");
+  assert.equal(getAndroidFirefoxPresentationRecoveryAction({ ...base, nowMs: 16000 }), "sink");
+});
+
+test("a prior generic SID reset skips the duplicate presentation toggle after a later recovered episode", () => {
+  const states = new Map([["TR_reused", {
+    subscriptionResetAttempted: true,
+    subscriptionResetAt: 2000,
+    lastPresentedFrameTs: 5000,
+  }]]);
+  const base = {
+    enabled: true,
+    current: true,
+    trackSid: "TR_reused",
+    recoveryStateBySid: states,
+  };
+
+  // The earlier muted episode recovered for real; its generic one-shot remains
+  // consumed, but normal presentation progress is recorded for the later stall.
+  assert.equal(getAndroidFirefoxPresentationRecoveryAction({
+    ...base, nowMs: 8000, presentedFrameTs: 8000,
+  }), "progress");
+  assert.equal(getAndroidFirefoxPresentationRecoveryAction({
+    ...base, nowMs: 11000, presentedFrameTs: 11000,
+  }), "progress");
+  assert.equal(getAndroidFirefoxPresentationRecoveryAction({
+    ...base, nowMs: 20000, presentedFrameTs: 11000,
+  }), "none");
+  assert.equal(getAndroidFirefoxPresentationRecoveryAction({
+    ...base, nowMs: 26000, presentedFrameTs: 11000,
+  }), "sink");
+  assert.equal(markAndroidFirefoxPresentationRecoveryAction({
+    ...base, nowMs: 26000, presentedFrameTs: 11000,
+  }, "sink"), true);
+  const afterSink = states.get("TR_reused");
+  assert.equal(afterSink.presentationSubscriptionResetSkipped, true);
+  assert.equal(afterSink.presentationSubscriptionResetAt, 26000);
+  assert.equal(getAndroidFirefoxPresentationRecoveryAction({
+    ...base, nowMs: 31999, presentedFrameTs: 0,
+  }), "none");
+  assert.equal(getAndroidFirefoxPresentationRecoveryAction({
+    ...base, nowMs: 32000, presentedFrameTs: 0,
+  }), "relay", "the ladder must not request a second false-to-true toggle");
+});
+
+test("relay presentation action bypasses fresh generic frame age and missing lastFix", () => {
+  assert.equal(isAndroidFirefoxPresentationRelayAction("relay"), true);
+  assert.equal(isAndroidFirefoxPresentationRelayAction("subscription"), false);
+  const fullscreenSource = fs.readFileSync(path.join(viewerDir, "participants-fullscreen.js"), "utf8");
+  assert.match(fullscreenSource,
+    /hasFrames && !isBlack && age < 4500 && !presentationRelayReady/);
+  assert.match(fullscreenSource,
+    /\(stalled \|\| presentationRelayReady\)[\s\S]*?\(presentationRelayReady \|\|[\s\S]*?meta\.lastFix > 0/);
+});
+
+test("presentation recovery never starts without a prior presented frame or current generation", () => {
+  const states = new Map();
+  assert.equal(getAndroidFirefoxPresentationRecoveryAction({
+    enabled: true,
+    current: true,
+    trackSid: "TR_none",
+    nowMs: 60000,
+    presentedFrameTs: 0,
+    recoveryStateBySid: states,
+  }), "none");
+  states.set("TR_stale", { lastPresentedFrameTs: 1000, presentationStalledTicks: 1 });
+  assert.equal(getAndroidFirefoxPresentationRecoveryAction({
+    enabled: true,
+    current: false,
+    trackSid: "TR_stale",
+    nowMs: 60000,
+    presentedFrameTs: 1000,
+    recoveryStateBySid: states,
+  }), "none");
+});
+
+test("only non-native Android Firefox suppresses screen presentation interactions", () => {
+  const cases = [
+    ["Mozilla/5.0 (Android 16; Mobile; rv:153.0) Gecko/153.0 Firefox/153.0", false, true],
+    ["Mozilla/5.0 (Android 16; Mobile; rv:153.0) Gecko/153.0 Firefox/153.0", true, false],
+    ["Mozilla/5.0 (Linux; Android 16) AppleWebKit/537.36 Chrome/140 Mobile", false, false],
+    ["Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:153.0) Gecko/20100101 Firefox/153.0", false, false],
+    ["Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 Safari/605.1.15", false, false],
+    ["Mozilla/5.0 (iPhone; CPU iPhone OS 19_0 like Mac OS X) AppleWebKit/605.1.15 Mobile", false, false],
+  ];
+  for (const [userAgent, native, expected] of cases) {
+    assert.equal(
+      shouldSuppressAndroidFirefoxScreenPresentationInteractions({ userAgent }, native),
+      expected,
+      userAgent
+    );
+  }
+});
+
+function createVisibleScreenFixture(options = {}) {
+  const track = { mediaStreamTrack: { readyState: options.readyState || "live" } };
+  const video = { isConnected: true, _lkTrack: track };
+  const rect = options.rect || { left: 20, top: 40, right: 220, bottom: 240, width: 200, height: 200 };
+  const tile = {
+    isConnected: true,
+    hidden: options.hidden === true,
+    style: {
+      display: options.display || "",
+      visibility: options.visibility || "",
+    },
+    getClientRects: () => options.noRects ? [] : [rect],
+    getBoundingClientRect: () => rect,
+    querySelector: (selector) => selector === "video" ? video : null,
+  };
+  const publication = {
+    track,
+    isSubscribed: options.subscribed !== false,
+  };
+  const sid = "TR_screen";
+  const meta = {
+    identity: options.identity || "remote-user",
+    publication,
+    tile,
+  };
+  return {
+    documentObject: { visibilityState: options.documentHidden ? "hidden" : "visible" },
+    getComputedStyle: () => ({
+      display: options.display || "block",
+      visibility: options.visibility || "visible",
+    }),
+    hiddenIdentities: new Set(options.identityHidden ? [meta.identity] : []),
+    localIdentity: "local-user",
+    metaBySid: new Map([[sid, meta]]),
+    tileBySid: new Map([[sid, tile]]),
+  };
+}
+
+test("utility scrim consumes only Android Firefox clicks intersecting a visible remote screen", () => {
+  const androidFirefoxUa =
+    "Mozilla/5.0 (Android 16; Mobile; rv:153.0) Gecko/153.0 Firefox/153.0";
+  const androidChromeUa =
+    "Mozilla/5.0 (Linux; Android 16) AppleWebKit/537.36 Chrome/153.0 Mobile Safari/537.36";
+  const desktopFirefoxUa =
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:153.0) Gecko/20100101 Firefox/153.0";
+  const windowsChromeUa =
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/153.0 Safari/537.36";
+
+  function runCase(options) {
+    let prevented = 0;
+    let stopped = 0;
+    let collapsed = 0;
+    let intersectionScans = 0;
+    let intersects = false;
+    const fixture = options.fixture || createVisibleScreenFixture();
+    const contained = containAndroidFirefoxUtilityScrimClick({
+      event: {
+        preventDefault() { prevented += 1; },
+        stopPropagation() { stopped += 1; },
+      },
+      navigatorObject: { userAgent: options.userAgent },
+      isNativeShell: options.native === true,
+      isTargetBrowser: isAndroidFirefoxBrowser,
+      intersectsVisibleRemoteScreen() {
+        intersectionScans += 1;
+        intersects = isPointInsideVisibleRemoteScreenPresentation({
+          ...fixture,
+          clientX: options.clientX,
+          clientY: options.clientY,
+        });
+        return intersects;
+      },
+    });
+    if (!contained) collapsed += 1;
+    return { collapsed, contained, intersectionScans, intersects, prevented, stopped };
+  }
+
+  assert.deepEqual(runCase({
+    userAgent: androidFirefoxUa, clientX: 100, clientY: 100,
+  }), {
+    collapsed: 0,
+    contained: true,
+    intersectionScans: 1,
+    intersects: true,
+    prevented: 1,
+    stopped: 1,
+  });
+
+  const collapseCases = [
+    ["outside tile", { userAgent: androidFirefoxUa, clientX: 300, clientY: 300 }],
+    ["keyboard/no coordinates", { userAgent: androidFirefoxUa }],
+    ["no screen", {
+      userAgent: androidFirefoxUa,
+      clientX: 100,
+      clientY: 100,
+      fixture: {
+        ...createVisibleScreenFixture(),
+        metaBySid: new Map(),
+        tileBySid: new Map(),
+      },
+    }],
+    ["Android Chrome", { userAgent: androidChromeUa, clientX: 100, clientY: 100 }],
+    ["desktop Firefox", { userAgent: desktopFirefoxUa, clientX: 100, clientY: 100 }],
+    ["Windows Chrome", { userAgent: windowsChromeUa, clientX: 100, clientY: 100 }],
+    ["macOS Safari", {
+      userAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 15_6) AppleWebKit/605.1.15 Version/19.0 Safari/605.1.15",
+      clientX: 100,
+      clientY: 100,
+    }],
+    ["iOS Safari", {
+      userAgent: "Mozilla/5.0 (iPhone; CPU iPhone OS 19_0 like Mac OS X) AppleWebKit/605.1.15 Mobile/15E148 Safari/604.1",
+      clientX: 100,
+      clientY: 100,
+    }],
+    ["native Android Firefox", {
+      userAgent: androidFirefoxUa, native: true, clientX: 100, clientY: 100,
+    }],
+    ["local screen", {
+      userAgent: androidFirefoxUa,
+      clientX: 100,
+      clientY: 100,
+      fixture: createVisibleScreenFixture({ identity: "local-user" }),
+    }],
+    ["hidden remote screen", {
+      userAgent: androidFirefoxUa,
+      clientX: 100,
+      clientY: 100,
+      fixture: createVisibleScreenFixture({ identityHidden: true }),
+    }],
+  ];
+  for (const [label, options] of collapseCases) {
+    const result = runCase(options);
+    assert.equal(result.collapsed, 1, label);
+    assert.equal(result.contained, false, label);
+    assert.equal(result.prevented, 0, label);
+    assert.equal(result.stopped, 0, label);
+    const isTargetBrowser = label === "outside tile" || label === "no screen" ||
+      label === "keyboard/no coordinates" || label === "local screen" ||
+      label === "hidden remote screen";
+    assert.equal(result.intersectionScans, isTargetBrowser ? 1 : 0,
+      label + " layout/intersection scans");
+  }
+});
+
+test("direct target tile clicks are consumed without focus mutation while non-target clicks retain it", () => {
+  const androidFirefoxUa =
+    "Mozilla/5.0 (Android 16; Mobile; rv:153.0) Gecko/153.0 Firefox/153.0";
+  const androidChromeUa =
+    "Mozilla/5.0 (Linux; Android 16) AppleWebKit/537.36 Chrome/153.0 Mobile Safari/537.36";
+
+  function runTileClick(userAgent) {
+    let prevented = 0;
+    let stopped = 0;
+    let focusMutations = 0;
+    const event = {
+      preventDefault() { prevented += 1; },
+      stopPropagation() { stopped += 1; },
+    };
+    const shouldContain = shouldSuppressAndroidFirefoxScreenPresentationInteractions(
+      { userAgent },
+      false
+    );
+    if (!containAndroidFirefoxScreenTileClick(event, shouldContain)) focusMutations += 1;
+    return { focusMutations, prevented, stopped };
+  }
+
+  assert.deepEqual(runTileClick(androidFirefoxUa), {
+    focusMutations: 0, prevented: 1, stopped: 1,
+  });
+  assert.deepEqual(runTileClick(androidChromeUa), {
+    focusMutations: 1, prevented: 0, stopped: 0,
+  });
+});
+
+test("Android Firefox getStats timeout stays single-flight until the raw promise settles", async () => {
+  let calls = 0;
+  let release;
+  const target = {
+    getStats() {
+      calls += 1;
+      if (calls === 1) return new Promise((resolve) => { release = resolve; });
+      return Promise.resolve(new Map());
+    },
+  };
+  const flights = new WeakMap();
+  const first = getAndroidFirefoxStatsSingleFlight(target, 1, flights);
+  const second = getAndroidFirefoxStatsSingleFlight(target, 1, flights);
+  assert.deepEqual(await Promise.all([first, second]), [null, null]);
+  assert.equal(calls, 1);
+  assert.equal(await getAndroidFirefoxStatsSingleFlight(target, 1, flights), null);
+  assert.equal(calls, 1);
+  release(new Map());
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.ok(await getAndroidFirefoxStatsSingleFlight(target, 20, flights) instanceof Map);
+  assert.equal(calls, 2);
+});
+
+test("stopped or replaced inbound-stats polls reject stale async continuations", () => {
+  const firstRoom = { sid: "RM_old" };
+  const nextRoom = { sid: "RM_new" };
+  const snapshot = { room: firstRoom, generation: 7 };
+  assert.equal(isInboundScreenStatsPollCurrent(snapshot, firstRoom, 7, true), true);
+  assert.equal(isInboundScreenStatsPollCurrent(snapshot, nextRoom, 7, true), false);
+  assert.equal(isInboundScreenStatsPollCurrent(snapshot, firstRoom, 8, true), false);
+  assert.equal(isInboundScreenStatsPollCurrent(snapshot, firstRoom, 7, false), false);
+});
+
+test("precommit stats start is refused, then the monitor binds the committed replacement on every platform", () => {
+  const scheduledIntervals = [];
+  const clearedIntervals = [];
+  const monitorContext = {
+    clearInterval(interval) { clearedIntervals.push(interval); },
+    clearTimeout,
+    console,
+    fetch() { throw new Error("stats callback must not run in this binding test"); },
+    navigator: {
+      userAgent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/153.0",
+    },
+    room: null,
+    setInterval(callback, delay) {
+      const interval = { callback, delay };
+      scheduledIntervals.push(interval);
+      return interval;
+    },
+    setTimeout,
+    TextEncoder,
+    window: { __ECHO_NATIVE__: false },
+  };
+  vm.createContext(monitorContext);
+  vm.runInContext(
+    fs.readFileSync(path.join(viewerDir, "screen-share-state.js"), "utf8"),
+    monitorContext,
+    { filename: "screen-share-state.js" }
+  );
+  vm.runInContext(
+    fs.readFileSync(path.join(viewerDir, "screen-share-adaptive.js"), "utf8"),
+    monitorContext,
+    { filename: "screen-share-adaptive.js" }
+  );
+
+  const replacementRoom = { sid: "RM_new" };
+  assert.equal(monitorContext.startInboundScreenStatsMonitor(replacementRoom), false,
+    "TrackSubscribed before Room commit must not bind a null/currently stale Room");
+  assert.equal(scheduledIntervals.length, 0);
+
+  monitorContext.room = replacementRoom;
+  assert.equal(monitorContext.startInboundScreenStatsMonitor(replacementRoom), false,
+    "the current Room must still be explicitly committed");
+  assert.equal(scheduledIntervals.length, 0);
+  replacementRoom._echoDiagnosticsCommitted = true;
+  assert.equal(monitorContext.startInboundScreenStatsMonitor(replacementRoom), true);
+  assert.equal(scheduledIntervals.length, 1,
+    "the post-commit start must create the diagnostics monitor on Windows too");
+  assert.equal(scheduledIntervals[0].delay, 3000);
+  assert.equal(resolveInboundScreenStatsMonitorBinding({
+    requestedRoom: replacementRoom,
+    currentRoom: replacementRoom,
+    boundRoom: replacementRoom,
+    active: true,
+  }), "keep");
+
+  const laterRoom = { sid: "RM_later", _echoDiagnosticsCommitted: true };
+  monitorContext.room = laterRoom;
+  assert.equal(monitorContext.startInboundScreenStatsMonitor(laterRoom), true);
+  assert.equal(clearedIntervals.length, 1,
+    "committing a different Room invalidates the old monitor before rebinding");
+  assert.equal(clearedIntervals[0], scheduledIntervals[0]);
+  assert.equal(scheduledIntervals.length, 2);
+  assert.equal(resolveInboundScreenStatsMonitorBinding({
+    requestedRoom: laterRoom,
+    currentRoom: laterRoom,
+    boundRoom: laterRoom,
+    active: true,
+  }), "keep");
+
+  // The binding policy deliberately has no browser gate: committed PC/Mac
+  // rooms retain the normal diagnostics path.
+  for (const label of ["Windows", "macOS", "Android Chrome", "iOS"]) {
+    const roomForPlatform = { sid: label, _echoDiagnosticsCommitted: true };
+    assert.equal(resolveInboundScreenStatsMonitorBinding({
+      requestedRoom: roomForPlatform,
+      currentRoom: roomForPlatform,
+      boundRoom: null,
+      active: false,
+    }), "start", label);
+  }
+
+  monitorContext.stopInboundScreenStatsMonitor();
+  assert.equal(clearedIntervals.length, 2);
+
+  const connectSource = fs.readFileSync(path.join(viewerDir, "connect.js"), "utf8");
+  assert.match(connectSource,
+    /room = newRoom;[\s\S]*?newRoom\._echoDiagnosticsCommitted = true;[\s\S]*?startInboundScreenStatsMonitor\(newRoom\)/);
+});
+
+test("ICE diagnostics choose the transport-selected pair instead of an arbitrary succeeded pair", () => {
+  const reports = new Map([
+    ["local-host", { id: "local-host", type: "local-candidate", candidateType: "host" }],
+    ["remote-prflx", { id: "remote-prflx", type: "remote-candidate", candidateType: "prflx" }],
+    ["local-relay", { id: "local-relay", type: "local-candidate", candidateType: "relay" }],
+    ["remote-relay", { id: "remote-relay", type: "remote-candidate", candidateType: "relay" }],
+    ["unused", {
+      id: "unused", type: "candidate-pair", state: "succeeded", nominated: false,
+      localCandidateId: "local-relay", remoteCandidateId: "remote-relay",
+    }],
+    ["selected", {
+      id: "selected", type: "candidate-pair", state: "succeeded", nominated: true,
+      localCandidateId: "local-host", remoteCandidateId: "remote-prflx",
+    }],
+    ["transport", { id: "transport", type: "transport", selectedCandidatePairId: "selected" }],
+  ]);
+  const selected = resolveSelectedIceCandidatePair(reports);
+  assert.equal(selected.pair.id, "selected");
+  assert.equal(selected.local.candidateType, "host");
+  assert.equal(selected.remote.candidateType, "prflx");
+});
+
+test("runtime wiring keeps every automated target recovery relay-only and bounded", () => {
+  const appSource = fs.readFileSync(path.join(viewerDir, "app.js"), "utf8");
+  const connectSource = fs.readFileSync(path.join(viewerDir, "connect.js"), "utf8");
+  const fullscreenSource = fs.readFileSync(path.join(viewerDir, "participants-fullscreen.js"), "utf8");
+  const gridSource = fs.readFileSync(path.join(viewerDir, "participants-grid.js"), "utf8");
+  assert.match(connectSource, /function reconnectAndroidFirefoxRoomOverRelay[\s\S]*?forceRelay: true/);
+  assert.match(connectSource, /handleReconnecting\(\{[\s\S]*?reconnect: reconnectAndroidFirefoxRoomOverRelay/);
+  assert.match(connectSource, /handleDisconnected\(\{[\s\S]*?reconnect: reconnectAndroidFirefoxRoomOverRelay/);
+  assert.match(connectSource, /rtcConfig\.iceTransportPolicy = "relay"/);
+  assert.match(connectSource, /alreadyUsingRelay: newRoom\._echoAndroidFirefoxRelayAttempted === true/);
+  assert.match(fullscreenSource, /_lastPresentedFrameTs = element\._lastFrameTs/);
+  assert.match(fullscreenSource, /replaceAndroidFirefoxPresentationVideoElement/);
+  assert.match(gridSource,
+    /containAndroidFirefoxScreenTileClick\([\s\S]*?suppressAndroidFirefoxPresentationInteractions[\s\S]*?\)\) return/);
+  assert.match(appSource,
+    /shellUtilityScrim\.addEventListener\("click", function\(event\)[\s\S]*?intersectsVisibleRemoteScreen: function\(\)[\s\S]*?event\.clientX[\s\S]*?event\.clientY[\s\S]*?if \(containScrimClick\) return;[\s\S]*?setClubhouseUtilityCollapsed\(true/);
+  const toolsHandlerStart = appSource.indexOf('if (shellUtilityButton && shellLayout)');
+  const scrimHandlerStart = appSource.indexOf('if (shellUtilityScrim)', toolsHandlerStart);
+  assert.ok(toolsHandlerStart >= 0 && scrimHandlerStart > toolsHandlerStart);
+  const toolsHandler = appSource.slice(toolsHandlerStart, scrimHandlerStart);
+  assert.match(toolsHandler, /setClubhouseUtilityCollapsed/);
+  assert.doesNotMatch(toolsHandler, /containAndroidFirefox|isPointInsideVisibleRemoteScreen/);
+});

--- a/core/viewer/android-firefox-room-disconnect-recovery.test.js
+++ b/core/viewer/android-firefox-room-disconnect-recovery.test.js
@@ -4,8 +4,12 @@ const fs = require("node:fs");
 const path = require("node:path");
 const vm = require("node:vm");
 const {
+  createAndroidFirefoxCandidateReleaseError,
   createAndroidFirefoxRoomDisconnectRecovery,
+  disconnectAndroidFirefoxRejectedRelayCandidate,
+  isAndroidFirefoxCandidateReleaseError,
   resolvePostConnectMicrophoneBehavior,
+  verifyAndroidFirefoxRelayCandidateRoom,
 } = require("./room-switch-state.js");
 
 const rnnoiseSource = fs.readFileSync(path.join(__dirname, "rnnoise.js"), "utf8");
@@ -46,6 +50,7 @@ const isAndroidFirefoxBrowser = loadRealBrowserPredicate();
 function createHarness(options = {}) {
   const timers = [];
   const attempts = [];
+  const attemptFailures = [];
   let nextTimerId = 1;
   let currentRoom = options.room || { sid: "old-room" };
   let hidden = options.hidden === true;
@@ -72,6 +77,7 @@ function createHarness(options = {}) {
       if (timer) timer.cancelled = true;
     },
     onAttempt(state) { attempts.push(state.attempt); },
+    onAttemptFailed(state) { attemptFailures.push(state); },
   });
 
   async function fireNextTimer() {
@@ -103,6 +109,7 @@ function createHarness(options = {}) {
 
   return {
     attempts,
+    attemptFailures,
     controller,
     disconnect,
     fireNextTimer,
@@ -200,6 +207,192 @@ test("brief duplicate-identity race retries with bounded deterministic backoff",
   assert.equal(harness.getReconnectCalls(), 3);
   assert.deepEqual(harness.attempts, [1, 2, 3]);
   assert.deepEqual(harness.controller.snapshot(), { enabled: true, active: false });
+});
+
+test("a completed rejected-candidate cleanup permits retry two and the next verified candidate succeeds", async () => {
+  const harness = createHarness({ userAgent: androidFirefoxUa });
+  const verificationResults = [];
+  const rejectedCandidates = [];
+  const reconnect = async ({ reconnectCalls, setCurrentRoom }) => {
+    const policy = reconnectCalls === 1 ? "all" : "relay";
+    const candidate = {
+      sid: "candidate-" + reconnectCalls,
+      _echoAndroidFirefoxRelayAttempted: true,
+      disconnectCalls: 0,
+      disconnect(stopTracks) {
+        candidate.disconnectCalls += 1;
+        assert.equal(stopTracks, true);
+        return Promise.resolve();
+      },
+      engine: {
+        pcManager: {
+          publisher: { pc: { getConfiguration: () => ({ iceTransportPolicy: policy }) } },
+          subscriber: { pc: { getConfiguration: () => ({ iceTransportPolicy: "relay" }) } },
+        },
+      },
+    };
+    const verification = verifyAndroidFirefoxRelayCandidateRoom(candidate);
+    verificationResults.push(verification.verified);
+    if (!verification.verified) {
+      rejectedCandidates.push(candidate);
+      assert.equal(
+        await disconnectAndroidFirefoxRejectedRelayCandidate(candidate),
+        true
+      );
+      const error = new Error("relay candidate verification failed");
+      error.name = "AndroidFirefoxRelayVerificationError";
+      throw error;
+    }
+    candidate._echoAndroidFirefoxRelayForced = true;
+    setCurrentRoom(candidate);
+  };
+
+  assert.equal(harness.disconnect(14, reconnect), true);
+  await harness.fireNextTimer();
+  assert.deepEqual(verificationResults, [false]);
+  assert.deepEqual(harness.attempts, [1]);
+  assert.deepEqual(harness.liveTimers().map((timer) => timer.delay), [2000]);
+  assert.equal(harness.getCurrentRoom().sid, "old-room");
+  assert.equal(rejectedCandidates[0]._echoRecoveryDisconnectComplete, true);
+  assert.equal(rejectedCandidates[0].disconnectCalls, 1);
+
+  await harness.fireNextTimer();
+  assert.deepEqual(verificationResults, [false, true]);
+  assert.deepEqual(harness.attempts, [1, 2]);
+  assert.equal(harness.getCurrentRoom()._echoAndroidFirefoxRelayAttempted, true);
+  assert.equal(harness.getCurrentRoom()._echoAndroidFirefoxRelayForced, true);
+  assert.deepEqual(harness.controller.snapshot(), { enabled: true, active: false });
+});
+
+test("rejected-candidate disconnect rejection is terminal and never starts fresh connect two", async () => {
+  let candidateDisconnectCalls = 0;
+  const harness = createHarness({ userAgent: androidFirefoxUa });
+  const reconnect = async () => {
+    const candidate = {
+      disconnect(stopTracks) {
+        candidateDisconnectCalls += 1;
+        assert.equal(stopTracks, true);
+        return Promise.reject(new Error("candidate sendLeave failed"));
+      },
+    };
+    await disconnectAndroidFirefoxRejectedRelayCandidate(candidate);
+  };
+
+  assert.equal(harness.disconnect(14, reconnect), true);
+  await harness.fireNextTimer();
+
+  assert.equal(harness.getReconnectCalls(), 1);
+  assert.equal(candidateDisconnectCalls, 1);
+  assert.deepEqual(harness.attempts, [1]);
+  assert.equal(harness.liveTimers().length, 0);
+  assert.equal(harness.attemptFailures.length, 1);
+  assert.equal(isAndroidFirefoxCandidateReleaseError(harness.attemptFailures[0].error), true);
+  assert.equal(harness.attemptFailures[0].error.retryable, false);
+  assert.deepEqual(harness.controller.snapshot(), {
+    enabled: true,
+    active: true,
+    attemptCount: 1,
+    scheduled: false,
+    inFlight: false,
+    waiting: false,
+    exhausted: true,
+  });
+  assert.equal(harness.disconnect(14, reconnect), false, "duplicate event cannot reopen recovery");
+  assert.equal(harness.controller.resume(), false);
+  assert.equal(harness.getReconnectCalls(), 1);
+});
+
+test("missing rejected-candidate cleanup helper fails closed without starting retry two", async () => {
+  const harness = createHarness({ userAgent: androidFirefoxUa });
+  const reconnect = () => {
+    throw createAndroidFirefoxCandidateReleaseError(
+      "Android Firefox rejected-candidate teardown helper is unavailable"
+    );
+  };
+
+  assert.equal(harness.disconnect(14, reconnect), true);
+  await harness.fireNextTimer();
+
+  assert.equal(harness.getReconnectCalls(), 1);
+  assert.deepEqual(harness.attempts, [1]);
+  assert.equal(harness.liveTimers().length, 0);
+  assert.equal(harness.attemptFailures.length, 1);
+  assert.equal(isAndroidFirefoxCandidateReleaseError(harness.attemptFailures[0].error), true);
+  assert.equal(harness.attemptFailures[0].error.retryable, false);
+  assert.equal(harness.controller.snapshot().exhausted, true);
+  assert.equal(harness.disconnect(14, reconnect), false);
+  assert.equal(harness.controller.resume(), false);
+  assert.equal(harness.getReconnectCalls(), 1);
+});
+
+test("unproven rejected-candidate timeout is terminal and cannot overlap a fresh connect", async () => {
+  const cleanupTimers = [];
+  let candidateDisconnectCalls = 0;
+  const cleanupOptions = {
+    timeoutMs: 1500,
+    schedule(callback, delay) {
+      const timer = { callback, delay, cancelled: false };
+      cleanupTimers.push(timer);
+      return timer;
+    },
+    cancelSchedule(timer) { timer.cancelled = true; },
+  };
+  const harness = createHarness({ userAgent: androidFirefoxUa });
+  const reconnect = async () => {
+    const candidate = {
+      disconnect(stopTracks) {
+        candidateDisconnectCalls += 1;
+        assert.equal(stopTracks, true);
+        return new Promise(() => {});
+      },
+    };
+    await disconnectAndroidFirefoxRejectedRelayCandidate(candidate, cleanupOptions);
+  };
+
+  assert.equal(harness.disconnect(14, reconnect), true);
+  const firstAttempt = harness.fireNextTimer();
+  await Promise.resolve();
+  await Promise.resolve();
+
+  assert.equal(harness.getReconnectCalls(), 1);
+  assert.equal(candidateDisconnectCalls, 1);
+  assert.equal(cleanupTimers.length, 1);
+  assert.equal(cleanupTimers[0].delay, 1500);
+  assert.equal(harness.liveTimers().length, 0);
+  assert.equal(harness.controller.snapshot().inFlight, true);
+  assert.equal(harness.disconnect(14, reconnect), false, "in-flight cleanup must coalesce events");
+
+  cleanupTimers[0].callback();
+  await firstAttempt;
+
+  assert.equal(harness.getReconnectCalls(), 1);
+  assert.equal(candidateDisconnectCalls, 1);
+  assert.equal(harness.liveTimers().length, 0);
+  assert.equal(harness.attemptFailures.length, 1);
+  assert.equal(isAndroidFirefoxCandidateReleaseError(harness.attemptFailures[0].error), true);
+  assert.match(harness.attemptFailures[0].error.message, /timed out/);
+  assert.equal(harness.controller.snapshot().exhausted, true);
+  assert.equal(harness.controller.resume(), false);
+});
+
+test("relay verification requires both publisher and subscriber peer connections", () => {
+  const candidate = {
+    engine: {
+      pcManager: {
+        publisher: { pc: { getConfiguration: () => ({ iceTransportPolicy: "relay" }) } },
+        subscriber: { pc: { getConfiguration: () => ({ iceTransportPolicy: "all" }) } },
+      },
+    },
+  };
+  assert.deepEqual(verifyAndroidFirefoxRelayCandidateRoom(candidate), {
+    publisherPolicy: "relay",
+    subscriberPolicy: "all",
+    verified: false,
+  });
+  candidate.engine.pcManager.subscriber.pc.getConfiguration = () => ({ iceTransportPolicy: "relay" });
+  assert.equal(verifyAndroidFirefoxRelayCandidateRoom(candidate).verified, true);
+  delete candidate.engine.pcManager.subscriber;
+  assert.equal(verifyAndroidFirefoxRelayCandidateRoom(candidate).verified, false);
 });
 
 test("failed recovery exhausts its bounded retry budget and cannot be restarted by duplicate events", async () => {
@@ -329,5 +522,13 @@ test("production wiring is target-gated and invokes only supported connectToRoom
   assert.match(
     connectSource,
     /if \(restoreMicAfterConnect\)[\s\S]*?else if \(preserveDisabledMicAfterConnect\)[\s\S]*?syncDesiredMicToActual\(false\)[\s\S]*?else \{/
+  );
+  assert.match(
+    connectSource,
+    /await disconnectRejectedRelayCandidate\(newRoom, \{ timeoutMs: 1500 \}\)[\s\S]*?catch \(cleanupError\)[\s\S]*?throw cleanupError[\s\S]*?AndroidFirefoxRelayVerificationError[\s\S]*?throw relayVerificationError/
+  );
+  assert.match(
+    connectSource,
+    /typeof disconnectRejectedRelayCandidate !== "function"[\s\S]*?createAndroidFirefoxCandidateReleaseError[\s\S]*?throw createCandidateReleaseError/
   );
 });

--- a/core/viewer/android-firefox-screen-recovery.test.js
+++ b/core/viewer/android-firefox-screen-recovery.test.js
@@ -3,6 +3,7 @@ const assert = require("node:assert/strict");
 const {
   attemptAndroidFirefoxConnectedMediaRelayRecovery,
   attemptAndroidFirefoxScreenSubscriptionReset,
+  isAndroidFirefoxConnectedMediaStallCurrent,
 } = require("./participants-fullscreen.js");
 
 function createGeneration() {
@@ -320,6 +321,25 @@ test("relay handoff carries a dynamic exact-generation stall predicate", () => {
   options.isHidden = () => false;
   fixture.metaBySid.delete("TR_old");
   assert.equal(isStillStalled(), false, "metadata generation changed");
+});
+
+test("unmuted relay escalation requires the exact validated presentation episode", () => {
+  const fixture = createGeneration();
+  fixture.publication.track.mediaStreamTrack.muted = false;
+  const options = {
+    ...fixture.options,
+    roomConnected: true,
+    frameAgeMs: 9000,
+    allowUnmutedPresentationStall: true,
+    isPresentationCurrent: () => true,
+  };
+
+  assert.equal(isAndroidFirefoxConnectedMediaStallCurrent(options), true);
+  options.isPresentationCurrent = () => false;
+  assert.equal(isAndroidFirefoxConnectedMediaStallCurrent(options), false);
+  delete options.isPresentationCurrent;
+  assert.equal(isAndroidFirefoxConnectedMediaStallCurrent(options), false,
+    "an unmuted track cannot reuse the older muted-track predicate");
 });
 
 test("same-SID subscribed replacement inherits the bounded relay escalation state", () => {

--- a/core/viewer/android-firefox-stalled-reconnect-recovery.test.js
+++ b/core/viewer/android-firefox-stalled-reconnect-recovery.test.js
@@ -5,7 +5,9 @@ const path = require("node:path");
 const vm = require("node:vm");
 const {
   createAndroidFirefoxRoomDisconnectRecovery,
+  disconnectAndroidFirefoxRejectedRelayCandidate,
   disconnectAndroidFirefoxRecoverySource,
+  isAndroidFirefoxCandidateReleaseError,
   resolvePostConnectMicrophoneBehavior,
 } = require("./room-switch-state.js");
 
@@ -403,6 +405,66 @@ test("never-settling source teardown releases once at its deadline and remains s
   assert.equal(sourceRoom._echoRecoveryDisconnectComplete, undefined);
   assert.equal(await disconnectAndroidFirefoxRecoverySource(sourceRoom, options), false);
   assert.equal(disconnectCalls, 1, "released teardown must not start again");
+});
+
+test("timed-out rejected relay candidate teardown is terminal even if disconnect completes late", async () => {
+  const timers = [];
+  let disconnectCalls = 0;
+  let finishLateDisconnect;
+  let nextRetryStarts = 0;
+  const candidateRoom = {
+    disconnect(stopTracks) {
+      disconnectCalls += 1;
+      assert.equal(stopTracks, true);
+      return new Promise((resolve) => { finishLateDisconnect = resolve; });
+    },
+  };
+  const options = {
+    timeoutMs: 1500,
+    schedule(callback, delay) {
+      const timer = { callback, delay, cancelled: false };
+      timers.push(timer);
+      return timer;
+    },
+    cancelSchedule(timer) { timer.cancelled = true; },
+  };
+
+  const cleanup = disconnectAndroidFirefoxRejectedRelayCandidate(candidateRoom, options);
+  const duplicateCleanup = disconnectAndroidFirefoxRejectedRelayCandidate(candidateRoom, options);
+  const nextRetry = cleanup.then(
+    function() { nextRetryStarts += 1; },
+    function() { return false; }
+  );
+  await Promise.resolve();
+  await Promise.resolve();
+
+  assert.equal(candidateRoom._echoAndroidFirefoxStaleCandidate, true);
+  assert.equal(candidateRoom._echoExpectedDisconnect, true);
+  assert.equal(candidateRoom._echoRecoveryDisconnect, true);
+  assert.equal(disconnectCalls, 1, "candidate cleanup must be single-flight");
+  assert.equal(timers.length, 1);
+  assert.equal(timers[0].delay, 1500);
+  assert.equal(nextRetryStarts, 0, "the controller cannot start retry two during candidate teardown");
+
+  timers[0].callback();
+  const results = await Promise.allSettled([cleanup, duplicateCleanup]);
+  assert.deepEqual(results.map((result) => result.status), ["rejected", "rejected"]);
+  for (const result of results) {
+    assert.equal(isAndroidFirefoxCandidateReleaseError(result.reason), true);
+    assert.equal(result.reason.retryable, false);
+    assert.match(result.reason.message, /timed out/);
+  }
+  await nextRetry;
+  assert.equal(nextRetryStarts, 0);
+  assert.equal(candidateRoom._echoRecoveryDisconnectReleased, true);
+  assert.equal(candidateRoom._echoRecoveryDisconnectTimedOut, true);
+
+  finishLateDisconnect();
+  await Promise.resolve();
+  await Promise.resolve();
+  assert.equal(nextRetryStarts, 0, "late candidate teardown completion is inert");
+  assert.equal(disconnectCalls, 1);
+  assert.equal(await disconnectAndroidFirefoxRejectedRelayCandidate(candidateRoom, options), false);
 });
 
 test("controller cannot overlap fresh connects while a wedged teardown waits for its deadline", async () => {
@@ -829,6 +891,8 @@ test("mic preservation policy remains recovery-only and production wiring tears 
   assert.match(connectSource, /_echoRecoveryDisconnectTimedOut === true[\s\S]*?continuing fresh handoff/);
   assert.match(connectSource, /newRoom\._echoRecoveryDisconnect === true\)[\s\S]*?if \(newRoom === room && typeof stopInboundScreenStatsMonitor/);
   assert.match(connectSource, /reuseAdmin: true,[\s\S]*?preserveMicIntent: true,[\s\S]*?androidFirefoxRecoverySourceRoom: newRoom/);
+  assert.match(connectSource,
+    /await disconnectRejectedRelayCandidate\(newRoom, \{ timeoutMs: 1500 \}\)[\s\S]*?throw relayVerificationError/);
   assert.match(connectSource, /forceAndroidFirefoxRelay = controlledAndroidFirefoxReplacement &&\s+androidFirefoxForceRelay === true/);
   assert.match(connectSource, /_echoAndroidFirefoxConnectedMediaRelayRecovery = function[\s\S]*?handleConnectedMediaStall\(\{[\s\S]*?alreadyUsingRelay:[\s\S]*?forceRelay: true/);
   assert.match(connectSource, /handleConnectedMediaStall\(\{[\s\S]*?isStillStalled: detail\?\.isStillStalled,[\s\S]*?onValidated: detail\?\.onValidated/);

--- a/core/viewer/app.js
+++ b/core/viewer/app.js
@@ -490,7 +490,24 @@ if (shellUtilityButton && shellLayout) {
 }
 
 if (shellUtilityScrim) {
-  shellUtilityScrim.addEventListener("click", function() {
+  shellUtilityScrim.addEventListener("click", function(event) {
+    var containScrimClick = typeof containAndroidFirefoxUtilityScrimClick === "function" &&
+      containAndroidFirefoxUtilityScrimClick({
+        event: event,
+        navigatorObject: typeof navigator === "object" ? navigator : null,
+        isNativeShell: typeof window === "object" && window.__ECHO_NATIVE__ === true,
+        isTargetBrowser: typeof isAndroidFirefoxBrowser === "function"
+          ? isAndroidFirefoxBrowser
+          : null,
+        intersectsVisibleRemoteScreen: function() {
+          return typeof isPointInsideVisibleRemoteScreenPresentation === "function" &&
+            isPointInsideVisibleRemoteScreenPresentation({
+              clientX: event.clientX,
+              clientY: event.clientY,
+            });
+        },
+      });
+    if (containScrimClick) return;
     setClubhouseUtilityCollapsed(true, { restoreFocus: true });
   });
 }

--- a/core/viewer/connect.js
+++ b/core/viewer/connect.js
@@ -727,8 +727,12 @@ async function connectToRoom({
       androidFirefoxForceRelay: recoveryState?.forceRelay === true,
     });
   }
+  function reconnectAndroidFirefoxRoomOverRelay(recoveryState) {
+    return reconnectAndroidFirefoxRoom(Object.assign({}, recoveryState || {}, { forceRelay: true }));
+  }
   if (androidFirefoxRoomDisconnectRecoveryEnabled) {
-    newRoom._echoAndroidFirefoxRelayForced = forceAndroidFirefoxRelay;
+    newRoom._echoAndroidFirefoxRelayAttempted = forceAndroidFirefoxRelay;
+    newRoom._echoAndroidFirefoxRelayForced = false;
     newRoom._echoAndroidFirefoxConnectedMediaRelayRecovery = function(detail) {
       if (newRoom !== room || String(newRoom.state || "").toLowerCase() !== "connected") {
         return false;
@@ -736,12 +740,12 @@ async function connectToRoom({
       return androidFirefoxRoomDisconnectRecovery?.handleConnectedMediaStall({
         room: newRoom,
         trackSid: detail?.trackSid || null,
-        alreadyUsingRelay: newRoom._echoAndroidFirefoxRelayForced === true,
+        alreadyUsingRelay: newRoom._echoAndroidFirefoxRelayAttempted === true,
         isStillStalled: detail?.isStillStalled,
         onValidated: detail?.onValidated,
         micWasEnabled: desiredMicEnabledForRoomSwitch() === true,
         reconnect: function(recoveryState) {
-          return reconnectAndroidFirefoxRoom(Object.assign({}, recoveryState, { forceRelay: true }));
+          return reconnectAndroidFirefoxRoom(Object.assign({}, recoveryState || {}, { forceRelay: true }));
         },
       }) === true;
     };
@@ -750,7 +754,7 @@ async function connectToRoom({
     if (!androidFirefoxRoomDisconnectRecoveryEnabled) return;
     var accepted = androidFirefoxRoomDisconnectRecovery?.handleReconnecting({
       room: newRoom,
-      reconnect: reconnectAndroidFirefoxRoom,
+      reconnect: reconnectAndroidFirefoxRoomOverRelay,
       micWasEnabled: captureAndroidFirefoxRecoveryMicIntent(),
     });
     if (accepted) {
@@ -850,7 +854,7 @@ async function connectToRoom({
         room: newRoom,
         reason: reason,
         disconnectReasons: LK.DisconnectReason,
-        reconnect: reconnectAndroidFirefoxRoom,
+        reconnect: reconnectAndroidFirefoxRoomOverRelay,
         micWasEnabled: captureAndroidFirefoxRecoveryMicIntent(),
       });
       if (recoveryAccepted) {
@@ -1643,12 +1647,63 @@ async function connectToRoom({
   var rtcConfig = { iceServers: iceServers };
   if (forceAndroidFirefoxRelay) {
     rtcConfig.iceTransportPolicy = "relay";
-    debugLog("[android-firefox-room-recovery] forcing TURN relay for connected-media recovery");
+    debugLog("[android-firefox-room-recovery] forcing TURN relay for automated recovery");
   }
   await newRoom.connect(sfuUrl, accessToken, {
     autoSubscribe: true,
     rtcConfig: rtcConfig,
   });
+  if (androidFirefoxRoomDisconnectRecoveryEnabled && forceAndroidFirefoxRelay) {
+    var verifyRelayCandidate = window.EchoRoomSwitchState?.verifyAndroidFirefoxRelayCandidateRoom;
+    var relayVerification = typeof verifyRelayCandidate === "function"
+      ? verifyRelayCandidate(newRoom)
+      : { publisherPolicy: null, subscriberPolicy: null, verified: false };
+    newRoom._echoAndroidFirefoxRelayForced = relayVerification.verified === true;
+    debugLog("[android-firefox-room-recovery] relay configuration publisher=" +
+      (relayVerification.publisherPolicy || "unknown") + " subscriber=" +
+      (relayVerification.subscriberPolicy || "unknown") +
+      " verified=" + newRoom._echoAndroidFirefoxRelayForced);
+    if (!newRoom._echoAndroidFirefoxRelayForced) {
+      // Reject inside the controller-owned reconnect attempt. A proven public
+      // disconnect keeps the normal bounded retry path; an unproven candidate
+      // release is tagged terminal so another same-identity Room cannot start.
+      var disconnectRejectedRelayCandidate =
+        window.EchoRoomSwitchState?.disconnectAndroidFirefoxRejectedRelayCandidate;
+      if (typeof disconnectRejectedRelayCandidate !== "function") {
+        var createCandidateReleaseError =
+          window.EchoRoomSwitchState?.createAndroidFirefoxCandidateReleaseError;
+        if (typeof createCandidateReleaseError === "function") {
+          throw createCandidateReleaseError(
+            "Android Firefox rejected-candidate teardown helper is unavailable"
+          );
+        }
+        // Fail closed if connect.js and room-switch-state.js ever load from
+        // different cache generations. The current controller recognizes this
+        // exact tag and must not open another same-identity candidate.
+        var unavailableCleanupError = new Error(
+          "Android Firefox rejected-candidate teardown helper is unavailable"
+        );
+        unavailableCleanupError.name = "AndroidFirefoxCandidateReleaseError";
+        unavailableCleanupError.code =
+          "ANDROID_FIREFOX_REJECTED_CANDIDATE_RELEASE_UNPROVEN";
+        unavailableCleanupError.terminal = true;
+        unavailableCleanupError.retryable = false;
+        throw unavailableCleanupError;
+      }
+      try {
+        await disconnectRejectedRelayCandidate(newRoom, { timeoutMs: 1500 });
+      } catch (cleanupError) {
+        debugLog("[android-firefox-room-recovery] rejected relay candidate teardown failed: " +
+          (cleanupError?.message || cleanupError));
+        throw cleanupError;
+      }
+      var relayVerificationError = new Error(
+        "Android Firefox recovery candidate did not verify relay transport"
+      );
+      relayVerificationError.name = "AndroidFirefoxRelayVerificationError";
+      throw relayVerificationError;
+    }
+  }
   if (seq !== connectSequence) {
     newRoom._echoExpectedDisconnect = true;
     newRoom.disconnect();
@@ -1670,6 +1725,9 @@ async function connectToRoom({
   // heartbeat, Jam, chat, and native-presenter requests remain authenticated.
   window.EchoWebDiagnosticsRuntime?.credentialBoundary?.(hadOldRoom || !!currentAccessToken);
   newRoom._echoDiagnosticsCommitted = true;
+  if (typeof startInboundScreenStatsMonitor === "function") {
+    startInboundScreenStatsMonitor(newRoom);
+  }
   window.EchoWebDiagnosticsRuntime?.recordConnectionState?.("connected", null);
   currentAccessToken = window.EchoRoomSwitchState &&
     typeof window.EchoRoomSwitchState.commitConnectedAccessToken === "function"

--- a/core/viewer/participants-fullscreen.js
+++ b/core/viewer/participants-fullscreen.js
@@ -17,6 +17,140 @@ function isCurrentScreenRecoveryGeneration(options) {
   return true;
 }
 
+function isAndroidFirefoxPresentationRecoveryGeneration(options) {
+  if (!isCurrentScreenRecoveryGeneration(options)) return false;
+  if (typeof options.isRoomConnected === "function") {
+    try {
+      if (options.isRoomConnected() !== true) return false;
+    } catch (_error) {
+      return false;
+    }
+  } else if (options.roomConnected !== true) {
+    return false;
+  }
+  var publication = options.publication;
+  var mediaTrack = publication?.track?.mediaStreamTrack;
+  if (publication?.isSubscribed !== true || !mediaTrack || mediaTrack.readyState !== "live") return false;
+  if (mediaTrack.muted === true) return false;
+  var video = options.video || options.tile?.querySelector?.("video");
+  if (!video || video !== options.tile?.querySelector?.("video")) return false;
+  if (video._lkTrack !== publication.track || video.paused === true) return false;
+  if (typeof options.isDocumentVisible === "function") {
+    try {
+      if (options.isDocumentVisible() !== true) return false;
+    } catch (_error) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function getAndroidFirefoxPresentationRecoveryAction(options) {
+  if (!options || options.enabled !== true || !options.recoveryStateBySid || !options.trackSid) {
+    return "none";
+  }
+  var nowMs = Number(options.nowMs);
+  if (!Number.isFinite(nowMs)) return "none";
+  var state = options.recoveryStateBySid.get(options.trackSid) || {};
+  var presentedFrameTs = Number(options.presentedFrameTs) || 0;
+  if (options.current === false) return "none";
+
+  if (presentedFrameTs > (Number(state.lastPresentedFrameTs) || 0)) {
+    var recoveredAfterAction = Number(state.presentationActionFrameTs) > 0 &&
+      presentedFrameTs > Number(state.presentationActionFrameTs);
+    state.lastPresentedFrameTs = presentedFrameTs;
+    state.presentationStalledTicks = 0;
+    state.presentationLastStallTickAt = 0;
+    if (recoveredAfterAction) {
+      var previousProgressTickAt = Number(state.presentationRearmLastProgressTickAt) || 0;
+      state.presentationRearmProgressTicks = previousProgressTickAt > 0 &&
+        nowMs - previousProgressTickAt <= 15000
+        ? (Number(state.presentationRearmProgressTicks) || 0) + 1
+        : 1;
+      state.presentationRearmLastProgressTickAt = nowMs;
+      if (state.presentationRearmProgressTicks >= 2) {
+        delete state.presentationSinkResetAttempted;
+        delete state.presentationSinkResetAt;
+        delete state.presentationActionFrameTs;
+        delete state.presentationSubscriptionResetAttempted;
+        delete state.presentationSubscriptionResetAt;
+        delete state.presentationSubscriptionResetSkipped;
+        delete state.presentationRearmProgressTicks;
+        delete state.presentationRearmLastProgressTickAt;
+        if (state.subscriptionResetKind === "presentation") {
+          delete state.subscriptionResetAttempted;
+          delete state.subscriptionResetAt;
+          delete state.subscriptionResetKind;
+        }
+      }
+    } else {
+      delete state.presentationRearmProgressTicks;
+      delete state.presentationRearmLastProgressTickAt;
+    }
+    options.recoveryStateBySid.set(options.trackSid, state);
+    return "progress";
+  }
+
+  // A single intermittent frame is not recovery. It must be followed by frame
+  // progress on the next watchdog observation before the SID can rearm.
+  if (state.presentationRearmProgressTicks) {
+    delete state.presentationRearmProgressTicks;
+    delete state.presentationRearmLastProgressTickAt;
+  }
+
+  var lastPresentedFrameTs = Number(state.lastPresentedFrameTs) || presentedFrameTs;
+  if (!(lastPresentedFrameTs > 0) || nowMs - lastPresentedFrameTs < 8000) return "none";
+  state.presentationLastStallTickAt = nowMs;
+  state.presentationStalledTicks = (Number(state.presentationStalledTicks) || 0) + 1;
+  options.recoveryStateBySid.set(options.trackSid, state);
+  if (state.presentationStalledTicks < 2) return "none";
+  if (state.presentationSinkResetAttempted !== true) return "sink";
+  if (nowMs - (Number(state.presentationSinkResetAt) || 0) < 6000) return "none";
+  if (state.presentationSubscriptionResetAttempted !== true &&
+      state.subscriptionResetAttempted === true &&
+      state.subscriptionResetKind !== "presentation") {
+    state.presentationSubscriptionResetAttempted = true;
+    state.presentationSubscriptionResetAt = Number(state.presentationSinkResetAt) || nowMs;
+    state.presentationSubscriptionResetSkipped = true;
+    options.recoveryStateBySid.set(options.trackSid, state);
+  }
+  if (state.presentationSubscriptionResetAttempted !== true) return "subscription";
+  if (nowMs - (Number(state.presentationSubscriptionResetAt) || 0) < 6000) return "none";
+  return "relay";
+}
+
+function isAndroidFirefoxPresentationRelayAction(action) {
+  return action === "relay";
+}
+
+function markAndroidFirefoxPresentationRecoveryAction(options, action) {
+  if (!options?.recoveryStateBySid || !options.trackSid) return false;
+  var state = options.recoveryStateBySid.get(options.trackSid) || {};
+  var nowMs = Number(options.nowMs);
+  if (!Number.isFinite(nowMs)) return false;
+  if (action === "sink") {
+    state.presentationSinkResetAttempted = true;
+    state.presentationSinkResetAt = nowMs;
+    state.presentationActionFrameTs = Number(state.lastPresentedFrameTs) ||
+      Number(options.presentedFrameTs) || 0;
+    if (state.subscriptionResetAttempted === true &&
+        state.subscriptionResetKind !== "presentation") {
+      state.presentationSubscriptionResetAttempted = true;
+      state.presentationSubscriptionResetAt = nowMs;
+      state.presentationSubscriptionResetSkipped = true;
+    }
+  } else if (action === "subscription") {
+    state.presentationSubscriptionResetAttempted = true;
+    state.presentationSubscriptionResetAt = nowMs;
+    state.presentationActionFrameTs = Number(state.lastPresentedFrameTs) ||
+      Number(options.presentedFrameTs) || 0;
+  } else {
+    return false;
+  }
+  options.recoveryStateBySid.set(options.trackSid, state);
+  return true;
+}
+
 function attemptAndroidFirefoxScreenSubscriptionReset(options) {
   if (!options || options.enabled !== true) return false;
   var meta = options.meta;
@@ -29,7 +163,8 @@ function attemptAndroidFirefoxScreenSubscriptionReset(options) {
   if (recoveryState?.subscriptionResetAttempted === true) return false;
   if (publication.isSubscribed !== true || typeof publication.setSubscribed !== "function") return false;
   var mediaTrack = publication.track?.mediaStreamTrack;
-  if (!mediaTrack || mediaTrack.readyState !== "live" || mediaTrack.muted !== true) return false;
+  if (!mediaTrack || mediaTrack.readyState !== "live") return false;
+  if (mediaTrack.muted !== true && options.allowUnmutedPresentationStall !== true) return false;
   if (!(options.frameAgeMs > 3000) || !(options.firstLineRecoveryAt > 0)) return false;
 
   // Mark before touching the subscription. TrackUnsubscribed can arrive
@@ -40,10 +175,14 @@ function attemptAndroidFirefoxScreenSubscriptionReset(options) {
     : (typeof performance === "object" && typeof performance.now === "function"
         ? performance.now()
         : Date.now());
-  options.recoveryStateBySid.set(trackSid, {
+  var nextRecoveryState = Object.assign({}, recoveryState || {}, {
     subscriptionResetAttempted: true,
     subscriptionResetAt: resetAtMs,
   });
+  if (options.allowUnmutedPresentationStall === true) {
+    nextRecoveryState.subscriptionResetKind = "presentation";
+  }
+  options.recoveryStateBySid.set(trackSid, nextRecoveryState);
   if (typeof options.markResubscribeIntent === "function") {
     options.markResubscribeIntent(trackSid);
   }
@@ -96,7 +235,17 @@ function isAndroidFirefoxConnectedMediaStallCurrent(options) {
   if (!(frameAgeMs > 3000)) return false;
 
   var mediaTrack = options.publication.track?.mediaStreamTrack;
-  return !!mediaTrack && mediaTrack.readyState === "live" && mediaTrack.muted === true;
+  if (!mediaTrack || mediaTrack.readyState !== "live") return false;
+  if (mediaTrack.muted === true) return true;
+  if (options.allowUnmutedPresentationStall !== true ||
+      typeof options.isPresentationCurrent !== "function") {
+    return false;
+  }
+  try {
+    return options.isPresentationCurrent() === true;
+  } catch (_error) {
+    return false;
+  }
 }
 
 function attemptAndroidFirefoxConnectedMediaRelayRecovery(options) {
@@ -391,7 +540,89 @@ function startScreenWatchdog() {
       const publication = meta.publication;
       const track = publication?.track;
 
-      if (hasFrames && !isBlack && age < 4500) return;
+      var androidFirefoxRecoveryEnabled = typeof isAndroidFirefoxBrowser === "function" &&
+        isAndroidFirefoxBrowser(
+          typeof navigator === "object" ? navigator : null,
+          typeof window === "object" && window.__ECHO_NATIVE__ === true
+        );
+      var localScreenIdentity = room?.localParticipant?.identity || null;
+      var isRemoteScreen = !!meta.identity && meta.identity !== localScreenIdentity;
+      var presentationState = androidFirefoxScreenRecoveryBySid.get(trackSid) || {};
+      var basicPresentationCurrent = androidFirefoxRecoveryEnabled && isRemoteScreen &&
+        isAndroidFirefoxPresentationRecoveryGeneration({
+          trackSid: trackSid,
+          meta: meta,
+          publication: publication,
+          tile: tile,
+          video: video,
+          roomConnected: String(room?.state || "").toLowerCase() === "connected",
+          getCurrentMeta: function(sid) { return screenTrackMeta.get(sid); },
+          getCurrentTile: function(sid) { return screenTileBySid.get(sid); },
+          isHidden: function(identity) { return hiddenScreens.has(identity); },
+          isDocumentVisible: function() {
+            return typeof document !== "object" || document.visibilityState !== "hidden";
+          },
+        });
+      var initialPresentationReady = video.paused !== true && video.readyState >= 2 &&
+        video.videoWidth > 0 && video.videoHeight > 0 && video._lastPresentedFrameTs > 0;
+      var presentationCurrent = basicPresentationCurrent &&
+        (initialPresentationReady || presentationState.presentationSinkResetAttempted === true);
+      var presentationAction = getAndroidFirefoxPresentationRecoveryAction({
+        enabled: androidFirefoxRecoveryEnabled && isRemoteScreen,
+        current: presentationCurrent,
+        trackSid: trackSid,
+        nowMs: now,
+        presentedFrameTs: video._lastPresentedFrameTs || 0,
+        recoveryStateBySid: androidFirefoxScreenRecoveryBySid,
+      });
+
+      if (presentationAction === "sink") {
+        if (replaceAndroidFirefoxPresentationVideoElement(tile, track, publication)) {
+          markAndroidFirefoxPresentationRecoveryAction({
+            trackSid: trackSid,
+            nowMs: now,
+            presentedFrameTs: video._lastPresentedFrameTs || 0,
+            recoveryStateBySid: androidFirefoxScreenRecoveryBySid,
+          }, "sink");
+          debugLog("[android-firefox-recovery] replacing stalled presentation sink sid=" + trackSid);
+          requestVideoKeyFrame(publication, track);
+          return;
+        }
+      }
+
+      if (presentationAction === "subscription") {
+        var presentationResetScheduled = attemptAndroidFirefoxScreenSubscriptionReset({
+          enabled: true,
+          allowUnmutedPresentationStall: true,
+          trackSid: trackSid,
+          meta: meta,
+          publication: publication,
+          tile: tile,
+          frameAgeMs: now - (Number(presentationState.lastPresentedFrameTs) || 0),
+          firstLineRecoveryAt: meta.lastFix || Number(presentationState.presentationSinkResetAt) || now,
+          nowMs: now,
+          recoveryStateBySid: androidFirefoxScreenRecoveryBySid,
+          getCurrentMeta: function(sid) { return screenTrackMeta.get(sid); },
+          getCurrentTile: function(sid) { return screenTileBySid.get(sid); },
+          isHidden: function(identity) { return hiddenScreens.has(identity); },
+          markResubscribeIntent: markResubscribeIntent,
+          requestKeyFrame: requestVideoKeyFrame,
+          schedule: setTimeout,
+          log: debugLog,
+        });
+        if (presentationResetScheduled) {
+          markAndroidFirefoxPresentationRecoveryAction({
+            trackSid: trackSid,
+            nowMs: now,
+            presentedFrameTs: video._lastPresentedFrameTs || 0,
+            recoveryStateBySid: androidFirefoxScreenRecoveryBySid,
+          }, "subscription");
+          return;
+        }
+      }
+
+      var presentationRelayReady = isAndroidFirefoxPresentationRelayAction(presentationAction);
+      if (hasFrames && !isBlack && age < 4500 && !presentationRelayReady) return;
       // Grace period: don't run recovery on tiles less than 8 seconds old.
       // New tiles need time to receive first frames before recovery kicks in.
       var tileAge = now - (meta.createdAt || 0);
@@ -403,15 +634,10 @@ function startScreenWatchdog() {
       // the normal keyframe/reattach recovery one full watchdog pass first,
       // then perform one exact-SID subscription reset. No other browser or the
       // native desktop shell can enter this path.
-      var androidFirefoxRecoveryEnabled = typeof isAndroidFirefoxBrowser === "function" &&
-        isAndroidFirefoxBrowser(
-          typeof navigator === "object" ? navigator : null,
-          typeof window === "object" && window.__ECHO_NATIVE__ === true
-        );
-      var localScreenIdentity = room?.localParticipant?.identity || null;
-      var isRemoteScreen = !!meta.identity && meta.identity !== localScreenIdentity;
-      if (androidFirefoxRecoveryEnabled && isRemoteScreen && stalled &&
-          meta.lastFix > 0 && now - meta.lastFix >= 2500) {
+      if (androidFirefoxRecoveryEnabled && isRemoteScreen &&
+          (stalled || presentationRelayReady) &&
+          (presentationRelayReady ||
+            (meta.lastFix > 0 && now - meta.lastFix >= 2500))) {
         var resetScheduled = attemptAndroidFirefoxScreenSubscriptionReset({
           enabled: true,
           trackSid: trackSid,
@@ -433,8 +659,10 @@ function startScreenWatchdog() {
         if (resetScheduled) return;
 
         var connectedMediaRecoveryRoom = room;
+        var allowUnmutedPresentationStall = presentationRelayReady;
         var relayRecoveryAccepted = attemptAndroidFirefoxConnectedMediaRelayRecovery({
           enabled: true,
+          allowUnmutedPresentationStall: allowUnmutedPresentationStall,
           roomConnected: String(connectedMediaRecoveryRoom?.state || "").toLowerCase() === "connected",
           isRoomConnected: function() {
             return room === connectedMediaRecoveryRoom &&
@@ -444,7 +672,9 @@ function startScreenWatchdog() {
           meta: meta,
           publication: publication,
           tile: tile,
-          frameAgeMs: age,
+          frameAgeMs: allowUnmutedPresentationStall
+            ? now - (Number(presentationState.lastPresentedFrameTs) || 0)
+            : age,
           getFrameAgeMs: function() {
             var currentMeta = screenTrackMeta.get(trackSid);
             var currentTile = screenTileBySid.get(trackSid);
@@ -452,6 +682,15 @@ function startScreenWatchdog() {
             if (!currentMeta || !currentTile || !currentVideo ||
                 currentVideo._lkTrack !== currentMeta.publication?.track) {
               return null;
+            }
+            if (allowUnmutedPresentationStall) {
+              var currentState = androidFirefoxScreenRecoveryBySid.get(trackSid) || {};
+              var currentPresentedFrameTs = Number(currentVideo._lastPresentedFrameTs) || 0;
+              var lastKnownPresentedFrameTs = Math.max(
+                currentPresentedFrameTs,
+                Number(currentState.lastPresentedFrameTs) || 0
+              );
+              return performance.now() - lastKnownPresentedFrameTs;
             }
             return performance.now() - (currentVideo._lastFrameTs || 0);
           },
@@ -462,6 +701,32 @@ function startScreenWatchdog() {
           getCurrentMeta: function(sid) { return screenTrackMeta.get(sid); },
           getCurrentTile: function(sid) { return screenTileBySid.get(sid); },
           isHidden: function(identity) { return hiddenScreens.has(identity); },
+          isPresentationCurrent: function() {
+            if (!allowUnmutedPresentationStall) return false;
+            var currentMeta = screenTrackMeta.get(trackSid);
+            var currentTile = screenTileBySid.get(trackSid);
+            var currentVideo = currentTile?.querySelector("video");
+            var currentState = androidFirefoxScreenRecoveryBySid.get(trackSid) || {};
+            if (currentState.presentationSinkResetAttempted !== true ||
+                currentState.presentationSubscriptionResetAttempted !== true) {
+              return false;
+            }
+            return room === connectedMediaRecoveryRoom &&
+              isAndroidFirefoxPresentationRecoveryGeneration({
+                trackSid: trackSid,
+                meta: currentMeta,
+                publication: currentMeta?.publication,
+                tile: currentTile,
+                video: currentVideo,
+                roomConnected: String(connectedMediaRecoveryRoom?.state || "").toLowerCase() === "connected",
+                getCurrentMeta: function(sid) { return screenTrackMeta.get(sid); },
+                getCurrentTile: function(sid) { return screenTileBySid.get(sid); },
+                isHidden: function(identity) { return hiddenScreens.has(identity); },
+                isDocumentVisible: function() {
+                  return typeof document !== "object" || document.visibilityState !== "hidden";
+                },
+              });
+          },
           recover: function(detail) {
             if (typeof requestAndroidFirefoxConnectedMediaRelayRecovery !== "function") return false;
             return requestAndroidFirefoxConnectedMediaRelayRecovery(detail);
@@ -592,6 +857,46 @@ function replaceScreenVideoElement(tile, track, publication) {
   }
   ensureVideoPlays(track, newEl);
   ensureVideoSubscribed(publication, newEl);
+}
+
+function replaceAndroidFirefoxPresentationVideoElement(tile, track, publication) {
+  if (!tile || !track) return false;
+  var oldVideo = tile.querySelector("video");
+  if (!oldVideo) return false;
+  var overlay = tile.querySelector(".tile-overlay");
+  var nextVideo = createAttachedVideoElement(track);
+  if (!nextVideo || nextVideo === oldVideo) return false;
+  configureVideoElement(nextVideo, true);
+  nextVideo.classList.add("screen-video-surface");
+  nextVideo.style.setProperty("object-fit", "contain", "important");
+  nextVideo.style.width = "100%";
+  nextVideo.style.height = "100%";
+  nextVideo.style.background = "transparent";
+
+  // Build and configure the replacement first. Only after a usable sink exists
+  // do we stop diagnostics and detach/null the old element, so a failed element
+  // creation can never destroy the sole working attachment.
+  if (overlay) cleanupVideoDiagnostics(overlay);
+  oldVideo._playGeneration = (oldVideo._playGeneration || 0) + 1;
+  oldVideo._ensurePlayId = (oldVideo._ensurePlayId || 0) + 1;
+  if (oldVideo._monitorTimer) {
+    clearInterval(oldVideo._monitorTimer);
+    oldVideo._monitorTimer = null;
+  }
+  try {
+    if (typeof track.detach === "function") track.detach(oldVideo);
+  } catch (_error) {}
+  try {
+    oldVideo._objectFitGuard?.disconnect?.();
+  } catch (_error) {}
+  try {
+    oldVideo.srcObject = null;
+  } catch (_error) {}
+  try { window._pausedVideos?.delete?.(oldVideo); } catch (_error) {}
+  oldVideo.replaceWith(nextVideo);
+  if (overlay) attachVideoDiagnostics(track, nextVideo, overlay);
+  ensureVideoPlays(track, nextVideo);
+  return tile.querySelector("video") === nextVideo && nextVideo._lkTrack === track;
 }
 
 function kickStartScreenVideo(publication, track, element) {
@@ -793,8 +1098,11 @@ function attachVideoDiagnostics(track, element, overlay) {
   const mediaTrack = track?.mediaStreamTrack;
   const frameRate = createVideoFrameRateTracker(() => performance.now());
   element._lastFrameTs = performance.now();
+  element._lastPresentedFrameTs = Number(element._lastPresentedFrameTs) || 0;
   element._firstFrameTs = element._firstFrameTs || 0;
   let lastMediaTime = element.currentTime || 0;
+  const hasVideoFrameCallback = typeof element.requestVideoFrameCallback === "function";
+  let lastPlaybackQualityFrames = null;
   let blackStreak = 0;
   const canvas = document.createElement("canvas");
   canvas.width = 16;
@@ -838,6 +1146,18 @@ function attachVideoDiagnostics(track, element, overlay) {
         element._firstFrameTs = now;
       }
     }
+    if (!hasVideoFrameCallback && typeof element.getVideoPlaybackQuality === "function") {
+      try {
+        const totalFrames = Number(element.getVideoPlaybackQuality()?.totalVideoFrames);
+        if (Number.isFinite(totalFrames)) {
+          if (lastPlaybackQualityFrames !== null && totalFrames > lastPlaybackQualityFrames) {
+            element._lastPresentedFrameTs = now;
+            if (!element._firstFrameTs) element._firstFrameTs = now;
+          }
+          lastPlaybackQualityFrames = totalFrames;
+        }
+      } catch (_error) {}
+    }
     const fps = frameRate.sample(now);
     const w = element.videoWidth || 0;
     const h = element.videoHeight || 0;
@@ -853,22 +1173,28 @@ function attachVideoDiagnostics(track, element, overlay) {
       black: isBlack,
       firstFrameTs: element._firstFrameTs || 0,
       lastFrameTs: element._lastFrameTs || 0,
+      lastPresentedFrameTs: element._lastPresentedFrameTs || 0,
       presentedFrames: frameRate.presentedFrames(),
       updatedAt: Date.now(),
     };
     overlay.textContent = `${w}x${h} | fps ${fps.toFixed(1)} | ${muted} | rs ${ready}${isBlack ? " | black" : ""}`;
   };
 
-  if (typeof element.requestVideoFrameCallback === "function") {
+  if (hasVideoFrameCallback) {
     const onFrame = (_now, metadata) => {
+      if (overlay._echoDiagnosticVideo !== element || !element.isConnected) return;
       frameRate.noteFrame(metadata);
       element._lastFrameTs = performance.now();
+      element._lastPresentedFrameTs = element._lastFrameTs;
       if (!element._firstFrameTs) {
         element._firstFrameTs = element._lastFrameTs;
       }
-      element.requestVideoFrameCallback(onFrame);
+      element._echoVideoFrameCallbackId = element.requestVideoFrameCallback(onFrame);
     };
-    element.requestVideoFrameCallback(onFrame);
+    overlay._echoDiagnosticVideo = element;
+    element._echoVideoFrameCallbackId = element.requestVideoFrameCallback(onFrame);
+  } else {
+    overlay._echoDiagnosticVideo = element;
   }
 
   const timer = setInterval(updateOverlay, 1000);
@@ -892,9 +1218,13 @@ if (typeof module === "object" && module.exports) {
     attemptAndroidFirefoxScreenSubscriptionReset,
     attemptAndroidFirefoxConnectedMediaRelayRecovery,
     createVideoFrameRateTracker,
+    getAndroidFirefoxPresentationRecoveryAction,
     getVideoPresentationSnapshot,
     isAndroidFirefoxConnectedMediaStallCurrent,
+    isAndroidFirefoxPresentationRecoveryGeneration,
+    isAndroidFirefoxPresentationRelayAction,
     isCurrentScreenRecoveryGeneration,
+    markAndroidFirefoxPresentationRecoveryAction,
   };
 }
 
@@ -902,6 +1232,13 @@ function cleanupVideoDiagnostics(overlay) {
   if (!overlay) return;
   const timer = Number(overlay.dataset.timer || 0);
   if (timer) clearInterval(timer);
+  var element = overlay._echoDiagnosticVideo;
+  if (element && element._echoVideoFrameCallbackId != null &&
+      typeof element.cancelVideoFrameCallback === "function") {
+    try { element.cancelVideoFrameCallback(element._echoVideoFrameCallbackId); } catch (_error) {}
+  }
+  if (element) element._echoVideoFrameCallbackId = null;
+  overlay._echoDiagnosticVideo = null;
 }
 
 // ── Camera recovery ──

--- a/core/viewer/participants-grid.js
+++ b/core/viewer/participants-grid.js
@@ -4,6 +4,99 @@
 
 // ── Screen tile management ──
 
+function shouldSuppressAndroidFirefoxScreenPresentationInteractions(nav, isNative) {
+  return typeof isAndroidFirefoxBrowser === "function" &&
+    isAndroidFirefoxBrowser(nav || null, isNative === true);
+}
+
+function shouldContainAndroidFirefoxUtilityScrimClick(options) {
+  if (!options || typeof options.isTargetBrowser !== "function") return false;
+  try {
+    if (options.isTargetBrowser(
+      options.navigatorObject || null,
+      options.isNativeShell === true
+    ) !== true) {
+      return false;
+    }
+  } catch (_error) {
+    return false;
+  }
+  if (typeof options.intersectsVisibleRemoteScreen !== "function") return false;
+  try {
+    return options.intersectsVisibleRemoteScreen() === true;
+  } catch (_error) {
+    return false;
+  }
+}
+
+function containAndroidFirefoxUtilityScrimClick(options) {
+  if (!shouldContainAndroidFirefoxUtilityScrimClick(options)) return false;
+  options.event?.preventDefault?.();
+  options.event?.stopPropagation?.();
+  return true;
+}
+
+function containAndroidFirefoxScreenTileClick(event, shouldContain) {
+  if (shouldContain !== true) return false;
+  event?.preventDefault?.();
+  event?.stopPropagation?.();
+  return true;
+}
+
+function isPointInsideVisibleRemoteScreenPresentation(options) {
+  var opts = options || {};
+  var clientX = Number(opts.clientX);
+  var clientY = Number(opts.clientY);
+  if (!Number.isFinite(clientX) || !Number.isFinite(clientY)) return false;
+  var metaBySid = opts.metaBySid ||
+    (typeof screenTrackMeta !== "undefined" ? screenTrackMeta : null);
+  var tileBySid = opts.tileBySid ||
+    (typeof screenTileBySid !== "undefined" ? screenTileBySid : null);
+  var hiddenIdentities = opts.hiddenIdentities ||
+    (typeof hiddenScreens !== "undefined" ? hiddenScreens : null);
+  var documentObject = opts.documentObject ||
+    (typeof document === "object" ? document : null);
+  var localIdentity = opts.localIdentity ||
+    (typeof room !== "undefined" ? room?.localParticipant?.identity : null);
+  var styleReader = opts.getComputedStyle ||
+    (typeof window === "object" && typeof window.getComputedStyle === "function"
+      ? window.getComputedStyle.bind(window)
+      : null);
+  if (!metaBySid || typeof metaBySid.forEach !== "function" ||
+      !tileBySid || typeof tileBySid.get !== "function") {
+    return false;
+  }
+  if (!localIdentity || documentObject?.visibilityState === "hidden") return false;
+
+  var found = false;
+  metaBySid.forEach(function(meta, trackSid) {
+    if (found || !meta || !meta.publication || !meta.publication.track) return;
+    if (!meta.identity || meta.identity === localIdentity) return;
+    if (meta.publication.isSubscribed === false) return;
+    var mediaTrack = meta.publication.track.mediaStreamTrack;
+    if (!mediaTrack || mediaTrack.readyState !== "live") return;
+    if (meta.identity && hiddenIdentities?.has?.(meta.identity)) return;
+    var tile = tileBySid.get(trackSid);
+    if (!tile || tile !== meta.tile || tile.isConnected !== true || tile.hidden === true) return;
+    if (tile.style?.display === "none" || tile.style?.visibility === "hidden") return;
+    if (styleReader) {
+      try {
+        var style = styleReader(tile);
+        if (style?.display === "none" || style?.visibility === "hidden") return;
+      } catch (_error) {}
+    }
+    if (typeof tile.getClientRects === "function" && tile.getClientRects().length === 0) return;
+    var video = tile.querySelector?.("video");
+    if (!video || video.isConnected !== true || video._lkTrack !== meta.publication.track) return;
+    if (typeof tile.getBoundingClientRect !== "function") return;
+    var rect = tile.getBoundingClientRect();
+    if (!rect || !(rect.width > 0) || !(rect.height > 0)) return;
+    found = clientX >= rect.left && clientX <= rect.right &&
+      clientY >= rect.top && clientY <= rect.bottom;
+  });
+  return found;
+}
+
 function addTile(label, element) {
   const tile = document.createElement("div");
   tile.className = "tile";
@@ -53,7 +146,16 @@ function addScreenTile(label, element, trackSid) {
     if (poster.parentNode) removePoster();
   }, 5000);
 
-  tile.addEventListener("click", () => {
+  var suppressAndroidFirefoxPresentationInteractions =
+    shouldSuppressAndroidFirefoxScreenPresentationInteractions(
+      typeof navigator === "object" ? navigator : null,
+      typeof window === "object" && window.__ECHO_NATIVE__ === true
+    );
+  tile.addEventListener("click", (event) => {
+    if (containAndroidFirefoxScreenTileClick(
+      event,
+      suppressAndroidFirefoxPresentationInteractions
+    )) return;
     if (screenGridEl.classList.contains("is-focused") && tile.classList.contains("is-focused")) {
       screenGridEl.classList.remove("is-focused");
       tile.classList.remove("is-focused");
@@ -73,8 +175,17 @@ function addScreenTile(label, element, trackSid) {
   fsBtn.title = "Fullscreen";
   fsBtn.setAttribute("aria-label", "Open shared screen fullscreen");
   fsBtn.innerHTML = "&#x26F6;"; // ⛶ fullscreen icon
+  if (suppressAndroidFirefoxPresentationInteractions) {
+    fsBtn.hidden = true;
+    fsBtn.disabled = true;
+    fsBtn.classList.add("hidden");
+  }
   fsBtn.addEventListener("click", function(e) {
     e.stopPropagation(); // don't trigger tile focus toggle
+    if (suppressAndroidFirefoxPresentationInteractions) {
+      e.preventDefault();
+      return;
+    }
     var video = tile.querySelector("video");
     if (video) enterVideoFullscreen(video);
   });
@@ -213,4 +324,14 @@ function hideRefreshButton() {
   if (refreshVideosButton) {
     refreshVideosButton.classList.add('hidden');
   }
+}
+
+if (typeof module === "object" && module.exports) {
+  module.exports = {
+    containAndroidFirefoxScreenTileClick,
+    containAndroidFirefoxUtilityScrimClick,
+    isPointInsideVisibleRemoteScreenPresentation,
+    shouldContainAndroidFirefoxUtilityScrimClick,
+    shouldSuppressAndroidFirefoxScreenPresentationInteractions,
+  };
 }

--- a/core/viewer/room-switch-state.js
+++ b/core/viewer/room-switch-state.js
@@ -148,6 +148,27 @@
     };
   }
 
+  const ANDROID_FIREFOX_CANDIDATE_RELEASE_ERROR_CODE =
+    "ANDROID_FIREFOX_REJECTED_CANDIDATE_RELEASE_UNPROVEN";
+
+  function createAndroidFirefoxCandidateReleaseError(message, cause) {
+    const error = new Error(message);
+    error.name = "AndroidFirefoxCandidateReleaseError";
+    error.code = ANDROID_FIREFOX_CANDIDATE_RELEASE_ERROR_CODE;
+    error.terminal = true;
+    error.retryable = false;
+    if (cause !== undefined) error.cause = cause;
+    return error;
+  }
+
+  function isAndroidFirefoxCandidateReleaseError(error) {
+    return !!error &&
+      error.name === "AndroidFirefoxCandidateReleaseError" &&
+      error.code === ANDROID_FIREFOX_CANDIDATE_RELEASE_ERROR_CODE &&
+      error.terminal === true &&
+      error.retryable === false;
+  }
+
   async function disconnectAndroidFirefoxRecoverySource(sourceRoom, options) {
     if (!sourceRoom || typeof sourceRoom.disconnect !== "function") {
       throw new Error("Android Firefox recovery source Room is unavailable");
@@ -218,6 +239,52 @@
       }
       throw error;
     }
+  }
+
+  function verifyAndroidFirefoxRelayCandidateRoom(candidateRoom) {
+    let publisherPolicy = null;
+    let subscriberPolicy = null;
+    try {
+      publisherPolicy = candidateRoom?.engine?.pcManager?.publisher?.pc
+        ?.getConfiguration?.()?.iceTransportPolicy || null;
+    } catch (_error) {}
+    try {
+      subscriberPolicy = candidateRoom?.engine?.pcManager?.subscriber?.pc
+        ?.getConfiguration?.()?.iceTransportPolicy || null;
+    } catch (_error) {}
+    return {
+      publisherPolicy,
+      subscriberPolicy,
+      verified: publisherPolicy === "relay" && subscriberPolicy === "relay",
+    };
+  }
+
+  async function disconnectAndroidFirefoxRejectedRelayCandidate(candidateRoom, options) {
+    if (!candidateRoom) {
+      throw createAndroidFirefoxCandidateReleaseError(
+        "Android Firefox rejected relay candidate Room is unavailable"
+      );
+    }
+    candidateRoom._echoAndroidFirefoxStaleCandidate = true;
+    candidateRoom._echoExpectedDisconnect = true;
+    let released;
+    try {
+      released = await disconnectAndroidFirefoxRecoverySource(candidateRoom, options);
+    } catch (cause) {
+      throw createAndroidFirefoxCandidateReleaseError(
+        "Android Firefox rejected relay candidate disconnect failed",
+        cause
+      );
+    }
+    if (candidateRoom._echoRecoveryDisconnectComplete !== true) {
+      const timedOut = candidateRoom._echoRecoveryDisconnectTimedOut === true;
+      throw createAndroidFirefoxCandidateReleaseError(
+        timedOut
+          ? "Android Firefox rejected relay candidate disconnect timed out"
+          : "Android Firefox rejected relay candidate disconnect completion is unproven"
+      );
+    }
+    return released;
   }
 
   function createAndroidFirefoxRoomDisconnectRecovery(options) {
@@ -383,6 +450,7 @@
       }
 
       let failed = false;
+      let failureError = null;
       try {
         await recovery.reconnect({
           room: recovery.room,
@@ -390,6 +458,7 @@
         });
       } catch (error) {
         failed = true;
+        failureError = error;
         if (typeof opts.onAttemptFailed === "function") {
           opts.onAttemptFailed({ room: recovery.room, attempt: attemptIndex + 1, error });
         }
@@ -403,6 +472,24 @@
       }
       if (!isCurrentRecovery(recovery)) {
         clearActiveRecovery(recovery);
+        return false;
+      }
+      if (isAndroidFirefoxCandidateReleaseError(failureError)) {
+        // A fresh Room must never start while the prior rejected candidate may
+        // still own the same identity. Public Room.disconnect(true) is the
+        // only supported proof of release, so stop this recovery generation
+        // instead of creating overlapping candidates after a rejection or
+        // deadline-only release.
+        recovery.exhausted = true;
+        recovery.waiting = false;
+        if (typeof opts.onExhausted === "function") {
+          opts.onExhausted({
+            room: recovery.room,
+            attempts: recovery.nextAttemptIndex,
+            error: failureError,
+            terminal: true,
+          });
+        }
         return false;
       }
       return queueNextAttempt(recovery);
@@ -660,9 +747,13 @@
 
   return {
     commitConnectedAccessToken,
+    createAndroidFirefoxCandidateReleaseError,
     createAndroidFirefoxRoomDisconnectRecovery,
     createRoomSwitchState,
+    disconnectAndroidFirefoxRejectedRelayCandidate,
     disconnectAndroidFirefoxRecoverySource,
+    isAndroidFirefoxCandidateReleaseError,
     resolvePostConnectMicrophoneBehavior,
+    verifyAndroidFirefoxRelayCandidateRoom,
   };
 });

--- a/core/viewer/screen-share-adaptive.js
+++ b/core/viewer/screen-share-adaptive.js
@@ -11,6 +11,98 @@ function getScreenPresentationStatsForIdentity(identity) {
   return video?._echoPresentationStats || null;
 }
 
+var _androidFirefoxStatsFlights = typeof WeakMap === "function" ? new WeakMap() : null;
+var _inboundScreenStatsPollGeneration = 0;
+var _inboundScreenStatsBoundRoom = null;
+
+function resolveInboundScreenStatsMonitorBinding(options) {
+  var opts = options || {};
+  var requestedRoom = opts.requestedRoom || opts.currentRoom || null;
+  if (!requestedRoom || requestedRoom !== opts.currentRoom ||
+      requestedRoom._echoDiagnosticsCommitted !== true) {
+    return "refuse";
+  }
+  if (opts.active === true && opts.boundRoom === requestedRoom) return "keep";
+  if (opts.active === true) return "restart";
+  return "start";
+}
+
+function isInboundScreenStatsPollCurrent(snapshot, currentRoom, currentGeneration, active) {
+  return !!snapshot && active === true && snapshot.room === currentRoom &&
+    snapshot.generation === currentGeneration;
+}
+
+function getAndroidFirefoxStatsSingleFlight(target, timeoutMs, flights, schedule, cancelSchedule) {
+  if (!target || typeof target.getStats !== "function") return Promise.resolve(null);
+  var flightMap = flights || _androidFirefoxStatsFlights;
+  if (!flightMap) return Promise.resolve(null);
+  var existing = flightMap.get(target);
+  if (existing?.timedOut === true) return Promise.resolve(null);
+  if (!existing) {
+    var raw = Promise.resolve().then(function() { return target.getStats(); });
+    var settled = raw.then(
+      function(value) { return { ok: true, value: value }; },
+      function(error) { return { ok: false, error: error }; }
+    );
+    existing = { promise: settled, timedOut: false };
+    flightMap.set(target, existing);
+    settled.then(function() {
+      if (flightMap.get(target) === existing) flightMap.delete(target);
+    });
+  }
+  var entry = existing;
+  var delay = typeof schedule === "function" ? schedule : setTimeout;
+  var cancel = typeof cancelSchedule === "function" ? cancelSchedule : clearTimeout;
+  var waitMs = Number.isFinite(timeoutMs) && timeoutMs >= 0 ? timeoutMs : 1000;
+  return new Promise(function(resolve) {
+    var done = false;
+    var timer = delay(function() {
+      if (done) return;
+      done = true;
+      entry.timedOut = true;
+      resolve(null);
+    }, waitMs);
+    entry.promise.then(function(outcome) {
+      if (done) return;
+      done = true;
+      cancel(timer);
+      resolve(outcome.ok ? outcome.value : null);
+    });
+  });
+}
+
+function resolveSelectedIceCandidatePair(stats) {
+  if (!stats || typeof stats.forEach !== "function") return null;
+  var reports = [];
+  var byId = new Map();
+  stats.forEach(function(report) {
+    reports.push(report);
+    if (report?.id) byId.set(report.id, report);
+  });
+  var pair = null;
+  var transport = reports.find(function(report) {
+    return report?.type === "transport" && !!report.selectedCandidatePairId;
+  });
+  if (transport) pair = byId.get(transport.selectedCandidatePairId) || null;
+  if (!pair) {
+    pair = reports.find(function(report) {
+      return report?.type === "candidate-pair" && report.selected === true;
+    }) || null;
+  }
+  if (!pair) {
+    pair = reports.find(function(report) {
+      return report?.type === "candidate-pair" && report.nominated === true &&
+        report.state === "succeeded";
+    }) || null;
+  }
+  if (!pair) return null;
+  return {
+    pair: pair,
+    local: byId.get(pair.localCandidateId) || null,
+    remote: byId.get(pair.remoteCandidateId) || null,
+  };
+}
+
 function buildNativePresenterUnavailableReport(reason) {
   return {
     state: "fallback",
@@ -74,41 +166,70 @@ function exposeNativePresenterReportGlobals(root) {
   root.resolveNativePresenterStatusForReport = resolveNativePresenterStatusForReport;
 }
 
-function startInboundScreenStatsMonitor() {
-  if (_inboundScreenStatsInterval) return;
+function startInboundScreenStatsMonitor(requestedRoom) {
+  var monitorRoom = requestedRoom || room || null;
+  var bindingAction = resolveInboundScreenStatsMonitorBinding({
+    requestedRoom: monitorRoom,
+    currentRoom: typeof room !== "undefined" ? room : null,
+    boundRoom: _inboundScreenStatsBoundRoom,
+    active: _inboundScreenStatsInterval != null,
+  });
+  if (bindingAction === "refuse") return false;
+  if (bindingAction === "keep") return true;
+  if (bindingAction === "restart") stopInboundScreenStatsMonitor();
+  _inboundScreenStatsBoundRoom = monitorRoom;
+  var monitorSnapshot = {
+    room: monitorRoom,
+    generation: ++_inboundScreenStatsPollGeneration,
+  };
+  function isCurrentPoll() {
+    return isInboundScreenStatsPollCurrent(
+      monitorSnapshot,
+      room,
+      _inboundScreenStatsPollGeneration,
+      _inboundScreenStatsInterval != null && _inboundScreenStatsBoundRoom === monitorSnapshot.room
+    );
+  }
   _inboundScreenStatsInterval = setInterval(async () => {
     try {
-      if (!room || !room.remoteParticipants) return;
+      if (!isCurrentPoll() || !monitorSnapshot.room?.remoteParticipants) return;
+      var monitorRoom = monitorSnapshot.room;
       const LK = getLiveKitClient();
+      var boundedAndroidFirefoxStats = typeof isAndroidFirefoxBrowser === "function" &&
+        isAndroidFirefoxBrowser(
+          typeof navigator === "object" ? navigator : null,
+          typeof window === "object" && window.__ECHO_NATIVE__ === true
+        );
+      var subscriberStatsUnavailable = false;
       // Extract ICE candidate-pair info once per poll cycle (from subscriber PeerConnection)
       var _iceType = "";
       var _iceLocalType = null, _iceRemoteType = null;
       try {
-        const subPc = room.engine?.pcManager?.subscriber?.pc;
+        const subPc = monitorRoom.engine?.pcManager?.subscriber?.pc;
         if (subPc) {
-          const pcStats = await subPc.getStats();
-          const iceCandidates = new Map();
-          pcStats.forEach(function(r) {
-            if (r.type === "local-candidate" || r.type === "remote-candidate") iceCandidates.set(r.id, r);
-          });
-          pcStats.forEach(function(r) {
-            if (r.type === "candidate-pair" && r.state === "succeeded") {
-              const lc = iceCandidates.get(r.localCandidateId);
-              const rc = iceCandidates.get(r.remoteCandidateId);
-              var lType = lc?.candidateType || "?";
-              var rType = rc?.candidateType || "?";
-              var rtt = r.currentRoundTripTime ? Math.round(r.currentRoundTripTime * 1000) : "?";
+          const pcStats = boundedAndroidFirefoxStats
+            ? await getAndroidFirefoxStatsSingleFlight(subPc, 1000)
+            : await subPc.getStats();
+          if (!isCurrentPoll()) return;
+          if (!pcStats) {
+            subscriberStatsUnavailable = boundedAndroidFirefoxStats;
+          } else {
+            var selectedPair = resolveSelectedIceCandidatePair(pcStats);
+            if (selectedPair) {
+              var lType = selectedPair.local?.candidateType || "?";
+              var rType = selectedPair.remote?.candidateType || "?";
+              var rtt = selectedPair.pair.currentRoundTripTime
+                ? Math.round(selectedPair.pair.currentRoundTripTime * 1000)
+                : "?";
               _iceType = `ice=${lType}->${rType} rtt=${rtt}ms`;
               _iceLocalType = lType !== "?" ? lType : null;
               _iceRemoteType = rType !== "?" ? rType : null;
-              // rtt collected in _iceType debug string above; not POSTed yet —
-              // remove the dead intermediate variable. Add back end-to-end if
-              // we want it on the dashboard later.
             }
-          });
+          }
         }
       } catch (e) { /* ignore ICE stats errors */ }
-      room.remoteParticipants.forEach(async (participant) => {
+      monitorRoom.remoteParticipants.forEach(async (participant) => {
+        if (!isCurrentPoll()) return;
         const effectiveIdentity = isScreenIdentity(participant.identity)
           ? getParentIdentity(participant.identity)
           : participant.identity;
@@ -124,12 +245,17 @@ function startInboundScreenStatsMonitor() {
           // Get receiver stats from the track's mediaStreamTrack
           const mst = pub.track.mediaStreamTrack;
           if (!mst) continue;
-          const pc = room.engine?.pcManager?.subscriber?.pc;
+          const pc = monitorRoom.engine?.pcManager?.subscriber?.pc;
           if (!pc) continue;
           const receivers = pc.getReceivers();
           const receiver = receivers.find(r => r.track === mst);
           if (!receiver) continue;
-          const stats = await receiver.getStats();
+          if (boundedAndroidFirefoxStats && subscriberStatsUnavailable) continue;
+          const stats = boundedAndroidFirefoxStats
+            ? await getAndroidFirefoxStatsSingleFlight(receiver, 1000)
+            : await receiver.getStats();
+          if (!isCurrentPoll()) return;
+          if (!stats) continue;
           var isCamera = pub.source === LK?.Track?.Source?.Camera;
           var sourceLabel = isCamera ? "camera" : "screen";
           stats.forEach((report) => {
@@ -231,7 +357,7 @@ function startInboundScreenStatsMonitor() {
               // Instead of switching simulcast layers (which causes 1080p->360p jumps),
               // we tell the PUBLISHER to reduce their encoder bitrate. Resolution stays
               // 1080p@60fps; only compression level changes. Uses data channel messages.
-              if (!isCamera && participant && room?.localParticipant) {
+              if (!isCamera && participant && monitorRoom?.localParticipant) {
                 var pubIdent = participant.identity;
                 var ctrl = _pubBitrateControl.get(pubIdent);
                 if (!ctrl) {
@@ -384,10 +510,10 @@ function startInboundScreenStatsMonitor() {
                     reason: isSevereCongestion ? "severe" : isCongestion ? "congestion" :
                             ctrl.probePhase === "probing" ? "probe" : "hold",
                     lossRate: Math.round(lossRate * 1000) / 1000,
-                    senderIdentity: room.localParticipant.identity
+                    senderIdentity: monitorRoom.localParticipant.identity
                   };
                   try {
-                    room.localParticipant.publishData(
+                    monitorRoom.localParticipant.publishData(
                       new TextEncoder().encode(JSON.stringify(capMsg)),
                       { reliable: true, destinationIdentities: [pubIdent] }
                     );
@@ -413,10 +539,10 @@ function startInboundScreenStatsMonitor() {
                     targetBitrateMed: BITRATE_DEFAULT_MED,
                     targetBitrateLow: BITRATE_DEFAULT_LOW,
                     reason: "restore", lossRate: 0,
-                    senderIdentity: room.localParticipant.identity
+                    senderIdentity: monitorRoom.localParticipant.identity
                   };
                   try {
-                    room.localParticipant.publishData(
+                    monitorRoom.localParticipant.publishData(
                       new TextEncoder().encode(JSON.stringify(restoreMsg)),
                       { reliable: true, destinationIdentities: [pubIdent] }
                     );
@@ -628,7 +754,8 @@ function startInboundScreenStatsMonitor() {
     // viewer). Server merges into client_stats map keyed by JWT subject.
     // Critical for diagnosing per-receiver mysteries — added 2026-04-08.
     try {
-      if (room && currentAccessToken) {
+      if (isCurrentPoll() && monitorSnapshot.room && currentAccessToken) {
+        var reportRoom = monitorSnapshot.room;
         var inboundArr2 = [];
         _inboundDropTracker.forEach(function(dt, key) {
           if (!dt._lastReport) return;
@@ -667,6 +794,7 @@ function startInboundScreenStatsMonitor() {
             captureHealth = await tauriInvoke("get_capture_health");
           }
         } catch (e) { /* IPC unavailable, e.g. browser viewer */ }
+        if (!isCurrentPoll()) return;
         var displayStatus = typeof getEchoDisplayStatusSnapshot === "function"
           ? getEchoDisplayStatusSnapshot()
           : null;
@@ -674,6 +802,7 @@ function startInboundScreenStatsMonitor() {
           ? getCaptureSourceReportSnapshot()
           : null;
         var nativePresenter = await resolveNativePresenterStatusForReport();
+        if (!isCurrentPoll()) return;
 
         // Fire the POST whenever we have ANYTHING to report — either receive-side
         // inbound stats (other publishers exist) OR local capture health (we are
@@ -688,8 +817,8 @@ function startInboundScreenStatsMonitor() {
               Authorization: "Bearer " + currentAccessToken,
             },
             body: JSON.stringify({
-              identity: room?.localParticipant?.identity || "",
-              name: room?.localParticipant?.name || "",
+              identity: reportRoom?.localParticipant?.identity || "",
+              name: reportRoom?.localParticipant?.name || "",
               room: currentRoomName || "",
               inbound: inboundArr2,
               capture_health: captureHealth,
@@ -702,6 +831,7 @@ function startInboundScreenStatsMonitor() {
       }
     } catch (e) {}
   }, 3000);
+  return true;
 }
 
 exposeNativePresenterReportGlobals(typeof globalThis === "object" ? globalThis : null);
@@ -710,12 +840,18 @@ if (typeof module === "object" && module.exports) {
   module.exports = {
     buildNativePresenterUnavailableReport,
     exposeNativePresenterReportGlobals,
+    getAndroidFirefoxStatsSingleFlight,
     getNativePresenterStatusForReport,
+    isInboundScreenStatsPollCurrent,
+    resolveInboundScreenStatsMonitorBinding,
+    resolveSelectedIceCandidatePair,
     resolveNativePresenterStatusForReport,
   };
 }
 
 function stopInboundScreenStatsMonitor() {
+  _inboundScreenStatsPollGeneration += 1;
+  _inboundScreenStatsBoundRoom = null;
   if (_inboundScreenStatsInterval) {
     clearInterval(_inboundScreenStatsInterval);
     _inboundScreenStatsInterval = null;


### PR DESCRIPTION
## Summary
- recover Android Firefox screen presentation stalls even when the LiveKit track remains live/unmuted
- make automated Android Firefox recovery use and verify TURN relay, with bounded fail-closed candidate cleanup
- contain the mobile stream/scrim/fullscreen interactions implicated in the tap-triggered stall
- keep inbound stats generation-safe across Room replacement and bound Firefox getStats hangs

## Boundary
- viewer-only change under `core/viewer`
- media/reconnect/interaction mutations require non-native Android Firefox
- Windows, macOS, native/Tauri, Android Chrome, and iOS retain their existing media behavior
- no desktop client, publisher, control, SFU, or TURN binary changes

## Verification
- `npm run verify:quick` (342/342)
- focused Android Firefox recovery suite (63/63)
- syntax checks for changed runtime JavaScript
- `git diff --check`
- two independent adversarial reviews: GO

## Live acceptance required
This is a controlled production trial, not yet a declaration that the bug is fixed. Validate real Android Firefox through a source-content change, stream tap, Tools toggle, 5+ minutes of advancing decoded/presented frames, and close/reopen/rejoin. Confirm desktop sharing remains healthy.