### PR TITLE
Self-heal stale Spotify Connect sessions

### DIFF
--- a/core/client/Cargo.toml
+++ b/core/client/Cargo.toml
@@ -28,6 +28,11 @@ windows-core = "0.58"
 [target.'cfg(windows)'.dependencies.windows]
 version = "0.58"
 features = [
+    "ApplicationModel",
+    "Foundation",
+    "Foundation_Collections",
+    "Management_Deployment",
+    "Media_Control",
     "implement",
     "Win32_Foundation",
     "Win32_Graphics_Direct3D",

--- a/core/client/README.md
+++ b/core/client/README.md
@@ -88,11 +88,33 @@ diagnostic only: recovery accepts the current Spotify process only when it is
 in Echo's current Windows session and its Store package family and app ID still
 match the journal.
 
+## Spotify Connect self-recovery
+
+Start Jam performs one bounded preflight; there is no background watchdog. If
+the configured Spotify Connect device is missing while the Echo Jam source is
+armed and healthy, the control plane asks the provisioned Windows source client
+to re-activate the already-running Microsoft Store Spotify identity and polls
+Spotify for registration. If that exact Store app remains unregistered, Echo
+may restart it once and poll again. The complete recovery shares the existing
+15-second Jam-start deadline; there is no second independent timeout.
+
+Echo never restarts its desktop client, the control service, or unrelated
+processes during this repair. It refuses to interrupt an active Spotify media
+session, validates the exact Store package family/app ID/current Windows
+session, fences cancellation and connection replacement, and allows only one
+restart attempt per minute. A closed or unarmed Spotify app still requires the
+normal user action to open Spotify and enable Jam sharing. Errors explicitly
+distinguish a missing **Spotify Connect device** from an offline **Echo Jam
+source**.
+
 ## Release boundary
 
-Protocol v3 is a coordinated desktop-and-server change. Deploy the control
-plane and its complete server-served viewer snapshot, and install the matching
-Echo Desktop binary on the configured Spotify source PC. Ordinary listener PCs
-do not receive Jam-source credentials and do not need the source binary; they
-receive the updated viewer from the server. Do not run a protocol-v3 server
-against an older source client or publish only part of the viewer bundle.
+The `spotify_connect_repair_v1` capability is an optional protocol-v3
+capability. Install the source desktop binary first; the old server ignores the
+extra Availability field. Then deploy the control plane and its complete
+server-served viewer snapshot. If the server lands first, an older source stays
+protocol-compatible but a Start that needs repair fails closed with an update
+message. Ordinary listener PCs do not receive Jam-source credentials and do not
+need the source binary; they receive the updated viewer from the server. Always
+publish the viewer as one
+complete snapshot.

--- a/core/client/src/audio_capture.rs
+++ b/core/client/src/audio_capture.rs
@@ -337,6 +337,23 @@ pub fn find_spotify_root_pid() -> std::result::Result<u32, String> {
     })
 }
 
+/// Return every Spotify.exe PID in Echo's interactive Windows session.
+///
+/// This deliberately excludes Spotify processes in other signed-in sessions so
+/// Jam recovery can restart only the source PC user's Spotify instance.
+pub(crate) fn find_spotify_process_ids() -> std::result::Result<Vec<u32>, String> {
+    let current_pid = unsafe { GetCurrentProcessId() };
+    let current_session = process_session_id(current_pid)
+        .ok_or_else(|| "Cannot determine Echo's Windows session".to_string())?;
+    let mut pids = find_processes_by_name("Spotify.exe")
+        .into_iter()
+        .filter_map(|(pid, _)| (process_session_id(pid) == Some(current_session)).then_some(pid))
+        .collect::<Vec<_>>();
+    pids.sort_unstable();
+    pids.dedup();
+    Ok(pids)
+}
+
 /// Verify that an existing Jam capture is still bound to the Spotify root
 /// selected for Echo's current Windows session. Spotify can exit without
 /// WASAPI reporting a terminal capture event, so the Jam source polls this

--- a/core/client/src/jam_source.rs
+++ b/core/client/src/jam_source.rs
@@ -8,6 +8,9 @@ use crate::audio_capture::{
     find_spotify_root_pid, start_owned_process_capture, validate_spotify_root_pid,
     OwnedProcessCapture, ProcessCaptureEvent,
 };
+use crate::spotify_connect_repair::{
+    repair_spotify_connect, SpotifyConnectRepairAction, SpotifyConnectRepairOutcome,
+};
 use crate::spotify_output_route::{
     SpotifyOutputRouteLease, SpotifyOutputRouter, StartupRecoveryOutcome,
     DEFAULT_SPOTIFY_ROUTE_TARGET,
@@ -21,7 +24,7 @@ use std::os::windows::ffi::OsStrExt;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tokio::sync::watch;
 use tokio_tungstenite::tungstenite::client::IntoClientRequest;
 use tokio_tungstenite::tungstenite::http::header::{AUTHORIZATION, USER_AGENT};
@@ -35,6 +38,11 @@ use windows::Win32::Storage::Packaging::Appx::{GetApplicationUserModelId, GetPac
 use windows::Win32::System::Threading::{OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION};
 
 const PROTOCOL_VERSION: u8 = 3;
+const SPOTIFY_CONNECT_REPAIR_CAPABILITY: &str = "spotify_connect_repair_v1";
+// A restart may already be in its restorative phase (2s graceful + 3s force
+// wait). Give that blocking worker enough time to relaunch Spotify before a
+// connection teardown or app shutdown proceeds.
+const SPOTIFY_CONNECT_REPAIR_CLEANUP_TIMEOUT: Duration = Duration::from_secs(10);
 const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(5);
 const SHUTDOWN_POLL_INTERVAL: Duration = Duration::from_millis(250);
 const WEBSOCKET_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
@@ -44,7 +52,8 @@ const ROUTE_JOURNAL_FILE_NAME: &str = "jam-source-route-journal.json";
 const AMBIGUOUS_DISCONNECT_ROUTE_RELEASE_GRACE: Duration = Duration::from_secs(36);
 const TAKEOVER_DISABLE_FALLBACK: Duration = Duration::from_secs(3);
 const SHUTDOWN_STOP_ACK_TIMEOUT: Duration = Duration::from_secs(16);
-const SPOTIFY_STORE_PACKAGE_PREFIX: &str = "SpotifyAB.SpotifyMusic_";
+const SPOTIFY_CONNECT_RESTART_COOLDOWN: Duration = Duration::from_secs(60);
+const SPOTIFY_STORE_PACKAGE_FAMILY: &str = "SpotifyAB.SpotifyMusic_zpdnekdrzrea0";
 const SPOTIFY_STORE_APP_SUFFIX: &str = "!Spotify";
 const MOVEFILE_REPLACE_EXISTING: u32 = 0x1;
 const MOVEFILE_WRITE_THROUGH: u32 = 0x8;
@@ -132,6 +141,8 @@ struct JamSourceLocalControlInner {
     preferences_tx: watch::Sender<JamSourceLocalPreferences>,
     takeover_active: AtomicBool,
     agent_running: AtomicBool,
+    spotify_connect_repair_active: AtomicBool,
+    last_spotify_connect_restart_at: Mutex<Option<Instant>>,
     preference_error: Mutex<Option<String>>,
     last_error: Mutex<Option<String>>,
 }
@@ -182,6 +193,8 @@ impl JamSourceLocalControl {
                 preferences_tx,
                 takeover_active: AtomicBool::new(false),
                 agent_running: AtomicBool::new(false),
+                spotify_connect_repair_active: AtomicBool::new(false),
+                last_spotify_connect_restart_at: Mutex::new(None),
                 preference_error: Mutex::new(preference_error),
                 last_error: Mutex::new(None),
             }),
@@ -309,6 +322,63 @@ impl JamSourceLocalControl {
             .last_error
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner()) = error;
+    }
+
+    fn begin_spotify_connect_repair(
+        &self,
+        action: SpotifyConnectRepairAction,
+    ) -> Result<SpotifyConnectRepairGuard, String> {
+        self.inner
+            .spotify_connect_repair_active
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .map_err(|_| {
+                "A Spotify Connect repair is already running on this source PC".to_string()
+            })?;
+        if action == SpotifyConnectRepairAction::Restart {
+            let mut last_restart = self
+                .inner
+                .last_spotify_connect_restart_at
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            if last_restart
+                .map(|started| started.elapsed() < SPOTIFY_CONNECT_RESTART_COOLDOWN)
+                .unwrap_or(false)
+            {
+                self.inner
+                    .spotify_connect_repair_active
+                    .store(false, Ordering::Release);
+                return Err(format!(
+                    "Spotify Connect restart is cooling down for {} seconds",
+                    SPOTIFY_CONNECT_RESTART_COOLDOWN.as_secs()
+                ));
+            }
+            *last_restart = Some(Instant::now());
+        }
+        Ok(SpotifyConnectRepairGuard {
+            control: self.clone(),
+        })
+    }
+
+    fn finish_spotify_connect_repair(&self) {
+        self.inner
+            .spotify_connect_repair_active
+            .store(false, Ordering::Release);
+    }
+
+    fn spotify_connect_repair_active(&self) -> bool {
+        self.inner
+            .spotify_connect_repair_active
+            .load(Ordering::Acquire)
+    }
+}
+
+struct SpotifyConnectRepairGuard {
+    control: JamSourceLocalControl,
+}
+
+impl Drop for SpotifyConnectRepairGuard {
+    fn drop(&mut self) {
+        self.control.finish_spotify_connect_repair();
     }
 }
 
