### PR TITLE
Isolate Android Firefox presentation recovery

### DIFF
--- a/core/viewer/android-firefox-presentation-recovery-loader.js
+++ b/core/viewer/android-firefox-presentation-recovery-loader.js
@@ -1,0 +1,88 @@
+(function(root) {
+  "use strict";
+
+  var RECOVERY_SCRIPT = "android-firefox-presentation-recovery.js?v=0.6.34.1786572903";
+  var TARGET_USER_AGENT = /Android[^)]*Mobile/i;
+  var TARGET_FIREFOX = /Firefox\/\d/i;
+  var FLAG_PARAM = "echoAndroidFirefoxPresentationRecovery";
+  var FLAG_STORAGE_KEY = "echo-android-firefox-presentation-recovery";
+  var moduleRequested = false;
+
+  function isExactTarget(environment) {
+    var env = environment || {};
+    if (env.isNativeShell === true) return false;
+    var userAgent = String(env.userAgent || "");
+    return TARGET_USER_AGENT.test(userAgent) && TARGET_FIREFOX.test(userAgent) &&
+      !/FxiOS\/\d/i.test(userAgent);
+  }
+
+  function readFlag(environment) {
+    var env = environment || {};
+    var search = String(env.search || "");
+    try {
+      var invite = new URLSearchParams(search).get(FLAG_PARAM);
+      if (invite === "0") return false;
+      if (invite === "1") return true;
+    } catch (_error) {}
+    try {
+      var storage = env.storage || (typeof env.getStorage === "function" ? env.getStorage() : null);
+      var stored = storage && storage.getItem(FLAG_STORAGE_KEY);
+      if (stored === "0") return false;
+      if (stored === "1") return true;
+    } catch (_error) {}
+    // Exact Android Firefox phones are the production cohort. The explicit
+    // override remains available for an immediate server-only kill switch.
+    return true;
+  }
+
+  function shouldLoad(environment) {
+    return isExactTarget(environment) && readFlag(environment);
+  }
+
+  function load(environment) {
+    var env = environment || {};
+    if (!shouldLoad(env) || !env.document || !env.document.createElement) return false;
+    if (moduleRequested) return false;
+    try {
+      if (env.document.querySelector &&
+          env.document.querySelector('script[data-echo-android-firefox-presentation-recovery="1"]')) {
+        moduleRequested = true;
+        return false;
+      }
+    } catch (_error) {}
+    var script = env.document.createElement("script");
+    script.src = RECOVERY_SCRIPT;
+    script.async = false;
+    script.dataset.echoAndroidFirefoxPresentationRecovery = "1";
+    moduleRequested = true;
+    (env.document.head || env.document.documentElement).appendChild(script);
+    return true;
+  }
+
+  function safelyGetStorage(rootObject) {
+    try { return rootObject.localStorage; } catch (_error) { return null; }
+  }
+
+  var api = {
+    FLAG_PARAM: FLAG_PARAM,
+    FLAG_STORAGE_KEY: FLAG_STORAGE_KEY,
+    RECOVERY_SCRIPT: RECOVERY_SCRIPT,
+    isExactTarget: isExactTarget,
+    load: load,
+    readFlag: readFlag,
+    shouldLoad: shouldLoad,
+  };
+
+  if (typeof module === "object" && module.exports) module.exports = api;
+  root.EchoAndroidFirefoxPresentationRecoveryLoader = api;
+
+  if (root.document && root.navigator) {
+    load({
+      document: root.document,
+      getStorage: function() { return safelyGetStorage(root); },
+      isNativeShell: root.__ECHO_NATIVE__ === true,
+      search: root.location && root.location.search,
+      userAgent: root.navigator.userAgent,
+    });
+  }
+})(typeof window === "object" ? window : globalThis);

