### PR TITLE
Fix Android Firefox presentation fallback

### DIFF
--- a/core/viewer/android-firefox-presentation-recovery-loader.js
+++ b/core/viewer/android-firefox-presentation-recovery-loader.js
@@ -1,7 +1,7 @@
 (function(root) {
   "use strict";
 
-  var RECOVERY_SCRIPT = "android-firefox-presentation-recovery.js?v=0.6.34.1786572903";
+  var RECOVERY_SCRIPT = "android-firefox-presentation-recovery.js?v=0.6.35.1786648741";
   var TARGET_USER_AGENT = /Android[^)]*Mobile/i;
   var TARGET_FIREFOX = /Firefox\/\d/i;
   var FLAG_PARAM = "echoAndroidFirefoxPresentationRecovery";

--- a/core/viewer/android-firefox-presentation-recovery-loader.test.js
+++ b/core/viewer/android-firefox-presentation-recovery-loader.test.js
@@ -115,6 +115,14 @@ test("loader is idempotent after its automatic exact-target request", () => {
   assert.equal(result.requests.length, 1, "a duplicate loader evaluation finds the existing tag");
 });
 
+test("loader independently cache-busts the corrected presentation module", () => {
+  const result = loadLoader({ userAgent: androidFirefox });
+  assert.deepEqual(result.requests, [
+    "android-firefox-presentation-recovery.js?v=0.6.35.1786648741",
+  ]);
+  assert.equal(result.api.RECOVERY_SCRIPT, result.requests[0]);
+});
+
 test("the shared runtime isolation allowlist contains only the loader seam", () => {
   const index = fs.readFileSync(path.join(__dirname, "index.html"), "utf8");
   assert.equal((index.match(/android-firefox-presentation-recovery-loader\.js/g) || []).length, 1);

--- a/core/viewer/android-firefox-presentation-recovery.js
+++ b/core/viewer/android-firefox-presentation-recovery.js
@@ -7,6 +7,44 @@
   var SUBSCRIPTION_DELAY_MS = 500;
   var REARM_PROGRESS_FRAMES = 2;
   var stateBySid = new Map();
+  var diagnostics = {
+    fallbackActivations: 0,
+    fallbackProgressSamples: 0,
+    fallbackSamples: 0,
+    sinkAttempts: 0,
+    subscriptionAttempts: 0,
+    unavailableSamples: 0,
+  };
+
+  function logRecovery(message) {
+    if (typeof debugLog !== "function") return;
+    try { debugLog("[android-firefox-presentation-recovery] " + message); }
+    catch (_error) {}
+  }
+
+  function finiteFrameCounter(value) {
+    if (value === null || value === undefined) return null;
+    var number = Number(value);
+    return Number.isFinite(number) && number >= 0 ? number : null;
+  }
+
+  function readPresentedFrameSample(video) {
+    var stats = video && video._echoPresentationStats;
+    var presentedFrames = finiteFrameCounter(stats && stats.presentedFrames);
+    if (presentedFrames !== null) {
+      return { frames: presentedFrames, source: "presented-frames" };
+    }
+    if (!video || typeof video.getVideoPlaybackQuality !== "function") return null;
+    try {
+      var quality = video.getVideoPlaybackQuality();
+      var totalVideoFrames = finiteFrameCounter(quality && quality.totalVideoFrames);
+      return totalVideoFrames === null
+        ? null
+        : { frames: totalVideoFrames, source: "playback-quality" };
+    } catch (_error) {
+      return null;
+    }
+  }
 
   function currentTarget(rootObject) {
     var win = rootObject || root;
@@ -104,7 +142,7 @@
       state.track === current.track && state.video === current.video;
   }
 
-  function createGenerationState(generation, current) {
+  function createGenerationState(generation, current, trackSid) {
     return {
       lastProgressAt: 0,
       meta: generation.meta,
@@ -113,18 +151,43 @@
       room: generation.room,
       tile: generation.tile,
       track: current.track,
+      trackSid: trackSid,
       video: current.video,
     };
   }
 
   function observePresentedFrame(video, now, state) {
-    var stats = video && video._echoPresentationStats;
-    var frames = Number(stats && stats.presentedFrames);
-    if (!Number.isFinite(frames)) return false;
+    var sample = readPresentedFrameSample(video);
+    if (!sample) {
+      diagnostics.unavailableSamples += 1;
+      return false;
+    }
+    var frames = sample.frames;
+    if (sample.source === "playback-quality") diagnostics.fallbackSamples += 1;
+    if (state.presentationCounterSource !== sample.source) {
+      state.presentationCounterSource = sample.source;
+      state.lastPresentedFrames = frames;
+      if (sample.source === "playback-quality") {
+        diagnostics.fallbackActivations += 1;
+        logRecovery("using playback-quality frame fallback sid=" + (state.trackSid || "unknown"));
+      }
+      if (state.sawPresentedFrame === true) {
+        // The two counters are not comparable. Rebase and give the new source
+        // one polling interval instead of misclassifying the source change as
+        // an immediate stall.
+        state.lastProgressAt = now;
+        return true;
+      }
+      if (frames < 1) return false;
+      if (sample.source === "playback-quality") diagnostics.fallbackProgressSamples += 1;
+      recordPresentationProgress(state, now);
+      return true;
+    }
     if (state.video && state.video !== video) {
       state.video = video;
       state.lastPresentedFrames = frames;
       if (frames < 1) return false;
+      if (sample.source === "playback-quality") diagnostics.fallbackProgressSamples += 1;
       recordPresentationProgress(state, now);
       return true;
     }
@@ -138,11 +201,18 @@
     if (frames === state.lastPresentedFrames) return false;
     if (frames < state.lastPresentedFrames) {
       state.lastPresentedFrames = frames;
-      if (frames < 1) return false;
+      if (frames < 1) {
+        // Firefox may reset VideoPlaybackQuality when its decoder/sink is
+        // rebound. Zero is not proof of a frame, but it is a new baseline.
+        if (state.sawPresentedFrame === true) state.lastProgressAt = now;
+        return true;
+      }
+      if (sample.source === "playback-quality") diagnostics.fallbackProgressSamples += 1;
       recordPresentationProgress(state, now);
       return true;
     }
     state.lastPresentedFrames = frames;
+    if (sample.source === "playback-quality") diagnostics.fallbackProgressSamples += 1;
     recordPresentationProgress(state, now);
     return true;
   }
@@ -167,7 +237,7 @@
         return;
       }
       if (!state) {
-        state = createGenerationState(generation, current);
+        state = createGenerationState(generation, current, trackSid);
       }
       stateBySid.set(trackSid, state);
       var presentationReady = current.video.paused !== true && current.video.readyState >= 2 &&
@@ -180,6 +250,8 @@
       if (!(state.lastProgressAt > 0) || now - state.lastProgressAt < STALL_MS) return;
       state.progressTicks = 0;
       if (!state.sinkAttempted) {
+        diagnostics.sinkAttempts += 1;
+        logRecovery("reattaching stalled presentation sink sid=" + trackSid);
         var reattached = reattachSink(trackSid, generation);
         // Consume the first-line attempt even when the browser rejects it so a
         // failed same-node reattach cannot block the one bounded SID reset.
@@ -191,6 +263,8 @@
       if (!state.subscriptionAttempted && !state.subscriptionEverAttempted &&
           now - state.sinkAttemptedAt >= SINK_GRACE_MS) {
         if (resetSubscription(trackSid, generation)) {
+          diagnostics.subscriptionAttempts += 1;
+          logRecovery("resetting stalled presentation subscription sid=" + trackSid);
           state.subscriptionAttempted = true;
           state.subscriptionEverAttempted = true;
           state.subscriptionAttemptedAt = now;
@@ -219,7 +293,8 @@
 
   var api = { currentGeneration: currentGeneration, currentTarget: currentTarget,
     createGenerationState: createGenerationState, exactGeneration: exactGeneration, inspect: inspect,
-    observePresentedFrame: observePresentedFrame, reattachSink: reattachSink,
+    diagnostics: diagnostics, observePresentedFrame: observePresentedFrame,
+    readPresentedFrameSample: readPresentedFrameSample, reattachSink: reattachSink,
     resetSubscription: resetSubscription, start: start, stateBySid: stateBySid,
     stateOwnsGeneration: stateOwnsGeneration };
   root.EchoAndroidFirefoxPresentationRecovery = api;

--- a/core/viewer/android-firefox-presentation-recovery.test.js
+++ b/core/viewer/android-firefox-presentation-recovery.test.js
@@ -9,6 +9,7 @@ const androidFirefox =
 
 function createHarness() {
   const calls = [];
+  const logs = [];
   const timeouts = [];
   const intervals = [];
   const videos = [];
@@ -69,6 +70,7 @@ function createHarness() {
       setTimeout(callback, delay) { timeouts.push({ callback, delay }); return timeouts.length; },
     },
     configureVideoElement() { calls.push(["configure"]); },
+    debugLog(message) { logs.push(message); },
     ensureVideoPlays() { calls.push(["play"]); },
     ensureVideoSubscribed() { calls.push(["ensureSubscribed"]); },
     markResubscribeIntent(sid) { calls.push(["intent", sid]); },
@@ -80,7 +82,16 @@ function createHarness() {
     fs.readFileSync(path.join(__dirname, "android-firefox-presentation-recovery.js"), "utf8"),
     context,
   );
-  return { api: context.module.exports, calls, context, intervals, meta, publication, room, tile, timeouts, videos };
+  return { api: context.module.exports, calls, context, intervals, logs, meta, publication, room, tile, timeouts, videos };
+}
+
+function usePlaybackQualityFallback(video, totalFrames) {
+  video._echoPresentationStats.presentedFrames = null;
+  video._playbackQualityFrames = totalFrames;
+  video.getVideoPlaybackQuality = function() {
+    return { totalVideoFrames: this._playbackQualityFrames };
+  };
+  return video;
 }
 
 test("a never-presented live track cannot enter the presentation recovery ladder", () => {
@@ -91,6 +102,75 @@ test("a never-presented live track cannot enter the presentation recovery ladder
   assert.equal(harness.api.inspect(20000), 0);
   assert.deepEqual(harness.calls, []);
   assert.equal(harness.timeouts.length, 0);
+});
+
+test("playback-quality fallback proves progress and enters the same bounded stall ladder", () => {
+  const harness = createHarness();
+  const video = usePlaybackQualityFallback(harness.tile.currentVideo, 20);
+  harness.api.stateBySid.clear();
+
+  assert.equal(harness.api.inspect(1000), 0, "the first played frame proves presentation");
+  assert.equal(harness.api.stateBySid.get("TR_screen").sawPresentedFrame, true);
+  video._playbackQualityFrames = 24;
+  assert.equal(harness.api.inspect(4000), 0, "an increasing total records progress");
+  assert.equal(harness.api.inspect(11999), 0, "an unchanged total remains inside the stall grace");
+  assert.equal(harness.api.inspect(12001), 1, "an unchanged total beyond eight seconds reattaches");
+
+  assert.equal(harness.calls.filter((entry) => entry[0] === "reattach").length, 1);
+  assert.equal(harness.api.diagnostics.fallbackActivations, 1);
+  assert.equal(harness.api.diagnostics.fallbackProgressSamples, 2);
+  assert.match(harness.logs.join("\n"), /using playback-quality frame fallback sid=TR_screen/);
+  assert.match(harness.logs.join("\n"), /reattaching stalled presentation sink sid=TR_screen/);
+});
+
+test("playback-quality counter reset rebases without inventing a presented frame", () => {
+  const harness = createHarness();
+  const video = usePlaybackQualityFallback(harness.tile.currentVideo, 40);
+  harness.api.stateBySid.clear();
+
+  harness.api.inspect(1000);
+  video._playbackQualityFrames = 0;
+  assert.equal(harness.api.inspect(4000), 0, "a reset to zero only establishes a new baseline");
+  assert.equal(harness.api.stateBySid.get("TR_screen").lastProgressAt, 4000);
+  video._playbackQualityFrames = 1;
+  assert.equal(harness.api.inspect(7000), 0, "the first post-reset frame is genuine progress");
+  assert.equal(harness.api.inspect(14999), 0);
+  assert.equal(harness.api.inspect(15001), 1, "a later unchanged counter still detects a stall");
+});
+
+test("missing or throwing playback-quality APIs fail closed when presented frames are unavailable", () => {
+  for (const configure of [
+    (video) => { video._echoPresentationStats.presentedFrames = null; },
+    (video) => {
+      video._echoPresentationStats.presentedFrames = null;
+      video.getVideoPlaybackQuality = () => { throw new Error("unsupported"); };
+    },
+    (video) => {
+      video._echoPresentationStats.presentedFrames = Number.NaN;
+      video.getVideoPlaybackQuality = () => ({ totalVideoFrames: null });
+    },
+  ]) {
+    const harness = createHarness();
+    configure(harness.tile.currentVideo);
+    harness.api.stateBySid.clear();
+    assert.equal(harness.api.inspect(1000), 0);
+    assert.equal(harness.api.inspect(20000), 0);
+    assert.equal(harness.api.stateBySid.get("TR_screen").sawPresentedFrame, undefined);
+    assert.deepEqual(harness.calls, []);
+  }
+});
+
+test("finite presented-frame diagnostics always win over playback-quality fallback", () => {
+  const harness = createHarness();
+  let fallbackReads = 0;
+  harness.tile.currentVideo.getVideoPlaybackQuality = () => {
+    fallbackReads += 1;
+    return { totalVideoFrames: 999 };
+  };
+  harness.api.stateBySid.clear();
+  assert.equal(harness.api.inspect(1000), 0);
+  assert.equal(fallbackReads, 0);
+  assert.equal(harness.api.stateBySid.get("TR_screen").presentationCounterSource, "presented-frames");
 });
 
 test("a proven presentation stall reattaches only its stable sink, then performs one exact-SID resubscribe", () => {
@@ -198,6 +278,42 @@ test("same SID in a new publication and video generation cannot inherit presenta
   harness.api.inspect(40000);
   assert.deepEqual(harness.calls.filter((entry) => entry[0] === "replacementSubscribed"), []);
   assert.equal(harness.api.stateBySid.get("TR_screen").sawPresentedFrame, undefined);
+});
+
+test("same SID playback-quality replacement generation cannot inherit presentation proof", () => {
+  const harness = createHarness();
+  usePlaybackQualityFallback(harness.tile.currentVideo, 12);
+  harness.api.stateBySid.clear();
+  harness.api.inspect(1000);
+  assert.equal(harness.api.stateBySid.get("TR_screen").sawPresentedFrame, true);
+
+  const replacementVideo = usePlaybackQualityFallback({
+    ...harness.tile.currentVideo,
+    _echoPresentationStats: { presentedFrames: null },
+  }, 0);
+  const replacementTrack = {
+    mediaStreamTrack: { readyState: "live", muted: false },
+    attach() {},
+    detach() {},
+  };
+  replacementVideo._lkTrack = replacementTrack;
+  const replacementPublication = {
+    isSubscribed: true,
+    track: replacementTrack,
+    setSubscribed(value) { this.isSubscribed = value; harness.calls.push(["replacementSubscribed", value]); },
+  };
+  const replacementMeta = {
+    identity: "remote",
+    publication: replacementPublication,
+    tile: harness.tile,
+  };
+  harness.tile.currentVideo = replacementVideo;
+  harness.context.screenTrackMeta.set("TR_screen", replacementMeta);
+
+  assert.equal(harness.api.inspect(20000), 0);
+  assert.equal(harness.api.inspect(40000), 0);
+  assert.equal(harness.api.stateBySid.get("TR_screen").sawPresentedFrame, undefined);
+  assert.deepEqual(harness.calls.filter((entry) => entry[0] === "replacementSubscribed"), []);
 });
 
 test("state for a removed SID is swept on the next inspection", () => {


### PR DESCRIPTION
## What changed

- Fall back to Firefox `getVideoPlaybackQuality().totalVideoFrames` when rVFC presentation telemetry is unavailable.
- Keep the existing exact Android Firefox, non-native, current-generation recovery gates.
- Independently cache-bust the cohort-only recovery module.
- Cover null counters, progress/stalls, resets, API failure, and replacement generations.

## Root cause

The live Android Firefox canary decoded initially, then froze while remaining Room-connected. Firefox reported `presented_frames: null`; the isolated recovery module coerced that value to zero and never established the prior-frame proof required to arm its bounded sink/reset ladder.

## Desktop boundary

Only the Android Firefox recovery loader/module and their tests changed. Shared PC screen-share, layout, adaptive, Room, and Jam files are byte-for-byte unchanged.

## Verification

- Focused Android Firefox tests: 21/21.
- `npm run verify:quick`: 344/344 viewer tests; guardrails pass.
- `git diff --check`: clean.
- Independent adversarial review: GO.
- Live pre-fix canary: desktop ultrawide PASS at 1920x804 for 7+ minutes; isolated phone failure reproduced.

## Release impact

Server-served viewer only. A real Android Firefox post-deploy canary remains mandatory before declaring the bug fixed.
