### PR TITLE
Route Battlefield 6 audio around process capture

### DIFF
--- a/core/viewer/screen-share-native.js
+++ b/core/viewer/screen-share-native.js
@@ -119,9 +119,29 @@ function getCaptureSourceReportSnapshot() {
   return window._echoCaptureSourceReport || null;
 }
 
+function _isBattlefield6NativeGameSource(source) {
+  if (!source || source.sourceType !== 'game') return false;
+
+  // Prefer the executable identity whenever the picker provides one. An
+  // explicit non-BF6 executable must not be overridden by a coincidental
+  // window title.
+  var executable = source.exeName || source.exe_name || null;
+  if (typeof executable === 'string' && executable.trim()) {
+    var executableName = executable.trim().split(/[\\\\/]/).pop();
+    return /^(?:bf6|battlefield6)\.exe$/i.test(executableName);
+  }
+
+  // Older desktop clients expose only the source title. Keep this exact so a
+  // browser, launcher, guide, or similarly named game cannot change routes.
+  var title = typeof source.title === 'string'
+    ? source.title.trim().replace(/\s+/g, ' ')
+    : '';
+  return /^(?:bf6|battlefield(?:[\u2122\u00ae])? 6(?:[\u2122\u00ae])?)$/i.test(title);
+}
+
 function nativeAudioCaptureRequestForSource(source) {
   if (!source) return null;
-  if (source.sourceType === 'monitor') {
+  if (source.sourceType === 'monitor' || _isBattlefield6NativeGameSource(source)) {
     return { mode: 'system-exclude-echo', pid: 0, toast: 'System audio streaming (Echo voice excluded)' };
   }
   if ((source.sourceType === 'game' || source.sourceType === 'window') &&

--- a/core/viewer/screen-share-native.test.js
+++ b/core/viewer/screen-share-native.test.js
@@ -416,6 +416,87 @@ test("monitor audio capture requests system audio with Echo playback excluded", 
   );
 });
 
+test("Battlefield 6 executable variants request system audio with Echo excluded", () => {
+  const { context } = loadScreenShareNative();
+  const sources = [
+    { sourceType: "game", pid: 601, title: "Loading", exe_name: "BF6.exe" },
+    { sourceType: "game", pid: 602, title: "Loading", exeName: "C:\\Games\\Battlefield6.EXE" },
+  ];
+
+  for (const source of sources) {
+    const request = context.nativeAudioCaptureRequestForSource(source);
+    assert.equal(request.mode, "system-exclude-echo");
+    assert.equal(request.pid, 0);
+  }
+});
+
+test("Battlefield 6 exact title variants are used only when executable identity is absent", () => {
+  const { context } = loadScreenShareNative();
+  for (const title of ["BF6", "Battlefield 6", "Battlefield\u2122 6", " Battlefield  6 "]) {
+    const request = context.nativeAudioCaptureRequestForSource({
+      sourceType: "game",
+      pid: 603,
+      title,
+    });
+    assert.equal(request.mode, "system-exclude-echo", title);
+  }
+});
+
+test("Battlefield 6 matching rejects false positives and preserves other source routes", () => {
+  const { context } = loadScreenShareNative();
+  const falsePositives = [
+    { sourceType: "window", pid: 701, title: "Battlefield 6" },
+    { sourceType: "game", pid: 702, title: "Battlefield 6 Beta" },
+    { sourceType: "game", pid: 703, title: "My BF6 stream" },
+    { sourceType: "game", pid: 704, title: "BF6", exe_name: "chrome.exe" },
+    { sourceType: "game", pid: 705, title: "Battlefield 6", exeName: "bf2042.exe" },
+    { sourceType: "game", pid: 706, title: "Battlefield 6", exe_name: "notbf6.exe" },
+  ];
+
+  for (const source of falsePositives) {
+    const request = context.nativeAudioCaptureRequestForSource(source);
+    assert.equal(request.mode, "process", JSON.stringify(source));
+    assert.equal(request.pid, source.pid);
+  }
+
+  assert.equal(
+    JSON.stringify(context.nativeAudioCaptureRequestForSource({
+      sourceType: "game",
+      pid: 801,
+      title: "Crimson Desert",
+      exe_name: "CrimsonDesert.exe",
+    })),
+    JSON.stringify({ mode: "process", pid: 801, toast: "Game audio streaming" })
+  );
+  assert.equal(
+    JSON.stringify(context.nativeAudioCaptureRequestForSource({
+      sourceType: "window",
+      pid: 802,
+      title: "PowerPoint",
+    })),
+    JSON.stringify({ mode: "process", pid: 802, toast: "Window audio streaming" })
+  );
+});
+
+test("Battlefield 6 audio routing does not mutate capture geometry", () => {
+  const { context } = loadScreenShareNative();
+  const source = {
+    sourceType: "game",
+    id: 4242,
+    pid: 5678,
+    title: "BF6",
+    width: 3440,
+    height: 1440,
+    fullscreenLike: true,
+    monitorId: "DISPLAY1",
+  };
+  const before = JSON.stringify(source);
+
+  context.nativeAudioCaptureRequestForSource(source);
+
+  assert.equal(JSON.stringify(source), before);
+});
+
 test("native audio capture uses the Echo-excluding system command for monitor audio", async () => {
   const { context, calls } = loadScreenShareNative();
 
@@ -465,6 +546,36 @@ test("native audio capture uses the Echo-excluding system command for monitor au
     calls.some((call) => call.command === "start_system_audio_capture"),
     false
   );
+});
+
+test("Battlefield 6 audio request invokes only the Echo-excluding system command", async () => {
+  const { context, calls } = loadScreenShareNative();
+  const audioInvocations = [];
+  context.showCapturePicker = async () => ({
+    sourceType: "game",
+    id: 4242,
+    pid: 5678,
+    title: "Battlefield 6",
+    captureMode: "auto",
+  });
+  context.tauriInvoke = async (command, args) => {
+    calls.push({ command, args });
+    if (command === "get_os_build_number") return 26100;
+    return null;
+  };
+  context.startNativeAudioCapture = async (pid, options) => {
+    audioInvocations.push({ pid, options });
+  };
+  context._startQualityWarnListener = () => {};
+
+  await context.startScreenShareManual();
+  await Promise.resolve();
+
+  assert.equal(audioInvocations.length, 1);
+  assert.equal(audioInvocations[0].pid, 0);
+  assert.equal(audioInvocations[0].options.system, false);
+  assert.equal(audioInvocations[0].options.systemExcludeEcho, true);
+  assert.equal(calls.some((call) => call.command === "start_screen_share"), true);
 });
 
 test("native stop clears local screen tile and removes the screen companion", async () => {


### PR DESCRIPTION
## What changed

- route native Battlefield 6 game-share audio through Echo's existing system-loopback path that excludes Echo playback
- keep every other game/window on the existing per-process capture route
- add strict executable/title matching, false-positive coverage, command-routing coverage, and a geometry immutability check

## Root cause

Live diagnostics showed the local audio drop began exactly when Echo activated Windows process-loopback capture against `bf6.exe`. Battlefield continued producing PCM, Windows did not mute the game or endpoint, and WGC/NVENC video stayed healthy. Avoiding direct activation against Battlefield is the narrowest mitigation.

## Release impact

Viewer-only. No desktop binary, WGC/encoder, layout/ultrawide, Jam, mobile, or Rust changes.

## Validation

- `node --test core/viewer/screen-share-native.test.js` — 23/23
- `npm run verify:quick` — guardrails clean, viewer 349/349
- `git diff --check`

Live acceptance remains required after deployment: local Battlefield audio must remain audible while a remote listener receives the shared audio.
