### PR TITLE
Prepare Echo Chamber 0.6.35 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.6.35
+
+- Mobile: Android Firefox presentation recovery now loads only on that exact browser target and can recover a stalled screen sink without changing shared desktop stage, ultrawide, fullscreen, or Jam behavior.
+- Jam: A provisioned Windows Spotify source can safely repair a stale Spotify Connect registration for the already-running Microsoft Store app, including a rotated device ID matched by the uniquely configured device name.
+- Safety: Spotify repair is capability-negotiated, connection-fenced, deadline-bounded, blocked during playback or active capture, and never runs for authentication, rate-limit, upstream, restricted-device, or malformed-response failures.
+- Reliability: Jam Start remains single-flight while source repair is pending, and old desktop source clients fail closed with an actionable update requirement.
+- Release: Desktop and control package versions are aligned at 0.6.35.
+
 ## 0.6.34
 
 - Jam Library: Search Spotify tracks and playlists, save them as shared Echo Favorites, and filter or sort the library by the people who contributed each item.

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -1304,7 +1304,7 @@ dependencies = [
 
 [[package]]
 name = "echo-core-client"
-version = "0.6.34"
+version = "0.6.35"
 dependencies = [
  "base64 0.22.1",
  "futures-util",
@@ -1326,7 +1326,7 @@ dependencies = [
 
 [[package]]
 name = "echo-core-control"
-version = "0.6.34"
+version = "0.6.35"
 dependencies = [
  "argon2",
  "axum",

--- a/core/client/Cargo.toml
+++ b/core/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "echo-core-client"
-version = "0.6.34"
+version = "0.6.35"
 edition = "2021"
 description = "Echo Chamber native desktop client"
 

--- a/core/client/tauri.conf.json
+++ b/core/client/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "Echo Chamber",
-  "version": "0.6.34",
+  "version": "0.6.35",
   "identifier": "com.echochamber.app",
   "build": {
     "frontendDist": "../viewer"

--- a/core/control/Cargo.toml
+++ b/core/control/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "echo-core-control"
-version = "0.6.34"
+version = "0.6.35"
 edition = "2021"
 
 [dependencies]

--- a/core/viewer/changelog.js
+++ b/core/viewer/changelog.js
@@ -8,6 +8,15 @@
 
 var ECHO_CHANGELOG = [
   {
+    version: "v0.6.35",
+    title: "Safer Mobile Screens & Jam Recovery",
+    notes: [
+      "Android Firefox can recover a stalled shared-screen presentation without changing the desktop stage or ultrawide layout.",
+      "The Spotify source can repair a stale Connect registration for the already-running Store app without requiring a manual source re-registration.",
+      "Jam recovery stays single-flight and refuses to interrupt active Spotify playback or run on upstream and authentication failures."
+    ]
+  },
+  {
     version: "v0.6.34",
     title: "Shared Jam Library & History",
     notes: [


### PR DESCRIPTION
## What changed
- bump Echo Desktop, control, Tauri, and lockfile package versions to 0.6.35
- add 0.6.35 release notes for isolated Android Firefox presentation recovery and Spotify Connect self-healing
- add the matching viewer changelog entry

## Why
The merged Jam repair requires a new Windows source-client binary before the matching control/viewer rollout. The currently installed source already reports 0.6.34, so a distinct 0.6.35 release is required for unambiguous installation and updater behavior.

## Release impact
- Both: Windows desktop binary plus matching control/viewer deployment
- Windows-only; no macOS build or release
- Required order: publish/install the 0.6.35 source client first, verify capability, then deploy control plus the complete viewer snapshot

## Validation
- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File core\\deploy\\test-local-release-lib.ps1`
- `cargo check --locked -p echo-core-control`
- `cargo check --locked -p echo-core-client`
- `node --check core\\viewer\\changelog.js`
- `git diff --check`