--- a/core/viewer/android-firefox-presentation-recovery-loader.test.js
+++ b/core/viewer/android-firefox-presentation-recovery-loader.test.js
@@ -1,0 +1,129 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const vm = require("node:vm");
+
+function loadLoader(environment) {
+  const requests = [];
+  const timers = [];
+  const listeners = [];
+  const document = {
+    createElement(tagName) {
+      assert.equal(tagName, "script");
+      return { dataset: {} };
+    },
+    documentElement: { appendChild(script) { requests.push(script.src); } },
+    head: { appendChild(script) { requests.push(script.src); } },
+    querySelector(selector) {
+      assert.equal(selector, 'script[data-echo-android-firefox-presentation-recovery="1"]');
+      return requests.length > 0 ? { dataset: { echoAndroidFirefoxPresentationRecovery: "1" } } : null;
+    },
+  };
+  const storageValues = new Map(Object.entries(environment.storage || {}));
+  let storageReads = 0;
+  const windowObject = {
+    __ECHO_NATIVE__: environment.native === true,
+    addEventListener() { listeners.push("window"); },
+    document,
+    location: { search: environment.search || "" },
+    navigator: { userAgent: environment.userAgent },
+    setInterval() { timers.push("interval"); },
+    setTimeout() { timers.push("timeout"); },
+  };
+  Object.defineProperty(windowObject, "localStorage", {
+    configurable: true,
+    get() {
+      storageReads += 1;
+      if (environment.throwStorage === true) throw new Error("storage blocked");
+      return { getItem(key) { return storageValues.get(key) ?? null; } };
+    },
+  });
+  const context = {
+    URLSearchParams,
+    globalThis: null,
+    module: { exports: {} },
+    window: windowObject,
+  };
+  context.globalThis = context;
+  vm.createContext(context);
+  vm.runInContext(
+    fs.readFileSync(path.join(__dirname, "android-firefox-presentation-recovery-loader.js"), "utf8"),
+    context,
+  );
+  return { api: context.module.exports, context, document, listeners, requests, storageReads, timers };
+}
+
+const androidFirefox =
+  "Mozilla/5.0 (Android 16; Mobile; rv:153.0) Gecko/153.0 Firefox/153.0";
+
+test("only exact non-native Android Firefox phones request the recovery module", () => {
+  const platforms = [
+    ["Android Firefox phone", androidFirefox, false, 1],
+    ["Windows Chrome", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/153.0 Safari/537.36", false, 0],
+    ["Windows Firefox", "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:153.0) Gecko/20100101 Firefox/153.0", false, 0],
+    ["Windows WebView2 shell", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/153.0 Safari/537.36 Edg/153.0", true, 0],
+    ["macOS Chrome", "Mozilla/5.0 (Macintosh; Intel Mac OS X 15_7) AppleWebKit/537.36 Chrome/153.0 Safari/537.36", false, 0],
+    ["macOS Safari", "Mozilla/5.0 (Macintosh; Intel Mac OS X 15_7) AppleWebKit/605.1.15 Version/26.0 Safari/605.1.15", false, 0],
+    ["Android Chrome", "Mozilla/5.0 (Linux; Android 16; Pixel 10 Pro) AppleWebKit/537.36 Chrome/153.0 Mobile Safari/537.36", false, 0],
+    ["Android Firefox tablet", "Mozilla/5.0 (Android 16; Tablet; rv:153.0) Gecko/153.0 Firefox/153.0", false, 0],
+    ["iOS Safari", "Mozilla/5.0 (iPhone; CPU iPhone OS 26_0 like Mac OS X) AppleWebKit/605.1.15 Version/26.0 Mobile/15E148 Safari/604.1", false, 0],
+    ["iOS Firefox", "Mozilla/5.0 (iPhone; CPU iPhone OS 26_0 like Mac OS X) AppleWebKit/605.1.15 FxiOS/153.0 Mobile/15E148 Safari/605.1.15", false, 0],
+  ];
+
+  for (const [label, userAgent, native, expectedRequests] of platforms) {
+    const result = loadLoader({ native, userAgent });
+    assert.equal(result.requests.length, expectedRequests, label);
+    if (!expectedRequests) {
+      assert.deepEqual(result.listeners, [], label + " installs no listeners");
+      assert.deepEqual(result.timers, [], label + " installs no timers");
+    }
+  }
+});
+
+test("the phone feature flag is an immediate module-level kill switch", () => {
+  assert.equal(loadLoader({ userAgent: androidFirefox, search: "?echoAndroidFirefoxPresentationRecovery=0" }).requests.length, 0);
+  assert.equal(loadLoader({ userAgent: androidFirefox, storage: { "echo-android-firefox-presentation-recovery": "0" } }).requests.length, 0);
+  assert.equal(loadLoader({ userAgent: androidFirefox, search: "?echoAndroidFirefoxPresentationRecovery=1", storage: { "echo-android-firefox-presentation-recovery": "0" } }).requests.length, 1);
+});
+
+test("loader safely handles blocked storage and never reads it for non-target clients", () => {
+  const target = loadLoader({ userAgent: androidFirefox, throwStorage: true });
+  assert.equal(target.requests.length, 1);
+  assert.equal(target.storageReads, 1);
+
+  const desktop = loadLoader({
+    throwStorage: true,
+    userAgent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) Firefox/153.0",
+  });
+  assert.equal(desktop.requests.length, 0);
+  assert.equal(desktop.storageReads, 0);
+});
+
+test("loader is idempotent after its automatic exact-target request", () => {
+  const result = loadLoader({ userAgent: androidFirefox });
+  assert.equal(result.requests.length, 1);
+  assert.equal(result.api.load({
+    document: result.document,
+    userAgent: androidFirefox,
+  }), false);
+  assert.equal(result.requests.length, 1);
+  vm.runInContext(
+    fs.readFileSync(path.join(__dirname, "android-firefox-presentation-recovery-loader.js"), "utf8"),
+    result.context,
+  );
+  assert.equal(result.requests.length, 1, "a duplicate loader evaluation finds the existing tag");
+});
+
+test("the shared runtime isolation allowlist contains only the loader seam", () => {
+  const index = fs.readFileSync(path.join(__dirname, "index.html"), "utf8");
+  assert.equal((index.match(/android-firefox-presentation-recovery-loader\.js/g) || []).length, 1);
+  for (const sharedFile of [
+    "app.js", "connect.js", "participants-grid.js", "participants-fullscreen.js",
+    "screen-share-adaptive.js", "room-switch-state.js",
+  ]) {
+    const source = fs.readFileSync(path.join(__dirname, sharedFile), "utf8");
+    assert.doesNotMatch(source, /android-firefox-presentation-recovery\.js/,
+      sharedFile + " must not load or depend on the presentation module");
+  }
+});

--- a/core/viewer/android-firefox-presentation-recovery.js
+++ b/core/viewer/android-firefox-presentation-recovery.js
@@ -1,0 +1,228 @@
+(function(root) {
+  "use strict";
+
+  var POLL_MS = 3000;
+  var STALL_MS = 8000;
+  var SINK_GRACE_MS = 6000;
+  var SUBSCRIPTION_DELAY_MS = 500;
+  var REARM_PROGRESS_FRAMES = 2;
+  var stateBySid = new Map();
+
+  function currentTarget(rootObject) {
+    var win = rootObject || root;
+    var loader = win.EchoAndroidFirefoxPresentationRecoveryLoader;
+    return !!loader && loader.isExactTarget({
+      isNativeShell: win.__ECHO_NATIVE__ === true,
+      userAgent: win.navigator && win.navigator.userAgent,
+    });
+  }
+
+  function exactGeneration(trackSid, expected) {
+    if (!trackSid || !expected) return null;
+    var meta = typeof screenTrackMeta === "object" ? screenTrackMeta.get(trackSid) : null;
+    var tile = typeof screenTileBySid === "object" ? screenTileBySid.get(trackSid) : null;
+    if (!meta || !tile || meta !== expected.meta || tile !== expected.tile) return null;
+    if (meta.publication !== expected.publication || !tile.isConnected) return null;
+    if (tile.dataset && tile.dataset.trackSid !== trackSid) return null;
+    if (typeof room !== "object" || !room || room !== expected.room) return null;
+    if (String(room.state || "").toLowerCase() !== "connected") return null;
+    if (room.localParticipant && meta.identity === room.localParticipant.identity) return null;
+    if (typeof hiddenScreens === "object" && hiddenScreens.has(meta.identity)) return null;
+    return { meta: meta, publication: meta.publication, tile: tile };
+  }
+
+  function currentGeneration(trackSid, expected) {
+    var exact = exactGeneration(trackSid, expected);
+    if (!exact) return null;
+    var meta = exact.meta;
+    var tile = exact.tile;
+    var publication = exact.publication;
+    var track = publication && publication.track;
+    var mediaTrack = track && track.mediaStreamTrack;
+    var video = tile.querySelector && tile.querySelector("video");
+    if (!video || video._lkTrack !== track || publication.isSubscribed !== true) return null;
+    if (!mediaTrack || mediaTrack.readyState !== "live") return null;
+    if (String(room.state || "").toLowerCase() !== "connected") return null;
+    if (root.document && root.document.visibilityState === "hidden") return null;
+    return { meta: meta, publication: publication, tile: tile, track: track, video: video };
+  }
+
+  function reattachSink(trackSid, generation) {
+    var current = currentGeneration(trackSid, generation);
+    if (!current || typeof current.track.detach !== "function" ||
+        typeof current.track.attach !== "function") return false;
+    // Keep the production tile, video element, diagnostics callback, object-fit
+    // guard, fullscreen host, and Tools/focus handlers completely stable.
+    try { current.track.detach(current.video); } catch (_error) { return false; }
+    try {
+      current.track.attach(current.video);
+      current.video._lkTrack = current.track;
+    } catch (_error) {
+      try { current.track.attach(current.video); } catch (_ignored) {}
+      return false;
+    }
+    if (typeof configureVideoElement === "function") configureVideoElement(current.video, true);
+    if (typeof ensureVideoPlays === "function") ensureVideoPlays(current.track, current.video);
+    if (typeof ensureVideoSubscribed === "function") ensureVideoSubscribed(current.publication, current.video);
+    if (typeof requestVideoKeyFrame === "function") requestVideoKeyFrame(current.publication, current.track);
+    return current.tile.querySelector("video") === current.video && current.video._lkTrack === current.track;
+  }
+
+  function resetSubscription(trackSid, generation) {
+    var current = currentGeneration(trackSid, generation);
+    if (!current || typeof current.publication.setSubscribed !== "function") return false;
+    if (typeof markResubscribeIntent === "function") markResubscribeIntent(trackSid);
+    current.publication.setSubscribed(false);
+    root.setTimeout(function() {
+      var latest = exactGeneration(trackSid, generation);
+      if (!latest) return;
+      latest.publication.setSubscribed(true);
+      if (typeof requestVideoKeyFrame === "function") {
+        requestVideoKeyFrame(latest.publication, latest.publication.track || current.track);
+      }
+    }, SUBSCRIPTION_DELAY_MS);
+    return true;
+  }
+
+  function recordPresentationProgress(state, now) {
+    state.sawPresentedFrame = true;
+    state.lastProgressAt = now;
+    if (state.sinkAttempted !== true && state.subscriptionAttempted !== true) {
+      state.progressTicks = 0;
+      return;
+    }
+    state.progressTicks = (state.progressTicks || 0) + 1;
+    if (state.progressTicks < REARM_PROGRESS_FRAMES) return;
+    state.sinkAttempted = false;
+    state.subscriptionAttempted = false;
+    state.progressTicks = 0;
+  }
+
+  function stateOwnsGeneration(state, generation, current) {
+    return !!state && state.room === generation.room && state.meta === generation.meta &&
+      state.publication === generation.publication && state.tile === generation.tile &&
+      state.track === current.track && state.video === current.video;
+  }
+
+  function createGenerationState(generation, current) {
+    return {
+      lastProgressAt: 0,
+      meta: generation.meta,
+      progressTicks: 0,
+      publication: generation.publication,
+      room: generation.room,
+      tile: generation.tile,
+      track: current.track,
+      video: current.video,
+    };
+  }
+
+  function observePresentedFrame(video, now, state) {
+    var stats = video && video._echoPresentationStats;
+    var frames = Number(stats && stats.presentedFrames);
+    if (!Number.isFinite(frames)) return false;
+    if (state.video && state.video !== video) {
+      state.video = video;
+      state.lastPresentedFrames = frames;
+      if (frames < 1) return false;
+      recordPresentationProgress(state, now);
+      return true;
+    }
+    state.video = video;
+    if (!Number.isFinite(state.lastPresentedFrames)) {
+      state.lastPresentedFrames = frames;
+      if (frames < 1) return false;
+      recordPresentationProgress(state, now);
+      return true;
+    }
+    if (frames === state.lastPresentedFrames) return false;
+    if (frames < state.lastPresentedFrames) {
+      state.lastPresentedFrames = frames;
+      if (frames < 1) return false;
+      recordPresentationProgress(state, now);
+      return true;
+    }
+    state.lastPresentedFrames = frames;
+    recordPresentationProgress(state, now);
+    return true;
+  }
+
+  function inspect(now) {
+    if (!currentTarget(root) || typeof screenTrackMeta !== "object") return 0;
+    var actions = 0;
+    screenTrackMeta.forEach(function(meta, trackSid) {
+      var tile = typeof screenTileBySid === "object" ? screenTileBySid.get(trackSid) : null;
+      var publication = meta && meta.publication;
+      var generation = { meta: meta, publication: publication, room: room, tile: tile };
+      var observed = {
+        track: publication && publication.track,
+        video: tile && tile.querySelector && tile.querySelector("video"),
+      };
+      var state = stateBySid.get(trackSid);
+      if (state && !stateOwnsGeneration(state, generation, observed)) state = null;
+      var current = currentGeneration(trackSid, generation);
+      if (!current) {
+        if (state) stateBySid.set(trackSid, state);
+        else stateBySid.delete(trackSid);
+        return;
+      }
+      if (!state) {
+        state = createGenerationState(generation, current);
+      }
+      stateBySid.set(trackSid, state);
+      var presentationReady = current.video.paused !== true && current.video.readyState >= 2 &&
+        current.video.videoWidth > 0 && current.video.videoHeight > 0;
+      if (state.sinkAttempted !== true && !presentationReady) return;
+      if (observePresentedFrame(current.video, now, state)) return;
+      // A live track that never produced one genuinely presented frame belongs
+      // to #238's existing media-start recovery, not this presentation ladder.
+      if (state.sawPresentedFrame !== true) return;
+      if (!(state.lastProgressAt > 0) || now - state.lastProgressAt < STALL_MS) return;
+      state.progressTicks = 0;
+      if (!state.sinkAttempted) {
+        var reattached = reattachSink(trackSid, generation);
+        // Consume the first-line attempt even when the browser rejects it so a
+        // failed same-node reattach cannot block the one bounded SID reset.
+        state.sinkAttempted = true;
+        state.sinkAttemptedAt = now;
+        if (reattached) actions += 1;
+        return;
+      }
+      if (!state.subscriptionAttempted && !state.subscriptionEverAttempted &&
+          now - state.sinkAttemptedAt >= SINK_GRACE_MS) {
+        if (resetSubscription(trackSid, generation)) {
+          state.subscriptionAttempted = true;
+          state.subscriptionEverAttempted = true;
+          state.subscriptionAttemptedAt = now;
+          actions += 1;
+        }
+      }
+    });
+    stateBySid.forEach(function(_state, trackSid) {
+      if (!screenTrackMeta.has(trackSid)) stateBySid.delete(trackSid);
+    });
+    return actions;
+  }
+
+  function start() {
+    if (!currentTarget(root) || root.__echoAndroidFirefoxPresentationRecoveryTimer) return false;
+    root.__echoAndroidFirefoxPresentationRecoveryTimer = root.setInterval(function() {
+      try { inspect(typeof performance === "object" ? performance.now() : Date.now()); }
+      catch (error) {
+        if (typeof debugLog === "function") {
+          debugLog("[android-firefox-presentation-recovery] " + (error && error.message || error));
+        }
+      }
+    }, POLL_MS);
+    return true;
+  }
+
+  var api = { currentGeneration: currentGeneration, currentTarget: currentTarget,
+    createGenerationState: createGenerationState, exactGeneration: exactGeneration, inspect: inspect,
+    observePresentedFrame: observePresentedFrame, reattachSink: reattachSink,
+    resetSubscription: resetSubscription, start: start, stateBySid: stateBySid,
+    stateOwnsGeneration: stateOwnsGeneration };
+  root.EchoAndroidFirefoxPresentationRecovery = api;
+  if (typeof module === "object" && module.exports) module.exports = api;
+  start();
+})(typeof window === "object" ? window : globalThis);

--- a/core/viewer/android-firefox-presentation-recovery.test.js
+++ b/core/viewer/android-firefox-presentation-recovery.test.js
@@ -1,0 +1,243 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const vm = require("node:vm");
+
+const androidFirefox =
+  "Mozilla/5.0 (Android 16; Mobile; rv:153.0) Gecko/153.0 Firefox/153.0";
+
+function createHarness() {
+  const calls = [];
+  const timeouts = [];
+  const intervals = [];
+  const videos = [];
+  function video(frames) {
+    const value = {
+      _echoPresentationStats: { presentedFrames: frames },
+      _lkTrack: null,
+      classList: { add() {} },
+      isConnected: true,
+      paused: false,
+      readyState: 4,
+      srcObject: {},
+      style: { setProperty() {}, width: "", height: "", background: "" },
+      videoHeight: 1080,
+      videoWidth: 1920,
+    };
+    videos.push(value);
+    return value;
+  }
+  const initialVideo = video(10);
+  const track = {
+    mediaStreamTrack: { readyState: "live", muted: false },
+    detach(value) { calls.push(["detach", value]); },
+    attach(value) { calls.push(["reattach", value]); return value; },
+  };
+  initialVideo._lkTrack = track;
+  const publication = {
+    isSubscribed: true,
+    track,
+    setSubscribed(value) { this.isSubscribed = value; calls.push(["subscribed", value]); },
+  };
+  const overlay = {};
+  const tile = {
+    currentVideo: initialVideo,
+    dataset: { trackSid: "TR_screen" },
+    isConnected: true,
+    querySelector(selector) { return selector === "video" ? this.currentVideo : overlay; },
+  };
+  const meta = { identity: "remote", publication, tile };
+  const room = { state: "connected", localParticipant: { identity: "local" } };
+  const context = {
+    Map,
+    Date,
+    globalThis: null,
+    module: { exports: {} },
+    performance: { now: () => 0 },
+    screenTileBySid: new Map([["TR_screen", tile]]),
+    screenTrackMeta: new Map([["TR_screen", meta]]),
+    hiddenScreens: new Set(),
+    room,
+    window: {
+      EchoAndroidFirefoxPresentationRecoveryLoader: {
+        isExactTarget: () => true,
+      },
+      document: { visibilityState: "visible" },
+      navigator: { userAgent: androidFirefox },
+      setInterval(callback, delay) { intervals.push({ callback, delay }); return 1; },
+      setTimeout(callback, delay) { timeouts.push({ callback, delay }); return timeouts.length; },
+    },
+    configureVideoElement() { calls.push(["configure"]); },
+    ensureVideoPlays() { calls.push(["play"]); },
+    ensureVideoSubscribed() { calls.push(["ensureSubscribed"]); },
+    markResubscribeIntent(sid) { calls.push(["intent", sid]); },
+    requestVideoKeyFrame() { calls.push(["keyframe"]); },
+  };
+  context.globalThis = context;
+  vm.createContext(context);
+  vm.runInContext(
+    fs.readFileSync(path.join(__dirname, "android-firefox-presentation-recovery.js"), "utf8"),
+    context,
+  );
+  return { api: context.module.exports, calls, context, intervals, meta, publication, room, tile, timeouts, videos };
+}
+
+test("a never-presented live track cannot enter the presentation recovery ladder", () => {
+  const harness = createHarness();
+  harness.tile.currentVideo._echoPresentationStats.presentedFrames = 0;
+  harness.api.stateBySid.clear();
+  assert.equal(harness.api.inspect(1000), 0);
+  assert.equal(harness.api.inspect(20000), 0);
+  assert.deepEqual(harness.calls, []);
+  assert.equal(harness.timeouts.length, 0);
+});
+
+test("a proven presentation stall reattaches only its stable sink, then performs one exact-SID resubscribe", () => {
+  const harness = createHarness();
+  assert.equal(harness.api.inspect(1000), 0, "records genuine presentation progress");
+  assert.equal(harness.api.inspect(9001), 1, "eight-second presentation stall reattaches sink");
+  assert.equal(harness.calls.filter((entry) => entry[0] === "reattach").length, 1);
+  assert.equal(harness.tile.currentVideo, harness.videos[0], "production video node stays stable");
+  assert.equal(harness.calls.some((entry) => entry[0] === "subscribed"), false);
+
+  assert.equal(harness.api.inspect(15002), 1, "six-second sink grace permits one reset");
+  assert.deepEqual(harness.calls.filter((entry) => entry[0] === "subscribed"), [["subscribed", false]]);
+  assert.equal(harness.timeouts.length, 1);
+  assert.equal(harness.timeouts[0].delay, 500);
+  harness.publication.isSubscribed = true;
+  assert.equal(harness.api.inspect(25000), 0, "the same SID cannot schedule another reset");
+  assert.equal(harness.timeouts.length, 1);
+});
+
+test("a rejected same-node reattach cannot block the bounded SID reset", () => {
+  const harness = createHarness();
+  harness.publication.track.attach = undefined;
+  harness.api.inspect(1000);
+  assert.equal(harness.api.inspect(9001), 0);
+  assert.equal(harness.api.stateBySid.get("TR_screen").sinkAttempted, true);
+  assert.equal(harness.api.inspect(15002), 1);
+  assert.deepEqual(harness.calls.filter((entry) => entry[0] === "subscribed"), [["subscribed", false]]);
+  assert.equal(harness.timeouts.length, 1);
+});
+
+test("reattached sink progress rearms the bounded ladder after two observations", () => {
+  const harness = createHarness();
+  harness.api.inspect(1000);
+  harness.api.inspect(9001);
+  const stableVideo = harness.tile.currentVideo;
+  stableVideo._echoPresentationStats.presentedFrames = 11;
+  assert.equal(harness.api.inspect(10000), 0);
+  stableVideo._echoPresentationStats.presentedFrames = 12;
+  assert.equal(harness.api.inspect(11000), 0);
+  const state = harness.api.stateBySid.get("TR_screen");
+  assert.equal(state.sinkAttempted, false);
+  assert.equal(state.subscriptionAttempted, false);
+  assert.equal(state.sawPresentedFrame, true);
+});
+
+test("delayed subscription restoration is fenced to the exact Room, metadata, tile, and SID", () => {
+  for (const mutation of [
+    (h) => { h.context.room = { state: "connected", localParticipant: { identity: "local" } }; },
+    (h) => h.context.screenTrackMeta.delete("TR_screen"),
+    (h) => h.context.screenTileBySid.delete("TR_screen"),
+    (h) => { h.tile.dataset.trackSid = "TR_new"; },
+  ]) {
+    const harness = createHarness();
+    harness.api.inspect(1000);
+    harness.api.inspect(9001);
+    harness.api.inspect(15002);
+    mutation(harness);
+    harness.timeouts[0].callback();
+    assert.deepEqual(harness.calls.filter((entry) => entry[0] === "subscribed"), [["subscribed", false]]);
+  }
+});
+
+test("tab backgrounding after the reset cannot strand the exact subscription off", () => {
+  const harness = createHarness();
+  harness.api.inspect(1000);
+  harness.api.inspect(9001);
+  harness.api.inspect(15002);
+  harness.context.window.document.visibilityState = "hidden";
+  harness.timeouts[0].callback();
+  assert.deepEqual(harness.calls.filter((entry) => entry[0] === "subscribed"), [
+    ["subscribed", false],
+    ["subscribed", true],
+  ]);
+});
+
+test("same SID in a new publication and video generation cannot inherit presentation proof", () => {
+  const harness = createHarness();
+  harness.api.inspect(1000);
+  harness.api.inspect(9001);
+  assert.equal(harness.calls.filter((entry) => entry[0] === "reattach").length, 1);
+
+  const replacementVideo = {
+    ...harness.tile.currentVideo,
+    _echoPresentationStats: { presentedFrames: 0 },
+  };
+  const replacementTrack = {
+    mediaStreamTrack: { readyState: "live", muted: false },
+    attach() {},
+    detach() {},
+  };
+  replacementVideo._lkTrack = replacementTrack;
+  const replacementPublication = {
+    isSubscribed: true,
+    track: replacementTrack,
+    setSubscribed(value) { this.isSubscribed = value; harness.calls.push(["replacementSubscribed", value]); },
+  };
+  const replacementMeta = {
+    identity: "remote",
+    publication: replacementPublication,
+    tile: harness.tile,
+  };
+  harness.tile.currentVideo = replacementVideo;
+  harness.context.screenTrackMeta.set("TR_screen", replacementMeta);
+  harness.api.inspect(20000);
+  harness.api.inspect(40000);
+  assert.deepEqual(harness.calls.filter((entry) => entry[0] === "replacementSubscribed"), []);
+  assert.equal(harness.api.stateBySid.get("TR_screen").sawPresentedFrame, undefined);
+});
+
+test("state for a removed SID is swept on the next inspection", () => {
+  const harness = createHarness();
+  harness.api.inspect(1000);
+  assert.equal(harness.api.stateBySid.has("TR_screen"), true);
+  harness.context.screenTrackMeta.delete("TR_screen");
+  harness.context.screenTileBySid.delete("TR_screen");
+  harness.api.inspect(2000);
+  assert.equal(harness.api.stateBySid.has("TR_screen"), false);
+});
+
+test("disconnecting the exact Room during the reset delay blocks restoration", () => {
+  const harness = createHarness();
+  harness.api.inspect(1000);
+  harness.api.inspect(9001);
+  harness.api.inspect(15002);
+  harness.room.state = "disconnected";
+  harness.timeouts[0].callback();
+  assert.deepEqual(harness.calls.filter((entry) => entry[0] === "subscribed"), [["subscribed", false]]);
+});
+
+test("a recovered and restalled exact generation can never toggle its subscription twice", () => {
+  const harness = createHarness();
+  harness.api.inspect(1000);
+  harness.api.inspect(9001);
+  harness.api.inspect(15002);
+  harness.api.inspect(15100);
+  assert.equal(harness.api.stateBySid.get("TR_screen").subscriptionEverAttempted, true,
+    "the 500ms unsubscribe window must not discard the exact-generation cap");
+  harness.publication.isSubscribed = true;
+
+  harness.tile.currentVideo._echoPresentationStats.presentedFrames = 11;
+  harness.api.inspect(16000);
+  harness.tile.currentVideo._echoPresentationStats.presentedFrames = 12;
+  harness.api.inspect(17000);
+  harness.api.inspect(26001);
+  harness.api.inspect(33002);
+
+  assert.deepEqual(harness.calls.filter((entry) => entry[0] === "subscribed"), [["subscribed", false]]);
+  assert.equal(harness.timeouts.length, 1);
+  assert.equal(harness.api.stateBySid.get("TR_screen").subscriptionEverAttempted, true);
+});

--- a/core/viewer/index.html
+++ b/core/viewer/index.html
@@ -817,6 +817,7 @@
     <script src="admin-history.js?v=0.6.34.1785470400"></script>
     <script src="admin.js?v=0.6.34.1785470400"></script>
     <script src="connect.js?v=0.6.34.1786386773"></script>
+    <script src="android-firefox-presentation-recovery-loader.js?v=0.6.34.1786572903"></script>
     <script src="app.js?v=0.6.11.1777930912"></script>
     <script src="capture-picker.js?v=0.6.11.1777930912"></script>
     <script src="jam-visualizer.js?v=0.6.34.1785384000"></script>


### PR DESCRIPTION
## What changed

- adds a tiny always-loaded loader that requests recovery code only on non-native Android Firefox phones
- adds a target-only presentation watchdog that requires prior presented-frame progress
- recovers a stalled presentation by reattaching the existing video sink, then allows one exact-generation subscription reset
- keeps the existing #238 desktop/shared media path byte-for-byte unchanged
- adds UA, generation, lifecycle, and one-shot regression coverage

## Why

The previous mobile recovery changed shared presentation and stats code and regressed desktop ultrawide/stage behavior. This patch isolates new recovery behavior behind a module boundary: desktop, native, Android Chrome, macOS, and iOS do not request or evaluate the module.

## Impact

Server-served viewer only. No Windows desktop binary change. Real Android Firefox tap/close/rejoin acceptance remains required before production rollout.

## Validation

- focused Android Firefox tests: 15/15
- `npm run verify:quick`: 337/337
- `npm run verify:viewer:layout`: 157/157
- stage fullscreen: 11/11, including 3440/5120 and 32:9
- desktop layout: 3/3
- Tools/Jam smoke: 6/6
- `git diff --check`