@@ -541,9 +611,24 @@ impl Drop for JamSourceAgent {
 #[derive(Debug, Deserialize, PartialEq, Eq)]
 #[serde(tag = "type", rename_all = "lowercase")]
 enum ServerCommand {
-    Start { generation: u64 },
-    Stop { generation: u64 },
-    Restart { generation: u64 },
+    Start {
+        generation: u64,
+    },
+    Stop {
+        generation: u64,
+    },
+    Restart {
+        generation: u64,
+    },
+    #[serde(rename = "spotify_connect_repair")]
+    SpotifyConnectRepair {
+        request_id: u64,
+        action: SpotifyConnectRepairAction,
+    },
+    #[serde(rename = "spotify_connect_repair_cancel")]
+    SpotifyConnectRepairCancel {
+        request_id: u64,
+    },
 }
 
 #[derive(Debug, Serialize)]
@@ -553,6 +638,7 @@ enum SourceMessage<'a> {
         enabled: bool,
         #[serde(skip_serializing_if = "Option::is_none")]
         error: Option<&'a str>,
+        capabilities: &'static [&'static str],
     },
     Format {
         generation: u64,
@@ -573,6 +659,15 @@ enum SourceMessage<'a> {
     Restarting {
         generation: u64,
     },
+    #[serde(rename = "spotify_connect_repair")]
+    SpotifyConnectRepair {
+        request_id: u64,
+        success: bool,
+        outcome: &'a str,
+        was_running_before: bool,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        error: Option<&'a str>,
+    },
 }
 
 struct ActiveCapture {
@@ -585,6 +680,32 @@ struct ActiveTakeover {
     generation: u64,
     route: SpotifyOutputRouteLease,
     capture: Option<ActiveCapture>,
+}
+
+struct SpotifyConnectRepairTask {
+    request_id: u64,
+    cancelled: Arc<AtomicBool>,
+    task: tokio::task::JoinHandle<
+        Result<crate::spotify_connect_repair::SpotifyConnectRepairReport, String>,
+    >,
+}
+
+async fn next_spotify_connect_repair(
+    repair: &mut Option<SpotifyConnectRepairTask>,
+) -> Option<(
+    u64,
+    Result<crate::spotify_connect_repair::SpotifyConnectRepairReport, String>,
+)> {
+    let pending = match repair.as_mut() {
+        Some(pending) => pending,
+        None => return std::future::pending().await,
+    };
+    let request_id = pending.request_id;
+    let result = (&mut pending.task)
+        .await
+        .map_err(|error| format!("Spotify Connect repair worker failed: {error}"))
+        .and_then(|result| result);
+    Some((request_id, result))
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -785,6 +906,7 @@ async fn run_connection(
         &SourceMessage::Availability {
             enabled: source_enabled,
             error: availability_error.as_deref(),
+            capabilities: &[SPOTIFY_CONNECT_REPAIR_CAPABILITY],
         },
     )
     .await?;
@@ -795,6 +917,7 @@ async fn run_connection(
     shutdown_poll.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
     let mut active: Option<ActiveTakeover> = None;
+    let mut spotify_connect_repair: Option<SpotifyConnectRepairTask> = None;
     let mut generation_fence = GenerationFence::default();
     let mut disable_fallback_deadline = None;
     let mut shutdown_stop_deadline = None;
@@ -822,6 +945,17 @@ async fn run_connection(
 
                         match command {
                             ServerCommand::Start { generation } => {
+                                if control.spotify_connect_repair_active() || spotify_connect_repair.is_some() {
+                                    let error = "Jam start is blocked while Spotify Connect repair is active";
+                                    send_source_message(
+                                        &mut writer,
+                                        &SourceMessage::Error {
+                                            generation,
+                                            message: error,
+                                        },
+                                    ).await?;
+                                    continue;
+                                }
                                 if !source_enabled || !preferences_rx.borrow().takeover_enabled {
                                     let error = availability_error
                                         .as_deref()
@@ -958,6 +1092,69 @@ async fn run_connection(
                                     }
                                 }
                             }
+                            ServerCommand::SpotifyConnectRepair { request_id, action } => {
+                                let consent_enabled = preferences_rx.borrow().takeover_enabled;
+                                let route_journal_exists = control.route_journal_path().exists();
+                                let rejection = if !source_enabled || !consent_enabled {
+                                    Some("Spotify Connect repair is disabled on the Jam source PC")
+                                } else if active.is_some() || shutdown_stop_deadline.is_some() || shutdown.load(Ordering::SeqCst) {
+                                    Some("Spotify Connect repair is unavailable while a Jam source generation or shutdown is active")
+                                } else if route_journal_exists {
+                                    Some("Spotify Connect repair is blocked while an Echo Spotify route journal exists")
+                                } else if spotify_connect_repair.is_some() {
+                                    Some("A Spotify Connect repair is already running on the source PC")
+                                } else {
+                                    None
+                                };
+                                if let Some(error) = rejection {
+                                    send_source_message(
+                                        &mut writer,
+                                        &SourceMessage::SpotifyConnectRepair {
+                                            request_id,
+                                            success: false,
+                                            outcome: "busy",
+                                            was_running_before: false,
+                                            error: Some(error),
+                                        },
+                                    ).await?;
+                                    continue;
+                                }
+                                let repair_guard = match control.begin_spotify_connect_repair(action) {
+                                    Ok(guard) => guard,
+                                    Err(error) => {
+                                        send_source_message(
+                                            &mut writer,
+                                            &SourceMessage::SpotifyConnectRepair {
+                                                request_id,
+                                                success: false,
+                                                outcome: "busy",
+                                                was_running_before: false,
+                                                error: Some(&error),
+                                            },
+                                        ).await?;
+                                        continue;
+                                    }
+                                };
+                                let cancelled = Arc::new(AtomicBool::new(false));
+                                let task_cancelled = cancelled.clone();
+                                let task = tokio::task::spawn_blocking(move || {
+                                    let _repair_guard = repair_guard;
+                                    repair_spotify_connect(action, &task_cancelled)
+                                });
+                                spotify_connect_repair = Some(SpotifyConnectRepairTask {
+                                    request_id,
+                                    cancelled,
+                                    task,
+                                });
+                            }
+                            ServerCommand::SpotifyConnectRepairCancel { request_id } => {
+                                if let Some(repair) = spotify_connect_repair
+                                    .as_ref()
+                                    .filter(|repair| repair.request_id == request_id)
+                                {
+                                    repair.cancelled.store(true, Ordering::Release);
+                                }
+                            }
                         }
                     }
                     Some(Ok(Message::Ping(payload))) => {
@@ -968,11 +1165,76 @@ async fn run_connection(
                     Some(Err(error)) => return Err(error.into()),
                 }
             }
+            repair_result = next_spotify_connect_repair(&mut spotify_connect_repair) => {
+                let Some((request_id, result)) = repair_result else {
+                    continue;
+                };
+                spotify_connect_repair = None;
+                match result {
+                    Ok(report) => {
+                        let (next_enabled, next_error) = evaluate_local_availability(
+                            router,
+                            config,
+                            preferences_rx.borrow().takeover_enabled,
+                            control.preference_error(),
+                        );
+                        source_enabled = next_enabled;
+                        availability_error = next_error;
+                        control.set_last_error(availability_error.clone());
+                        send_source_message(
+                            &mut writer,
+                            &SourceMessage::Availability {
+                                enabled: source_enabled,
+                                error: availability_error.as_deref(),
+                                capabilities: &[SPOTIFY_CONNECT_REPAIR_CAPABILITY],
+                            },
+                        ).await?;
+                        let outcome = match report.outcome {
+                            SpotifyConnectRepairOutcome::Activated => "activated",
+                            SpotifyConnectRepairOutcome::Restarted => "restarted",
+                            SpotifyConnectRepairOutcome::NotRunning => "not_running",
+                        };
+                        log_jam_source(&format!(
+                            "[jam-source] Spotify Connect repair completed: {}",
+                            outcome
+                        ));
+                        send_source_message(
+                            &mut writer,
+                            &SourceMessage::SpotifyConnectRepair {
+                                request_id,
+                                success: true,
+                                outcome,
+                                was_running_before: report.was_running_before,
+                                error: None,
+                            },
+                        ).await?;
+                    }
+                    Err(error) => {
+                        control.set_last_error(Some(error.clone()));
+                        log_jam_source("[jam-source] Spotify Connect repair failed");
+                        send_source_message(
+                            &mut writer,
+                            &SourceMessage::SpotifyConnectRepair {
+                                request_id,
+                                success: false,
+                                outcome: "failed",
+                                was_running_before: false,
+                                error: Some(&error),
+                            },
+                        ).await?;
+                    }
+                }
+            }
             changed = preferences_rx.changed() => {
                 if changed.is_err() {
                     break;
                 }
                 let takeover_enabled = preferences_rx.borrow().takeover_enabled;
+                if !takeover_enabled {
+                    if let Some(repair) = spotify_connect_repair.as_ref() {
+                        repair.cancelled.store(true, Ordering::Release);
+                    }
+                }
                 if takeover_enabled {
                     disable_fallback_deadline = None;
                 }
@@ -998,6 +1260,7 @@ async fn run_connection(
                         &SourceMessage::Availability {
                             enabled: source_enabled,
                             error: availability_error.as_deref(),
+                            capabilities: &[SPOTIFY_CONNECT_REPAIR_CAPABILITY],
                         },
                     ).await?;
                 }
@@ -1110,6 +1373,7 @@ async fn run_connection(
                             &SourceMessage::Availability {
                                 enabled: source_enabled,
                                 error: availability_error.as_deref(),
+                                capabilities: &[SPOTIFY_CONNECT_REPAIR_CAPABILITY],
                             },
                         ).await?;
                     }
@@ -1123,6 +1387,9 @@ async fn run_connection(
             }
             _ = shutdown_poll.tick() => {
                 if shutdown.load(Ordering::SeqCst) && shutdown_stop_deadline.is_none() {
+                    if let Some(repair) = spotify_connect_repair.as_ref() {
+                        repair.cancelled.store(true, Ordering::Release);
+                    }
                     source_enabled = false;
                     availability_error = None;
                     disable_fallback_deadline = None;
@@ -1131,6 +1398,7 @@ async fn run_connection(
                         &SourceMessage::Availability {
                             enabled: false,
                             error: None,
+                            capabilities: &[SPOTIFY_CONNECT_REPAIR_CAPABILITY],
                         },
                     ).await?;
                     if let Some(generation) = active.as_ref().map(|takeover| takeover.generation) {
@@ -1177,6 +1445,17 @@ async fn run_connection(
         Ok(())
     }
     .await;
+
+    if let Some(repair) = spotify_connect_repair.take() {
+        repair.cancelled.store(true, Ordering::Release);
+        let mut task = repair.task;
+        if tokio::time::timeout(SPOTIFY_CONNECT_REPAIR_CLEANUP_TIMEOUT, &mut task)
+            .await
+            .is_err()
+        {
+            task.abort();
+        }
+    }
 
     // Close the socket before the release grace so the control plane observes
     // disconnect and has its full pause timeout before Spotify can be audible.
@@ -1328,22 +1607,31 @@ fn validate_store_spotify_root_pid(pid: u32) -> Result<(), String> {
     let process = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, pid) }
         .map(OwnedIdentityProcess)
         .map_err(|error| format!("Cannot inspect Spotify PID {}: {}", pid, error))?;
+    store_spotify_process_identity(pid, process.0).map(|_| ())
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct StoreSpotifyProcessIdentity {
+    pub(crate) package_family: String,
+    pub(crate) application_user_model_id: String,
+}
+
+pub(crate) fn store_spotify_process_identity(
+    pid: u32,
+    process: HANDLE,
+) -> Result<StoreSpotifyProcessIdentity, String> {
     let package_family = read_process_app_model_string(
-        |length, buffer| unsafe { GetPackageFamilyName(process.0, length, buffer) },
+        |length, buffer| unsafe { GetPackageFamilyName(process, length, buffer) },
         "GetPackageFamilyName",
     )?;
-    if !package_family
-        .get(..SPOTIFY_STORE_PACKAGE_PREFIX.len())
-        .map(|prefix| prefix.eq_ignore_ascii_case(SPOTIFY_STORE_PACKAGE_PREFIX))
-        .unwrap_or(false)
-    {
+    if !package_family.eq_ignore_ascii_case(SPOTIFY_STORE_PACKAGE_FAMILY) {
         return Err(format!(
             "Spotify PID {} is not the Microsoft Store Spotify app",
             pid
         ));
     }
     let application_user_model_id = read_process_app_model_string(
-        |length, buffer| unsafe { GetApplicationUserModelId(process.0, length, buffer) },
+        |length, buffer| unsafe { GetApplicationUserModelId(process, length, buffer) },
         "GetApplicationUserModelId",
     )?;
     let expected_aumid = format!("{}{}", package_family, SPOTIFY_STORE_APP_SUFFIX);
@@ -1353,7 +1641,10 @@ fn validate_store_spotify_root_pid(pid: u32) -> Result<(), String> {
             pid
         ));
     }
-    Ok(())
+    Ok(StoreSpotifyProcessIdentity {
+        package_family,
+        application_user_model_id,
+    })
 }
 
 fn read_process_app_model_string(
@@ -1758,6 +2049,49 @@ mod tests {
             parse_server_command(r#"{"type":"restart","generation":42}"#).unwrap(),
             ServerCommand::Restart { generation: 42 }
         );
+        assert_eq!(
+            parse_server_command(
+                r#"{"type":"spotify_connect_repair","request_id":7,"action":"activate"}"#
+            )
+            .unwrap(),
+            ServerCommand::SpotifyConnectRepair {
+                request_id: 7,
+                action: SpotifyConnectRepairAction::Activate,
+            }
+        );
+        assert_eq!(
+            parse_server_command(r#"{"type":"spotify_connect_repair_cancel","request_id":7}"#)
+                .unwrap(),
+            ServerCommand::SpotifyConnectRepairCancel { request_id: 7 }
+        );
+    }
+
+    #[test]
+    fn spotify_connect_restart_is_single_flight_and_cooled_down() {
+        let path = temporary_settings_path("spotify-connect-repair-state");
+        let control = JamSourceLocalControl::load(Some(&source_config()), path);
+
+        let guard = control
+            .begin_spotify_connect_repair(SpotifyConnectRepairAction::Restart)
+            .unwrap();
+        assert!(control.spotify_connect_repair_active());
+        let concurrent = control.begin_spotify_connect_repair(SpotifyConnectRepairAction::Activate);
+        assert!(concurrent
+            .err()
+            .expect("concurrent repair must fail")
+            .contains("already running"));
+        drop(guard);
+        assert!(!control.spotify_connect_repair_active());
+
+        let cooled_down = control.begin_spotify_connect_repair(SpotifyConnectRepairAction::Restart);
+        assert!(cooled_down
+            .err()
+            .expect("restart cooldown must fail")
+            .contains("cooling down"));
+        let activation = control
+            .begin_spotify_connect_repair(SpotifyConnectRepairAction::Activate)
+            .unwrap();
+        drop(activation);
     }
 
     #[test]

--- a/core/client/src/main.rs
+++ b/core/client/src/main.rs
@@ -7,6 +7,8 @@ mod audio_capture;
 mod audio_capture_stub;
 #[cfg(target_os = "windows")]
 mod jam_source;
+#[cfg(target_os = "windows")]
+mod spotify_connect_repair;
 #[cfg(not(target_os = "windows"))]
 use audio_capture_stub as audio_capture;
 

--- a/core/client/src/spotify_connect_repair.rs
+++ b/core/client/src/spotify_connect_repair.rs
@@ -1,0 +1,559 @@
+//! Bounded, on-demand Spotify Connect recovery for the provisioned Jam source.
+//!
+//! This module is Windows-only. It activates the registered Microsoft Store
+//! Spotify application identity and, only when explicitly requested after the
+//! server's registration poll fails, restarts Spotify processes in Echo's own
+//! interactive session. It never runs as a background watchdog.
+
+use crate::audio_capture::find_spotify_process_ids;
+use crate::jam_source::store_spotify_process_identity;
+use serde::Deserialize;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::{Duration, Instant};
+use windows::core::{HSTRING, PWSTR};
+use windows::Management::Deployment::PackageManager;
+use windows::Media::Control::{
+    GlobalSystemMediaTransportControlsSessionManager,
+    GlobalSystemMediaTransportControlsSessionPlaybackStatus,
+};
+use windows::Win32::Foundation::{CloseHandle, BOOL, HANDLE, LPARAM, WAIT_OBJECT_0, WPARAM};
+use windows::Win32::System::Com::{
+    CoCreateInstance, CoInitializeEx, CLSCTX_LOCAL_SERVER, COINIT_MULTITHREADED,
+};
+use windows::Win32::System::RemoteDesktop::ProcessIdToSessionId;
+use windows::Win32::System::Threading::{
+    OpenProcess, QueryFullProcessImageNameW, TerminateProcess, WaitForSingleObject,
+    PROCESS_NAME_WIN32, PROCESS_QUERY_LIMITED_INFORMATION, PROCESS_SYNCHRONIZE, PROCESS_TERMINATE,
+};
+use windows::Win32::System::WinRT::{RoInitialize, RO_INIT_MULTITHREADED};
+use windows::Win32::UI::Shell::{
+    ApplicationActivationManager, IApplicationActivationManager, AO_NOERRORUI,
+};
+use windows::Win32::UI::WindowsAndMessaging::{
+    EnumWindows, GetWindowThreadProcessId, PostMessageW, WM_CLOSE,
+};
+
+const SPOTIFY_STORE_PACKAGE_NAME: &str = "SpotifyAB.SpotifyMusic";
+const SPOTIFY_STORE_PACKAGE_FAMILY: &str = "SpotifyAB.SpotifyMusic_zpdnekdrzrea0";
+const SPOTIFY_STORE_APP_SUFFIX: &str = "!Spotify";
+const SPOTIFY_STORE_AUMID: &str = "SpotifyAB.SpotifyMusic_zpdnekdrzrea0!Spotify";
+const GRACEFUL_EXIT_TIMEOUT: Duration = Duration::from_secs(2);
+const FORCED_EXIT_TIMEOUT: Duration = Duration::from_secs(3);
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum SpotifyConnectRepairAction {
+    Activate,
+    Restart,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum SpotifyConnectRepairOutcome {
+    Activated,
+    Restarted,
+    NotRunning,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct SpotifyConnectRepairReport {
+    pub outcome: SpotifyConnectRepairOutcome,
+    pub was_running_before: bool,
+}
+
+pub(crate) fn repair_spotify_connect(
+    action: SpotifyConnectRepairAction,
+    cancelled: &AtomicBool,
+) -> Result<SpotifyConnectRepairReport, String> {
+    ensure_not_cancelled(cancelled)?;
+    repair_spotify_connect_with(
+        action,
+        find_exact_store_spotify_process_ids,
+        || activate_spotify_store_app(cancelled),
+        |pids| restart_spotify_processes(pids, cancelled),
+    )
+}
+
+fn repair_spotify_connect_with(
+    action: SpotifyConnectRepairAction,
+    list_processes: impl Fn() -> Result<Vec<u32>, String>,
+    activate: impl Fn() -> Result<(), String>,
+    restart_processes: impl Fn(&[u32]) -> Result<(), String>,
+) -> Result<SpotifyConnectRepairReport, String> {
+    match action {
+        SpotifyConnectRepairAction::Activate => {
+            let was_running = !list_processes()?.is_empty();
+            if !was_running {
+                return Ok(SpotifyConnectRepairReport {
+                    outcome: SpotifyConnectRepairOutcome::NotRunning,
+                    was_running_before: false,
+                });
+            }
+            activate().map_err(|error| {
+                format!(
+                    "Spotify app activation failed; Spotify may not be installed or its Windows app registration may be damaged: {error}"
+                )
+            })?;
+            Ok(SpotifyConnectRepairReport {
+                outcome: SpotifyConnectRepairOutcome::Activated,
+                was_running_before: was_running,
+            })
+        }
+        SpotifyConnectRepairAction::Restart => {
+            let pids = list_processes()?;
+            if pids.is_empty() {
+                return Ok(SpotifyConnectRepairReport {
+                    outcome: SpotifyConnectRepairOutcome::NotRunning,
+                    was_running_before: false,
+                });
+            }
+            restart_processes(&pids)?;
+            Ok(SpotifyConnectRepairReport {
+                outcome: SpotifyConnectRepairOutcome::Restarted,
+                was_running_before: true,
+            })
+        }
+    }
+}
+
+fn find_exact_store_spotify_process_ids() -> Result<Vec<u32>, String> {
+    let echo_session = process_session_id(std::process::id())?;
+    let mut exact = Vec::new();
+    for pid in find_spotify_process_ids()? {
+        let Ok(handle) = (unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, pid) })
+        else {
+            continue;
+        };
+        let process = OwnedProcess(handle);
+        if validate_spotify_process_for_restart(pid, &process, echo_session).is_ok() {
+            exact.push(pid);
+        }
+    }
+    exact.sort_unstable();
+    exact.dedup();
+    Ok(exact)
+}
+
+struct OwnedProcess(HANDLE);
+
+impl Drop for OwnedProcess {
+    fn drop(&mut self) {
+        unsafe {
+            let _ = CloseHandle(self.0);
+        }
+    }
+}
+
+fn restart_spotify_processes(pids: &[u32], cancelled: &AtomicBool) -> Result<(), String> {
+    ensure_not_cancelled(cancelled)?;
+    let echo_session = process_session_id(std::process::id())?;
+    let mut processes = Vec::with_capacity(pids.len());
+    for &pid in pids {
+        let handle = unsafe {
+            OpenProcess(
+                PROCESS_TERMINATE | PROCESS_SYNCHRONIZE | PROCESS_QUERY_LIMITED_INFORMATION,
+                false,
+                pid,
+            )
+        }
+        .map_err(|error| format!("Could not open Spotify PID {pid} for restart: {error}"))?;
+        let process = OwnedProcess(handle);
+        validate_spotify_process_for_restart(pid, &process, echo_session)?;
+        processes.push((pid, process));
+    }
+
+    ensure_not_cancelled(cancelled)?;
+    ensure_spotify_not_playing()?;
+    // This is the final cancellation boundary. Once the first WM_CLOSE may be
+    // posted, the operation is restorative: it must finish relaunching Spotify
+    // even if the server deadline, consent, or WebSocket changes mid-restart.
+    ensure_not_cancelled(cancelled)?;
+    let stop_result = (|| -> Result<(), String> {
+        request_graceful_spotify_close(pids)?;
+        if wait_for_processes(&processes, GRACEFUL_EXIT_TIMEOUT) {
+            return Ok(());
+        }
+
+        for (pid, process) in &processes {
+            if unsafe { WaitForSingleObject(process.0, 0) } == WAIT_OBJECT_0 {
+                continue;
+            }
+            // Revalidate the still-open process object immediately before the
+            // destructive fallback. Held handles fence PID reuse.
+            validate_spotify_process_for_restart(*pid, process, echo_session)?;
+            unsafe { TerminateProcess(process.0, 0) }
+                .map_err(|error| format!("Could not stop Spotify PID {pid}: {error}"))?;
+        }
+        if wait_for_processes(&processes, FORCED_EXIT_TIMEOUT) {
+            Ok(())
+        } else {
+            Err(format!(
+                "Spotify did not stop within {} seconds",
+                (GRACEFUL_EXIT_TIMEOUT + FORCED_EXIT_TIMEOUT).as_secs()
+            ))
+        }
+    })();
+    finish_restorative_restart(stop_result, activate_spotify_store_app_restorative)
+}
+
+fn ensure_spotify_not_playing() -> Result<(), String> {
+    let _ = unsafe { RoInitialize(RO_INIT_MULTITHREADED) };
+    let manager = GlobalSystemMediaTransportControlsSessionManager::RequestAsync()
+        .and_then(|operation| operation.get())
+        .map_err(|error| format!("Could not verify Spotify playback state: {error}"))?;
+    let sessions = manager
+        .GetSessions()
+        .map_err(|error| format!("Could not enumerate Windows media sessions: {error}"))?;
+    let count = sessions
+        .Size()
+        .map_err(|error| format!("Could not count Windows media sessions: {error}"))?;
+    for index in 0..count {
+        let session = sessions
+            .GetAt(index)
+            .map_err(|error| format!("Could not inspect a Windows media session: {error}"))?;
+        let source = session
+            .SourceAppUserModelId()
+            .map_err(|error| format!("Could not identify a Windows media session: {error}"))?
+            .to_string();
+        if !source.eq_ignore_ascii_case(SPOTIFY_STORE_AUMID) {
+            continue;
+        }
+        let status = session
+            .GetPlaybackInfo()
+            .and_then(|info| info.PlaybackStatus())
+            .map_err(|error| format!("Could not verify Spotify playback status: {error}"))?;
+        if status == GlobalSystemMediaTransportControlsSessionPlaybackStatus::Playing {
+            return Err(
+                "Spotify is currently playing; Echo did not interrupt it for Connect repair"
+                    .to_string(),
+            );
+        }
+    }
+    Ok(())
+}
+
+fn wait_for_processes(processes: &[(u32, OwnedProcess)], timeout: Duration) -> bool {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if processes
+            .iter()
+            .all(|(_, process)| unsafe { WaitForSingleObject(process.0, 0) } == WAIT_OBJECT_0)
+        {
+            return true;
+        }
+        if Instant::now() >= deadline {
+            return false;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+struct CloseWindowContext<'a> {
+    pids: &'a [u32],
+}
+
+unsafe extern "system" fn close_spotify_window(
+    hwnd: windows::Win32::Foundation::HWND,
+    lparam: LPARAM,
+) -> BOOL {
+    let context = &*(lparam.0 as *const CloseWindowContext<'_>);
+    let mut pid = 0_u32;
+    GetWindowThreadProcessId(hwnd, Some(&mut pid));
+    if context.pids.contains(&pid) {
+        let _ = PostMessageW(hwnd, WM_CLOSE, WPARAM(0), LPARAM(0));
+    }
+    BOOL(1)
+}
+
+fn request_graceful_spotify_close(pids: &[u32]) -> Result<(), String> {
+    let context = CloseWindowContext { pids };
+    unsafe {
+        EnumWindows(
+            Some(close_spotify_window),
+            LPARAM((&context as *const CloseWindowContext<'_>) as isize),
+        )
+    }
+    .map_err(|error| format!("Could not request a graceful Spotify restart: {error}"))
+}
+
+fn finish_restorative_restart(
+    stop_result: Result<(), String>,
+    activate: impl FnOnce() -> Result<(), String>,
+) -> Result<(), String> {
+    let activation_result = activate();
+    match (stop_result, activation_result) {
+        (Ok(()), Ok(())) => Ok(()),
+        (Err(stop_error), Ok(())) => Err(format!(
+            "Spotify restart did not stop cleanly, but restorative activation completed: {stop_error}"
+        )),
+        (Ok(()), Err(activation_error)) => Err(format!(
+            "Spotify stopped, but restorative activation failed: {activation_error}"
+        )),
+        (Err(stop_error), Err(activation_error)) => Err(format!(
+            "Spotify restart failed and restorative activation also failed: {stop_error}; {activation_error}"
+        )),
+    }
+}
+
+fn validate_spotify_process_for_restart(
+    pid: u32,
+    process: &OwnedProcess,
+    echo_session: u32,
+) -> Result<(), String> {
+    let mut buffer = vec![0_u16; 32_768];
+    let mut length = buffer.len() as u32;
+    unsafe {
+        QueryFullProcessImageNameW(
+            process.0,
+            PROCESS_NAME_WIN32,
+            PWSTR(buffer.as_mut_ptr()),
+            &mut length,
+        )
+    }
+    .map_err(|error| format!("Could not verify Spotify PID {pid} executable: {error}"))?;
+    let path = String::from_utf16_lossy(&buffer[..length as usize]);
+    let executable = path.rsplit(['\\', '/']).next().unwrap_or_default();
+    if !executable.eq_ignore_ascii_case("Spotify.exe") {
+        return Err(format!(
+            "Spotify restart was cancelled because PID {pid} now belongs to a different process"
+        ));
+    }
+    let session = process_session_id(pid)?;
+    if session != echo_session {
+        return Err(format!(
+            "Spotify restart was cancelled because PID {pid} is outside Echo's Windows session"
+        ));
+    }
+    store_spotify_process_identity(pid, process.0)?;
+    Ok(())
+}
+
+fn process_session_id(pid: u32) -> Result<u32, String> {
+    let mut session = 0_u32;
+    unsafe { ProcessIdToSessionId(pid, &mut session) }
+        .map_err(|error| format!("Could not determine Windows session for PID {pid}: {error}"))?;
+    Ok(session)
+}
+
+fn activate_spotify_store_app(cancelled: &AtomicBool) -> Result<(), String> {
+    ensure_not_cancelled(cancelled)?;
+    let result = activate_spotify_store_app_restorative();
+    ensure_not_cancelled(cancelled)?;
+    result
+}
+
+fn activate_spotify_store_app_restorative() -> Result<(), String> {
+    // Tokio workers may already be initialized with another COM apartment. A
+    // changed-mode result is harmless because CoCreateInstance can use that
+    // existing apartment; other initialization failures are surfaced below.
+    let _ = unsafe { CoInitializeEx(None, COINIT_MULTITHREADED) };
+    let _ = unsafe { RoInitialize(RO_INIT_MULTITHREADED) };
+    let application_user_model_id = installed_spotify_application_user_model_id()?;
+    let manager: IApplicationActivationManager =
+        unsafe { CoCreateInstance(&ApplicationActivationManager, None, CLSCTX_LOCAL_SERVER) }
+            .map_err(|error| format!("could not create the Windows activation manager: {error}"))?;
+    let pid = unsafe {
+        manager.ActivateApplication(
+            &HSTRING::from(&application_user_model_id),
+            &HSTRING::new(),
+            AO_NOERRORUI,
+        )
+    }
+    .map_err(|error| format!("Windows rejected Spotify app identity activation: {error}"))?;
+    validate_activated_spotify_process(pid, &application_user_model_id)
+}
+
+fn installed_spotify_application_user_model_id() -> Result<String, String> {
+    let manager = PackageManager::new()
+        .map_err(|error| format!("could not open the Windows package manager: {error}"))?;
+    let packages = manager
+        .FindPackagesByUserSecurityId(&HSTRING::new())
+        .map_err(|error| format!("could not enumerate installed Windows apps: {error}"))?;
+    let mut matches = Vec::new();
+    for package in packages {
+        let id = package
+            .Id()
+            .map_err(|error| format!("could not inspect a Windows app identity: {error}"))?;
+        let name = id
+            .Name()
+            .map_err(|error| format!("could not read a Windows app name: {error}"))?
+            .to_string();
+        if !name.eq_ignore_ascii_case(SPOTIFY_STORE_PACKAGE_NAME) {
+            continue;
+        }
+        let family = id
+            .FamilyName()
+            .map_err(|error| format!("could not read Spotify's package family: {error}"))?
+            .to_string();
+        if family.eq_ignore_ascii_case(SPOTIFY_STORE_PACKAGE_FAMILY) {
+            matches.push(format!("{family}{SPOTIFY_STORE_APP_SUFFIX}"));
+        }
+    }
+    matches.sort_unstable();
+    matches.dedup();
+    match matches.as_slice() {
+        [application_user_model_id] => Ok(application_user_model_id.clone()),
+        [] => Err("the Microsoft Store Spotify app is not installed for this Windows user".to_string()),
+        _ => Err("more than one Microsoft Store Spotify app identity is registered for this Windows user".to_string()),
+    }
+}
+
+fn validate_activated_spotify_process(
+    pid: u32,
+    expected_application_user_model_id: &str,
+) -> Result<(), String> {
+    if pid == 0 {
+        return Err("Windows activated Spotify without returning a process ID".to_string());
+    }
+    let handle = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, pid) }
+        .map(OwnedProcess)
+        .map_err(|error| format!("Could not inspect activated Spotify PID {pid}: {error}"))?;
+    validate_spotify_process_for_restart(pid, &handle, process_session_id(std::process::id())?)?;
+    let identity = store_spotify_process_identity(pid, handle.0)?;
+    if !identity
+        .application_user_model_id
+        .eq_ignore_ascii_case(expected_application_user_model_id)
+    {
+        return Err("Windows activated an unexpected Spotify application identity".to_string());
+    }
+    Ok(())
+}
+
+fn ensure_not_cancelled(cancelled: &AtomicBool) -> Result<(), String> {
+    if cancelled.load(Ordering::Acquire) {
+        Err("Spotify Connect repair was cancelled because the Jam source state changed".to_string())
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::Cell;
+
+    #[test]
+    fn activation_does_not_restart_an_already_running_spotify() {
+        let terminated = Cell::new(false);
+        let activated = Cell::new(false);
+        let report = repair_spotify_connect_with(
+            SpotifyConnectRepairAction::Activate,
+            || Ok(vec![101]),
+            || {
+                activated.set(true);
+                Ok(())
+            },
+            |_| {
+                terminated.set(true);
+                Ok(())
+            },
+        )
+        .unwrap();
+
+        assert_eq!(report.outcome, SpotifyConnectRepairOutcome::Activated);
+        assert!(report.was_running_before);
+        assert!(activated.get());
+        assert!(!terminated.get());
+    }
+
+    #[test]
+    fn activation_never_launches_a_closed_spotify() {
+        let activated = Cell::new(false);
+        let report = repair_spotify_connect_with(
+            SpotifyConnectRepairAction::Activate,
+            || Ok(Vec::new()),
+            || {
+                activated.set(true);
+                Ok(())
+            },
+            |_| panic!("nothing should be terminated"),
+        )
+        .unwrap();
+
+        assert_eq!(report.outcome, SpotifyConnectRepairOutcome::NotRunning);
+        assert!(!report.was_running_before);
+        assert!(!activated.get());
+    }
+
+    #[test]
+    fn restart_is_limited_to_the_exact_supplied_spotify_processes() {
+        let terminated = std::cell::RefCell::new(Vec::new());
+        let report = repair_spotify_connect_with(
+            SpotifyConnectRepairAction::Restart,
+            || Ok(vec![101, 102, 103]),
+            || Ok(()),
+            |pids| {
+                terminated.borrow_mut().extend_from_slice(pids);
+                Ok(())
+            },
+        )
+        .unwrap();
+
+        assert_eq!(report.outcome, SpotifyConnectRepairOutcome::Restarted);
+        assert_eq!(*terminated.borrow(), vec![101, 102, 103]);
+    }
+
+    #[test]
+    fn restart_refuses_to_launch_when_spotify_was_not_running() {
+        let activated = Cell::new(false);
+        let report = repair_spotify_connect_with(
+            SpotifyConnectRepairAction::Restart,
+            || Ok(Vec::new()),
+            || {
+                activated.set(true);
+                Ok(())
+            },
+            |_| panic!("nothing should be terminated"),
+        )
+        .unwrap();
+
+        assert_eq!(report.outcome, SpotifyConnectRepairOutcome::NotRunning);
+        assert!(!report.was_running_before);
+        assert!(!activated.get());
+    }
+
+    #[test]
+    fn missing_or_damaged_install_has_clear_activation_error() {
+        let error = repair_spotify_connect_with(
+            SpotifyConnectRepairAction::Activate,
+            || Ok(vec![101]),
+            || Err("application identity was not registered".to_string()),
+            |_| Ok(()),
+        )
+        .unwrap_err();
+
+        assert!(error.contains("may not be installed"));
+        assert!(error.contains("application identity was not registered"));
+    }
+
+    #[test]
+    fn pid_reuse_validation_failure_prevents_activation() {
+        let activated = Cell::new(false);
+        let error = repair_spotify_connect_with(
+            SpotifyConnectRepairAction::Restart,
+            || Ok(vec![101]),
+            || {
+                activated.set(true);
+                Ok(())
+            },
+            |_| Err("PID 101 now belongs to a different process".to_string()),
+        )
+        .unwrap_err();
+
+        assert!(error.contains("different process"));
+        assert!(!activated.get());
+    }
+
+    #[test]
+    fn cancellation_or_failure_after_first_close_still_runs_one_restorative_activation() {
+        let activated = Cell::new(0_u32);
+        let error =
+            finish_restorative_restart(Err("repair cancelled after WM_CLOSE".to_string()), || {
+                activated.set(activated.get() + 1);
+                Ok(())
+            })
+            .unwrap_err();
+
+        assert_eq!(activated.get(), 1);
+        assert!(error.contains("restorative activation completed"));
+    }
+}

--- a/core/control/src/jam_session.rs
+++ b/core/control/src/jam_session.rs
@@ -30,6 +30,9 @@ use tracing::{info, warn};
 const SPOTIFY_RELEASE_PAUSE_TIMEOUT: Duration = Duration::from_secs(15);
 const SPOTIFY_START_BIND_TIMEOUT: Duration = Duration::from_secs(15);
 const SPOTIFY_RECOVERY_OPERATION_TIMEOUT: Duration = Duration::from_secs(15);
+const SPOTIFY_CONNECT_REGISTRATION_POLL_INTERVAL: Duration = Duration::from_secs(1);
+const SPOTIFY_CONNECT_REGISTRATION_POLL_ATTEMPTS: usize = 4;
+const SPOTIFY_CONNECT_REPAIR_DEADLINE: Duration = Duration::from_secs(15);
 const SOURCE_START_RECHECK_INTERVAL: Duration = Duration::from_millis(100);
 const SPOTIFY_COMMITTED_QUEUE_FRONTIER: usize = 2;
 const MAX_QUEUE_REMOVAL_ENTRIES: usize = 1_000;
@@ -1124,26 +1127,39 @@ async fn refresh_spotify_token(state: &AppState, old: &SpotifyToken) -> Option<S
 struct SpotifyDevice {
     id: String,
     name: String,
+    is_restricted: bool,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum SpotifyDeviceResolveError {
+    Unavailable(String),
+    Other(StatusCode, String),
+}
+
+impl SpotifyDeviceResolveError {
+    fn into_response(self) -> (StatusCode, String) {
+        match self {
+            Self::Unavailable(message) => (StatusCode::SERVICE_UNAVAILABLE, message),
+            Self::Other(status, message) => (status, message),
+        }
+    }
 }
 
 fn select_spotify_device(
     candidates: Vec<SpotifyDevice>,
     configured_id: Option<&str>,
     configured_name: Option<&str>,
-) -> Result<SpotifyDevice, (StatusCode, String)> {
+) -> Result<SpotifyDevice, SpotifyDeviceResolveError> {
     if let Some(configured_id) = configured_id {
-        return candidates
-            .into_iter()
-            .find(|device| device.id == configured_id)
-            .ok_or_else(|| {
-                (
-                    StatusCode::SERVICE_UNAVAILABLE,
-                    format!(
-                        "Configured Spotify device ID '{}' is offline, restricted, or no longer valid",
-                        configured_id
-                    ),
-                )
-            });
+        if let Some(device) = candidates.iter().find(|device| device.id == configured_id) {
+            return ensure_spotify_device_usable(device.clone());
+        }
+        if configured_name.is_none() {
+            return Err(SpotifyDeviceResolveError::Unavailable(format!(
+                "Spotify Connect device ID '{}' is unavailable",
+                configured_id
+            )));
+        }
     }
 
     let configured_name = configured_name.unwrap_or_default();
@@ -1151,13 +1167,13 @@ fn select_spotify_device(
         .into_iter()
         .filter(|device| device.name.eq_ignore_ascii_case(configured_name));
     let first = matches.next().ok_or_else(|| {
-        (
-            StatusCode::SERVICE_UNAVAILABLE,
-            format!("Configured Spotify device '{}' is offline", configured_name),
-        )
+        SpotifyDeviceResolveError::Unavailable(format!(
+            "Spotify Connect device '{}' is unavailable",
+            configured_name
+        ))
     })?;
     if matches.next().is_some() {
-        return Err((
+        return Err(SpotifyDeviceResolveError::Other(
             StatusCode::CONFLICT,
             format!(
                 "More than one Spotify device is named '{}'; configure SPOTIFY_DEVICE_ID",
@@ -1165,14 +1181,49 @@ fn select_spotify_device(
             ),
         ));
     }
-    Ok(first)
+    ensure_spotify_device_usable(first)
+}
+
+fn ensure_spotify_device_usable(
+    device: SpotifyDevice,
+) -> Result<SpotifyDevice, SpotifyDeviceResolveError> {
+    if device.is_restricted {
+        return Err(SpotifyDeviceResolveError::Other(
+            StatusCode::SERVICE_UNAVAILABLE,
+            format!(
+                "Spotify Connect device '{}' is present but restricted; Echo did not restart Spotify",
+                device.name
+            ),
+        ));
+    }
+    Ok(device)
 }
 
 async fn resolve_spotify_device(state: &AppState) -> Result<SpotifyDevice, (StatusCode, String)> {
+    let deadline = tokio::time::Instant::now() + SPOTIFY_CONNECT_REPAIR_DEADLINE;
+    resolve_spotify_device_with_repair(
+        || async {
+            let source = state.jam_source.snapshot().await;
+            jam_source_start_preflight(&source)
+                .map_err(|(status, message)| SpotifyDeviceResolveError::Other(status, message))?;
+            resolve_spotify_device_once(state).await
+        },
+        |action| state.jam_source.repair_spotify_connect(action, deadline),
+        SPOTIFY_CONNECT_REGISTRATION_POLL_ATTEMPTS,
+        SPOTIFY_CONNECT_REGISTRATION_POLL_INTERVAL,
+        Some(deadline),
+    )
+    .await
+    .map_err(SpotifyDeviceResolveError::into_response)
+}
+
+async fn resolve_spotify_device_once(
+    state: &AppState,
+) -> Result<SpotifyDevice, SpotifyDeviceResolveError> {
     if state.config.spotify_device_id.is_none() && state.config.spotify_device_name.is_none() {
-        return Err((
+        return Err(SpotifyDeviceResolveError::Other(
             StatusCode::SERVICE_UNAVAILABLE,
-            "Spotify source device is not configured (set SPOTIFY_DEVICE_ID or SPOTIFY_DEVICE_NAME)"
+            "Spotify Connect device is not configured (set SPOTIFY_DEVICE_ID or SPOTIFY_DEVICE_NAME)"
                 .to_string(),
         ));
     }
@@ -1182,41 +1233,196 @@ async fn resolve_spotify_device(state: &AppState) -> Result<SpotifyDevice, (Stat
         "https://api.spotify.com/v1/me/player/devices",
         None,
     )
-    .await?;
+    .await
+    .map_err(|(status, message)| SpotifyDeviceResolveError::Other(status, message))?;
     if !response.status().is_success() {
-        return Err(spotify_response_error(response, "List Spotify devices").await);
+        let (status, message) = spotify_response_error(response, "List Spotify devices").await;
+        return Err(SpotifyDeviceResolveError::Other(status, message));
     }
     let data: serde_json::Value = response.json().await.map_err(|error| {
-        (
+        SpotifyDeviceResolveError::Other(
             StatusCode::BAD_GATEWAY,
             format!("Spotify devices response was invalid: {}", error),
         )
     })?;
-    let candidates = data["devices"]
-        .as_array()
-        .into_iter()
-        .flatten()
-        .filter_map(|device| {
-            let id = device["id"].as_str()?.trim();
-            let name = device["name"].as_str()?.trim();
-            if id.is_empty()
-                || name.is_empty()
-                || device["is_restricted"].as_bool().unwrap_or(false)
-            {
-                return None;
-            }
-            Some(SpotifyDevice {
-                id: id.to_string(),
-                name: name.to_string(),
-            })
-        })
-        .collect::<Vec<_>>();
+    let candidates = parse_spotify_devices(&data)?;
 
     select_spotify_device(
         candidates,
         state.config.spotify_device_id.as_deref(),
         state.config.spotify_device_name.as_deref(),
     )
+}
+
+fn parse_spotify_devices(
+    data: &serde_json::Value,
+) -> Result<Vec<SpotifyDevice>, SpotifyDeviceResolveError> {
+    let devices = data
+        .get("devices")
+        .and_then(serde_json::Value::as_array)
+        .ok_or_else(|| {
+            SpotifyDeviceResolveError::Other(
+                StatusCode::BAD_GATEWAY,
+                "Spotify devices response was invalid: 'devices' was not an array".to_string(),
+            )
+        })?;
+    let mut candidates = Vec::with_capacity(devices.len());
+    for device in devices {
+        let Some(id_value) = device.get("id") else {
+            return Err(SpotifyDeviceResolveError::Other(
+                StatusCode::BAD_GATEWAY,
+                "Spotify devices response contained an invalid device entry".to_string(),
+            ));
+        };
+        // Spotify documents DeviceObject.id as nullable. Such entries cannot
+        // be targeted and must not poison an otherwise valid configured match.
+        if id_value.is_null() {
+            continue;
+        }
+        let id = id_value.as_str().ok_or_else(|| {
+            SpotifyDeviceResolveError::Other(
+                StatusCode::BAD_GATEWAY,
+                "Spotify devices response contained a non-string device ID".to_string(),
+            )
+        })?;
+        let name = device
+            .get("name")
+            .and_then(serde_json::Value::as_str)
+            .ok_or_else(|| {
+                SpotifyDeviceResolveError::Other(
+                    StatusCode::BAD_GATEWAY,
+                    "Spotify devices response contained an invalid device name".to_string(),
+                )
+            })?;
+        let is_restricted = device
+            .get("is_restricted")
+            .and_then(serde_json::Value::as_bool)
+            .ok_or_else(|| {
+                SpotifyDeviceResolveError::Other(
+                    StatusCode::BAD_GATEWAY,
+                    "Spotify devices response contained an invalid restriction state".to_string(),
+                )
+            })?;
+        let id = id.trim();
+        let name = name.trim();
+        if id.is_empty() || name.is_empty() {
+            return Err(SpotifyDeviceResolveError::Other(
+                StatusCode::BAD_GATEWAY,
+                "Spotify devices response contained an empty device ID or name".to_string(),
+            ));
+        }
+        candidates.push(SpotifyDevice {
+            id: id.to_string(),
+            name: name.to_string(),
+            is_restricted,
+        });
+    }
+
+    Ok(candidates)
+}
+
+async fn resolve_spotify_device_with_repair<Resolve, ResolveFuture, Repair, RepairFuture>(
+    mut resolve: Resolve,
+    mut repair: Repair,
+    poll_attempts: usize,
+    poll_interval: Duration,
+    deadline: Option<tokio::time::Instant>,
+) -> Result<SpotifyDevice, SpotifyDeviceResolveError>
+where
+    Resolve: FnMut() -> ResolveFuture,
+    ResolveFuture: Future<Output = Result<SpotifyDevice, SpotifyDeviceResolveError>>,
+    Repair: FnMut(crate::jam_source::SpotifyConnectRepairAction) -> RepairFuture,
+    RepairFuture: Future<Output = Result<crate::jam_source::SpotifyConnectRepairResult, String>>,
+{
+    let unavailable = match await_spotify_deadline(deadline, resolve()).await? {
+        Ok(device) => return Ok(device),
+        Err(SpotifyDeviceResolveError::Unavailable(message)) => message,
+        Err(error) => return Err(error),
+    };
+
+    let activated = repair(crate::jam_source::SpotifyConnectRepairAction::Activate)
+        .await
+        .map_err(|error| {
+            SpotifyDeviceResolveError::Other(
+                StatusCode::SERVICE_UNAVAILABLE,
+                format!("{unavailable}. Echo could not activate Spotify on the source PC: {error}"),
+            )
+        })?;
+    if let Some(device) =
+        poll_spotify_connect_registration(&mut resolve, poll_attempts, poll_interval, deadline)
+            .await?
+    {
+        return Ok(device);
+    }
+
+    if activated.was_running_before {
+        repair(crate::jam_source::SpotifyConnectRepairAction::Restart)
+            .await
+            .map_err(|error| {
+                SpotifyDeviceResolveError::Other(
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    format!(
+                        "{unavailable}. Echo could not restart Spotify on the source PC: {error}"
+                    ),
+                )
+            })?;
+        if let Some(device) =
+            poll_spotify_connect_registration(&mut resolve, poll_attempts, poll_interval, deadline)
+                .await?
+        {
+            return Ok(device);
+        }
+    }
+
+    Err(SpotifyDeviceResolveError::Unavailable(format!(
+        "{unavailable} after Echo tried to re-register Spotify on the source PC"
+    )))
+}
+
+async fn poll_spotify_connect_registration<Resolve, ResolveFuture>(
+    resolve: &mut Resolve,
+    attempts: usize,
+    interval: Duration,
+    deadline: Option<tokio::time::Instant>,
+) -> Result<Option<SpotifyDevice>, SpotifyDeviceResolveError>
+where
+    Resolve: FnMut() -> ResolveFuture,
+    ResolveFuture: Future<Output = Result<SpotifyDevice, SpotifyDeviceResolveError>>,
+{
+    for attempt in 0..attempts {
+        match await_spotify_deadline(deadline, resolve()).await? {
+            Ok(device) => return Ok(Some(device)),
+            Err(SpotifyDeviceResolveError::Unavailable(_)) => {}
+            Err(error) => return Err(error),
+        }
+        if attempt + 1 < attempts && !interval.is_zero() {
+            await_spotify_deadline(deadline, tokio::time::sleep(interval)).await?;
+        }
+    }
+    Ok(None)
+}
+
+async fn await_spotify_deadline<T, F>(
+    deadline: Option<tokio::time::Instant>,
+    future: F,
+) -> Result<T, SpotifyDeviceResolveError>
+where
+    F: Future<Output = T>,
+{
+    match deadline {
+        Some(deadline) => tokio::time::timeout_at(deadline, future)
+            .await
+            .map_err(|_| {
+                SpotifyDeviceResolveError::Other(
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    format!(
+                        "Spotify Connect device recovery exceeded the {} second start deadline",
+                        SPOTIFY_CONNECT_REPAIR_DEADLINE.as_secs()
+                    ),
+                )
+            }),
+        None => Ok(future.await),
+    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -1377,6 +1583,7 @@ fn bound_spotify_device(jam: &JamState, generation: u64) -> Option<SpotifyDevice
     Some(SpotifyDevice {
         id: jam.spotify_device_id.clone()?,
         name: jam.spotify_device_name.clone().unwrap_or_default(),
+        is_restricted: false,
     })
 }
 
@@ -3274,6 +3481,7 @@ pub(crate) async fn jam_state(
         "source_last_frame_ms": source.last_frame_ms,
         "source_peak": source.peak,
         "source_ready": source.ready,
+        "spotify_connect_repair_supported": source.spotify_connect_repair_supported,
     })))
 }
 
@@ -5876,6 +6084,7 @@ mod tests {
         SpotifyDevice {
             id: id.to_string(),
             name: name.to_string(),
+            is_restricted: false,
         }
     }
 
@@ -5899,6 +6108,7 @@ mod tests {
             channels: None,
             last_frame_ms: None,
             peak: 0.0,
+            spotify_connect_repair_supported: false,
         }
     }
 
@@ -6183,6 +6393,17 @@ mod tests {
     }
 
     #[test]
+    fn rotated_spotify_device_id_uses_one_exact_name_match() {
+        let selected = select_spotify_device(
+            vec![spotify_device("new-id", "Echo PC")],
+            Some("stale-id"),
+            Some("Echo PC"),
+        )
+        .expect("unique configured name should repair a rotated device ID");
+        assert_eq!(selected.id, "new-id");
+    }
+
+    #[test]
     fn duplicate_exact_spotify_device_names_are_rejected() {
         let error = select_spotify_device(
             vec![
@@ -6193,7 +6414,232 @@ mod tests {
             Some("ECHO PC"),
         )
         .unwrap_err();
-        assert_eq!(error.0, StatusCode::CONFLICT);
+        assert_eq!(error.into_response().0, StatusCode::CONFLICT);
+    }
+
+    #[test]
+    fn configured_restricted_spotify_device_never_triggers_repair() {
+        let mut restricted = spotify_device("id-a", "Echo PC");
+        restricted.is_restricted = true;
+        let error =
+            select_spotify_device(vec![restricted], Some("id-a"), Some("Echo PC")).unwrap_err();
+        assert!(matches!(&error, SpotifyDeviceResolveError::Other(_, _)));
+        assert!(error.into_response().1.contains("restricted"));
+    }
+
+    #[test]
+    fn malformed_spotify_devices_schema_is_not_missing_device() {
+        for data in [
+            serde_json::json!({}),
+            serde_json::json!({"devices": {}}),
+            serde_json::json!({"devices": [{"id":"id-a","name":"Echo PC","is_restricted":"no"}]}),
+        ] {
+            let error = parse_spotify_devices(&data).unwrap_err();
+            assert_eq!(error.into_response().0, StatusCode::BAD_GATEWAY);
+        }
+    }
+
+    #[test]
+    fn documented_null_spotify_device_id_does_not_hide_valid_target() {
+        let devices = parse_spotify_devices(&serde_json::json!({
+            "devices": [
+                {"id": null, "name": "Untargetable", "is_restricted": false},
+                {"id": "id-a", "name": "Echo PC", "is_restricted": false}
+            ]
+        }))
+        .expect("nullable non-targetable neighbor is skipped");
+        let selected = select_spotify_device(devices, Some("id-a"), Some("Echo PC"))
+            .expect("valid configured target remains selectable");
+        assert_eq!(selected.id, "id-a");
+    }
+
+    fn spotify_connect_unavailable() -> SpotifyDeviceResolveError {
+        SpotifyDeviceResolveError::Unavailable(
+            "Spotify Connect device 'Echo PC' is unavailable".to_string(),
+        )
+    }
+
+    fn repair_result(was_running_before: bool) -> crate::jam_source::SpotifyConnectRepairResult {
+        crate::jam_source::SpotifyConnectRepairResult {
+            outcome: "ok".to_string(),
+            was_running_before,
+        }
+    }
+
+    #[tokio::test]
+    async fn healthy_spotify_connect_device_takes_no_repair_action() {
+        let actions = std::cell::RefCell::new(Vec::new());
+        let result = resolve_spotify_device_with_repair(
+            || std::future::ready(Ok(spotify_device("device-a", "Echo PC"))),
+            |action| {
+                actions.borrow_mut().push(action);
+                std::future::ready(Ok(repair_result(true)))
+            },
+            2,
+            Duration::ZERO,
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.id, "device-a");
+        assert!(actions.borrow().is_empty());
+    }
+
+    #[tokio::test]
+    async fn delayed_spotify_registration_recovers_without_restart() {
+        let resolutions = std::cell::RefCell::new(std::collections::VecDeque::from([
+            Err(spotify_connect_unavailable()),
+            Err(spotify_connect_unavailable()),
+            Ok(spotify_device("device-a", "Echo PC")),
+        ]));
+        let actions = std::cell::RefCell::new(Vec::new());
+        let result = resolve_spotify_device_with_repair(
+            || std::future::ready(resolutions.borrow_mut().pop_front().unwrap()),
+            |action| {
+                actions.borrow_mut().push(action);
+                std::future::ready(Ok(repair_result(true)))
+            },
+            3,
+            Duration::ZERO,
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.id, "device-a");
+        assert_eq!(
+            *actions.borrow(),
+            vec![crate::jam_source::SpotifyConnectRepairAction::Activate]
+        );
+    }
+
+    #[tokio::test]
+    async fn stale_running_spotify_restarts_only_after_activation_poll_expires() {
+        let resolutions = std::cell::RefCell::new(std::collections::VecDeque::from([
+            Err(spotify_connect_unavailable()),
+            Err(spotify_connect_unavailable()),
+            Err(spotify_connect_unavailable()),
+            Ok(spotify_device("device-a", "Echo PC")),
+        ]));
+        let actions = std::cell::RefCell::new(Vec::new());
+        let result = resolve_spotify_device_with_repair(
+            || std::future::ready(resolutions.borrow_mut().pop_front().unwrap()),
+            |action| {
+                actions.borrow_mut().push(action);
+                std::future::ready(Ok(repair_result(true)))
+            },
+            2,
+            Duration::ZERO,
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.id, "device-a");
+        assert_eq!(
+            *actions.borrow(),
+            vec![
+                crate::jam_source::SpotifyConnectRepairAction::Activate,
+                crate::jam_source::SpotifyConnectRepairAction::Restart,
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn freshly_activated_spotify_is_never_restarted_in_the_same_start() {
+        let actions = std::cell::RefCell::new(Vec::new());
+        let error = resolve_spotify_device_with_repair(
+            || std::future::ready(Err(spotify_connect_unavailable())),
+            |action| {
+                actions.borrow_mut().push(action);
+                std::future::ready(Ok(repair_result(false)))
+            },
+            1,
+            Duration::ZERO,
+            None,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(matches!(&error, SpotifyDeviceResolveError::Unavailable(_)));
+        assert_eq!(
+            *actions.borrow(),
+            vec![crate::jam_source::SpotifyConnectRepairAction::Activate]
+        );
+    }
+
+    #[tokio::test]
+    async fn non_missing_spotify_errors_never_request_local_repair() {
+        for status in [
+            StatusCode::UNAUTHORIZED,
+            StatusCode::FORBIDDEN,
+            StatusCode::TOO_MANY_REQUESTS,
+            StatusCode::BAD_GATEWAY,
+            StatusCode::INTERNAL_SERVER_ERROR,
+        ] {
+            let actions = std::cell::RefCell::new(Vec::new());
+            let error = resolve_spotify_device_with_repair(
+                || {
+                    std::future::ready(Err(SpotifyDeviceResolveError::Other(
+                        status,
+                        "upstream failure".to_string(),
+                    )))
+                },
+                |action| {
+                    actions.borrow_mut().push(action);
+                    std::future::ready(Ok(repair_result(true)))
+                },
+                1,
+                Duration::ZERO,
+                None,
+            )
+            .await
+            .unwrap_err();
+            assert_eq!(error.into_response().0, status);
+            assert!(actions.borrow().is_empty());
+        }
+    }
+
+    #[tokio::test]
+    async fn missing_spotify_install_has_connect_specific_failure_wording() {
+        let error = resolve_spotify_device_with_repair(
+            || std::future::ready(Err(spotify_connect_unavailable())),
+            |_| {
+                std::future::ready(Err(
+                    "Spotify may not be installed or its app registration is damaged".to_string(),
+                ))
+            },
+            1,
+            Duration::ZERO,
+            None,
+        )
+        .await
+        .unwrap_err()
+        .into_response();
+
+        assert_eq!(error.0, StatusCode::SERVICE_UNAVAILABLE);
+        assert!(error.1.contains("Spotify Connect device"));
+        assert!(error.1.contains("may not be installed"));
+        assert!(!error.1.contains("Echo Jam source is offline"));
+    }
+
+    #[tokio::test]
+    async fn exhausted_repair_never_reports_the_echo_source_offline() {
+        let error = resolve_spotify_device_with_repair(
+            || std::future::ready(Err(spotify_connect_unavailable())),
+            |_| std::future::ready(Ok(repair_result(false))),
+            1,
+            Duration::ZERO,
+            None,
+        )
+        .await
+        .unwrap_err()
+        .into_response();
+
+        assert!(error.1.contains("Spotify Connect device"));
+        assert!(error.1.contains("tried to re-register Spotify"));
+        assert!(!error.1.to_ascii_lowercase().contains("source is offline"));
     }
 
     #[test]

--- a/core/control/src/jam_source.rs
+++ b/core/control/src/jam_source.rs
@@ -22,6 +22,7 @@ const MAX_AUDIO_MESSAGE_BYTES: usize = 4 * 1024 * 1024;
 const SOURCE_ACTIVITY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
 const SOURCE_FRAME_STALL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(3);
 const CAPTURE_RESTART_DEBOUNCE: std::time::Duration = std::time::Duration::from_secs(15);
+const SPOTIFY_CONNECT_REPAIR_CAPABILITY: &str = "spotify_connect_repair_v1";
 
 #[derive(Clone, Debug)]
 pub(crate) enum SourceEvent {
@@ -59,6 +60,35 @@ pub(crate) enum SourceEvent {
         channels: u32,
         samples: Vec<f32>,
     },
+    SpotifyConnectRepair {
+        connection_id: u64,
+        request_id: u64,
+        success: bool,
+        outcome: String,
+        was_running_before: bool,
+        error: Option<String>,
+    },
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum SpotifyConnectRepairAction {
+    Activate,
+    Restart,
+}
+
+impl SpotifyConnectRepairAction {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Activate => "activate",
+            Self::Restart => "restart",
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct SpotifyConnectRepairResult {
+    pub(crate) outcome: String,
+    pub(crate) was_running_before: bool,
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -76,6 +106,7 @@ pub(crate) struct JamSourceSnapshot {
     pub(crate) channels: Option<u32>,
     pub(crate) last_frame_ms: Option<u64>,
     pub(crate) peak: f32,
+    pub(crate) spotify_connect_repair_supported: bool,
 }
 
 struct ConnectedSource {
@@ -83,10 +114,39 @@ struct ConnectedSource {
     command_tx: mpsc::UnboundedSender<Message>,
 }
 
+struct PendingRepairCancelGuard {
+    command_tx: mpsc::UnboundedSender<Message>,
+    request_id: u64,
+    armed: bool,
+}
+
+impl PendingRepairCancelGuard {
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for PendingRepairCancelGuard {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        let _ = self.command_tx.send(Message::Text(
+            serde_json::json!({
+                "type": "spotify_connect_repair_cancel",
+                "request_id": self.request_id,
+            })
+            .to_string(),
+        ));
+    }
+}
+
 struct SourceInner {
     connection: Option<ConnectedSource>,
     availability_known: bool,
     enabled: bool,
+    spotify_connect_repair_supported: bool,
+    pending_repair: Option<(u64, u64)>,
     desired_generation: Option<u64>,
     ready_generation: Option<u64>,
     format_generation: Option<u64>,
@@ -110,6 +170,8 @@ impl Default for SourceInner {
             connection: None,
             availability_known: false,
             enabled: false,
+            spotify_connect_repair_supported: false,
+            pending_repair: None,
             desired_generation: None,
             ready_generation: None,
             format_generation: None,
@@ -135,6 +197,7 @@ pub(crate) struct JamSourceRegistry {
     inner: Arc<Mutex<SourceInner>>,
     events: broadcast::Sender<SourceEvent>,
     next_connection_id: Arc<AtomicU64>,
+    next_repair_request_id: Arc<AtomicU64>,
 }
 
 impl JamSourceRegistry {
@@ -149,6 +212,7 @@ impl JamSourceRegistry {
             inner: Arc::new(Mutex::new(inner)),
             events,
             next_connection_id: Arc::new(AtomicU64::new(1)),
+            next_repair_request_id: Arc::new(AtomicU64::new(1)),
         }
     }
 
@@ -183,6 +247,9 @@ impl JamSourceRegistry {
         }
         if !inner.enabled {
             return Err("Jam source is disabled on the source PC".to_string());
+        }
+        if inner.pending_repair.is_some() {
+            return Err("Spotify Connect repair is still finishing on the source PC".to_string());
         }
         command_tx
             .send(Message::Text(message))
@@ -288,6 +355,119 @@ impl JamSourceRegistry {
         true
     }
 
+    /// Run one bounded, capability-negotiated repair on the source PC. Callers
+    /// serialize this through `jam_lifecycle`; the request ID additionally
+    /// fences delayed replies from earlier attempts or replaced connections.
+    pub(crate) async fn repair_spotify_connect(
+        &self,
+        action: SpotifyConnectRepairAction,
+        deadline: tokio::time::Instant,
+    ) -> Result<SpotifyConnectRepairResult, String> {
+        if deadline <= tokio::time::Instant::now() {
+            return Err("Spotify Connect repair start deadline expired".to_string());
+        }
+        let request_id = self.next_repair_request_id.fetch_add(1, Ordering::Relaxed);
+        let (connection_id, mut events, mut cancel_guard) = {
+            let mut inner = tokio::time::timeout_at(deadline, self.inner.lock())
+                .await
+                .map_err(|_| "Spotify Connect repair start deadline expired".to_string())?;
+            if inner
+                .last_activity_at
+                .map(|at| at.elapsed() > SOURCE_ACTIVITY_TIMEOUT)
+                .unwrap_or(true)
+            {
+                return Err("Echo Jam source heartbeat is stale".to_string());
+            }
+            if !inner.spotify_connect_repair_supported {
+                return Err(
+                    "The Echo Jam source desktop app does not support Spotify Connect repair; update it before retrying"
+                        .to_string(),
+                );
+            }
+            if inner.pending_repair.is_some() {
+                return Err("A Spotify Connect repair is already running".to_string());
+            }
+            let connection = inner
+                .connection
+                .as_ref()
+                .ok_or_else(|| "Echo Jam source is offline".to_string())?;
+            let connection_id = connection.connection_id;
+            let command_tx = connection.command_tx.clone();
+            // Subscribe while holding the same registry lock used by
+            // register/unregister. Their lifecycle events are published before
+            // that lock is released, so this receiver cannot consume a stale
+            // replacement event for the connection captured below.
+            let events = self.subscribe();
+            inner.pending_repair = Some((connection_id, request_id));
+            if command_tx
+                .send(Message::Text(
+                    serde_json::json!({
+                        "type": "spotify_connect_repair",
+                        "request_id": request_id,
+                        "action": action.as_str(),
+                    })
+                    .to_string(),
+                ))
+                .is_err()
+            {
+                inner.pending_repair = None;
+                return Err(
+                    "Echo Jam source disconnected during Spotify Connect repair".to_string()
+                );
+            }
+            let cancel_guard = PendingRepairCancelGuard {
+                command_tx,
+                request_id,
+                armed: true,
+            };
+            (connection_id, events, cancel_guard)
+        };
+
+        let reply = tokio::time::timeout_at(deadline, async {
+            loop {
+                match events.recv().await {
+                    Ok(SourceEvent::SpotifyConnectRepair {
+                        connection_id: reply_connection_id,
+                        request_id: reply_id,
+                        success,
+                        outcome,
+                        was_running_before,
+                        error,
+                    }) if reply_connection_id == connection_id && reply_id == request_id => {
+                        return if success {
+                            Ok(SpotifyConnectRepairResult {
+                                outcome,
+                                was_running_before,
+                            })
+                        } else {
+                            Err(error.unwrap_or_else(|| {
+                                "Spotify Connect repair failed on the source PC".to_string()
+                            }))
+                        };
+                    }
+                    Ok(SourceEvent::ConnectionReplaced { .. })
+                    | Ok(SourceEvent::Disconnected { .. }) => {
+                        return Err("Echo Jam source disconnected during Spotify Connect repair"
+                            .to_string());
+                    }
+                    Ok(_) => {}
+                    Err(broadcast::error::RecvError::Lagged(_)) => continue,
+                    Err(broadcast::error::RecvError::Closed) => {
+                        return Err("Echo Jam source repair channel closed".to_string())
+                    }
+                }
+            }
+        })
+        .await;
+        match reply {
+            Ok(reply) => {
+                cancel_guard.disarm();
+                reply
+            }
+            Err(_) => Err("Spotify Connect repair timed out on the source PC".to_string()),
+        }
+    }
+
     pub(crate) async fn snapshot(&self) -> JamSourceSnapshot {
         let inner = self.inner.lock().await;
         let activity_stale = inner.connection.is_some()
@@ -354,12 +534,13 @@ impl JamSourceRegistry {
             channels: inner.channels,
             last_frame_ms,
             peak: inner.peak,
+            spotify_connect_repair_supported: inner.spotify_connect_repair_supported,
         }
     }
 
     async fn register(&self, command_tx: mpsc::UnboundedSender<Message>) -> u64 {
         let connection_id = self.next_connection_id.fetch_add(1, Ordering::Relaxed);
-        let (old, replaced_generation) = {
+        {
             let mut inner = self.inner.lock().await;
             let old = inner.connection.replace(ConnectedSource {
                 connection_id,
@@ -371,6 +552,8 @@ impl JamSourceRegistry {
             }
             inner.availability_known = false;
             inner.enabled = false;
+            inner.spotify_connect_repair_supported = false;
+            inner.pending_repair = None;
             inner.status = if self.configured {
                 "negotiating".to_string()
             } else {
@@ -389,57 +572,54 @@ impl JamSourceRegistry {
             inner.restart_pending_generation = None;
             inner.last_restart = None;
             inner.peak = 0.0;
-            (old, replaced_generation)
-        };
-        let event = if let Some(old) = old {
-            let _ = old.command_tx.send(Message::Close(None));
-            SourceEvent::ConnectionReplaced {
-                generation: replaced_generation,
-            }
-        } else {
-            SourceEvent::Connected
-        };
-        let _ = self.events.send(event);
+            let event = if let Some(old) = old {
+                let _ = old.command_tx.send(Message::Close(None));
+                SourceEvent::ConnectionReplaced {
+                    generation: replaced_generation,
+                }
+            } else {
+                SourceEvent::Connected
+            };
+            // Publish before releasing the registry lock. A repair subscribes
+            // and captures its connection under this same lock, so it cannot
+            // mistake this event for a later connection's lifecycle.
+            let _ = self.events.send(event);
+        }
         connection_id
     }
 
     async fn unregister(&self, connection_id: u64) {
-        let (removed, generation) = {
-            let mut inner = self.inner.lock().await;
-            if inner
-                .connection
-                .as_ref()
-                .map(|connection| connection.connection_id)
-                == Some(connection_id)
-            {
-                let generation = inner.desired_generation;
-                inner.connection = None;
-                inner.desired_generation = None;
-                inner.availability_known = false;
-                inner.enabled = false;
-                inner.ready_generation = None;
-                inner.format_generation = None;
-                inner.sample_rate = None;
-                inner.channels = None;
-                inner.pid = None;
-                inner.ready_at = None;
-                inner.last_activity_at = None;
-                inner.last_frame_at = None;
-                inner.last_audible_at = None;
-                inner.restart_pending_generation = None;
-                inner.last_restart = None;
-                inner.peak = 0.0;
-                inner.status = if self.configured {
-                    "offline".to_string()
-                } else {
-                    "unconfigured".to_string()
-                };
-                (true, generation)
+        let mut inner = self.inner.lock().await;
+        if inner
+            .connection
+            .as_ref()
+            .map(|connection| connection.connection_id)
+            == Some(connection_id)
+        {
+            let generation = inner.desired_generation;
+            inner.connection = None;
+            inner.desired_generation = None;
+            inner.availability_known = false;
+            inner.enabled = false;
+            inner.spotify_connect_repair_supported = false;
+            inner.pending_repair = None;
+            inner.ready_generation = None;
+            inner.format_generation = None;
+            inner.sample_rate = None;
+            inner.channels = None;
+            inner.pid = None;
+            inner.ready_at = None;
+            inner.last_activity_at = None;
+            inner.last_frame_at = None;
+            inner.last_audible_at = None;
+            inner.restart_pending_generation = None;
+            inner.last_restart = None;
+            inner.peak = 0.0;
+            inner.status = if self.configured {
+                "offline".to_string()
             } else {
-                (false, None)
-            }
-        };
-        if removed {
+                "unconfigured".to_string()
+            };
             let _ = self.events.send(SourceEvent::Disconnected { generation });
         }
     }
@@ -498,6 +678,8 @@ enum SourceTextMessage {
     Availability {
         enabled: bool,
         error: Option<String>,
+        #[serde(default)]
+        capabilities: Vec<String>,
     },
     Format {
         generation: u64,
@@ -517,6 +699,14 @@ enum SourceTextMessage {
     },
     Restarting {
         generation: u64,
+    },
+    #[serde(rename = "spotify_connect_repair")]
+    SpotifyConnectRepair {
+        request_id: u64,
+        success: bool,
+        outcome: String,
+        was_running_before: bool,
+        error: Option<String>,
     },
 }
 
@@ -601,10 +791,17 @@ async fn handle_text(registry: &JamSourceRegistry, connection_id: u64, text: &st
         return;
     }
     match message {
-        SourceTextMessage::Availability { enabled, error } => {
+        SourceTextMessage::Availability {
+            enabled,
+            error,
+            capabilities,
+        } => {
             inner.last_activity_at = Some(Instant::now());
             inner.availability_known = true;
             inner.enabled = enabled;
+            inner.spotify_connect_repair_supported = capabilities
+                .iter()
+                .any(|capability| capability == SPOTIFY_CONNECT_REPAIR_CAPABILITY);
             let error = error
                 .map(|message| message.chars().take(500).collect::<String>())
                 .filter(|message| !message.trim().is_empty());
@@ -754,6 +951,31 @@ async fn handle_text(registry: &JamSourceRegistry, connection_id: u64, text: &st
             inner.peak = 0.0;
             let _ = registry.events.send(SourceEvent::Restarting { generation });
         }
+        SourceTextMessage::SpotifyConnectRepair {
+            request_id,
+            success,
+            outcome,
+            was_running_before,
+            error,
+        } => {
+            if inner.pending_repair != Some((connection_id, request_id)) {
+                return;
+            }
+            inner.pending_repair = None;
+            inner.last_activity_at = Some(Instant::now());
+            let outcome = outcome.chars().take(100).collect::<String>();
+            let error = error
+                .map(|message| message.chars().take(500).collect::<String>())
+                .filter(|message| !message.trim().is_empty());
+            let _ = registry.events.send(SourceEvent::SpotifyConnectRepair {
+                connection_id,
+                request_id,
+                success,
+                outcome,
+                was_running_before,
+                error,
+            });
+        }
     }
 }
 
@@ -842,11 +1064,250 @@ mod tests {
         .await;
     }
 
+    async fn arm_with_spotify_connect_repair(registry: &JamSourceRegistry, connection_id: u64) {
+        handle_text(
+            registry,
+            connection_id,
+            r#"{"type":"availability","enabled":true,"capabilities":["spotify_connect_repair_v1"]}"#,
+        )
+        .await;
+    }
+
     #[test]
     fn source_token_comparison_requires_exact_match() {
         assert!(constant_time_eq(b"source-secret", b"source-secret"));
         assert!(!constant_time_eq(b"source-secret", b"source-secreu"));
         assert!(!constant_time_eq(b"short", b"longer"));
+    }
+
+    #[tokio::test]
+    async fn spotify_connect_repair_is_capability_gated() {
+        let registry = JamSourceRegistry::new(true);
+        let (command_tx, mut command_rx) = mpsc::unbounded_channel();
+        let connection_id = registry.register(command_tx).await;
+        arm(&registry, connection_id).await;
+
+        assert!(!registry.snapshot().await.spotify_connect_repair_supported);
+        let error = registry
+            .repair_spotify_connect(
+                SpotifyConnectRepairAction::Activate,
+                tokio::time::Instant::now() + std::time::Duration::from_secs(5),
+            )
+            .await
+            .unwrap_err();
+        assert!(error.contains("does not support Spotify Connect repair"));
+        assert!(command_rx.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn spotify_connect_repair_is_single_flight_and_connection_fenced() {
+        let registry = JamSourceRegistry::new(true);
+        let (command_tx, mut command_rx) = mpsc::unbounded_channel();
+        let connection_id = registry.register(command_tx).await;
+        arm_with_spotify_connect_repair(&registry, connection_id).await;
+        assert!(registry.snapshot().await.spotify_connect_repair_supported);
+
+        let first_registry = registry.clone();
+        let first = tokio::spawn(async move {
+            first_registry
+                .repair_spotify_connect(
+                    SpotifyConnectRepairAction::Activate,
+                    tokio::time::Instant::now() + std::time::Duration::from_secs(5),
+                )
+                .await
+        });
+        let Message::Text(command) = command_rx.recv().await.expect("repair command") else {
+            panic!("expected repair text command");
+        };
+        let command: serde_json::Value = serde_json::from_str(&command).unwrap();
+        let request_id = command["request_id"].as_u64().unwrap();
+        assert_eq!(command["action"], "activate");
+
+        let duplicate = registry
+            .repair_spotify_connect(
+                SpotifyConnectRepairAction::Restart,
+                tokio::time::Instant::now() + std::time::Duration::from_secs(5),
+            )
+            .await
+            .unwrap_err();
+        assert_eq!(duplicate, "A Spotify Connect repair is already running");
+
+        handle_text(
+            &registry,
+            connection_id,
+            &serde_json::json!({
+                "type": "spotify_connect_repair",
+                "request_id": request_id,
+                "success": true,
+                "outcome": "activated",
+                "was_running_before": true,
+            })
+            .to_string(),
+        )
+        .await;
+        let result = first.await.unwrap().unwrap();
+        assert_eq!(result.outcome, "activated");
+        assert!(result.was_running_before);
+        assert!(registry.inner.lock().await.pending_repair.is_none());
+    }
+
+    #[tokio::test]
+    async fn replacing_source_connection_cancels_and_clears_pending_repair() {
+        let registry = JamSourceRegistry::new(true);
+        let (command_tx, mut command_rx) = mpsc::unbounded_channel();
+        let connection_id = registry.register(command_tx).await;
+        arm_with_spotify_connect_repair(&registry, connection_id).await;
+
+        let repair_registry = registry.clone();
+        let repair = tokio::spawn(async move {
+            repair_registry
+                .repair_spotify_connect(
+                    SpotifyConnectRepairAction::Activate,
+                    tokio::time::Instant::now() + std::time::Duration::from_secs(5),
+                )
+                .await
+        });
+        command_rx.recv().await.expect("repair command");
+        let (replacement_tx, _replacement_rx) = mpsc::unbounded_channel();
+        registry.register(replacement_tx).await;
+
+        let error = repair.await.unwrap().unwrap_err();
+        assert!(error.contains("disconnected during Spotify Connect repair"));
+        let inner = registry.inner.lock().await;
+        assert!(inner.pending_repair.is_none());
+        assert!(!inner.spotify_connect_repair_supported);
+    }
+
+    #[tokio::test]
+    async fn repair_deadline_cancels_exact_worker_and_blocks_start_until_reply() {
+        let registry = JamSourceRegistry::new(true);
+        let (command_tx, mut command_rx) = mpsc::unbounded_channel();
+        let connection_id = registry.register(command_tx).await;
+        arm_with_spotify_connect_repair(&registry, connection_id).await;
+
+        let repair_registry = registry.clone();
+        let repair = tokio::spawn(async move {
+            repair_registry
+                .repair_spotify_connect(
+                    SpotifyConnectRepairAction::Restart,
+                    tokio::time::Instant::now() + std::time::Duration::from_millis(25),
+                )
+                .await
+        });
+        let Message::Text(command) = command_rx.recv().await.expect("repair command") else {
+            panic!("expected repair command");
+        };
+        let command: serde_json::Value = serde_json::from_str(&command).unwrap();
+        let request_id = command["request_id"].as_u64().unwrap();
+
+        let error = repair.await.unwrap().unwrap_err();
+        assert!(error.contains("timed out"));
+        let Message::Text(cancel) = command_rx.recv().await.expect("cancel command") else {
+            panic!("expected cancel command");
+        };
+        let cancel: serde_json::Value = serde_json::from_str(&cancel).unwrap();
+        assert_eq!(cancel["type"], "spotify_connect_repair_cancel");
+        assert_eq!(cancel["request_id"], request_id);
+        assert_eq!(
+            registry.start(9).await.unwrap_err(),
+            "Spotify Connect repair is still finishing on the source PC"
+        );
+
+        handle_text(
+            &registry,
+            connection_id,
+            &serde_json::json!({
+                "type": "spotify_connect_repair",
+                "request_id": request_id,
+                "success": false,
+                "outcome": "cancelled",
+                "was_running_before": true,
+                "error": "cancelled",
+            })
+            .to_string(),
+        )
+        .await;
+        assert!(registry.inner.lock().await.pending_repair.is_none());
+        registry
+            .start(9)
+            .await
+            .expect("start after cancellation reply");
+    }
+
+    #[tokio::test]
+    async fn dropped_repair_future_cancels_exact_worker_without_releasing_start_fence() {
+        let registry = JamSourceRegistry::new(true);
+        let (command_tx, mut command_rx) = mpsc::unbounded_channel();
+        let connection_id = registry.register(command_tx).await;
+        arm_with_spotify_connect_repair(&registry, connection_id).await;
+
+        let repair_registry = registry.clone();
+        let repair = tokio::spawn(async move {
+            repair_registry
+                .repair_spotify_connect(
+                    SpotifyConnectRepairAction::Restart,
+                    tokio::time::Instant::now() + std::time::Duration::from_secs(30),
+                )
+                .await
+        });
+        let Message::Text(command) = command_rx.recv().await.expect("repair command") else {
+            panic!("expected repair command");
+        };
+        let command: serde_json::Value = serde_json::from_str(&command).unwrap();
+        let request_id = command["request_id"].as_u64().unwrap();
+
+        repair.abort();
+        assert!(repair.await.unwrap_err().is_cancelled());
+        let Message::Text(cancel) = command_rx.recv().await.expect("drop cancel command") else {
+            panic!("expected cancel command");
+        };
+        let cancel: serde_json::Value = serde_json::from_str(&cancel).unwrap();
+        assert_eq!(cancel["request_id"], request_id);
+        assert_eq!(
+            registry.start(10).await.unwrap_err(),
+            "Spotify Connect repair is still finishing on the source PC"
+        );
+
+        handle_text(
+            &registry,
+            connection_id,
+            &serde_json::json!({
+                "type": "spotify_connect_repair",
+                "request_id": request_id,
+                "success": false,
+                "outcome": "cancelled",
+                "was_running_before": true,
+                "error": "cancelled",
+            })
+            .to_string(),
+        )
+        .await;
+        registry
+            .start(10)
+            .await
+            .expect("reply releases start fence");
+    }
+
+    #[tokio::test]
+    async fn repair_never_sends_after_deadline_while_registry_lock_is_contended() {
+        let registry = JamSourceRegistry::new(true);
+        let (command_tx, mut command_rx) = mpsc::unbounded_channel();
+        let connection_id = registry.register(command_tx).await;
+        arm_with_spotify_connect_repair(&registry, connection_id).await;
+
+        let held = registry.inner.lock().await;
+        let error = registry
+            .repair_spotify_connect(
+                SpotifyConnectRepairAction::Activate,
+                tokio::time::Instant::now() + std::time::Duration::from_millis(20),
+            )
+            .await
+            .unwrap_err();
+        drop(held);
+
+        assert!(error.contains("deadline expired"));
+        assert!(command_rx.try_recv().is_err());
+        assert!(registry.inner.lock().await.pending_repair.is_none());
     }
 
     #[tokio::test]

--- a/core/viewer/jam-session-state.js
+++ b/core/viewer/jam-session-state.js
@@ -169,6 +169,7 @@
       sourceStatus !== "negotiating" && !sourceUnavailable &&
       (input.source_ready === true || ["ready", "live", "silent", "stalled"].includes(sourceStatus));
     const active = input.active === true;
+    const starting = input.starting === true;
     const spotifyConnected = input.spotify_connected === true;
     const spotifyIsPlaying = input.spotify_is_playing === true;
     const playbackStopSupported = input.playback_stop_supported === true;
@@ -230,6 +231,7 @@
       compatible,
       compatibilityMessage,
       active,
+      starting,
       spotifyConnected,
       spotifyIsPlaying,
       playbackStopSupported,
@@ -245,7 +247,7 @@
       sourceError,
       sourceLastFrameMs: numberOrNull(input.source_last_frame_ms),
       sourcePeak: numberOrNull(input.source_peak),
-      canStart: compatible && !active && spotifyConnected && sourceReady,
+      canStart: compatible && !active && !starting && spotifyConnected && sourceReady,
       // New listeners fail closed on stalled PCM. Queue/skip intentionally stay
       // available against the current source so they can recover Spotify playback.
       canJoin: compatible && active && sourceReady,

--- a/core/viewer/jam-session-state.test.js
+++ b/core/viewer/jam-session-state.test.js
@@ -159,6 +159,21 @@ test("ready, live, and silent sources are capture-ready for a new Jam", () => {
   }).sourceMessage, "Host source audio is live");
 });
 
+test("Start Jam is disabled while the server is already starting one", () => {
+  const contract = evaluateJamContract({
+    jam_protocol_version: 3,
+    source_enabled: true,
+    source_availability_known: true,
+    spotify_connected: true,
+    active: false,
+    starting: true,
+    source_status: "ready",
+  });
+
+  assert.equal(contract.starting, true);
+  assert.equal(contract.canStart, false);
+});
+
 test("Start Jam fails closed until source availability is known and enabled", () => {
   const base = {
     jam_protocol_version: 3,

--- a/core/viewer/jam.js
+++ b/core/viewer/jam.js
@@ -31,6 +31,7 @@ var _jamIsSourceHost = null;
 var _jamSourceLocalControl = null;
 var _jamSourceLocalControlPromise = null;
 var _jamSourceLocalControlPending = false;
+var _jamStartPending = false;
 var _jamSourceLocalControlLegacy = false;
 var _jamSourceLocalControlsBound = false;
 var _jamSourceLocalPollTimer = null;
@@ -460,6 +461,7 @@ function jamActionAllowed(action) {
   }
   if (action === "configure") return contract.canConfigure !== false;
   if (action === "start") {
+    if (_jamStartPending) return false;
     if (!contract.canStart) {
       showJamError(contract.spotifyConnected ? contract.sourceMessage : "Connect Spotify before starting a Jam");
       return false;
@@ -514,7 +516,7 @@ function applyJamContractToControls() {
   if (connectBtn) connectBtn.disabled = !contract.compatible;
   if (libraryRefreshBtn) libraryRefreshBtn.disabled = _jamImportPending || !contract.compatible;
   if (startBtn) {
-    startBtn.disabled = !contract.canStart;
+    startBtn.disabled = _jamStartPending || !contract.canStart;
     startBtn.title = contract.canStart
       ? "Start Jam"
       : !contract.compatible
@@ -917,8 +919,11 @@ async function connectSpotify() {
 // ──────────────────────────────────────────
 
 async function startJam() {
+  if (_jamStartPending) return;
   try {
     if (!jamActionAllowed("start")) return;
+    _jamStartPending = true;
+    applyJamContractToControls();
     await detectJamSourceHost();
     var identity = room && room.localParticipant ? room.localParticipant.identity : "";
     debugLog("[jam] startJam requested");
@@ -965,6 +970,9 @@ async function startJam() {
   } catch (e) {
     showJamError("Start jam error: " + e.message);
     debugLog("[jam] startJam error: " + e);
+  } finally {
+    _jamStartPending = false;
+    applyJamContractToControls();
   }
 }
 
@@ -3165,7 +3173,7 @@ function renderJamPanel() {
   var skipBtn = document.getElementById("jam-skip-btn");
   if (startBtn) {
     startBtn.style.display = _jamState.active ? "none" : "";
-    startBtn.disabled = !contract.canStart;
+    startBtn.disabled = _jamStartPending || !contract.canStart;
   }
   if (stopBtn) {
     stopBtn.style.display = _jamState.active && contract.playbackStopSupported ? "" : "none";

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -169,6 +169,27 @@ should report protocol 3, `source_availability_known: true`,
 Once the Jam is active, source status should be `ready` while Spotify is paused
 or warming up and `live` while audible playback is flowing.
 
+Start Jam also performs bounded Spotify Connect recovery. When the configured
+Connect device is absent but the Echo Jam source is armed and healthy, Echo
+re-activates the already-running Microsoft Store Spotify identity and polls for
+registration. If the exact Store app remains stale, idle, and unregistered, the
+source client may restart it once and poll again. The entire repair shares the
+15-second Jam-start deadline. There is no permanent watchdog, and this path
+never restarts Echo or a shared service. A healthy device takes no recovery
+action. A closed Spotify app still requires the operator to open it and arm Jam
+sharing. Operational errors must say
+**Spotify Connect device** when Spotify registration is missing; **Echo Jam
+source is offline** is reserved for a failed source WebSocket/heartbeat.
+
+Install the Windows source desktop binary before the server/viewer rollout. The
+old server ignores the optional capability; a new server detects an older
+source and fails repair with an update-required message. Verify authenticated
+`/api/jam/state` reports `spotify_connect_repair_supported: true`. Recovery is
+single-flight, refuses active local Spotify playback, and has a one-minute
+source-side restart cooldown that survives source WebSocket reconnects. If it
+still fails, confirm the Store Spotify app is open and signed into the same
+Premium account before restarting anything manually.
+
 Echo exposes one global shared Jam at a time. Any authenticated Echo user can
 start it, join it, search, add songs, skip, and use **Stop Music** from Echo's Jam panel. Those users
 do not need Spotify accounts and should add their songs through Echo, not through
@@ -309,6 +330,10 @@ sides are updated, an authenticated `/api/jam/state` response must report
 `live` while audible playback is expected before declaring the full Jam audio
 path operational. `silent` is a short playback/capture warmup state; `stalled`
 means Echo expected audible playback but did not receive it.
+
+The Spotify Connect self-recovery capability is also release impact **both**:
+deploy the control executable/viewer snapshot and update the configured Windows
+source desktop. Ordinary listener desktop binaries are unaffected.
 
 ## Default local URLs
 


### PR DESCRIPTION
## Summary
- self-heal an already-running Microsoft Store Spotify source when its Connect registration goes stale
- accept a rotated Spotify device ID only through one unique configured-name match
- serialize and fence repair by connection/request, disable duplicate Jam starts, and share one 15-second start deadline
- refuse repair for active playback, restricted devices, malformed/upstream errors, wrong Store identity/session, active Jam routing, or missing client capability

## Safety
- one explicit Start-triggered repair only; no background watchdog
- exact Store PFN/AUMID and held process handles; 60-second source-side restart cooldown
- cancellation is honored before the first destructive close; once closing begins, restorative Spotify activation always completes
- client-first rollout: install the source desktop binary before deploying control/viewer

## Verification
- `cargo test --quiet` (client): 121 passed, 2 ignored
- `cargo test` (control): 253 passed
- `npm run verify:quick`: guardrails + 323 viewer tests passed
- rustfmt check and `git diff --check` passed
- independent control and full safety reviews: GO

## Release impact
Both: Windows source desktop binary first, then control + complete viewer snapshot. Ordinary listener binaries are unaffected.