### PR TITLE
Move modules into Stage with independent camera tiles

### DIFF
--- a/core/viewer-tests/tests/camera-lobby.layout.spec.js
+++ b/core/viewer-tests/tests/camera-lobby.layout.spec.js
@@ -191,7 +191,7 @@ for (const scenario of [
     name: "many cameras stay balanced and contained in a narrow lobby",
     count: 6,
     viewport: { width: 520, height: 780 },
-    expectedTracks: { columns: 2, rows: 3 },
+    expectedTracks: { columns: 3, rows: 2 },
   },
 ]) {
   test(scenario.name, async ({ page }) => {
@@ -240,9 +240,18 @@ test("layout sizing does not break the Camera Lobby's enlarged tile", async ({ p
   await expect(tile).toHaveClass(/enlarged/);
   const enlarged = await tile.evaluate((element) => {
     const rect = element.getBoundingClientRect();
+    const grid = document.getElementById("camera-lobby-grid").getBoundingClientRect();
+    const header = document.querySelector("#camera-lobby .camera-lobby-header").getBoundingClientRect();
     const panel = document.getElementById("camera-lobby").getBoundingClientRect();
     return {
       bottom: rect.bottom,
+      grid: {
+        bottom: grid.bottom,
+        left: grid.left,
+        right: grid.right,
+        top: grid.top,
+      },
+      headerBottom: header.bottom,
       left: rect.left,
       panel: {
         bottom: panel.bottom,
@@ -254,10 +263,12 @@ test("layout sizing does not break the Camera Lobby's enlarged tile", async ({ p
       top: rect.top,
     };
   });
-  expect(Math.abs(enlarged.left - (enlarged.panel.left + 20))).toBeLessThanOrEqual(2);
-  expect(Math.abs(enlarged.top - (enlarged.panel.top + 20))).toBeLessThanOrEqual(2);
-  expect(Math.abs(enlarged.right - (enlarged.panel.right - 20))).toBeLessThanOrEqual(2);
-  expect(Math.abs(enlarged.bottom - (enlarged.panel.bottom - 20))).toBeLessThanOrEqual(2);
+  expect(Math.abs(enlarged.left - enlarged.grid.left)).toBeLessThanOrEqual(2);
+  expect(Math.abs(enlarged.top - enlarged.grid.top)).toBeLessThanOrEqual(2);
+  expect(Math.abs(enlarged.right - enlarged.grid.right)).toBeLessThanOrEqual(2);
+  expect(Math.abs(enlarged.bottom - enlarged.grid.bottom)).toBeLessThanOrEqual(2);
+  expect(enlarged.top).toBeGreaterThanOrEqual(enlarged.headerBottom - 1);
+  expectContained(enlarged, enlarged.panel, "enlarged camera tile");
 
   await tile.click();
   await expect(tile).not.toHaveClass(/enlarged/);

--- a/core/viewer-tests/tests/shell.phase1.spec.js
+++ b/core/viewer-tests/tests/shell.phase1.spec.js
@@ -281,21 +281,28 @@ test("canonical nodes, media tracks, participant state, and Chat draft survive r
     window.EchoLayoutTestScenario.captureIdentitySnapshot();
   }, { selectors: shellSelectors, draft: preservedDraft });
 
-  async function expectPreserved(label) {
+  async function expectPreserved(label, expectedShell) {
     const preserved = await page.evaluate((selectors) => {
       const savedNodes = window.__echoCanonicalNodeSnapshot;
+      const panel = document.getElementById("chat-panel");
+      const stageHost = document.getElementById("stage-module-host");
       return {
         canonicalNodes: selectors.every((selector, index) => (
           document.querySelectorAll(selector).length === 1 &&
           document.querySelector(selector) === savedNodes[index] &&
           savedNodes[index].isConnected
         )),
+        chatInStageHost: stageHost.contains(panel),
+        chatRendered: panel.getClientRects().length > 0 && getComputedStyle(panel).visibility !== "hidden",
         identity: window.EchoLayoutTestScenario.inspectIdentitySnapshot(),
+        stageModule: window.EchoStageModules.activeModule(),
       };
     }, shellSelectors);
 
     expect(preserved, label).toEqual({
       canonicalNodes: true,
+      chatInStageHost: expectedShell === "v2",
+      chatRendered: true,
       identity: {
         cameraSdkTrack: true,
         cameraStream: true,
@@ -304,7 +311,7 @@ test("canonical nodes, media tracks, participant state, and Chat draft survive r
         cameraVideo: true,
         chatFocused: true,
         chatInput: true,
-        chatOpen: true,
+        chatOpen: expectedShell === "legacy",
         chatPanel: true,
         draft: preservedDraft,
         participantCard: true,
@@ -320,22 +327,23 @@ test("canonical nodes, media tracks, participant state, and Chat draft survive r
         screenVideo: true,
         shareFocused: true,
       },
+      stageModule: "chat",
     });
   }
 
-  await expectPreserved("initial V2 state");
+  await expectPreserved("initial V2 state", "v2");
   await settleResize(page, { width: 1024, height: 768 }, "lounge");
-  await expectPreserved("lounge resize");
+  await expectPreserved("lounge resize", "v2");
   await settleResize(page, { width: 640, height: 480 }, "compact");
-  await expectPreserved("compact resize");
+  await expectPreserved("compact resize", "v2");
 
   await page.evaluate(() => window.EchoUiShell.applyVariant("legacy"));
   await expect(page.locator("html")).toHaveAttribute("data-ui-shell", "legacy");
-  await expectPreserved("legacy live toggle");
+  await expectPreserved("legacy live toggle", "legacy");
 
   await page.evaluate(() => window.EchoUiShell.applyVariant("v2"));
   await expect(page.locator("html")).toHaveAttribute("data-ui-shell", "v2");
-  await expectPreserved("V2 live toggle");
+  await expectPreserved("V2 live toggle", "v2");
   await expectCanonicalStructure(page);
 });
 
@@ -1304,7 +1312,7 @@ for (const viewport of [
   { width: 390, height: 844 },
   { width: 412, height: 915 },
 ]) {
-  test(`${viewport.width}x${viewport.height} mini default People sheet exposes a dismissible live Stage`, async ({ page }) => {
+  test(`${viewport.width}x${viewport.height} mini default Active Users preserves a live Stage and hides only through Users`, async ({ page }) => {
     await page.setViewportSize(viewport);
     await openPhaseOneViewer(page, {
       participants: 2,
@@ -1317,10 +1325,12 @@ for (const viewport of [
     const layout = page.locator('.room-layout[data-ui-region="workspace"]');
     const stage = page.locator('.room-main[data-ui-region="primary-stage"]');
     const utility = page.locator('.utility-host[data-ui-region="utility-host"]');
+    const users = page.locator("#room-sidebar");
     const grid = page.locator("#screen-grid");
     const tile = grid.locator(":scope > .tile");
     const video = tile.locator("video.screen-video-surface");
     const fullscreen = tile.locator(".tile-fullscreen-btn");
+    const toggle = page.locator("#shell-toggle-utility");
 
     await expect(layout).not.toHaveClass(/utility-collapsed/);
     await expect(utility).toHaveAttribute("data-active-tool", "people");
@@ -1328,7 +1338,12 @@ for (const viewport of [
     await expect(tile).toHaveAttribute("data-grid-visible", "");
     await expect(video).toHaveCount(1);
     await expect(fullscreen).toBeVisible();
-    await expect.poll(() => stage.evaluate((element) => element.inert)).toBe(true);
+    await expect(toggle).toHaveAttribute("aria-expanded", "true");
+    await expect.poll(() => stage.evaluate((element) => element.inert)).toBe(false);
+    await expect.poll(() => grid.evaluate((element) => element.inert)).toBe(false);
+    await expect.poll(() => utility.evaluate((element) => element.inert)).toBe(false);
+    await expect.poll(() => users.evaluate((element) => element.inert)).toBe(false);
+    await expect(page.locator("#utility-scrim")).toBeHidden();
     await expect.poll(() => video.evaluate((element) => ({
       hasCurrentData: element.readyState >= HTMLMediaElement.HAVE_CURRENT_DATA,
       sourceTrackState: element.srcObject?.getVideoTracks()[0]?.readyState || null,
@@ -1350,7 +1365,6 @@ for (const viewport of [
       const workspace = document.querySelector('.room-layout[data-ui-region="workspace"]');
       const primaryStage = document.querySelector('.room-main[data-ui-region="primary-stage"]');
       const utilityHost = document.querySelector('.utility-host[data-ui-region="utility-host"]');
-      const scrim = document.getElementById("utility-scrim");
       const screenTile = document.querySelector("#screen-grid > .tile[data-grid-visible]");
       const screenVideo = screenTile.querySelector("video.screen-video-surface");
       const fullscreenButton = screenTile.querySelector(".tile-fullscreen-btn");
@@ -1378,12 +1392,15 @@ for (const viewport of [
       return {
         exposedTile,
         hitPoint,
-        hitTargetIsScrim: hitTarget === scrim || scrim.contains(hitTarget),
+        hitTargetOnTile: hitTarget === screenTile || screenTile.contains(hitTarget),
+        stage: stageRect,
         tile: tileRect,
+        utility: utilityRect,
         utilityHeightRatio: utilityRect.height / workspaceRect.height,
         video: videoRect,
         videoHeight: screenVideo.videoHeight,
         videoWidth: screenVideo.videoWidth,
+        workspace: workspaceRect,
       };
     });
 
@@ -1396,11 +1413,26 @@ for (const viewport of [
     expect(geometry.video.height).toBeGreaterThan(1);
     expect(geometry.videoWidth).toBeGreaterThan(0);
     expect(geometry.videoHeight).toBeGreaterThan(0);
-    expect(geometry.hitTargetIsScrim).toBe(true);
+    expect(geometry.hitTargetOnTile).toBe(true);
+    for (const region of [geometry.stage, geometry.utility]) {
+      expect(region.left).toBeGreaterThanOrEqual(geometry.workspace.left - 1);
+      expect(region.right).toBeLessThanOrEqual(geometry.workspace.right + 1);
+      expect(region.top).toBeGreaterThanOrEqual(geometry.workspace.top - 1);
+      expect(region.bottom).toBeLessThanOrEqual(geometry.workspace.bottom + 1);
+    }
 
     await page.mouse.click(geometry.hitPoint.x, geometry.hitPoint.y);
+    await expect(tile).toHaveClass(/is-focused/);
+    await expect(layout).not.toHaveClass(/utility-collapsed/);
+    await expect(toggle).toHaveAttribute("aria-expanded", "true");
+
+    await toggle.click();
     await expect(layout).toHaveClass(/utility-collapsed/);
     await expect.poll(() => stage.evaluate((element) => element.inert)).toBe(false);
+    await expect.poll(() => grid.evaluate((element) => element.inert)).toBe(false);
+    await expect.poll(() => utility.evaluate((element) => element.inert)).toBe(true);
+    await expect(users).toHaveAttribute("aria-hidden", "true");
+    await expect(toggle).toHaveAttribute("aria-expanded", "false");
     await expect.poll(() => utility.evaluate((element) => getComputedStyle(element).visibility)).toBe("hidden");
 
     const restored = await page.evaluate(() => {
@@ -1494,7 +1526,7 @@ for (const viewport of [
   { width: 1024, height: 768, mode: "lounge" },
   { width: 800, height: 600, mode: "compact" },
 ]) {
-  test(`${viewport.mode} utility expansion gates the stage and collapse restores it`, async ({ page }) => {
+  test(`${viewport.mode} Active Users remains independent while explicit hiding leaves the Stage live`, async ({ page }) => {
     await page.setViewportSize(viewport);
     await openPhaseOneViewer(page, { participants: 4, cameras: 1, screenShares: 1 });
     await expect(page.locator("html")).toHaveAttribute("data-ui-mode", viewport.mode);
@@ -1502,12 +1534,22 @@ for (const viewport of [
     const stage = page.locator('.room-main[data-ui-region="primary-stage"]');
     const layout = page.locator('.room-layout[data-ui-region="workspace"]');
     const utility = page.locator('.utility-host[data-ui-region="utility-host"]');
+    const users = page.locator("#room-sidebar");
+    const grid = page.locator("#screen-grid");
     const toggle = page.locator("#shell-toggle-utility");
-    await expect.poll(() => stage.evaluate((element) => element.inert)).toBe(true);
+    await expect(layout).not.toHaveClass(/utility-collapsed/);
+    await expect(toggle).toHaveAttribute("aria-expanded", "true");
+    await expect.poll(() => stage.evaluate((element) => element.inert)).toBe(false);
+    await expect.poll(() => grid.evaluate((element) => element.inert)).toBe(false);
+    await expect.poll(() => utility.evaluate((element) => element.inert)).toBe(false);
+    await expect.poll(() => users.evaluate((element) => element.inert)).toBe(false);
 
     await toggle.click();
     await expect(layout).toHaveClass(/utility-collapsed/);
     await expect.poll(() => stage.evaluate((element) => element.inert)).toBe(false);
+    await expect.poll(() => grid.evaluate((element) => element.inert)).toBe(false);
+    await expect.poll(() => utility.evaluate((element) => element.inert)).toBe(true);
+    await expect(users).toHaveAttribute("aria-hidden", "true");
     await expect(toggle).toHaveAttribute("aria-expanded", "false");
     await expect.poll(() => utility.evaluate((element) => getComputedStyle(element).visibility)).toBe("hidden");
 
@@ -1525,7 +1567,7 @@ for (const viewport of [
   { width: 800, height: 600, mode: "compact" },
   { width: 600, height: 900, mode: "mini" },
 ]) {
-  test(`${viewport.mode} Chat uses essentially the full workspace`, async ({ page }) => {
+  test(`${viewport.mode} Chat fills its Stage while Active Users remains independently visible`, async ({ page }) => {
     await page.setViewportSize(viewport);
     await openPhaseOneViewer(page, {
       participants: 4,
@@ -1534,22 +1576,62 @@ for (const viewport of [
       chatOpen: true,
     });
     await expect(page.locator("html")).toHaveAttribute("data-ui-mode", viewport.mode);
+    await expect(page.locator("html")).toHaveAttribute("data-stage-module", "chat");
+    const toggle = page.locator("#shell-toggle-utility");
+    await expect(toggle).toHaveAttribute("aria-expanded", "true");
+    await expect(page.locator("#room-sidebar")).toBeVisible();
+    await page.locator("#chat-input").fill("Chat draft survives independent Users visibility");
+
     const geometry = await page.evaluate(() => {
       const workspace = document.querySelector('.room-layout[data-ui-region="workspace"]').getBoundingClientRect();
+      const stage = document.querySelector('.room-main[data-ui-region="primary-stage"]').getBoundingClientRect();
       const chat = document.getElementById("chat-panel").getBoundingClientRect();
+      const users = document.getElementById("room-sidebar").getBoundingClientRect();
       return {
-        heightRatio: chat.height / workspace.height,
-        widthRatio: chat.width / workspace.width,
+        heightRatio: chat.height / stage.height,
+        widthRatio: chat.width / stage.width,
         chat: { bottom: chat.bottom, left: chat.left, right: chat.right, top: chat.top },
+        stage: { bottom: stage.bottom, height: stage.height, left: stage.left, right: stage.right, top: stage.top, width: stage.width },
+        users: { bottom: users.bottom, height: users.height, left: users.left, right: users.right, top: users.top, width: users.width },
         workspace: { bottom: workspace.bottom, left: workspace.left, right: workspace.right, top: workspace.top },
       };
     });
     expect(geometry.widthRatio).toBeGreaterThanOrEqual(0.95);
     expect(geometry.heightRatio).toBeGreaterThanOrEqual(0.95);
-    expect(geometry.chat.left).toBeGreaterThanOrEqual(geometry.workspace.left - 1);
-    expect(geometry.chat.right).toBeLessThanOrEqual(geometry.workspace.right + 1);
-    expect(geometry.chat.top).toBeGreaterThanOrEqual(geometry.workspace.top - 1);
-    expect(geometry.chat.bottom).toBeLessThanOrEqual(geometry.workspace.bottom + 1);
+    expect(geometry.chat.left).toBeGreaterThanOrEqual(geometry.stage.left - 1);
+    expect(geometry.chat.right).toBeLessThanOrEqual(geometry.stage.right + 1);
+    expect(geometry.chat.top).toBeGreaterThanOrEqual(geometry.stage.top - 1);
+    expect(geometry.chat.bottom).toBeLessThanOrEqual(geometry.stage.bottom + 1);
+    expect(geometry.stage.bottom).toBeLessThanOrEqual(geometry.users.top + 1);
+    for (const region of [geometry.stage, geometry.users]) {
+      expect(region.left).toBeGreaterThanOrEqual(geometry.workspace.left - 1);
+      expect(region.right).toBeLessThanOrEqual(geometry.workspace.right + 1);
+      expect(region.top).toBeGreaterThanOrEqual(geometry.workspace.top - 1);
+      expect(region.bottom).toBeLessThanOrEqual(geometry.workspace.bottom + 1);
+    }
+
+    const chatNode = await page.locator("#chat-panel").elementHandle();
+    await toggle.click();
+    await expect(toggle).toHaveAttribute("aria-expanded", "false");
+    await expect(page.locator("#room-sidebar")).toBeHidden();
+    await expect(page.locator("#chat-input")).toHaveValue("Chat draft survives independent Users visibility");
+    expect(await page.locator("#chat-panel").evaluate((panel, saved) => panel === saved, chatNode)).toBe(true);
+
+    const expanded = await page.evaluate(() => {
+      const workspace = document.querySelector('.room-layout[data-ui-region="workspace"]').getBoundingClientRect();
+      const stage = document.querySelector('.room-main[data-ui-region="primary-stage"]').getBoundingClientRect();
+      const chat = document.getElementById("chat-panel").getBoundingClientRect();
+      return {
+        chatHeightRatio: chat.height / stage.height,
+        chatWidthRatio: chat.width / stage.width,
+        stageHeightRatio: stage.height / workspace.height,
+        stageWidthRatio: stage.width / workspace.width,
+      };
+    });
+    expect(expanded.chatWidthRatio).toBeGreaterThanOrEqual(0.95);
+    expect(expanded.chatHeightRatio).toBeGreaterThanOrEqual(0.95);
+    expect(expanded.stageWidthRatio).toBeGreaterThanOrEqual(0.95);
+    expect(expanded.stageHeightRatio).toBeGreaterThanOrEqual(0.95);
   });
 }
 

--- a/core/viewer-tests/tests/shell.phase2.utility.spec.js
+++ b/core/viewer-tests/tests/shell.phase2.utility.spec.js
@@ -190,6 +190,18 @@ test.beforeEach(async ({ page }) => {
       });
       return;
     }
+    if (url.pathname === "/api/client-stats-report" && request.method() === "POST") {
+      await route.fulfill({ status: 204, body: "" });
+      return;
+    }
+    if (url.pathname === "/api/soundboard/list" && request.method() === "GET") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ sounds: [] }),
+      });
+      return;
+    }
     if (url.pathname === "/api/jam/state" && request.method() === "GET") {
       increment(model, key);
       await route.fulfill({
@@ -700,11 +712,13 @@ async function openPhaseTwoViewer(page, scenario = {}) {
         identity: "layout-fixture-1",
         name: "Fixture Host",
         publishData: async function() {},
+        trackPublications: new Map(),
       },
+      remoteParticipants: new Map(),
     };
     adminToken = "phase-2-admin-token";
     currentAccessToken = "phase-2-participant-token";
-    ["open-chat", "open-jam", "dock-output", "open-settings"].forEach((id) => {
+    ["open-chat", "open-jam", "open-camera-lobby", "open-soundboard", "dock-output", "open-settings"].forEach((id) => {
       const element = document.getElementById(id);
       if (element) element.disabled = false;
     });
@@ -749,30 +763,67 @@ async function searchJam(page, query = "clubhouse") {
   await expect(page.locator(".jam-result-item")).toHaveCount(6);
 }
 
-async function expectActiveTool(page, tool) {
-  await expect(page.locator("#utility-host")).toHaveAttribute("data-active-tool", tool);
-  await expect(page.locator("html")).toHaveAttribute("data-ui-utility", tool);
-  const state = await page.evaluate((activeTool) => {
-    const tools = {
-      people: document.getElementById("room-sidebar"),
+async function expectStageModule(page, module) {
+  const host = page.locator("#stage-module-host");
+  const stage = page.locator(".room-main");
+  const activeModule = module === "screens" ? "" : module;
+  await expect(host).toHaveAttribute("data-active-module", activeModule);
+  if (activeModule) {
+    await expect(page.locator("html")).toHaveAttribute("data-stage-module", activeModule);
+    await expect(stage).toHaveAttribute("data-active-module", activeModule);
+    await expect(stage).toHaveClass(/stage-module-open/);
+    await expect(host).toBeVisible();
+  } else {
+    await expect(page.locator("html")).not.toHaveAttribute("data-stage-module", /.+/);
+    await expect(stage).not.toHaveAttribute("data-active-module", /.+/);
+    await expect(stage).not.toHaveClass(/stage-module-open/);
+    await expect(host).toBeHidden();
+  }
+
+  const state = await page.evaluate((activeModule) => {
+    const modules = {
+      screens: document.getElementById("screen-grid"),
       chat: document.getElementById("chat-panel"),
       jam: document.getElementById("jam-panel"),
+      camera: document.getElementById("camera-lobby"),
+      soundboard: document.getElementById("soundboard-compact"),
     };
-    return Object.fromEntries(Object.entries(tools).map(([name, element]) => [name, {
-      ariaHidden: element.getAttribute("aria-hidden"),
-      hidden: element.classList.contains("hidden"),
-      inert: element.inert,
-      rendered: element.getClientRects().length > 0 && getComputedStyle(element).visibility !== "hidden",
-      expected: name === activeTool,
+    return Object.fromEntries(Object.entries(modules).map(([name, element]) => [name, {
+      ariaHidden: element && element.getAttribute("aria-hidden"),
+      hidden: !element || element.classList.contains("hidden"),
+      inert: !element || element.inert,
+      rendered: !!element && element.getClientRects().length > 0 && getComputedStyle(element).visibility !== "hidden",
+      expected: name === activeModule,
     }]));
-  }, tool);
+  }, module);
 
   for (const [name, value] of Object.entries(state)) {
     expect(value.rendered, `${name} rendered state`).toBe(value.expected);
-    expect(value.hidden, `${name} hidden class`).toBe(!value.expected);
     expect(value.inert, `${name} inert state`).toBe(!value.expected);
-    expect(value.ariaHidden, `${name} aria-hidden state`).toBe(value.expected ? "false" : "true");
+    if (name !== "screens") {
+      expect(value.hidden, `${name} hidden class`).toBe(!value.expected);
+      expect(value.ariaHidden, `${name} aria-hidden state`).toBe(value.expected ? "false" : "true");
+    }
   }
+}
+
+async function expectUsersVisible(page, visible) {
+  const sidebar = page.locator("#room-sidebar");
+  const presentation = await sidebar.evaluate((element) => ({
+    ariaHidden: element.getAttribute("aria-hidden"),
+    inert: element.inert,
+    rendered: element.getClientRects().length > 0 && getComputedStyle(element).visibility !== "hidden",
+  }));
+  expect(presentation.rendered, "Active Users rendered state").toBe(visible);
+  expect(presentation.inert, "Active Users inert state").toBe(!visible);
+  expect(presentation.ariaHidden, "Active Users aria-hidden state").toBe(visible ? "false" : "true");
+  await expect(page.locator("#shell-toggle-utility")).toHaveAttribute("aria-expanded", String(visible));
+}
+
+async function setUsersVisible(page, visible) {
+  const toggle = page.locator("#shell-toggle-utility");
+  if ((await toggle.getAttribute("aria-expanded")) !== String(visible)) await toggle.click();
+  await expectUsersVisible(page, visible);
 }
 
 async function resizeTo(page, viewport, expectedMode) {
@@ -785,46 +836,97 @@ async function resizeTo(page, viewport, expectedMode) {
   await expect(page.locator("html")).toHaveAttribute("data-ui-mode", expectedMode);
 }
 
-test("one logical utility owns stable People, Chat, and portaled Jam tools without losing form state", async ({ page }) => {
+test("changed Stage-module assets share one cache cohort", async ({ page }) => {
+  await page.goto("/?echo-ui-shell-v2=1", { waitUntil: "domcontentloaded" });
+  const versions = await page.evaluate((assetNames) => {
+    const references = Array.from(document.querySelectorAll("link[href], script[src]"));
+    return Object.fromEntries(assetNames.map((assetName) => {
+      const reference = references.find((element) => {
+        const rawUrl = element.getAttribute("href") || element.getAttribute("src") || "";
+        return new URL(rawUrl, location.href).pathname.endsWith(`/${assetName}`);
+      });
+      const rawUrl = reference && (reference.getAttribute("href") || reference.getAttribute("src"));
+      return [assetName, rawUrl ? new URL(rawUrl, location.href).searchParams.get("v") : null];
+    }));
+  }, [
+    "clubhouse-shell.css",
+    "state.js",
+    "soundboard.js",
+    "participants-grid.js",
+    "grid-layout.js",
+    "participants-avatar.js",
+    "participants-fullscreen.js",
+    "audio-routing.js",
+    "media-controls.js",
+    "connect.js",
+    "app.js",
+  ]);
+  expect(Object.values(versions).every(Boolean), JSON.stringify(versions, null, 2)).toBe(true);
+  expect(new Set(Object.values(versions)).size, JSON.stringify(versions, null, 2)).toBe(1);
+});
+
+test("Stage modules preserve their nodes and form state while Active Users remains independent", async ({ page }) => {
   await page.setViewportSize({ width: 1280, height: 720 });
   await openPhaseTwoViewer(page);
+  await page.evaluate(() => {
+    const grid = document.getElementById("screen-grid");
+    const tile = grid.querySelector(":scope > .tile");
+    const video = tile.querySelector("video");
+    window.__phase2StageScreenSnapshot = {
+      grid,
+      mediaStreamTrack: video.srcObject && video.srcObject.getVideoTracks()[0],
+      sdkTrack: video._lkTrack,
+      srcObject: video.srcObject,
+      tile,
+      video,
+    };
+  });
 
   const structure = await page.evaluate(() => {
-    const host = document.getElementById("utility-host");
-    const overlay = document.getElementById("shell-overlay-root");
+    const host = document.getElementById("stage-module-host");
+    const stage = document.querySelector(".room-main");
     const jam = document.getElementById("jam-panel");
     window.__phase2JamNode = jam;
     return {
-      ariaOwns: host.getAttribute("aria-owns"),
+      cameraInsideHost: host.contains(document.getElementById("camera-lobby")),
       chatInsideHost: host.contains(document.getElementById("chat-panel")),
       jamInsideHost: host.contains(jam),
-      jamInsideOverlay: overlay.contains(jam),
       jamCount: document.querySelectorAll("#jam-panel").length,
       peopleInsideHost: host.contains(document.getElementById("room-sidebar")),
-      toolCount: document.querySelectorAll("[data-ui-tool]").length,
+      soundboardInsideHost: host.contains(document.getElementById("soundboard-compact")),
+      stageContainsHost: stage.contains(host),
     };
   });
   expect(structure).toEqual({
-    ariaOwns: "jam-panel",
+    cameraInsideHost: true,
     chatInsideHost: true,
-    jamInsideHost: false,
-    jamInsideOverlay: true,
+    jamInsideHost: true,
     jamCount: 1,
-    peopleInsideHost: true,
-    toolCount: 3,
+    peopleInsideHost: false,
+    soundboardInsideHost: true,
+    stageContainsHost: true,
   });
-  await expectActiveTool(page, "people");
+  await expectStageModule(page, "screens");
+  await expectUsersVisible(page, true);
 
   await page.locator("#open-chat").click();
-  await expectActiveTool(page, "chat");
+  await expectStageModule(page, "chat");
+  await expectUsersVisible(page, true);
   await page.locator("#chat-input").fill("A clubhouse Chat draft that must survive tool switches");
 
   await page.keyboard.press("Escape");
-  await expectActiveTool(page, "people");
+  await expectStageModule(page, "screens");
+  await expectUsersVisible(page, true);
   await expect(page.locator("#open-chat")).toBeFocused();
 
   await openJam(page);
-  await expectActiveTool(page, "jam");
+  await expectStageModule(page, "jam");
+  await expectUsersVisible(page, true);
+  await page.locator(".room-main").evaluate((stage) => {
+    stage.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+  await expectStageModule(page, "jam");
+  await expectUsersVisible(page, true);
   await searchJam(page);
   await page.locator("#jam-volume-slider").evaluate((input) => {
     input.value = "73";
@@ -836,71 +938,976 @@ test("one logical utility owns stable People, Chat, and portaled Jam tools witho
   expect(jamScrollTop).toBeGreaterThan(0);
 
   await page.locator("#shell-toggle-utility").click();
-  await expect(page.locator(".room-layout")).toHaveClass(/utility-collapsed/);
-  await expect(page.locator("#jam-panel")).toBeHidden();
-  await expect.poll(() => page.locator("#jam-panel").evaluate((panel) => panel.inert)).toBe(true);
-  await expect.poll(() => page.locator("#utility-host").evaluate((host) => host.inert)).toBe(true);
+  await expectUsersVisible(page, false);
+  await expectStageModule(page, "jam");
 
   await page.locator("#shell-toggle-utility").click();
-  await expectActiveTool(page, "jam");
+  await expectUsersVisible(page, true);
+  await expectStageModule(page, "jam");
   await page.locator("#close-jam").click();
-  await expectActiveTool(page, "people");
+  await expectStageModule(page, "screens");
+  await expectUsersVisible(page, true);
   await page.locator("#open-chat").click();
-  await expectActiveTool(page, "chat");
+  await expectStageModule(page, "chat");
   await expect(page.locator("#chat-input")).toHaveValue("A clubhouse Chat draft that must survive tool switches");
 
   await page.keyboard.press("Escape");
   await page.locator("#open-jam").click();
-  await expectActiveTool(page, "jam");
+  await expectStageModule(page, "jam");
   await expect(page.locator("#jam-search-input")).toHaveValue("clubhouse");
   await expect(page.locator(".jam-result-item")).toHaveCount(6);
   await expect(page.locator("#jam-volume-slider")).toHaveValue("73");
   expect(await page.locator("#jam-browser").evaluate((browser) => browser.scrollTop)).toBe(jamScrollTop);
   expect(await page.evaluate(() => window.__phase2JamNode === document.getElementById("jam-panel"))).toBe(true);
+  await page.locator("#close-jam").click();
+  await expectStageModule(page, "screens");
+  expect(await page.evaluate(() => {
+    const saved = window.__phase2StageScreenSnapshot;
+    const grid = document.getElementById("screen-grid");
+    const tile = grid.querySelector(":scope > .tile");
+    const video = tile.querySelector("video");
+    return {
+      grid: saved.grid === grid,
+      mediaStreamTrack: saved.mediaStreamTrack === (video.srcObject && video.srcObject.getVideoTracks()[0]),
+      sdkTrack: saved.sdkTrack === video._lkTrack,
+      srcObject: saved.srcObject === video.srcObject,
+      tile: saved.tile === tile && tile.isConnected,
+      trackState: saved.mediaStreamTrack.readyState,
+      video: saved.video === video && video.isConnected,
+    };
+  })).toEqual({
+    grid: true,
+    mediaStreamTrack: true,
+    sdkTrack: true,
+    srcObject: true,
+    tile: true,
+    trackState: "live",
+    video: true,
+  });
 });
 
-test("utility navigation uses stable Tools labels instead of changing meanings", async ({ page }) => {
+test("Stage navigation uses stable Users and Back to Stage labels", async ({ page }) => {
   await page.setViewportSize({ width: 1024, height: 768 });
   await openPhaseTwoViewer(page);
 
   const utilityToggle = page.locator("#shell-toggle-utility");
-  await expect(utilityToggle).toHaveText("Tools");
-  await expect(utilityToggle).toHaveAttribute("aria-label", "Hide clubhouse tools");
-  await expect(page.locator("#room-sidebar h2")).toHaveText("People & tools");
-  await expect(page.locator("#room-sidebar")).toHaveAttribute("aria-label", "People and tools");
+  await expect(utilityToggle).toHaveText("Users");
+  await expect(utilityToggle).toHaveAttribute("aria-label", "Hide active users");
+  await expect(page.locator("#room-sidebar h2")).toHaveText("Active Users");
+  await expect(page.locator("#room-sidebar")).toHaveAttribute("aria-label", "Active Users");
+  await expectUsersVisible(page, true);
 
   await page.locator("#open-chat").click();
-  await expectActiveTool(page, "chat");
-  await expect(utilityToggle).toHaveText("Tools");
-  await expect(page.locator("#close-chat")).toHaveText("All tools");
-  await expect(page.locator("#close-chat")).toHaveAttribute("aria-label", "Back to People and tools");
+  await expectStageModule(page, "chat");
+  await expectUsersVisible(page, true);
+  await expect(utilityToggle).toHaveText("Users");
+  await expect(page.locator("#close-chat")).toHaveText("Back to Stage");
   await page.locator("#close-chat").click();
+  await expectStageModule(page, "screens");
 
   await openJam(page);
-  await expectActiveTool(page, "jam");
-  await expect(utilityToggle).toHaveText("Tools");
-  await expect(page.locator("#close-jam")).toHaveText("All tools");
-  await expect(page.locator("#close-jam")).toHaveAttribute("aria-label", "Back to People and tools");
+  await expectStageModule(page, "jam");
+  await expectUsersVisible(page, true);
+  await expect(utilityToggle).toHaveText("Users");
+  await expect(page.locator("#close-jam")).toHaveText("Back to Stage");
 
   await utilityToggle.click();
-  await expect(utilityToggle).toHaveText("Tools");
-  await expect(utilityToggle).toHaveAttribute("aria-label", "Show clubhouse tools");
+  await expectUsersVisible(page, false);
+  await expectStageModule(page, "jam");
+  await expect(utilityToggle).toHaveText("Users");
+  await expect(utilityToggle).toHaveAttribute("aria-label", "Show active users");
   await utilityToggle.click();
-  await expectActiveTool(page, "jam");
-  await expect(utilityToggle).toHaveAttribute("aria-label", "Hide clubhouse tools");
+  await expectUsersVisible(page, true);
+  await expectStageModule(page, "jam");
+  await expect(utilityToggle).toHaveAttribute("aria-label", "Hide active users");
 
   await page.evaluate(() => window.EchoUiShell.applyVariant("legacy"));
   await expect(page.locator("html")).toHaveAttribute("data-ui-shell", "legacy");
   await expect(page.locator("#room-sidebar h2")).toHaveText("Active Users");
   await expect(page.locator("#room-sidebar")).toHaveAttribute("aria-label", "People");
-  await expect(page.locator("#close-chat")).toHaveText("Close");
-  await expect(page.locator("#close-chat")).not.toHaveAttribute("aria-label", /.+/);
-  await expect(page.locator("#close-jam")).toHaveText("Close");
-  await expect(page.locator("#close-jam")).not.toHaveAttribute("aria-label", /.+/);
 
   await page.evaluate(() => window.EchoUiShell.applyVariant("v2"));
-  await expect(page.locator("#room-sidebar h2")).toHaveText("People & tools");
-  await expect(page.locator("#room-sidebar")).toHaveAttribute("aria-label", "People and tools");
+  await expect(page.locator("#room-sidebar h2")).toHaveText("Active Users");
+  await expect(page.locator("#room-sidebar")).toHaveAttribute("aria-label", "Active Users");
+  await expectUsersVisible(page, true);
+});
+
+test("Active Users preference is independent from Stage modules across desktop and ultrawide widths", async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 720 });
+  await openPhaseTwoViewer(page, {
+    cameras: 1,
+    participants: 3,
+    screenShares: 1,
+    shareAspects: [32 / 9],
+  });
+  await page.evaluate(() => {
+    const grid = document.getElementById("screen-grid");
+    const tile = grid.querySelector(":scope > .tile");
+    const video = tile.querySelector("video");
+    window.__phase2ModuleMatrixScreen = {
+      grid,
+      mediaStreamTrack: video.srcObject && video.srcObject.getVideoTracks()[0],
+      sdkTrack: video._lkTrack,
+      srcObject: video.srcObject,
+      tile,
+      video,
+    };
+  });
+
+  for (const viewport of [
+    { width: 1280, height: 720 },
+    { width: 1920, height: 1080 },
+    { width: 3440, height: 1440 },
+    { width: 5120, height: 1440 },
+  ]) {
+    await resizeTo(page, viewport, "theater");
+    for (const usersVisible of [true, false]) {
+      await setUsersVisible(page, usersVisible);
+      await page.evaluate(() => window.EchoStageModules.open("jam", null, { focus: false }));
+      await expectStageModule(page, "jam");
+      await expectUsersVisible(page, usersVisible);
+
+      const geometry = await page.evaluate(() => {
+        function rect(element) {
+          const bounds = element.getBoundingClientRect();
+          return {
+            bottom: bounds.bottom,
+            left: bounds.left,
+            right: bounds.right,
+            top: bounds.top,
+          };
+        }
+        return {
+          host: rect(document.getElementById("stage-module-host")),
+          jam: rect(document.getElementById("jam-panel")),
+          stage: rect(document.querySelector(".room-main")),
+        };
+      });
+      for (const region of [geometry.host, geometry.jam]) {
+        expect(region.left, `${viewport.width}px module left`).toBeGreaterThanOrEqual(geometry.stage.left - 1);
+        expect(region.right, `${viewport.width}px module right`).toBeLessThanOrEqual(geometry.stage.right + 1);
+        expect(region.top, `${viewport.width}px module top`).toBeGreaterThanOrEqual(geometry.stage.top - 1);
+        expect(region.bottom, `${viewport.width}px module bottom`).toBeLessThanOrEqual(geometry.stage.bottom + 1);
+      }
+
+      await page.evaluate(() => window.EchoStageModules.close("jam", { restoreFocus: false }));
+      await expectStageModule(page, "screens");
+      await expectUsersVisible(page, usersVisible);
+    }
+  }
+
+  await setUsersVisible(page, true);
+  for (const module of ["chat", "jam", "camera", "soundboard"]) {
+    await page.evaluate((name) => window.EchoStageModules.open(name, null, { focus: false }), module);
+    await expectStageModule(page, module);
+    await expectUsersVisible(page, true);
+  }
+  await page.evaluate(() => window.EchoStageModules.close("soundboard", { restoreFocus: false }));
+  await expectStageModule(page, "screens");
+  await expectUsersVisible(page, true);
+
+  expect(await page.evaluate(() => {
+    const saved = window.__phase2ModuleMatrixScreen;
+    const grid = document.getElementById("screen-grid");
+    const tile = grid.querySelector(":scope > .tile");
+    const video = tile.querySelector("video");
+    return {
+      grid: saved.grid === grid,
+      mediaStreamTrack: saved.mediaStreamTrack === (video.srcObject && video.srcObject.getVideoTracks()[0]),
+      sdkTrack: saved.sdkTrack === video._lkTrack,
+      srcObject: saved.srcObject === video.srcObject,
+      tile: saved.tile === tile && tile.isConnected,
+      trackState: saved.mediaStreamTrack.readyState,
+      video: saved.video === video && video.isConnected,
+    };
+  })).toEqual({
+    grid: true,
+    mediaStreamTrack: true,
+    sdkTrack: true,
+    srcObject: true,
+    tile: true,
+    trackState: "live",
+    video: true,
+  });
+});
+
+test("Soundboard quick play and edit remain one inert-safe Stage module", async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 720 });
+  await openPhaseTwoViewer(page);
+
+  const expectSoundboardSurface = async (activeSurface) => {
+    expect(await page.evaluate((expectedSurface) => {
+      const surfaces = {
+        edit: document.getElementById("soundboard"),
+        quick: document.getElementById("soundboard-compact"),
+      };
+      return Object.fromEntries(Object.entries(surfaces).map(([name, element]) => [name, {
+        ariaHidden: element.getAttribute("aria-hidden"),
+        hidden: element.classList.contains("hidden"),
+        inert: element.inert,
+        rendered: element.getClientRects().length > 0 && getComputedStyle(element).visibility !== "hidden",
+        expected: name === expectedSurface,
+      }]));
+    }, activeSurface)).toEqual({
+      edit: {
+        ariaHidden: activeSurface === "edit" ? "false" : "true",
+        expected: activeSurface === "edit",
+        hidden: activeSurface !== "edit",
+        inert: activeSurface !== "edit",
+        rendered: activeSurface === "edit",
+      },
+      quick: {
+        ariaHidden: activeSurface === "quick" ? "false" : "true",
+        expected: activeSurface === "quick",
+        hidden: activeSurface !== "quick",
+        inert: activeSurface !== "quick",
+        rendered: activeSurface === "quick",
+      },
+    });
+  };
+
+  await expectStageModule(page, "screens");
+  await expectSoundboardSurface(null);
+  await expectUsersVisible(page, true);
+
+  await page.locator("#open-soundboard").click();
+  await expectStageModule(page, "soundboard");
+  await expectSoundboardSurface("quick");
+  await expectUsersVisible(page, true);
+
+  await page.locator("#shell-toggle-utility").click();
+  await expectUsersVisible(page, false);
+  await page.locator("#open-soundboard-edit").click();
+  await expect(page.locator("#back-to-soundboard")).toBeFocused();
+  await expect(page.locator("html")).toHaveAttribute("data-stage-module", "soundboard");
+  await expect(page.locator(".room-main")).toHaveClass(/stage-module-open/);
+  await expect(page.locator("#stage-module-host")).toHaveAttribute("data-active-module", "soundboard");
+  await expectSoundboardSurface("edit");
+  await expectUsersVisible(page, false);
+
+  await page.locator("#back-to-soundboard").click();
+  await expect(page.locator("#open-soundboard-edit")).toBeFocused();
+  await expectStageModule(page, "soundboard");
+  await expectSoundboardSurface("quick");
+  await expectUsersVisible(page, false);
+  await page.locator("#close-soundboard").click();
+  await expectStageModule(page, "screens");
+  await expectSoundboardSurface(null);
+  await expectUsersVisible(page, false);
+});
+
+test("Soundboard Quick Play and Edit remain reachable at short and narrow Stage sizes", async ({ page }) => {
+  const viewports = [
+    { width: 640, height: 360 },
+    { width: 844, height: 390 },
+    { width: 360, height: 640 },
+  ];
+
+  await page.setViewportSize(viewports[0]);
+  await openPhaseTwoViewer(page);
+  await page.evaluate(() => {
+    currentRoomName = null;
+    soundboardSounds.clear();
+    for (let index = 1; index <= 48; index += 1) {
+      soundboardSounds.set(`phase2-sound-${index}`, {
+        icon: "🔊",
+        id: `phase2-sound-${index}`,
+        name: `Fixture Sound ${String(index).padStart(2, "0")}`,
+        volume: 100,
+      });
+    }
+  });
+
+  const expectLastQuickSoundReachable = async (label) => {
+    await page.evaluate(() => {
+      const panel = document.getElementById("soundboard-compact");
+      const grid = document.getElementById("soundboard-compact-grid");
+      panel.scrollTop = panel.scrollHeight;
+      grid.scrollTop = grid.scrollHeight;
+    });
+    await nextPaint(page);
+    const geometry = await page.evaluate(() => {
+      const panel = document.getElementById("soundboard-compact");
+      const grid = document.getElementById("soundboard-compact-grid");
+      const last = grid.lastElementChild;
+      const panelRect = panel.getBoundingClientRect();
+      const gridRect = grid.getBoundingClientRect();
+      const lastRect = last.getBoundingClientRect();
+      return {
+        gridClientHeight: grid.clientHeight,
+        gridOverflowsVertically: grid.scrollHeight > grid.clientHeight + 1,
+        lastVisible: lastRect.top >= Math.max(panelRect.top, gridRect.top) - 1 &&
+          lastRect.bottom <= Math.min(panelRect.bottom, gridRect.bottom) + 1,
+        panelHasNoHorizontalOverflow: panel.scrollWidth <= panel.clientWidth + 1,
+      };
+    });
+    expect(geometry.gridClientHeight, `${label} Quick Play grid height`).toBeGreaterThanOrEqual(60);
+    expect(geometry.gridOverflowsVertically, `${label} Quick Play grid overflow`).toBe(true);
+    expect(geometry.lastVisible, `${label} final Quick Play sound`).toBe(true);
+    expect(geometry.panelHasNoHorizontalOverflow, `${label} Quick Play horizontal overflow`).toBe(true);
+  };
+
+  for (const viewport of viewports) {
+    const label = `${viewport.width}x${viewport.height}`;
+    await page.setViewportSize(viewport);
+    await nextPaint(page);
+    await page.locator("#open-soundboard").click();
+    await expectStageModule(page, "soundboard");
+    await page.evaluate(() => {
+      document.getElementById("soundboard-compact").scrollTop = 0;
+    });
+    await nextPaint(page);
+
+    const quick = await page.evaluate(() => {
+      const panel = document.getElementById("soundboard-compact");
+      const panelRect = panel.getBoundingClientRect();
+      const contained = (selector) => {
+        const rect = document.querySelector(selector).getBoundingClientRect();
+        return rect.left >= panelRect.left - 1 && rect.right <= panelRect.right + 1 &&
+          rect.top >= panelRect.top - 1 && rect.bottom <= panelRect.bottom + 1;
+      };
+      return {
+        ariaHidden: panel.getAttribute("aria-hidden"),
+        controlsContained: [
+          "#close-soundboard",
+          "#open-soundboard-edit",
+          "#toggle-soundboard-volume-compact",
+          "#soundboard-compact-search",
+        ].every(contained),
+        inert: panel.inert,
+        noHorizontalOverflow: panel.scrollWidth <= panel.clientWidth + 1,
+      };
+    });
+    expect(quick, `${label} initial Quick Play geometry`).toEqual({
+      ariaHidden: "false",
+      controlsContained: true,
+      inert: false,
+      noHorizontalOverflow: true,
+    });
+    await expectLastQuickSoundReachable(label);
+
+    await page.locator("#toggle-soundboard-volume-compact").click();
+    await expect(page.locator("#toggle-soundboard-volume-compact")).toHaveAttribute("aria-expanded", "true");
+    await expect(page.locator("#soundboard-volume-panel-compact")).toHaveAttribute("aria-hidden", "false");
+    await expectLastQuickSoundReachable(`${label} expanded volume`);
+    await page.locator("#toggle-soundboard-volume-compact").click();
+    await expect(page.locator("#toggle-soundboard-volume-compact")).toHaveAttribute("aria-expanded", "false");
+
+    await page.locator("#open-soundboard-edit").click();
+    await expect(page.locator("#back-to-soundboard")).toBeFocused();
+    await page.evaluate(() => {
+      document.getElementById("soundboard").scrollTop = 0;
+    });
+    await nextPaint(page);
+    const edit = await page.evaluate(() => {
+      const panel = document.getElementById("soundboard");
+      const panelRect = panel.getBoundingClientRect();
+      const contained = (selector) => {
+        const rect = document.querySelector(selector).getBoundingClientRect();
+        return rect.left >= panelRect.left - 1 && rect.right <= panelRect.right + 1 &&
+          rect.top >= panelRect.top - 1 && rect.bottom <= panelRect.bottom + 1;
+      };
+      return {
+        ariaHidden: panel.getAttribute("aria-hidden"),
+        controlsContained: [
+          "#toggle-soundboard-volume",
+          "#back-to-soundboard",
+          "#close-soundboard-stage",
+        ].every(contained),
+        inert: panel.inert,
+        noHorizontalOverflow: panel.scrollWidth <= panel.clientWidth + 1,
+        verticallyScrollable: panel.scrollHeight > panel.clientHeight + 1,
+      };
+    });
+    expect(edit, `${label} initial Edit geometry`).toEqual({
+      ariaHidden: "false",
+      controlsContained: true,
+      inert: false,
+      noHorizontalOverflow: true,
+      verticallyScrollable: true,
+    });
+
+    await page.evaluate(() => {
+      const panel = document.getElementById("soundboard");
+      panel.scrollTop = panel.scrollHeight;
+    });
+    await nextPaint(page);
+    const upload = await page.evaluate(() => {
+      const panel = document.getElementById("soundboard");
+      const panelRect = panel.getBoundingClientRect();
+      const uploadPanel = panel.querySelector(".soundboard-upload");
+      const uploadRect = uploadPanel.getBoundingClientRect();
+      const contained = (selector) => {
+        const rect = panel.querySelector(selector).getBoundingClientRect();
+        return rect.left >= panelRect.left - 1 && rect.right <= panelRect.right + 1 &&
+          rect.top >= panelRect.top - 1 && rect.bottom <= panelRect.bottom + 1;
+      };
+      return {
+        controlsContained: [
+          "#sound-name",
+          "#sound-upload-button",
+          ".sound-file",
+          "#sound-clip-volume",
+        ].every(contained),
+        fullyVisible: uploadRect.left >= panelRect.left - 1 && uploadRect.right <= panelRect.right + 1 &&
+          uploadRect.top >= panelRect.top - 1 && uploadRect.bottom <= panelRect.bottom + 1,
+        height: uploadRect.height,
+        noHorizontalOverflow: panel.scrollWidth <= panel.clientWidth + 1,
+      };
+    });
+    expect(upload.controlsContained, `${label} Edit upload controls`).toBe(true);
+    expect(upload.fullyVisible, `${label} Edit upload section`).toBe(true);
+    expect(upload.height, `${label} Edit upload natural height`).toBeGreaterThanOrEqual(120);
+    expect(upload.noHorizontalOverflow, `${label} Edit horizontal overflow after scroll`).toBe(true);
+
+    await page.locator("#close-soundboard-stage").click();
+    await expectStageModule(page, "screens");
+    await expectUsersVisible(page, true);
+  }
+});
+
+test("legacy rollback repairs module geometry, opener ownership, and the latest legacy intent", async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 720 });
+  await openPhaseTwoViewer(page);
+
+  await page.evaluate(() => {
+    const opener = document.createElement("button");
+    opener.id = "phase2-transient-jam-opener";
+    opener.type = "button";
+    opener.textContent = "Transient Jam";
+    document.querySelector(".room-top").appendChild(opener);
+    openJamPanel(opener);
+  });
+  await expectStageModule(page, "jam");
+
+  await page.evaluate(() => window.EchoUiShell.applyVariant("legacy"));
+  await expect(page.locator("html")).toHaveAttribute("data-ui-shell", "legacy");
+  await expect(page.locator("#jam-panel")).toBeVisible();
+  await expect(page.locator("#open-jam")).toHaveAttribute("aria-controls", "jam-panel");
+  await expect(page.locator("#phase2-transient-jam-opener")).toHaveAttribute("aria-controls", "jam-panel");
+  await expect(page.locator("#stage-module-host")).toHaveAttribute("aria-hidden", "true");
+  expect(await page.locator("#stage-module-host").evaluate((host) => host.childElementCount)).toBe(0);
+
+  await page.evaluate(() => closeJamPanel());
+  await expect(page.locator("#jam-panel")).toBeHidden();
+  expect(await page.evaluate(() => window.EchoStageModules.activeModule())).toBeNull();
+  await page.evaluate(() => window.EchoUiShell.applyVariant("v2"));
+  await expectStageModule(page, "screens");
+  await expect(page.locator("#open-jam")).toHaveAttribute("aria-controls", "stage-module-host");
+
+  await page.locator("#open-soundboard").click();
+  await expectStageModule(page, "soundboard");
+  await page.evaluate(() => {
+    window.__phase2LegacySoundboardNode = document.getElementById("soundboard-compact");
+    window.EchoUiShell.applyVariant("legacy");
+  });
+  await expect(page.locator("html")).toHaveAttribute("data-ui-shell", "legacy");
+  await expect(page.locator("#soundboard-compact")).toBeVisible();
+
+  const legacySoundboard = await page.evaluate(() => {
+    const opener = document.getElementById("open-soundboard");
+    const panel = document.getElementById("soundboard-compact");
+    const openerRect = opener.getBoundingClientRect();
+    return {
+      expectedRight: window.innerWidth - openerRect.right,
+      expectedTop: openerRect.bottom + 6,
+      right: Number.parseFloat(panel.style.right),
+      sameNode: window.__phase2LegacySoundboardNode === panel,
+      top: Number.parseFloat(panel.style.top),
+    };
+  });
+  expect(legacySoundboard.sameNode).toBe(true);
+  expect(legacySoundboard.top).toBeCloseTo(legacySoundboard.expectedTop, 1);
+  expect(legacySoundboard.right).toBeCloseTo(legacySoundboard.expectedRight, 1);
+  for (const [opener, controlled] of [
+    ["#open-chat", "chat-panel"],
+    ["#open-jam", "jam-panel"],
+    ["#open-camera-lobby", "camera-lobby"],
+    ["#open-soundboard", "soundboard-compact"],
+  ]) {
+    await expect(page.locator(opener)).toHaveAttribute("aria-controls", controlled);
+  }
+
+  await page.evaluate(() => openChat());
+  await expect(page.locator("#chat-panel")).toBeVisible();
+  expect(await page.evaluate(() => window.EchoStageModules.activeModule())).toBe("chat");
+  await page.evaluate(() => window.EchoUiShell.applyVariant("v2"));
+  await expectStageModule(page, "chat");
+  await expect(page.locator("#soundboard-compact")).toBeHidden();
+  await page.evaluate(() => window.EchoStageModules.close("chat", { restoreFocus: false }));
+  await expectStageModule(page, "screens");
+});
+
+test("leaving Jam pauses its visualizer and a removed opener falls back to canonical focus", async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 720 });
+  await openPhaseTwoViewer(page);
+
+  await page.evaluate(() => {
+    window.__phase2OriginalJamVisualizerController = window._jamAudioVisualizerController;
+    window.__phase2JamPauseCalls = 0;
+    window._jamAudioVisualizerController = {
+      pause() {
+        window.__phase2JamPauseCalls += 1;
+      },
+    };
+    window.EchoStageModules.open("jam", null, { focus: false });
+  });
+  await expectStageModule(page, "jam");
+
+  await page.evaluate(() => window.EchoStageModules.open("chat", null, { focus: false }));
+  await expectStageModule(page, "chat");
+  expect(await page.evaluate(() => window.__phase2JamPauseCalls)).toBeGreaterThan(0);
+  await page.evaluate(() => {
+    window.EchoStageModules.close("chat", { restoreFocus: false });
+    window._jamAudioVisualizerController = window.__phase2OriginalJamVisualizerController;
+    delete window.__phase2OriginalJamVisualizerController;
+    delete window.__phase2JamPauseCalls;
+  });
+  await expectStageModule(page, "screens");
+
+  await page.evaluate(() => {
+    const opener = document.createElement("button");
+    opener.id = "phase2-removed-jam-opener";
+    opener.type = "button";
+    opener.textContent = "Temporary Jam opener";
+    document.querySelector(".room-top").appendChild(opener);
+    window.EchoStageModules.open("jam", opener, { focus: false });
+  });
+  await expectStageModule(page, "jam");
+  await page.evaluate(() => {
+    document.getElementById("phase2-removed-jam-opener").remove();
+    window.EchoStageModules.close("jam");
+  });
+  await expectStageModule(page, "screens");
+  await expect(page.locator("#open-jam")).toBeFocused();
+});
+
+test("Camera Lobby teardown is isolated from avatar and Stage media across module and Room changes", async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 720 });
+  await openPhaseTwoViewer(page, { cameras: 2, participants: 4, screenShares: 1 });
+  await page.evaluate(() => window.EchoLayoutTestScenario.captureIdentitySnapshot());
+
+  await page.evaluate(() => {
+    window.__phase2MakeLobbyParticipant = function(identity, color) {
+      const LK = getLiveKitClient();
+      const canvas = document.createElement("canvas");
+      canvas.width = 640;
+      canvas.height = 360;
+      const context = canvas.getContext("2d");
+      context.fillStyle = color;
+      context.fillRect(0, 0, canvas.width, canvas.height);
+      const mediaStreamTrack = canvas.captureStream(1).getVideoTracks()[0];
+      const sdkTrack = {
+        detachCalls: 0,
+        detach: function() { this.detachCalls += 1; },
+        mediaStreamTrack,
+        sid: identity + "-camera",
+      };
+      const publication = {
+        kind: LK.Track.Kind.Video,
+        source: LK.Track.Source.Camera,
+        track: sdkTrack,
+        trackSid: sdkTrack.sid,
+      };
+      return {
+        canvas,
+        participant: {
+          identity,
+          name: identity,
+          trackPublications: new Map([[publication.trackSid, publication]]),
+        },
+        sdkTrack,
+      };
+    };
+    window.__phase2OldLobbyMedia = window.__phase2MakeLobbyParticipant("old-room-camera", "#7c3aed");
+    room = {
+      localParticipant: window.__phase2OldLobbyMedia.participant,
+      remoteParticipants: new Map(),
+    };
+  });
+
+  const mediaKeys = [
+    "cameraStream", "cameraSdkTrack", "cameraTrack", "cameraVideo",
+    "participantCard", "participantState", "screenStream", "screenSdkTrack",
+    "screenTile", "screenTrack", "screenVideo",
+  ];
+  for (const module of ["jam", "chat", "soundboard"]) {
+    await page.evaluate(() => openCameraLobby());
+    await expectStageModule(page, "camera");
+    await expect(page.locator("#camera-lobby-grid > .camera-lobby-tile")).toHaveCount(1);
+    await page.locator("#camera-lobby-grid > .camera-lobby-tile").click();
+    await expect(page.locator("#camera-lobby-grid > .camera-lobby-tile")).toHaveClass(/enlarged/);
+    await page.evaluate(() => {
+      window.__phase2DepartingLobbyVideo = document.querySelector("#camera-lobby-grid video");
+    });
+
+    await page.evaluate((nextModule) => {
+      window.EchoStageModules.open(nextModule, null, { focus: false });
+    }, module);
+    await expectStageModule(page, module);
+    await expect(page.locator("#camera-lobby-grid > .camera-lobby-tile")).toHaveCount(0);
+    expect(await page.evaluate(() => ({
+      connected: window.__phase2DepartingLobbyVideo.isConnected,
+      lkTrack: window.__phase2DepartingLobbyVideo._lkTrack,
+      srcObject: window.__phase2DepartingLobbyVideo.srcObject,
+    }))).toEqual({ connected: false, lkTrack: null, srcObject: null });
+
+    const identity = await page.evaluate(() => window.EchoLayoutTestScenario.inspectIdentitySnapshot());
+    for (const key of mediaKeys) expect(identity[key], `${module} preserves ${key}`).toBe(true);
+    await page.evaluate((activeModule) => {
+      window.EchoStageModules.close(activeModule, { restoreFocus: false });
+    }, module);
+    await expectStageModule(page, "screens");
+  }
+
+  await page.evaluate(() => openCameraLobby());
+  await expectStageModule(page, "camera");
+  await page.evaluate(() => {
+    window.__phase2OldRoomLobbyVideo = document.querySelector("#camera-lobby-grid video");
+    const next = window.__phase2MakeLobbyParticipant("new-room-camera", "#0f766e");
+    window.__phase2NewLobbyMedia = next;
+    const nextRoom = { localParticipant: next.participant, remoteParticipants: new Map() };
+    clearMedia();
+    room = nextRoom;
+    refreshActiveCameraLobbyForRoom(nextRoom);
+  });
+  await expectStageModule(page, "camera");
+  await expect(page.locator('#camera-lobby-grid > .camera-lobby-tile[data-identity="new-room-camera"]')).toHaveCount(1);
+  expect(await page.evaluate(() => ({
+    detachCalls: window.__phase2OldLobbyMedia.sdkTrack.detachCalls,
+    oldConnected: window.__phase2OldRoomLobbyVideo.isConnected,
+    oldReadyState: window.__phase2OldLobbyMedia.sdkTrack.mediaStreamTrack.readyState,
+    oldSrcObject: window.__phase2OldRoomLobbyVideo.srcObject,
+    staleEnlarged: !!document.querySelector("#camera-lobby-grid > .enlarged"),
+  }))).toEqual({
+    detachCalls: 4,
+    oldConnected: false,
+    oldReadyState: "live",
+    oldSrcObject: null,
+    staleEnlarged: false,
+  });
+});
+
+test("hidden Stage grid mutations recover after rapid module reopen on ultrawide displays", async ({ page }) => {
+  await page.setViewportSize({ width: 3440, height: 1440 });
+  await openPhaseTwoViewer(page, { cameras: 1, participants: 3, screenShares: 1, shareAspects: [32 / 9] });
+
+  for (const viewport of [
+    { width: 3440, height: 1440 },
+    { width: 5120, height: 1440 },
+  ]) {
+    await resizeTo(page, viewport, "theater");
+    await page.evaluate(() => {
+      const grid = document.getElementById("screen-grid");
+      const originalTile = grid.querySelector(":scope > .tile");
+      const originalVideo = originalTile.querySelector("video");
+      window.__phase2HiddenGridSnapshot = {
+        grid,
+        mediaStreamTrack: originalVideo.srcObject.getVideoTracks()[0],
+        sdkTrack: originalVideo._lkTrack,
+        srcObject: originalVideo.srcObject,
+        tile: originalTile,
+        video: originalVideo,
+      };
+      window.EchoStageModules.open("jam", null, { focus: false });
+      const lateTile = document.createElement("article");
+      lateTile.className = "tile";
+      lateTile.dataset.identity = "late-ultrawide-share";
+      lateTile.dataset.mediaKind = "screen";
+      lateTile.style.setProperty("--screen-source-aspect-ratio", String(16 / 9));
+      const title = document.createElement("h3");
+      title.textContent = "Late ultrawide share";
+      lateTile.appendChild(title);
+      grid.appendChild(lateTile);
+      window.__phase2LateGridTile = lateTile;
+    });
+    await expectStageModule(page, "jam");
+    // Drain the grid observer's delayed insertion retries, then model the exact
+    // zero-visible state a hidden measurement can publish. The final close must
+    // repair this state on its own; no insertion retry remains to mask a miss.
+    await page.waitForTimeout(1100);
+    await page.evaluate(() => {
+      const grid = document.getElementById("screen-grid");
+      grid.dataset.visibleTiles = "0";
+      grid.style.gridTemplateColumns = "";
+      grid.style.gridTemplateRows = "";
+      grid.querySelectorAll(":scope > .tile").forEach((tile) => {
+        tile.removeAttribute("data-grid-visible");
+        tile.style.width = "";
+        tile.style.height = "";
+      });
+    });
+    await expect(page.locator("#screen-grid")).toHaveAttribute("data-visible-tiles", "0");
+
+    await page.evaluate(() => {
+      window.EchoStageModules.close("jam", { restoreFocus: false });
+      window.EchoStageModules.open("jam", null, { focus: false });
+    });
+    await expectStageModule(page, "jam");
+    await page.evaluate(() => window.EchoStageModules.close("jam", { restoreFocus: false }));
+    await expectStageModule(page, "screens");
+    await expect.poll(() => page.locator("#screen-grid").getAttribute("data-visible-tiles")).toBe("2");
+    await expect(page.locator("#screen-grid > .tile[data-grid-visible]")).toHaveCount(2);
+    await expect.poll(() => page.locator("#screen-grid").evaluate((grid) => grid.style.gridTemplateColumns)).not.toBe("");
+
+    expect(await page.evaluate(() => {
+      const saved = window.__phase2HiddenGridSnapshot;
+      const video = saved.tile.querySelector("video");
+      return {
+        grid: saved.grid === document.getElementById("screen-grid"),
+        mediaStreamTrack: saved.mediaStreamTrack === video.srcObject.getVideoTracks()[0],
+        sdkTrack: saved.sdkTrack === video._lkTrack,
+        srcObject: saved.srcObject === video.srcObject,
+        tile: saved.tile.isConnected,
+        video: saved.video === video && video.isConnected,
+      };
+    })).toEqual({
+      grid: true,
+      mediaStreamTrack: true,
+      sdkTrack: true,
+      srcObject: true,
+      tile: true,
+      video: true,
+    });
+
+    await page.evaluate(() => {
+      window.__phase2LateGridTile.remove();
+      window._echoRecalcGrid();
+    });
+    await expect.poll(() => page.locator("#screen-grid").getAttribute("data-visible-tiles")).toBe("1");
+  }
+});
+
+test("short landscape keeps every Stage module and Active Users independently usable", async ({ page }) => {
+  await page.setViewportSize({ width: 640, height: 360 });
+  await openPhaseTwoViewer(page);
+
+  for (const viewport of [
+    { width: 640, height: 360 },
+    { width: 844, height: 390 },
+  ]) {
+    await resizeTo(page, viewport, "mini");
+    await expect(page.locator("html")).toHaveAttribute("data-ui-short", "");
+    for (const module of ["chat", "jam", "camera", "soundboard"]) {
+      await page.evaluate((name) => window.EchoStageModules.open(name, null, { focus: false }), module);
+      await expectStageModule(page, module);
+      await expectUsersVisible(page, true);
+      const geometry = await page.evaluate(() => {
+        const stage = document.querySelector(".room-main").getBoundingClientRect();
+        const users = document.getElementById("room-sidebar").getBoundingClientRect();
+        const host = document.getElementById("stage-module-host").getBoundingClientRect();
+        return {
+          host: { bottom: host.bottom, left: host.left, right: host.right, top: host.top },
+          stage: { bottom: stage.bottom, height: stage.height, left: stage.left, right: stage.right, top: stage.top, width: stage.width },
+          users: { bottom: users.bottom, height: users.height, left: users.left, right: users.right, top: users.top, width: users.width },
+        };
+      });
+      expect(geometry.stage.width).toBeGreaterThanOrEqual(300);
+      expect(geometry.stage.height).toBeGreaterThanOrEqual(180);
+      expect(geometry.users.width).toBeGreaterThanOrEqual(219);
+      expect(geometry.users.height).toBeGreaterThanOrEqual(180);
+      expect(geometry.stage.right).toBeLessThanOrEqual(geometry.users.left + 1);
+      expect(geometry.host.left).toBeGreaterThanOrEqual(geometry.stage.left - 1);
+      expect(geometry.host.right).toBeLessThanOrEqual(geometry.stage.right + 1);
+      await page.evaluate((name) => window.EchoStageModules.close(name, { restoreFocus: false }), module);
+      await expectStageModule(page, "screens");
+      await expectUsersVisible(page, true);
+    }
+  }
+});
+
+test("one participant's 32:9 screen and camera remain independent Stage tiles", async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 720 });
+  await openPhaseTwoViewer(page, {
+    cameras: 1,
+    participants: 3,
+    screenOwners: [2],
+    screenShares: 1,
+    shareAspects: [32 / 9],
+  });
+
+  const identity = "layout-fixture-2";
+  const card = page.locator(`.user-card[data-identity="${identity}"]`);
+  await expect(card).toHaveClass(/has-camera/);
+  await page.evaluate((participantIdentity) => {
+    const cardRef = participantCards.get(participantIdentity);
+    const cardElement = document.querySelector(`.user-card[data-identity="${participantIdentity}"]`);
+    const sourceVideo = cardElement.querySelector("video");
+    const track = sourceVideo._lkTrack;
+    const LK = getLiveKitClient();
+    const publication = {
+      kind: LK.Track.Kind.Video,
+      source: LK.Track.Source.Camera,
+      track,
+      trackSid: track.sid,
+    };
+    const participant = {
+      identity: participantIdentity,
+      name: "Friend 2",
+      trackPublications: new Map([[publication.trackSid, publication]]),
+    };
+    room.remoteParticipants.set(participantIdentity, participant);
+    cardRef.setCameraStageAvailable(true);
+    const screenTile = screenTileByIdentity.get(participantIdentity);
+    const screenVideo = screenTile.querySelector("video");
+    window.__phase2MixedStageSnapshot = {
+      cameraSdkTrack: track,
+      cameraSourceMediaTrack: sourceVideo.srcObject && sourceVideo.srcObject.getVideoTracks()[0],
+      cameraSourceStream: sourceVideo.srcObject,
+      cameraSourceVideo: sourceVideo,
+      screenMediaTrack: screenVideo.srcObject && screenVideo.srcObject.getVideoTracks()[0],
+      screenSdkTrack: screenVideo._lkTrack,
+      screenStream: screenVideo.srcObject,
+      screenTile,
+      screenVideo,
+    };
+  }, identity);
+
+  const settingsToggle = card.locator(".participant-settings-toggle");
+  await settingsToggle.click();
+  const settings = card.locator(".participant-settings-popover");
+  await expect(settings).toBeVisible();
+  await settings.getByRole("button", { name: "Show Friend 2's camera on my Stage" }).click();
+
+  const screenTile = page.locator(`#screen-grid > .tile[data-media-kind="screen"][data-identity="${identity}"]`);
+  const cameraTile = page.locator(`#screen-grid > .tile[data-media-kind="camera"][data-identity="${identity}"]`);
+  await expect(screenTile).toBeVisible();
+  await expect(cameraTile).toBeVisible();
+  await expect(page.locator("#screen-grid > .tile[data-grid-visible]")).toHaveCount(2);
+
+  expect(await page.evaluate((participantIdentity) => {
+    const saved = window.__phase2MixedStageSnapshot;
+    const currentSourceVideo = document.querySelector(
+      `.user-card[data-identity="${participantIdentity}"] video`,
+    );
+    const stageVideo = cameraStageTileByIdentity.get(participantIdentity).querySelector("video");
+    return {
+      distinctVideo: stageVideo !== currentSourceVideo,
+      mediaTrackShared: saved.cameraSourceMediaTrack ===
+        (stageVideo.srcObject && stageVideo.srcObject.getVideoTracks()[0]),
+      sdkTrackShared: saved.cameraSdkTrack === stageVideo._lkTrack,
+      sourceStreamPreserved: saved.cameraSourceStream === currentSourceVideo.srcObject,
+      sourceTrackLive: saved.cameraSourceMediaTrack.readyState,
+      sourceVideoPreserved: saved.cameraSourceVideo === currentSourceVideo && currentSourceVideo.isConnected,
+    };
+  }, identity)).toEqual({
+    distinctVideo: true,
+    mediaTrackShared: true,
+    sdkTrackShared: true,
+    sourceStreamPreserved: true,
+    sourceTrackLive: "live",
+    sourceVideoPreserved: true,
+  });
+
+  for (const viewport of [
+    { width: 1280, height: 720 },
+    { width: 3440, height: 1440 },
+    { width: 5120, height: 1440 },
+  ]) {
+    await resizeTo(page, viewport, "theater");
+    await expect.poll(() => page.evaluate(() => document.getElementById("screen-grid").style.gridTemplateColumns))
+      .not.toBe("");
+    const geometry = await page.evaluate((participantIdentity) => {
+      function rect(element) {
+        const bounds = element.getBoundingClientRect();
+        return {
+          bottom: bounds.bottom,
+          height: bounds.height,
+          left: bounds.left,
+          right: bounds.right,
+          top: bounds.top,
+          width: bounds.width,
+        };
+      }
+      const grid = document.getElementById("screen-grid");
+      const screen = grid.querySelector(
+        `:scope > .tile[data-media-kind="screen"][data-identity="${participantIdentity}"]`,
+      );
+      const camera = grid.querySelector(
+        `:scope > .tile[data-media-kind="camera"][data-identity="${participantIdentity}"]`,
+      );
+      const screenRect = rect(screen);
+      const cameraRect = rect(camera);
+      const overlapWidth = Math.max(0, Math.min(screenRect.right, cameraRect.right) -
+        Math.max(screenRect.left, cameraRect.left));
+      const overlapHeight = Math.max(0, Math.min(screenRect.bottom, cameraRect.bottom) -
+        Math.max(screenRect.top, cameraRect.top));
+      return {
+        camera: cameraRect,
+        cameraFit: getComputedStyle(camera.querySelector("video")).objectFit,
+        grid: rect(grid),
+        overlapArea: overlapWidth * overlapHeight,
+        screen: screenRect,
+        screenFit: getComputedStyle(screen.querySelector("video")).objectFit,
+      };
+    }, identity);
+    for (const region of [geometry.screen, geometry.camera]) {
+      expect(region.left).toBeGreaterThanOrEqual(geometry.grid.left - 1);
+      expect(region.right).toBeLessThanOrEqual(geometry.grid.right + 1);
+      expect(region.top).toBeGreaterThanOrEqual(geometry.grid.top - 1);
+      expect(region.bottom).toBeLessThanOrEqual(geometry.grid.bottom + 1);
+    }
+    expect(geometry.overlapArea).toBeLessThanOrEqual(1);
+    expect(geometry.screen.width / geometry.screen.height).toBeCloseTo(32 / 9, 2);
+    expect(geometry.camera.width / geometry.camera.height).toBeCloseTo(16 / 9, 2);
+    expect(geometry.screenFit).toBe("contain");
+    expect(geometry.cameraFit).toBe("contain");
+  }
+
+  await page.evaluate(() => window.EchoStageModules.open("jam", null, { focus: false }));
+  await expectStageModule(page, "jam");
+  await page.evaluate(() => window.EchoStageModules.close("jam", { restoreFocus: false }));
+  await expectStageModule(page, "screens");
+  expect(await page.evaluate((participantIdentity) => {
+    const saved = window.__phase2MixedStageSnapshot;
+    const currentScreenTile = screenTileByIdentity.get(participantIdentity);
+    const currentScreenVideo = currentScreenTile.querySelector("video");
+    const currentCameraTile = cameraStageTileByIdentity.get(participantIdentity);
+    return {
+      cameraTile: !!currentCameraTile && currentCameraTile.isConnected,
+      screenMediaTrack: saved.screenMediaTrack ===
+        (currentScreenVideo.srcObject && currentScreenVideo.srcObject.getVideoTracks()[0]),
+      screenSdkTrack: saved.screenSdkTrack === currentScreenVideo._lkTrack,
+      screenStream: saved.screenStream === currentScreenVideo.srcObject,
+      screenTile: saved.screenTile === currentScreenTile && currentScreenTile.isConnected,
+      screenVideo: saved.screenVideo === currentScreenVideo && currentScreenVideo.isConnected,
+    };
+  }, identity)).toEqual({
+    cameraTile: true,
+    screenMediaTrack: true,
+    screenSdkTrack: true,
+    screenStream: true,
+    screenTile: true,
+    screenVideo: true,
+  });
+
+  if (!(await settings.isVisible())) await settingsToggle.click();
+  await settings.getByRole("button", { name: /Hide the shared screen from Friend 2 on my Stage/i }).click();
+  await expect(screenTile).toBeHidden();
+  await expect(cameraTile).toBeVisible();
+  await settings.getByRole("button", { name: /Show the shared screen from Friend 2 on my Stage/i }).click();
+  await expect(screenTile).toBeVisible();
+  await settings.getByRole("button", { name: "Hide Friend 2's camera from my Stage" }).click();
+  await expect(cameraTile).toHaveCount(0);
+  await expect(screenTile).toBeVisible();
+
+  expect(await page.evaluate(() => {
+    const saved = window.__phase2MixedStageSnapshot;
+    return {
+      cameraIntentCount: stagedCameraIdentities.size,
+      cameraTileCount: cameraStageTileByIdentity.size,
+      sourceTrackState: saved.cameraSourceMediaTrack.readyState,
+      sourceVideo: saved.cameraSourceVideo.isConnected,
+      sourceVideoTrack: saved.cameraSourceMediaTrack ===
+        (saved.cameraSourceVideo.srcObject && saved.cameraSourceVideo.srcObject.getVideoTracks()[0]),
+    };
+  })).toEqual({
+    cameraIntentCount: 0,
+    cameraTileCount: 0,
+    sourceTrackState: "live",
+    sourceVideo: true,
+    sourceVideoTrack: true,
+  });
 });
 
 test("Ultra Instinct keeps the Goku GIF visible through the Phase 2 stage", async ({ page }) => {
@@ -994,7 +2001,8 @@ test("People actions stay visible and contained in the theater rail and mini she
     [{ width: 360, height: 640 }, "mini"],
   ]) {
     await resizeTo(page, viewport, expectedMode);
-    await expectActiveTool(page, "people");
+    await expectStageModule(page, "screens");
+    await expectUsersVisible(page, true);
     const geometry = await page.evaluate(() => {
       const sidebar = document.getElementById("room-sidebar").getBoundingClientRect();
       const titleRow = document.querySelector("#room-sidebar .sidebar-title-row");
@@ -1054,7 +2062,7 @@ test("People actions stay visible and contained in the theater rail and mini she
   }
 });
 
-test("responsive modes and live legacy rollback retain the same centered Jam node and state", async ({ page }) => {
+test("responsive modes and live legacy rollback retain the same Jam node, state, and Users preference", async ({ page }) => {
   await page.setViewportSize({ width: 1280, height: 720 });
   await openPhaseTwoViewer(page);
   await openJam(page);
@@ -1069,9 +2077,11 @@ test("responsive modes and live legacy rollback retain the same centered Jam nod
     [{ width: 900, height: 700 }, "lounge"],
     [{ width: 600, height: 900 }, "compact"],
     [{ width: 360, height: 640 }, "mini"],
+    [{ width: 640, height: 360 }, "mini"],
   ]) {
     await resizeTo(page, viewport, expectedMode);
-    await expectActiveTool(page, "jam");
+    await expectStageModule(page, "jam");
+    await expectUsersVisible(page, true);
     expect(await page.evaluate(() => window.__phase2ResponsiveJamNode === document.getElementById("jam-panel"))).toBe(true);
     await expect(page.locator("#jam-search-input")).toHaveValue("anthem");
     await expect(page.locator("#jam-volume-slider")).toHaveValue("64");
@@ -1098,22 +2108,24 @@ test("responsive modes and live legacy rollback retain the same centered Jam nod
 
   await page.evaluate(() => window.EchoUiShell.applyVariant("v2"));
   await expect(page.locator("html")).toHaveAttribute("data-ui-shell", "v2");
-  await expectActiveTool(page, "jam");
+  await expectStageModule(page, "jam");
+  await expectUsersVisible(page, true);
   expect(await page.evaluate(() => window.__phase2ResponsiveJamNode === document.getElementById("jam-panel"))).toBe(true);
 });
 
-test("Jam focus returns through Escape and Settings explicitly inerts the portaled tool", async ({ page }) => {
+test("Jam focus returns through Escape while Settings explicitly inerts the active Stage module", async ({ page }) => {
   await page.setViewportSize({ width: 1024, height: 768 });
   await openPhaseTwoViewer(page);
   await openJam(page);
 
   await expect(page.locator("#close-jam")).toBeFocused();
   await page.keyboard.press("Escape");
-  await expectActiveTool(page, "people");
+  await expectStageModule(page, "screens");
+  await expectUsersVisible(page, true);
   await expect(page.locator("#open-jam")).toBeFocused();
 
   await page.locator("#open-jam").click();
-  await expectActiveTool(page, "jam");
+  await expectStageModule(page, "jam");
   const output = page.locator("#dock-output");
   await output.click();
   await expect(page.locator("#settings-panel")).toBeVisible();
@@ -1127,38 +2139,36 @@ test("Jam focus returns through Escape and Settings explicitly inerts the portal
   await expect(output).toBeFocused();
   await expect(page.locator("#jam-panel")).toBeVisible();
   await expect.poll(() => page.locator("#jam-panel").evaluate((panel) => panel.inert)).toBe(false);
-  await expectActiveTool(page, "jam");
+  await expectStageModule(page, "jam");
+  await expectUsersVisible(page, true);
 
   await page.keyboard.press("Escape");
-  await expectActiveTool(page, "people");
+  await expectStageModule(page, "screens");
+  await expectUsersVisible(page, true);
   await expect(page.locator("#open-jam")).toBeFocused();
 });
 
-test("collapsed Chat records unread messages and a top overlay owns the first Escape", async ({ page }) => {
+test("hidden Users does not close Chat and a top overlay owns the first Escape", async ({ page }) => {
   await page.setViewportSize({ width: 1024, height: 768 });
   await openPhaseTwoViewer(page);
 
   await page.locator("#open-chat").click();
-  await expectActiveTool(page, "chat");
+  await expectStageModule(page, "chat");
+  await expectUsersVisible(page, true);
   await page.locator("#shell-toggle-utility").click();
-  await expect(page.locator(".room-layout")).toHaveClass(/utility-collapsed/);
-
-  await page.evaluate(() => incrementUnreadChat());
-  await expect(page.locator("#chat-badge")).toHaveText("1");
-  await expect(page.locator("#chat-badge")).not.toHaveClass(/hidden/);
-
-  await page.locator("#shell-toggle-utility").click();
-  await expectActiveTool(page, "chat");
-  await expect(page.locator("#chat-badge")).toHaveClass(/hidden/);
+  await expectUsersVisible(page, false);
+  await expectStageModule(page, "chat");
 
   await page.evaluate((src) => openImageLightbox(src), transparentDataUrl);
   await expect(page.locator(".image-lightbox")).toBeVisible();
   await page.keyboard.press("Escape");
   await expect(page.locator(".image-lightbox")).toHaveCount(0);
-  await expectActiveTool(page, "chat");
+  await expectStageModule(page, "chat");
+  await expectUsersVisible(page, false);
 
   await page.keyboard.press("Escape");
-  await expectActiveTool(page, "people");
+  await expectStageModule(page, "screens");
+  await expectUsersVisible(page, false);
 });
 
 test("source-PC settings stay collapsed while playback controls remain reachable", async ({ page }) => {
@@ -1278,6 +2288,8 @@ test("populated Jam remains inside the workspace and above the dock at represent
   await searchJam(page, "responsive");
 
   for (const [viewport, expectedMode] of [
+    [{ width: 5120, height: 1440 }, "theater"],
+    [{ width: 3440, height: 1440 }, "theater"],
     [{ width: 1920, height: 1080 }, "theater"],
     [{ width: 1366, height: 768 }, "theater"],
     [{ width: 1280, height: 720 }, "theater"],
@@ -1320,6 +2332,8 @@ test("populated Jam remains inside the workspace and above the dock at represent
         overviewEnd: rect("#jam-status"),
         search: rect("#jam-search-input"),
         scrimVisible: !document.getElementById("utility-scrim").classList.contains("hidden"),
+        screenInert: document.getElementById("screen-grid").inert,
+        stage: rect('[data-ui-region="primary-stage"]'),
         stageInert: document.querySelector('[data-ui-region="primary-stage"]').inert,
         targetSizes,
         textOverflow,
@@ -1328,14 +2342,16 @@ test("populated Jam remains inside the workspace and above the dock at represent
         visualizerCanvasCount: document.querySelectorAll("#jam-audio-visualizer canvas").length,
         visualizerOverflow: document.getElementById("jam-audio-visualizer").scrollWidth - document.getElementById("jam-audio-visualizer").clientWidth,
         viewport: { height: window.innerHeight, width: window.innerWidth },
+        usersInert: document.getElementById("room-sidebar").inert,
+        usersVisible: document.getElementById("room-sidebar").getClientRects().length > 0,
         workspace: rect('.room-layout[data-ui-region="workspace"]'),
       };
     });
 
-    expect(geometry.jam.left).toBeGreaterThanOrEqual(geometry.workspace.left - 1);
-    expect(geometry.jam.right).toBeLessThanOrEqual(geometry.workspace.right + 1);
-    expect(geometry.jam.top).toBeGreaterThanOrEqual(geometry.workspace.top - 1);
-    expect(geometry.jam.bottom).toBeLessThanOrEqual(geometry.workspace.bottom + 1);
+    expect(geometry.jam.left).toBeGreaterThanOrEqual(geometry.stage.left - 1);
+    expect(geometry.jam.right).toBeLessThanOrEqual(geometry.stage.right + 1);
+    expect(geometry.jam.top).toBeGreaterThanOrEqual(geometry.stage.top - 1);
+    expect(geometry.jam.bottom).toBeLessThanOrEqual(geometry.stage.bottom + 1);
     expect(geometry.jam.top).toBeGreaterThanOrEqual(geometry.header.bottom - 1);
     expect(geometry.jam.bottom).toBeLessThanOrEqual(geometry.dock.top - 1);
     expect(geometry.search.top).toBeGreaterThanOrEqual(geometry.jam.top - 1);
@@ -1353,18 +2369,20 @@ test("populated Jam remains inside the workspace and above the dock at represent
       expect(geometry.visualizer.left).toBeGreaterThanOrEqual(geometry.overview.left - 1);
       expect(geometry.visualizer.right).toBeLessThanOrEqual(geometry.overview.right + 1);
     }
-    expect(geometry.scrimVisible).toBe(true);
-    expect(geometry.stageInert).toBe(true);
+    expect(geometry.scrimVisible).toBe(false);
+    expect(geometry.screenInert).toBe(true);
+    expect(geometry.stageInert).toBe(false);
+    expect(geometry.usersInert).toBe(false);
+    expect(geometry.usersVisible).toBe(true);
     expect(geometry.dockInert).toBe(false);
-    if (expectedMode === "theater" || expectedMode === "lounge") {
-      expect(geometry.jam.width).toBeGreaterThanOrEqual(839.5);
-      expect(geometry.jam.width).toBeLessThanOrEqual(1120.5);
-      expect(geometry.jam.height).toBeLessThanOrEqual(840.5);
-      expect(geometry.bodyDisplay).toBe("grid");
+    expect(Math.abs(geometry.jam.width - geometry.stage.width)).toBeLessThanOrEqual(2.5);
+    expect(Math.abs(geometry.jam.height - geometry.stage.height)).toBeLessThanOrEqual(2.5);
+    const expectedJamBodyDisplay = geometry.jam.width >= 854 ? "grid" : "flex";
+    expect(geometry.bodyDisplay).toBe(expectedJamBodyDisplay);
+    if (expectedJamBodyDisplay === "grid") {
       expect(geometry.overview.right).toBeLessThanOrEqual(geometry.browser.left + 1);
       expect(geometry.browser.width).toBeGreaterThanOrEqual(459.5);
     } else {
-      expect(geometry.bodyDisplay).toBe("flex");
       expect(geometry.overviewEnd.bottom).toBeLessThanOrEqual(geometry.browser.top + 1);
     }
     expect(geometry.targetSizes.length).toBeGreaterThan(4);
@@ -2981,7 +3999,8 @@ test("Stop Music preserves the Jam while exact-host End Jam remains a distinct d
   await expect.poll(() => model.counts["POST /api/jam/playback/stop"] || 0).toBe(1);
   expect(model.counts["POST /api/jam/stop"] || 0).toBe(0);
   await expect(page.locator("#jam-panel")).toBeVisible();
-  await expectActiveTool(page, "jam");
+  await expectStageModule(page, "jam");
+  await expectUsersVisible(page, true);
   await expect(page.locator("#jam-now-playing")).toContainText("No music playing");
   expect(model.state.active).toBe(true);
   expect(model.state.generation).toBe(7);

--- a/core/viewer-tests/tests/stage.fullscreen.spec.js
+++ b/core/viewer-tests/tests/stage.fullscreen.spec.js
@@ -114,7 +114,7 @@ async function openStageFixture(page, scenario) {
 }
 
 async function closeClubhouseTools(page) {
-  const toolsToggle = page.getByRole("button", { name: "Hide clubhouse tools" });
+  const toolsToggle = page.getByRole("button", { name: "Hide active users" });
   if (await toolsToggle.isVisible()) {
     await toolsToggle.click();
     await waitForLayout(page, 3);

--- a/core/viewer/android-firefox-room-disconnect-recovery.test.js
+++ b/core/viewer/android-firefox-room-disconnect-recovery.test.js
@@ -324,7 +324,7 @@ test("production wiring is target-gated and invokes only supported connectToRoom
   );
   assert.match(
     connectSource,
-    /ConnectionStateChanged[\s\S]*?if \(androidFirefoxRoomDisconnectRecoveryEnabled && newRoom !== room\) \{[\s\S]*?return;/
+    /ConnectionStateChanged[\s\S]*?ignoreStaleRoomEvent\("connection state " \+ state\)/
   );
   assert.match(
     connectSource,

--- a/core/viewer/android-firefox-stalled-reconnect-recovery.test.js
+++ b/core/viewer/android-firefox-stalled-reconnect-recovery.test.js
@@ -835,6 +835,6 @@ test("mic preservation policy remains recovery-only and production wiring tears 
   assert.match(connectSource, /handleConnectedMediaStall\(\{[\s\S]*?micWasEnabled: desiredMicEnabledForRoomSwitch\(\) === true/);
   assert.match(connectSource, /if \(forceAndroidFirefoxRelay\) \{\s+rtcConfig\.iceTransportPolicy = "relay"/);
   assert.match(connectSource, /androidFirefoxForceRelay: recoveryState\?\.forceRelay === true/);
-  assert.match(connectSource, /ignoreAndroidFirefoxStaleRoomEvent\("local track unpublished"\)/);
+  assert.match(connectSource, /ignoreStaleRoomEvent\("local track unpublished"\)/);
   assert.match(connectSource, /androidFirefoxRoomDisconnectRecovery\?\.cancel\(room\);[\s\S]*?connectSequence \+= 1;[\s\S]*?room\._echoExpectedDisconnect = true/);
 });

--- a/core/viewer/app.js
+++ b/core/viewer/app.js
@@ -113,6 +113,9 @@ var shellOverflowMenu = document.getElementById("shell-overflow-menu");
 var shellHeader = document.querySelector('[data-ui-region="shell-header"]');
 var shellLayout = document.querySelector('[data-ui-region="workspace"]');
 var shellStage = document.querySelector('[data-ui-region="primary-stage"]');
+var shellStageHeader = shellStage?.querySelector(":scope > .grid-header");
+var shellScreenGrid = document.getElementById("screen-grid");
+var shellStageModuleHost = document.getElementById("stage-module-host");
 var shellUtilityHost = document.getElementById("utility-host");
 var shellUtilityScrim = document.getElementById("utility-scrim");
 var shellPeoplePanel = document.getElementById("room-sidebar");
@@ -120,16 +123,30 @@ var shellPeopleHeading = shellPeoplePanel?.querySelector(".sidebar-title-row h2"
 var shellJamPanel = document.getElementById("jam-panel");
 var shellOpenJamButton = document.getElementById("open-jam");
 var shellCloseJamButton = document.getElementById("close-jam");
+var shellCameraLobbyPanel = document.getElementById("camera-lobby");
+var shellSoundboardCompactPanel = document.getElementById("soundboard-compact");
+var shellSoundboardPanel = document.getElementById("soundboard");
 var clubhouseShell = document.getElementById("clubhouse-shell");
 var settingsScrim = document.getElementById("settings-scrim");
 var settingsReturnFocus = null;
 var settingsModalActive = false;
-var activeUtilityTool = "people";
-var utilityReturnFocus = {
-  people: shellUtilityButton,
+var activeStageModule = null;
+var stageModuleOpeners = {
   chat: openChatButton,
   jam: shellOpenJamButton,
+  camera: openCameraLobbyButton,
+  soundboard: openSoundboardButton,
 };
+var stageModuleReturnFocus = Object.assign({}, stageModuleOpeners);
+var legacyStageModuleControlIds = {
+  chat: "chat-panel",
+  jam: "jam-panel",
+  camera: "camera-lobby",
+  soundboard: "soundboard-compact",
+};
+var stageModulePortalAnchors = new Map();
+var stageModulePortalFocusGeneration = 0;
+var stageModulePortalPendingFocus = null;
 var syncingClubhouseUtility = false;
 
 function setShellOverflowOpen(open, options) {
@@ -221,49 +238,203 @@ function setSettingsPanelOpen(open, returnFocusTarget) {
   }
 }
 
-function normalizeUtilityTool(tool) {
-  return tool === "chat" || tool === "jam" ? tool : "people";
+function normalizeStageModule(module) {
+  return module === "chat" || module === "jam" || module === "camera" || module === "soundboard"
+    ? module
+    : null;
 }
 
-function focusUtilityReturnTarget(preferred) {
-  var candidates = [preferred, shellUtilityButton, shellMoreButton, connectBtn];
+function stageModuleNodes(module) {
+  if (module === "chat") return chatPanel ? [chatPanel] : [];
+  if (module === "jam") return shellJamPanel ? [shellJamPanel] : [];
+  if (module === "camera") return shellCameraLobbyPanel ? [shellCameraLobbyPanel] : [];
+  if (module === "soundboard") {
+    return [shellSoundboardCompactPanel, shellSoundboardPanel].filter(Boolean);
+  }
+  return [];
+}
+
+function allStageModuleNodes() {
+  return ["chat", "jam", "camera", "soundboard"].flatMap(stageModuleNodes);
+}
+
+function stageModuleOpenerNodes(module) {
+  return [stageModuleOpeners[module], stageModuleReturnFocus[module]].filter(function(opener, index, values) {
+    return opener && values.indexOf(opener) === index;
+  });
+}
+
+function rememberStageModulePortals() {
+  allStageModuleNodes().forEach(function(panel) {
+    if (stageModulePortalAnchors.has(panel) || !panel.parentNode) return;
+    var anchor = document.createComment("echo-stage-module:" + (panel.id || "panel"));
+    panel.parentNode.insertBefore(anchor, panel);
+    stageModulePortalAnchors.set(panel, anchor);
+  });
+}
+
+function restoreStageModulePortalFocus(element, panel, generation) {
+  requestAnimationFrame(function() {
+    if (generation !== stageModulePortalFocusGeneration) return;
+    var clearPendingFocus = function() {
+      if (stageModulePortalPendingFocus?.generation === generation) {
+        stageModulePortalPendingFocus = null;
+      }
+    };
+    if (!element || typeof element.focus !== "function" ||
+        element.ownerDocument !== document || panel?.ownerDocument !== document ||
+        !element.isConnected || !panel?.isConnected || !panel.contains(element)) {
+      clearPendingFocus();
+      return;
+    }
+    var current = document.activeElement;
+    if (current !== element && current !== document.body && current !== document.documentElement) {
+      clearPendingFocus();
+      return;
+    }
+    if (!isRenderedFocusable(element)) {
+      clearPendingFocus();
+      return;
+    }
+    element.focus({ preventScroll: true });
+    clearPendingFocus();
+  });
+}
+
+function moveStageModulePanels(useStageHost) {
+  rememberStageModulePortals();
+  var panels = allStageModuleNodes();
+  var focusedElement = document.activeElement;
+  var focusedPanel = panels.find(function(panel) {
+    return focusedElement && panel.contains(focusedElement);
+  });
+  if (!focusedPanel &&
+      (focusedElement === document.body || focusedElement === document.documentElement) &&
+      stageModulePortalPendingFocus?.element?.isConnected &&
+      stageModulePortalPendingFocus.panel?.contains(stageModulePortalPendingFocus.element)) {
+    focusedElement = stageModulePortalPendingFocus.element;
+    focusedPanel = stageModulePortalPendingFocus.panel;
+  }
+  var willMove = panels.some(function(panel) {
+    if (useStageHost && shellStageModuleHost) return panel.parentNode !== shellStageModuleHost;
+    var anchor = stageModulePortalAnchors.get(panel);
+    return !!anchor?.parentNode && panel.parentNode !== anchor.parentNode;
+  });
+  var focusGeneration = willMove
+    ? ++stageModulePortalFocusGeneration
+    : stageModulePortalFocusGeneration;
+  if (willMove) {
+    stageModulePortalPendingFocus = focusedPanel && focusedElement
+      ? { element: focusedElement, panel: focusedPanel, generation: focusGeneration }
+      : null;
+  }
+
+  panels.forEach(function(panel) {
+    if (useStageHost && shellStageModuleHost) {
+      if (panel.parentNode !== shellStageModuleHost) shellStageModuleHost.appendChild(panel);
+      panel.classList.add("clubhouse-stage-module");
+      panel.classList.toggle("clubhouse-utility-tool", panel === shellJamPanel);
+      panel.setAttribute("role", "region");
+      return;
+    }
+    var anchor = stageModulePortalAnchors.get(panel);
+    if (anchor?.parentNode && panel.parentNode !== anchor.parentNode) {
+      anchor.parentNode.insertBefore(panel, anchor.nextSibling);
+    }
+    panel.classList.remove("clubhouse-stage-module", "clubhouse-utility-tool");
+    panel.setAttribute("role", "dialog");
+  });
+
+  if (willMove && focusedPanel && focusedElement) {
+    restoreStageModulePortalFocus(focusedElement, focusedPanel, focusGeneration);
+  }
+}
+
+function inferVisibleStageModule() {
+  return ["chat", "jam", "camera", "soundboard"].find(function(module) {
+    return stageModuleNodes(module).some(function(panel) {
+      return !panel.classList.contains("hidden");
+    });
+  }) || null;
+}
+
+function focusReturnTarget(preferred, module) {
+  var candidates = [preferred, stageModuleOpeners[module], shellUtilityButton, shellMoreButton, connectBtn];
   var target = candidates.find(isRenderedFocusable);
   if (target) target.focus();
 }
 
-function focusActiveUtilityTool(tool) {
-  var peopleTarget = shellPeoplePanel
-    ? Array.from(shellPeoplePanel.querySelectorAll(
-        'button:not(:disabled), input:not(:disabled), [tabindex]:not([tabindex="-1"])'
-      )).find(isRenderedFocusable)
-    : null;
-  var target = tool === "chat" ? chatInput : tool === "jam" ? shellCloseJamButton : peopleTarget;
+function focusActiveStageModule(module) {
+  var target = module === "chat"
+    ? chatInput
+    : module === "jam"
+      ? shellCloseJamButton
+      : module === "camera"
+        ? closeCameraLobbyButton
+        : closeSoundboardButton;
   if (isRenderedFocusable(target)) target.focus();
 }
 
-function inferVisibleUtilityTool() {
-  if (shellJamPanel && !shellJamPanel.classList.contains("hidden")) return "jam";
-  if (chatPanel && !chatPanel.classList.contains("hidden") && shellLayout?.classList.contains("chat-open")) {
-    return "chat";
-  }
-  return "people";
+function scheduleStageGridRecalc() {
+  requestAnimationFrame(function() {
+    requestAnimationFrame(function() {
+      if (shellStage?.classList.contains("stage-module-open")) return;
+      if (typeof window._echoRecalcGrid === "function") window._echoRecalcGrid();
+    });
+  });
+}
+
+function syncStageModulePanels() {
+  ["chat", "jam", "camera", "soundboard"].forEach(function(module) {
+    var isActive = activeStageModule === module;
+    var nodes = stageModuleNodes(module);
+    if (isActive && module !== "soundboard") {
+      nodes.forEach(function(panel) { panel.classList.remove("hidden"); });
+    }
+    if (isActive && module === "soundboard" && nodes.every(function(panel) {
+      return panel.classList.contains("hidden");
+    })) {
+      shellSoundboardCompactPanel?.classList.remove("hidden");
+    }
+    nodes.forEach(function(panel) {
+      if (!isActive) panel.classList.add("hidden");
+      var visible = isActive && !panel.classList.contains("hidden");
+      panel.inert = !visible || settingsModalActive;
+      panel.setAttribute("aria-hidden", visible ? "false" : "true");
+    });
+  });
 }
 
 function syncClubhouseUtilityPresentation() {
-  if (!shellLayout || !shellStage || !shellUtilityHost) return;
+  if (!shellLayout || !shellStage || !shellUtilityHost || !shellStageModuleHost) return;
   if (syncingClubhouseUtility) return;
   syncingClubhouseUtility = true;
   try {
     var isV2 = document.documentElement.dataset.uiShell === "v2";
-    var mode = document.documentElement.dataset.uiMode;
     var collapsed = shellLayout.classList.contains("utility-collapsed");
 
     if (!isV2) {
-      if (!collapsed) activeUtilityTool = inferVisibleUtilityTool();
+      var stageModuleWasOpen = shellStage.classList.contains("stage-module-open");
+      if (!activeStageModule) activeStageModule = inferVisibleStageModule();
+      moveStageModulePanels(false);
       delete document.documentElement.dataset.uiUtility;
+      delete document.documentElement.dataset.stageModule;
       delete shellLayout.dataset.activeUtility;
+      delete shellStage.dataset.activeModule;
       if (shellLayout.classList.contains("jam-open")) shellLayout.classList.remove("jam-open");
+      if (activeStageModule === "chat" && !chatPanel?.classList.contains("hidden")) {
+        if (!shellLayout.classList.contains("chat-open")) shellLayout.classList.add("chat-open");
+      } else if (shellLayout.classList.contains("chat-open")) {
+        shellLayout.classList.remove("chat-open");
+      }
+      shellStage.classList.remove("stage-module-open");
       shellStage.inert = false;
+      if (shellStageHeader) shellStageHeader.inert = false;
+      if (shellScreenGrid) shellScreenGrid.inert = false;
+      shellStageModuleHost.classList.add("hidden");
+      shellStageModuleHost.inert = true;
+      shellStageModuleHost.dataset.activeModule = "";
+      shellStageModuleHost.setAttribute("aria-hidden", "true");
       shellUtilityHost.inert = false;
       shellUtilityHost.removeAttribute("aria-hidden");
       shellPeoplePanel?.classList.remove("hidden");
@@ -273,14 +444,19 @@ function syncClubhouseUtilityPresentation() {
         shellPeoplePanel.removeAttribute("aria-hidden");
       }
       if (shellPeopleHeading) shellPeopleHeading.textContent = "Active Users";
-      if (chatPanel) {
-        chatPanel.inert = false;
-        chatPanel.removeAttribute("aria-hidden");
-      }
-      if (shellJamPanel) {
-        shellJamPanel.inert = false;
-        shellJamPanel.removeAttribute("aria-hidden");
-        shellJamPanel.classList.remove("clubhouse-utility-tool");
+      allStageModuleNodes().forEach(function(panel) {
+        panel.inert = false;
+        panel.removeAttribute("aria-hidden");
+      });
+      Object.keys(stageModuleOpeners).forEach(function(module) {
+        stageModuleOpenerNodes(module).forEach(function(opener) {
+          opener.setAttribute("aria-controls", legacyStageModuleControlIds[module]);
+          opener.setAttribute("aria-expanded", "false");
+        });
+      });
+      if (shellSoundboardCompactPanel && !shellSoundboardCompactPanel.classList.contains("hidden") &&
+          typeof positionLegacySoundboardCompact === "function") {
+        positionLegacySoundboardCompact();
       }
       shellUtilityScrim?.classList.add("hidden");
       if (closeChatButton) {
@@ -291,63 +467,84 @@ function syncClubhouseUtilityPresentation() {
         shellCloseJamButton.textContent = "Close";
         shellCloseJamButton.removeAttribute("aria-label");
       }
+      if (closeCameraLobbyButton) {
+        closeCameraLobbyButton.textContent = "Close";
+        closeCameraLobbyButton.removeAttribute("aria-label");
+      }
+      if (closeSoundboardButton) {
+        closeSoundboardButton.textContent = "Back";
+        closeSoundboardButton.title = "Close";
+        closeSoundboardButton.removeAttribute("aria-label");
+      }
+      if (stageModuleWasOpen) scheduleStageGridRecalc();
       return;
     }
 
-    var externallyVisibleTool = inferVisibleUtilityTool();
-    if (externallyVisibleTool !== "people") {
-      activeUtilityTool = externallyVisibleTool;
-    } else if (!collapsed && activeUtilityTool !== "people") {
-      activeUtilityTool = "people";
-    }
-    activeUtilityTool = normalizeUtilityTool(activeUtilityTool);
-    var overlaysStage = activeUtilityTool === "jam" ||
-      mode === "lounge" || mode === "compact" || mode === "mini";
-    shellUtilityHost.dataset.activeTool = activeUtilityTool;
-    shellLayout.dataset.activeUtility = activeUtilityTool;
-    document.documentElement.dataset.uiUtility = activeUtilityTool;
-    shellLayout.classList.toggle("chat-open", activeUtilityTool === "chat");
-    shellLayout.classList.toggle("jam-open", activeUtilityTool === "jam");
+    if (!activeStageModule) activeStageModule = inferVisibleStageModule();
+    activeStageModule = normalizeStageModule(activeStageModule);
+    moveStageModulePanels(true);
+    shellUtilityHost.dataset.activeTool = "people";
+    shellLayout.dataset.activeUtility = "people";
+    document.documentElement.dataset.uiUtility = "people";
+    if (shellLayout.classList.contains("chat-open")) shellLayout.classList.remove("chat-open");
+    if (shellLayout.classList.contains("jam-open")) shellLayout.classList.remove("jam-open");
 
+    if (activeStageModule) {
+      document.documentElement.dataset.stageModule = activeStageModule;
+      shellStage.dataset.activeModule = activeStageModule;
+      shellStageModuleHost.dataset.activeModule = activeStageModule;
+    } else {
+      delete document.documentElement.dataset.stageModule;
+      delete shellStage.dataset.activeModule;
+      shellStageModuleHost.dataset.activeModule = "";
+    }
+    shellStage.classList.toggle("stage-module-open", !!activeStageModule);
+    shellStage.inert = false;
+    if (shellStageHeader) shellStageHeader.inert = !!activeStageModule || settingsModalActive;
+    if (shellScreenGrid) shellScreenGrid.inert = !!activeStageModule || settingsModalActive;
+    shellStageModuleHost.classList.toggle("hidden", !activeStageModule);
+    shellStageModuleHost.inert = !activeStageModule || settingsModalActive;
+    shellStageModuleHost.setAttribute("aria-hidden", activeStageModule ? "false" : "true");
+    syncStageModulePanels();
+    Object.keys(stageModuleOpeners).forEach(function(module) {
+      stageModuleOpenerNodes(module).forEach(function(opener) {
+        opener.setAttribute("aria-controls", "stage-module-host");
+        opener.setAttribute("aria-expanded", String(activeStageModule === module));
+      });
+    });
+
+    shellPeoplePanel?.classList.remove("hidden");
     if (shellPeoplePanel) {
-      var peopleActive = activeUtilityTool === "people";
-      shellPeoplePanel.setAttribute("aria-label", "People and tools");
-      shellPeoplePanel.classList.toggle("hidden", !peopleActive);
-      shellPeoplePanel.inert = !peopleActive || collapsed || settingsModalActive;
-      shellPeoplePanel.setAttribute("aria-hidden", peopleActive && !collapsed ? "false" : "true");
+      shellPeoplePanel.setAttribute("aria-label", "Active Users");
+      shellPeoplePanel.inert = collapsed || settingsModalActive;
+      shellPeoplePanel.setAttribute("aria-hidden", collapsed ? "true" : "false");
     }
-    if (shellPeopleHeading) shellPeopleHeading.textContent = "People & tools";
-    if (chatPanel) {
-      var chatActive = activeUtilityTool === "chat";
-      chatPanel.classList.toggle("hidden", !chatActive);
-      chatPanel.inert = !chatActive || collapsed || settingsModalActive;
-      chatPanel.setAttribute("aria-hidden", chatActive && !collapsed ? "false" : "true");
-    }
-    if (shellJamPanel) {
-      var jamActive = activeUtilityTool === "jam";
-      shellJamPanel.classList.toggle("hidden", !jamActive || collapsed);
-      shellJamPanel.classList.add("clubhouse-utility-tool");
-      shellJamPanel.inert = !jamActive || collapsed || settingsModalActive;
-      shellJamPanel.setAttribute("aria-hidden", jamActive && !collapsed ? "false" : "true");
-    }
-
+    if (shellPeopleHeading) shellPeopleHeading.textContent = "Active Users";
     shellUtilityHost.inert = collapsed || settingsModalActive;
     shellUtilityHost.setAttribute("aria-hidden", collapsed ? "true" : "false");
-    shellStage.inert = !!(overlaysStage && !collapsed && !settingsModalActive);
-    shellUtilityScrim?.classList.toggle("hidden", !overlaysStage || collapsed || settingsModalActive);
+    shellUtilityScrim?.classList.add("hidden");
+
     if (closeChatButton) {
-      closeChatButton.textContent = "All tools";
-      closeChatButton.setAttribute("aria-label", "Back to People and tools");
+      closeChatButton.textContent = "Back to Stage";
+      closeChatButton.setAttribute("aria-label", "Back to Stage");
     }
     if (shellCloseJamButton) {
-      shellCloseJamButton.textContent = "All tools";
-      shellCloseJamButton.setAttribute("aria-label", "Back to People and tools");
+      shellCloseJamButton.textContent = "Back to Stage";
+      shellCloseJamButton.setAttribute("aria-label", "Back to Stage");
     }
-
+    if (closeCameraLobbyButton) {
+      closeCameraLobbyButton.textContent = "Back to Stage";
+      closeCameraLobbyButton.setAttribute("aria-label", "Back to Stage");
+    }
+    if (closeSoundboardButton) {
+      closeSoundboardButton.textContent = "Back to Stage";
+      closeSoundboardButton.title = "Back to Stage";
+      closeSoundboardButton.setAttribute("aria-label", "Back to Stage");
+    }
     if (shellUtilityButton) {
-      shellUtilityButton.textContent = "Tools";
+      shellUtilityButton.textContent = "Users";
       shellUtilityButton.setAttribute("aria-expanded", collapsed ? "false" : "true");
-      shellUtilityButton.setAttribute("aria-label", (collapsed ? "Show" : "Hide") + " clubhouse tools");
+      shellUtilityButton.setAttribute("aria-label", (collapsed ? "Show" : "Hide") + " active users");
     }
   } finally {
     syncingClubhouseUtility = false;
@@ -357,51 +554,48 @@ function syncClubhouseUtilityPresentation() {
 function setClubhouseUtilityCollapsed(collapsed, options) {
   if (!shellLayout) return false;
   shellLayout.classList.toggle("utility-collapsed", !!collapsed);
-  // Collapsing hides the active tool. Restore its presentation before syncing
-  // on reopen so visibility inference does not accidentally reset it to People.
-  if (!collapsed && document.documentElement.dataset.uiShell === "v2") {
-    chatPanel?.classList.toggle("hidden", activeUtilityTool !== "chat");
-    shellJamPanel?.classList.toggle("hidden", activeUtilityTool !== "jam");
-  }
   syncClubhouseUtilityPresentation();
-  if (!collapsed && activeUtilityTool === "chat" && typeof clearUnreadChat === "function") {
-    clearUnreadChat();
-  }
   if (collapsed && options && options.restoreFocus) {
-    requestAnimationFrame(function() { focusUtilityReturnTarget(shellUtilityButton); });
+    requestAnimationFrame(function() { focusReturnTarget(shellUtilityButton); });
   }
   return true;
 }
 
-function openClubhouseUtility(tool, opener, options) {
-  activeUtilityTool = normalizeUtilityTool(tool);
-  if (isRenderedFocusable(opener)) utilityReturnFocus[activeUtilityTool] = opener;
+function openStageModule(module, opener, options) {
+  var normalized = normalizeStageModule(module);
+  if (!normalized) return false;
+  if (activeStageModule === "jam" && normalized !== "jam" &&
+      typeof pauseJamAudioVisualizer === "function") {
+    pauseJamAudioVisualizer();
+  }
+  if (activeStageModule === "camera" && normalized !== "camera" &&
+      typeof clearCameraLobbyMedia === "function") {
+    clearCameraLobbyMedia();
+  }
+  activeStageModule = normalized;
+  if (isRenderedFocusable(opener)) stageModuleReturnFocus[normalized] = opener;
   if (document.documentElement.dataset.uiShell !== "v2") return false;
-  shellLayout?.classList.remove("utility-collapsed");
-  shellLayout?.classList.toggle("chat-open", activeUtilityTool === "chat");
-  shellLayout?.classList.toggle("jam-open", activeUtilityTool === "jam");
-  chatPanel?.classList.toggle("hidden", activeUtilityTool !== "chat");
-  shellJamPanel?.classList.toggle("hidden", activeUtilityTool !== "jam");
   syncClubhouseUtilityPresentation();
   if (!options || options.focus !== false) {
-    requestAnimationFrame(function() { focusActiveUtilityTool(activeUtilityTool); });
+    requestAnimationFrame(function() { focusActiveStageModule(normalized); });
   }
   return true;
 }
 
-function closeClubhouseUtility(tool, options) {
-  var closingTool = normalizeUtilityTool(tool || activeUtilityTool);
-  var returnTarget = utilityReturnFocus[closingTool];
+function closeStageModule(module, options) {
+  var normalized = normalizeStageModule(module || activeStageModule);
+  if (!normalized) return false;
   if (document.documentElement.dataset.uiShell !== "v2") {
-    activeUtilityTool = inferVisibleUtilityTool();
+    if (activeStageModule === normalized) activeStageModule = null;
     return false;
   }
-  activeUtilityTool = "people";
-  if (shellJamPanel) shellJamPanel.classList.add("hidden");
-  if (chatPanel) chatPanel.classList.add("hidden");
+  var returnTarget = stageModuleReturnFocus[normalized];
+  stageModuleNodes(normalized).forEach(function(panel) { panel.classList.add("hidden"); });
+  if (activeStageModule === normalized) activeStageModule = null;
   syncClubhouseUtilityPresentation();
-  if (!options || options.restoreFocus !== false) {
-    requestAnimationFrame(function() { focusUtilityReturnTarget(returnTarget); });
+  if (!activeStageModule) scheduleStageGridRecalc();
+  if ((!options || options.restoreFocus !== false) && !activeStageModule) {
+    requestAnimationFrame(function() { focusReturnTarget(returnTarget, normalized); });
   }
   return true;
 }
@@ -422,14 +616,11 @@ function hasHigherPriorityEscapeSurface() {
 
 function keepFocusedUtilityControlVisible() {
   if (document.documentElement.dataset.uiShell !== "v2" ||
-      shellLayout?.classList.contains("utility-collapsed") ||
       settingsModalActive) return;
   var active = document.activeElement;
-  var activePanel = activeUtilityTool === "chat"
-    ? chatPanel
-    : activeUtilityTool === "jam"
-      ? shellJamPanel
-      : shellPeoplePanel;
+  var activePanel = activeStageModule
+    ? stageModuleNodes(activeStageModule).find(function(panel) { return panel.contains(active); })
+    : shellPeoplePanel;
   if (!active || !activePanel?.contains(active) || typeof active.scrollIntoView !== "function") return;
   requestAnimationFrame(function() {
     if (document.activeElement === active) {
@@ -438,11 +629,20 @@ function keepFocusedUtilityControlVisible() {
   });
 }
 
+window.EchoStageModules = Object.freeze({
+  activeModule: function() { return activeStageModule; },
+  close: closeStageModule,
+  open: openStageModule,
+  sync: syncClubhouseUtilityPresentation,
+});
+
+// Compatibility bridge for the existing Chat and Jam state owners. In V2 they
+// now target the Stage; legacy continues to use each feature's original panel.
 window.EchoClubhouseUtility = Object.freeze({
-  activeTool: function() { return activeUtilityTool; },
-  close: closeClubhouseUtility,
+  activeTool: function() { return activeStageModule || "people"; },
+  close: closeStageModule,
   collapse: setClubhouseUtilityCollapsed,
-  open: openClubhouseUtility,
+  open: openStageModule,
   sync: syncClubhouseUtilityPresentation,
 });
 
@@ -486,12 +686,6 @@ if (shellOverflowMenu) {
 if (shellUtilityButton && shellLayout) {
   shellUtilityButton.addEventListener("click", function() {
     setClubhouseUtilityCollapsed(!shellLayout.classList.contains("utility-collapsed"));
-  });
-}
-
-if (shellUtilityScrim) {
-  shellUtilityScrim.addEventListener("click", function() {
-    setClubhouseUtilityCollapsed(true, { restoreFocus: true });
   });
 }
 
@@ -547,21 +741,18 @@ document.addEventListener("keydown", function(event) {
     return;
   }
   // A single Escape dismisses only the topmost surface. Dynamic lightboxes,
-  // capture pickers, fullscreen media, and feature dialogs own it before the
-  // underlying People / Chat / Jam utility presentation.
+  // capture pickers, fullscreen media, and true modal dialogs own it before a
+  // Stage module. The Active Users rail is changed only by its explicit button.
   if (hasHigherPriorityEscapeSurface()) return;
-  if (document.documentElement.dataset.uiShell !== "v2" || shellLayout?.classList.contains("utility-collapsed")) {
-    return;
-  }
-  if (activeUtilityTool !== "people") {
+  if (document.documentElement.dataset.uiShell !== "v2") return;
+  if (activeStageModule) {
     event.preventDefault();
-    closeClubhouseUtility(activeUtilityTool);
+    if (activeStageModule === "chat" && typeof closeChat === "function") closeChat();
+    else if (activeStageModule === "jam" && typeof closeJamPanel === "function") closeJamPanel();
+    else if (activeStageModule === "camera" && typeof closeCameraLobby === "function") closeCameraLobby();
+    else if (activeStageModule === "soundboard" && typeof closeSoundboard === "function") closeSoundboard();
+    else closeStageModule(activeStageModule);
     return;
-  }
-  var mode = document.documentElement.dataset.uiMode;
-  if (mode === "lounge" || mode === "compact" || mode === "mini") {
-    event.preventDefault();
-    setClubhouseUtilityCollapsed(true, { restoreFocus: true });
   }
 });
 

--- a/core/viewer/audio-routing.js
+++ b/core/viewer/audio-routing.js
@@ -152,6 +152,67 @@ function cleanupGainNode(state, audioEl, isScreen) {
   }
 }
 
+function clearScreenAudioParticipantGeneration(participant, expectedRoom, mode) {
+  var mediaIdentity = normalizeScreenMediaIdentity(participant?.identity);
+  var result = { mediaIdentity: mediaIdentity, removed: 0 };
+  if (!participant || !expectedRoom || room !== expectedRoom) return result;
+  var removeReplacement = mode === "replaced";
+  var screenAudioSource = getLiveKitClient()?.Track?.Source?.ScreenShareAudio;
+  var removals = [];
+  var queuedElements = new Set();
+  function queueRemoval(element, trackSid) {
+    if (!element || queuedElements.has(element)) return;
+    if (element._echoMediaSource !== screenAudioSource) return;
+    if (element._echoRoom !== expectedRoom ||
+        element._echoParticipant?.identity !== participant.identity) return;
+    if (removeReplacement
+      ? element._echoParticipant === participant
+      : element._echoParticipant !== participant) return;
+    queuedElements.add(element);
+    removals.push([trackSid || element._echoTrackSid || element._lkTrack?.sid || "", element]);
+  }
+  audioElBySid.forEach(function(element, trackSid) {
+    queueRemoval(element, trackSid);
+  });
+  // A replacement publication can reuse a SID and overwrite audioElBySid
+  // before ParticipantConnected runs. The participant state still owns the
+  // old element, so sweep it as well to prevent stale audio playout.
+  participantState.forEach(function(state) {
+    state?.screenAudioEls?.forEach(function(element) {
+      queueRemoval(element, element._echoTrackSid);
+    });
+  });
+  removals.forEach(function(entry) {
+    var trackSid = entry[0];
+    var element = entry[1];
+    var state = participantState.get(element._echoMediaIdentity || mediaIdentity);
+    if (state) {
+      cleanupGainNode(state, element, true);
+      state.screenAudioEls.delete(element);
+      if (state.screenAudioSid === trackSid) {
+        var sameSidRemains = Array.from(state.screenAudioEls).some(function(candidate) {
+          return candidate?._echoTrackSid === trackSid;
+        });
+        if (!sameSidRemains) state.screenAudioSid = null;
+      }
+    }
+    try { element._lkTrack?.detach?.(element); } catch (_) {}
+    try { element.pause(); } catch (_) {}
+    try { element.srcObject = null; } catch (_) {}
+    element.remove();
+    if (audioElBySid.get(trackSid) === element) audioElBySid.delete(trackSid);
+    result.removed += 1;
+  });
+  var mediaState = participantState.get(mediaIdentity);
+  if (mediaState && mediaState.screenAudioEls.size === 0) {
+    if (mediaState.screenAnalyser?.cleanup) mediaState.screenAnalyser.cleanup();
+    mediaState.screenAnalyser = null;
+    var tile = screenTileByIdentity.get(mediaIdentity);
+    if (tile?._volWrap) tile._volWrap.classList.add("hidden");
+  }
+  return result;
+}
+
 function startMediaReconciler() {
   scheduleReconcileWaves("start");
 }
@@ -350,6 +411,17 @@ function handleTrackSubscribed(track, publication, participant) {
   debugLog("[track-source] " + effectiveParticipant.identity + " kind=" + track.kind +
     " source=" + source + " pub.source=" + publication?.source +
     " track.source=" + track?.source + (isScreenCompanion ? " (from $screen companion)" : ""));
+  if (track.kind === "video" && source === LK.Track.Source.Camera &&
+      !isCurrentCameraTrackGeneration(
+        effectiveParticipant.identity,
+        effectiveParticipant,
+        publication,
+        track,
+        room
+      )) {
+    debugLog("[camera-stage] ignored stale camera subscribe for " + effectiveParticipant.identity);
+    return;
+  }
   const handleKey = track.kind === "video" ? `${effectiveParticipant.identity}-${source || track.kind}` : getTrackSid(publication, track, `${effectiveParticipant.identity}-${source || track.kind}`);
 
   // Check if recently handled, but also verify track is actually displayed
@@ -424,6 +496,7 @@ function handleTrackSubscribed(track, publication, participant) {
     const screenTrackSid = publication?.trackSid || track?.sid || null;
     const existingTile = screenTileByIdentity.get(identity) || (screenTrackSid ? screenTileBySid.get(screenTrackSid) : null);
     if (existingTile && existingTile.isConnected) {
+      stampScreenTileGeneration(existingTile, publication, identity, participant, track, room);
       const existingVideo = existingTile.querySelector("video");
       if (!hiddenScreens.has(identity)) {
         existingTile.style.display = "";
@@ -433,6 +506,17 @@ function handleTrackSubscribed(track, publication, participant) {
       // SDP renegotiations fire unsub/resub for the same track every ~2s. Replacing
       // the video element interrupts play(), creating a loop of "interrupted by new load".
       if (existingVideo && existingVideo._lkTrack === track) {
+        if (screenTrackSid) {
+          registerScreenTrack(
+            screenTrackSid,
+            publication,
+            existingTile,
+            identity,
+            participant,
+            track,
+            room
+          );
+        }
         ensureVideoPlays(track, existingVideo);
         ensureVideoSubscribed(publication, existingVideo);
         forceVideoLayer(publication, existingVideo);
@@ -450,7 +534,15 @@ function handleTrackSubscribed(track, publication, participant) {
       if (screenTrackSid) {
         existingTile.dataset.trackSid = screenTrackSid;
         screenTileBySid.set(screenTrackSid, existingTile);
-        registerScreenTrack(screenTrackSid, publication, existingTile, effectiveParticipant.identity);
+        registerScreenTrack(
+          screenTrackSid,
+          publication,
+          existingTile,
+          effectiveParticipant.identity,
+          participant,
+          track,
+          room
+        );
         scheduleScreenRecovery(screenTrackSid, publication, existingTile.querySelector("video"));
       }
       screenTileByIdentity.set(identity, existingTile);
@@ -496,10 +588,26 @@ function handleTrackSubscribed(track, publication, participant) {
     setTimeout(() => requestVideoKeyFrame(publication, track), 600);
     const tile = addScreenTile(label, element, screenTrackSid);
     tile.dataset.identity = effectiveParticipant.identity;
+    stampScreenTileGeneration(
+      tile,
+      publication,
+      effectiveParticipant.identity,
+      participant,
+      track,
+      room
+    );
     debugLog("[screen-tile] CREATED for " + effectiveParticipant.identity + " trackSid=" + screenTrackSid + " label=" + label);
     ensureVideoSubscribed(publication, element);
     if (screenTrackSid) {
-      registerScreenTrack(screenTrackSid, publication, tile, effectiveParticipant.identity);
+      registerScreenTrack(
+        screenTrackSid,
+        publication,
+        tile,
+        effectiveParticipant.identity,
+        participant,
+        track,
+        room
+      );
       scheduleScreenRecovery(screenTrackSid, publication, element);
       screenResubscribeIntent.delete(screenTrackSid);
     }
@@ -594,6 +702,13 @@ function handleTrackSubscribed(track, publication, participant) {
     // Create audio element — use track.attach() then verify srcObject
     const element = track.attach();
     element._lkTrack = track;
+    element._echoRoom = room;
+    element._echoParticipant = participant;
+    element._echoPublication = publication;
+    element._echoMediaTrack = track;
+    element._echoTrackSid = trackSid;
+    element._echoMediaSource = source;
+    element._echoMediaIdentity = effectiveParticipant.identity;
     // Safety: ensure srcObject is set (some SDK versions may not set it immediately)
     if (!element.srcObject && track.mediaStreamTrack) {
       element.srcObject = new MediaStream([track.mediaStreamTrack]);
@@ -628,6 +743,10 @@ function handleTrackSubscribed(track, publication, participant) {
     // Re-trigger play when track's mediaStreamTrack unmutes (first data arrives)
     if (track.mediaStreamTrack) {
       track.mediaStreamTrack.addEventListener("unmute", () => {
+        if (!element.isConnected || element._echoRoom !== room ||
+            element._echoParticipant !== participant ||
+            element._echoPublication !== publication ||
+            element._echoMediaTrack !== track) return;
         debugLog(`audio track unmuted ${effectiveParticipant.identity} src=${source}`);
         ensureAudioPlays(element);
       });
@@ -689,16 +808,17 @@ function handleTrackUnsubscribed(track, publication, participant) {
     screenRecoveryAttempts.delete(trackSid);
   }
   if (track.kind === "video" && source === LK.Track.Source.ScreenShare) {
-    const identity = participant?.identity;
+    const publicationIdentity = participant?.identity;
+    const identity = normalizeScreenMediaIdentity(publicationIdentity);
     const tile = trackSid ? screenTileBySid.get(trackSid) : null;
     // Check if the publisher is still sharing — if so, this is a transient unsub
     // from SDP renegotiation and we should NOT destroy the tile.
     var stillPublishing = false;
-    if (identity && room && room.remoteParticipants) {
+    if (publicationIdentity && room && room.remoteParticipants) {
       var remoteP = null;
-      if (room.remoteParticipants.get) remoteP = room.remoteParticipants.get(identity);
+      if (room.remoteParticipants.get) remoteP = room.remoteParticipants.get(publicationIdentity);
       if (!remoteP) {
-        room.remoteParticipants.forEach(function(p) { if (p.identity === identity) remoteP = p; });
+        room.remoteParticipants.forEach(function(p) { if (p.identity === publicationIdentity) remoteP = p; });
       }
       if (remoteP) {
         var pubs = getParticipantPublications(remoteP);
@@ -730,9 +850,9 @@ function handleTrackUnsubscribed(track, publication, participant) {
       var stillPublishing = false;
       var remoteP = null;
       if (room && room.remoteParticipants) {
-        if (room.remoteParticipants.get) remoteP = room.remoteParticipants.get(identity);
+        if (room.remoteParticipants.get) remoteP = room.remoteParticipants.get(publicationIdentity);
         if (!remoteP) {
-          room.remoteParticipants.forEach(function(p) { if (p.identity === identity) remoteP = p; });
+          room.remoteParticipants.forEach(function(p) { if (p.identity === publicationIdentity) remoteP = p; });
         }
       }
       if (remoteP) {
@@ -756,26 +876,55 @@ function handleTrackUnsubscribed(track, publication, participant) {
     }
   } else if (track.kind === "video" && source === LK.Track.Source.Camera) {
     const identity = participant?.identity;
-    const cardRef = identity ? participantCards.get(identity) : null;
-    if (trackSid) cameraVideoBySid.delete(trackSid);
     if (identity) {
-      const pubs = participant ? getParticipantPublications(participant) : [];
-      const hasCam = pubs.some((pub) => pub?.source === LK.Track.Source.Camera && pub.track);
+      const expectedRoom = room;
+      if (!isCurrentCameraParticipantGeneration(identity, participant, expectedRoom)) {
+        debugLog(`[camera-stage] ignored stale camera unsubscribe participant ${identity}`);
+        return;
+      }
+      const pubs = getParticipantPublications(participant);
+      if (!pubs.includes(publication) || (publication.track && publication.track !== track)) {
+        debugLog(`[camera-stage] ignored stale camera unsubscribe publication ${identity}`);
+        return;
+      }
+      if (trackSid) {
+        const mappedCameraVideo = cameraVideoBySid.get(trackSid);
+        if (mappedCameraVideo?._echoCameraPublication === publication ||
+            (!mappedCameraVideo?._echoCameraPublication && mappedCameraVideo?._lkTrack === track)) {
+          cameraVideoBySid.delete(trackSid);
+        }
+      }
+      const hasCam = pubs.some((pub) => {
+        const pubSource = pub?.source || pub?.track?.source;
+        return pubSource === LK.Track.Source.Camera && !!pub.track;
+      });
       if (hasCam) {
         debugLog(`camera unsubscribe ignored ${identity} (active cam present)`);
         return;
       }
-      const existingTimer = cameraClearTimers.get(identity);
-      if (existingTimer) clearTimeout(existingTimer);
+      cancelCameraClearTimer(identity);
+      const generation = {
+        identity,
+        room: expectedRoom,
+        participant,
+        publication,
+        track,
+      };
       const timer = setTimeout(() => {
+        if (cameraClearTimers.get(identity) !== timer ||
+            cameraClearGenerationByIdentity.get(identity) !== generation) return;
         cameraClearTimers.delete(identity);
-        const state = participantState.get(identity);
-        const latestPubs = participant ? getParticipantPublications(participant) : [];
-        const activeCam = latestPubs.find((pub) => pub?.source === LK.Track.Source.Camera && pub.track);
-        if (activeCam?.track) {
-          debugLog(`camera clear aborted ${identity} (cam returned)`);
+        cameraClearGenerationByIdentity.delete(identity);
+        if (!isCurrentCameraUnsubscribeGeneration(generation)) {
+          debugLog(`camera clear aborted ${identity} (stale generation)`);
           return;
         }
+        const state = participantState.get(identity);
+        // A transient unsubscribe may recover with a replacement track, so
+        // remove only the stale secondary attachment and preserve Stage intent.
+        removeCameraStageTile(identity, { clearIntent: false });
+        setParticipantCameraStageAvailable(identity, false);
+        const cardRef = participantCards.get(identity);
         if (cardRef) {
           updateAvatarVideo(cardRef, null);
         }
@@ -783,15 +932,14 @@ function handleTrackUnsubscribed(track, publication, participant) {
         debugLog(`camera cleared ${identity} after unsubscribe`);
       }, 800);
       cameraClearTimers.set(identity, timer);
-    } else if (cardRef) {
-      updateAvatarVideo(cardRef, null);
+      cameraClearGenerationByIdentity.set(identity, generation);
     }
   } else if (track.kind === "audio") {
     const audioEl = audioElBySid.get(trackSid);
     // Grace period for screen share audio: delay removal to survive SDP renegotiations
     if (source === LK.Track.Source.ScreenShareAudio && audioEl && participant) {
       debugLog(`screen share audio unsubscribe ${participant.identity} sid=${trackSid} — delaying removal`);
-      const identity = participant.identity;
+      const identity = normalizeScreenMediaIdentity(participant.identity);
       setTimeout(() => {
         // Check if a new audio element was created for this track in the meantime
         const currentEl = audioElBySid.get(trackSid);
@@ -807,8 +955,10 @@ function handleTrackUnsubscribed(track, publication, participant) {
             if (pState) {
               cleanupGainNode(pState, audioEl, true);
               pState.screenAudioEls.delete(audioEl);
-              if (pState.screenAnalyser?.cleanup) pState.screenAnalyser.cleanup();
-              pState.screenAnalyser = null;
+              if (pState.screenAudioEls.size === 0) {
+                if (pState.screenAnalyser?.cleanup) pState.screenAnalyser.cleanup();
+                pState.screenAnalyser = null;
+              }
             }
           } else {
             debugLog(`screen share audio kept (track returned): ${identity} sid=${trackSid}`);
@@ -851,15 +1001,20 @@ function handleTrackUnsubscribed(track, publication, participant) {
       audioElBySid.delete(trackSid);
     }
     if (participant) {
-      const state = participantState.get(participant.identity);
+      const stateIdentity = source === LK.Track.Source.ScreenShareAudio
+        ? normalizeScreenMediaIdentity(participant.identity)
+        : participant.identity;
+      const state = participantState.get(stateIdentity);
       if (state) {
         if (source === LK.Track.Source.ScreenShareAudio) {
           cleanupGainNode(state, audioEl, true);
           state.screenAudioEls.delete(audioEl);
-          if (state.screenAnalyser?.cleanup) {
-            state.screenAnalyser.cleanup();
+          if (state.screenAudioEls.size === 0) {
+            if (state.screenAnalyser?.cleanup) {
+              state.screenAnalyser.cleanup();
+            }
+            state.screenAnalyser = null;
           }
-          state.screenAnalyser = null;
         } else {
           cleanupGainNode(state, audioEl, false);
           state.micAudioEls.delete(audioEl);

--- a/core/viewer/camera-stage.test.js
+++ b/core/viewer/camera-stage.test.js
@@ -1,0 +1,1149 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const vm = require("node:vm");
+
+class FakeClassList {
+  constructor(initial = "") {
+    this.values = new Set(String(initial).split(/\s+/).filter(Boolean));
+  }
+  add(...values) { values.forEach((value) => this.values.add(value)); }
+  remove(...values) { values.forEach((value) => this.values.delete(value)); }
+  contains(value) { return this.values.has(value); }
+  toggle(value, force) {
+    const next = force == null ? !this.values.has(value) : !!force;
+    if (next) this.values.add(value); else this.values.delete(value);
+    return next;
+  }
+}
+
+class FakeStyle {
+  constructor() { this.values = new Map(); }
+  setProperty(name, value) {
+    this.values.set(name, String(value));
+    if (name === "object-fit") this.objectFit = String(value);
+  }
+  getPropertyValue(name) { return this.values.get(name) || ""; }
+}
+
+class FakeElement {
+  constructor(tagName = "div") {
+    this.tagName = tagName.toUpperCase();
+    this.children = [];
+    this.parentElement = null;
+    this.isConnected = false;
+    this.dataset = {};
+    this.style = new FakeStyle();
+    this.classList = new FakeClassList();
+    this.listeners = new Map();
+    this.attributes = new Map();
+    this.videoWidth = 0;
+    this.videoHeight = 0;
+  }
+  set className(value) { this._className = value; this.classList = new FakeClassList(value); }
+  get className() { return this._className || ""; }
+  setConnected(value) {
+    this.isConnected = !!value;
+    this.children.forEach((child) => child.setConnected?.(value));
+  }
+  appendChild(child) {
+    child.parentElement = this;
+    child.setConnected?.(this.isConnected);
+    this.children.push(child);
+    return child;
+  }
+  append(...children) { children.forEach((child) => this.appendChild(child)); }
+  insertBefore(child, reference) {
+    child.parentElement = this;
+    child.setConnected?.(this.isConnected);
+    const index = reference ? this.children.indexOf(reference) : -1;
+    if (index < 0) this.children.push(child); else this.children.splice(index, 0, child);
+    return child;
+  }
+  replaceWith(replacement) {
+    if (!this.parentElement) return;
+    const parent = this.parentElement;
+    const index = parent.children.indexOf(this);
+    if (index >= 0) parent.children[index] = replacement;
+    replacement.parentElement = parent;
+    replacement.setConnected?.(parent.isConnected);
+    this.parentElement = null;
+    this.setConnected(false);
+  }
+  remove() {
+    if (this.parentElement) {
+      const index = this.parentElement.children.indexOf(this);
+      if (index >= 0) this.parentElement.children.splice(index, 1);
+    }
+    this.parentElement = null;
+    this.setConnected(false);
+  }
+  querySelector(selector) {
+    if (selector === "video") return this.children.find((child) => child.tagName === "VIDEO") || null;
+    if (selector === "h3") return this.children.find((child) => child.tagName === "H3") || null;
+    if (selector === ".tile-overlay") return this.children.find((child) => child.classList.contains("tile-overlay")) || null;
+    return null;
+  }
+  querySelectorAll(selector) {
+    if (selector === ".tile.is-focused") {
+      return this.children.filter((child) => child.classList.contains("tile") && child.classList.contains("is-focused"));
+    }
+    return [];
+  }
+  addEventListener(type, listener) {
+    if (!this.listeners.has(type)) this.listeners.set(type, []);
+    this.listeners.get(type).push(listener);
+  }
+  removeEventListener(type, listener) {
+    const listeners = this.listeners.get(type) || [];
+    this.listeners.set(type, listeners.filter((candidate) => candidate !== listener));
+  }
+  dispatch(type, event = {}) {
+    (this.listeners.get(type) || []).forEach((listener) => listener(event));
+  }
+  setAttribute(name, value) { this.attributes.set(name, String(value)); }
+  getAttribute(name) { return this.attributes.get(name) || null; }
+  pause() { this.paused = true; }
+}
+
+function makeTrack(sid) {
+  return {
+    sid,
+    attachCalls: 0,
+    detachCalls: [],
+    attach() { this.attachCalls += 1; },
+    detach(element) { this.detachCalls.push(element); },
+  };
+}
+
+function loadCameraStageHarness() {
+  const screenGridEl = new FakeElement("div");
+  screenGridEl.isConnected = true;
+  const cameraStageTileByIdentity = new Map();
+  const stagedCameraIdentities = new Set();
+  const screenTileByIdentity = new Map();
+  const screenTileBySid = new Map();
+  const screenTrackMeta = new Map();
+  let fullscreenVideo = null;
+  let cameraLobbyPopulateCalls = 0;
+  const cameraLobbyPanel = new FakeElement("div");
+  const localParticipant = { identity: "sam-1", name: "Sam", trackPublications: new Map() };
+  const remoteParticipants = new Map();
+  const context = {
+    window: { _pausedVideos: new Set(), _echoRecalcGrid() {} },
+    document: { createElement(tagName) { return new FakeElement(tagName); } },
+    MutationObserver: class { observe() {} disconnect() {} },
+    screenGridEl,
+    cameraStageTileByIdentity,
+    stagedCameraIdentities,
+    screenTileByIdentity,
+    screenTileBySid,
+    screenTrackMeta,
+    screenRecoveryAttempts: new Map(),
+    screenResubscribeIntent: new Map(),
+    hiddenScreens: new Set(),
+    watchedScreens: new Set(),
+    participantState: new Map(),
+    cameraVideoBySid: new Map(),
+    audioElBySid: new Map(),
+    ENABLE_SCREEN_WATCHDOG: false,
+    screenWatchdogTimer: null,
+    cameraLobbyPanel,
+    participantCards: new Map(),
+    cameraClearTimers: new Map(),
+    cameraClearGenerationByIdentity: new Map(),
+    cameraRecoveryAttempts: new Map(),
+    room: { localParticipant, remoteParticipants },
+    performance: { now() { return 5000; } },
+    getLiveKitClient() {
+      return {
+        Track: {
+          Source: {
+            Camera: "camera",
+            ScreenShare: "screen_share",
+            ScreenShareAudio: "screen_share_audio",
+          },
+          Kind: { Video: "video", Audio: "audio" },
+        },
+        VideoQuality: { LOW: 0, MEDIUM: 1, HIGH: 2 },
+      };
+    },
+    isScreenIdentity(identity) { return String(identity || "").endsWith("$screen"); },
+    getParentIdentity(identity) { return String(identity || "").replace(/\$screen$/, ""); },
+    getParticipantPublications(participant) { return participant.publications || []; },
+    createAttachedVideoElement(track) {
+      track.attachCalls += 1;
+      const video = new FakeElement("video");
+      video._lkTrack = track;
+      video.play = async () => {};
+      return video;
+    },
+    configureVideoElement(element) { element.configured = true; element.muted = true; },
+    ensureVideoPlays(track, element) { element.playEnsures = (element.playEnsures || 0) + 1; },
+    startBasicVideoMonitor(element) { element.monitorStarts = (element.monitorStarts || 0) + 1; },
+    enterVideoFullscreen(video) { fullscreenVideo = video; },
+    debugLog() {},
+    markResubscribeIntent(trackSid) {
+      context.screenResubscribeIntent.set(trackSid, context.performance.now());
+    },
+    populateCameraLobby() { cameraLobbyPopulateCalls += 1; },
+    setParticipantCameraStageAvailable() {},
+    updateAvatarVideo(cardRef, track) {
+      if (track) return;
+      cardRef.cameraRoom = null;
+      cardRef.cameraParticipant = null;
+      cardRef.cameraPublication = null;
+      cardRef.cameraTrack = null;
+      const video = cardRef.avatar?.querySelector("video");
+      if (video) video.remove();
+    },
+    cleanupVideoDiagnostics() {},
+    clearInterval() {},
+    clearTimeout() {},
+    setInterval() { return 1; },
+    setTimeout() { return 1; },
+    console,
+  };
+  context.global = context;
+  vm.createContext(context);
+  vm.runInContext(
+    fs.readFileSync(path.join(__dirname, "participants-grid.js"), "utf8"),
+    context,
+    { filename: "participants-grid.js" }
+  );
+  return {
+    context,
+    screenGridEl,
+    cameraStageTileByIdentity,
+    stagedCameraIdentities,
+    screenTileByIdentity,
+    screenTileBySid,
+    screenTrackMeta,
+    localParticipant,
+    cameraLobbyPanel,
+    get fullscreenVideo() { return fullscreenVideo; },
+    get cameraLobbyPopulateCalls() { return cameraLobbyPopulateCalls; },
+  };
+}
+
+function loadCameraRecoveryHarness() {
+  const harness = loadCameraStageHarness();
+  const scheduled = [];
+  let avatarUpdates = 0;
+  harness.context.setTimeout = (callback) => {
+    scheduled.push(callback);
+    return scheduled.length;
+  };
+  harness.context.updateAvatarVideo = () => { avatarUpdates += 1; };
+  vm.runInContext(
+    fs.readFileSync(path.join(__dirname, "participants-fullscreen.js"), "utf8"),
+    harness.context,
+    { filename: "participants-fullscreen.js" }
+  );
+  return {
+    ...harness,
+    scheduled,
+    get avatarUpdates() { return avatarUpdates; },
+  };
+}
+
+function loadScreenGenerationHarness(loadAudioRouting = false) {
+  const harness = loadCameraStageHarness();
+  const scheduled = [];
+  harness.context.setTimeout = (callback, delay) => {
+    scheduled.push({ callback, delay });
+    return scheduled.length;
+  };
+  vm.runInContext(
+    fs.readFileSync(path.join(__dirname, "participants-fullscreen.js"), "utf8"),
+    harness.context,
+    { filename: "participants-fullscreen.js" }
+  );
+  // These lifecycle tests exercise generation ownership, not canvas sampling.
+  harness.context.attachVideoDiagnostics = () => {};
+  harness.context.cleanupVideoDiagnostics = () => {};
+  if (loadAudioRouting) {
+    vm.runInContext(
+      fs.readFileSync(path.join(__dirname, "audio-routing.js"), "utf8"),
+      harness.context,
+      { filename: "audio-routing.js" }
+    );
+  }
+  return { ...harness, scheduled };
+}
+
+test("camera and screen for one identity coexist without sharing tile state", () => {
+  const harness = loadCameraStageHarness();
+  const screenTile = new FakeElement("div");
+  screenTile.className = "tile";
+  screenTile.dataset.identity = "sam-1";
+  screenTile.dataset.mediaKind = "screen";
+  harness.screenGridEl.appendChild(screenTile);
+  harness.screenTileByIdentity.set("sam-1", screenTile);
+  const track = makeTrack("camera-1");
+  harness.stagedCameraIdentities.add("sam-1");
+
+  const cameraTile = harness.context.upsertCameraStageTile("sam-1", "Sam", track, { trackSid: "camera-1" });
+
+  assert.equal(harness.screenGridEl.children.length, 2);
+  assert.equal(harness.screenTileByIdentity.get("sam-1"), screenTile);
+  assert.equal(harness.cameraStageTileByIdentity.get("sam-1"), cameraTile);
+  assert.equal(cameraTile.dataset.mediaKind, "camera");
+  assert.equal(cameraTile.querySelector("video").muted, true);
+});
+
+test("same camera track is idempotent and replacement keeps the tile stable", () => {
+  const harness = loadCameraStageHarness();
+  harness.stagedCameraIdentities.add("sam-1");
+  const firstTrack = makeTrack("camera-1");
+  const firstTile = harness.context.upsertCameraStageTile("sam-1", "Sam", firstTrack, { trackSid: "camera-1" });
+  const firstVideo = firstTile.querySelector("video");
+
+  const duplicate = harness.context.upsertCameraStageTile("sam-1", "Samuel", firstTrack, { trackSid: "camera-1" });
+  assert.equal(duplicate, firstTile);
+  assert.equal(duplicate.querySelector("video"), firstVideo);
+  assert.equal(harness.screenGridEl.children.length, 1);
+
+  const replacementTrack = makeTrack("camera-2");
+  const replacement = harness.context.upsertCameraStageTile("sam-1", "Samuel", replacementTrack, { trackSid: "camera-2" });
+  assert.equal(replacement, firstTile);
+  assert.notEqual(replacement.querySelector("video"), firstVideo);
+  assert.equal(replacement.dataset.cameraTrackSid, "camera-2");
+  assert.deepEqual(firstTrack.detachCalls, [firstVideo]);
+  assert.equal(harness.screenGridEl.children.length, 1);
+});
+
+test("transient camera removal preserves intent while authoritative clear removes it", () => {
+  const harness = loadCameraStageHarness();
+  const track = makeTrack("camera-1");
+  harness.stagedCameraIdentities.add("sam-1");
+  harness.context.upsertCameraStageTile("sam-1", "Sam", track, { trackSid: "camera-1" });
+
+  harness.context.removeCameraStageTile("sam-1", { clearIntent: false });
+  assert.equal(harness.cameraStageTileByIdentity.has("sam-1"), false);
+  assert.equal(harness.stagedCameraIdentities.has("sam-1"), true);
+
+  harness.context.upsertCameraStageTile("sam-1", "Sam", makeTrack("camera-2"), { trackSid: "camera-2" });
+  harness.context.removeCameraStageTile("sam-1", { clearIntent: true });
+  assert.equal(harness.cameraStageTileByIdentity.has("sam-1"), false);
+  assert.equal(harness.stagedCameraIdentities.has("sam-1"), false);
+
+  harness.stagedCameraIdentities.add("sam-1");
+  harness.context.upsertCameraStageTile("sam-1", "Sam", makeTrack("camera-3"), { trackSid: "camera-3" });
+  harness.context.clearCameraStageTiles();
+  assert.equal(harness.cameraStageTileByIdentity.size, 0);
+  assert.equal(harness.stagedCameraIdentities.size, 0);
+});
+
+test("showing and hiding camera never changes subscription or creates camera audio controls", () => {
+  const harness = loadCameraStageHarness();
+  const track = makeTrack("camera-1");
+  let subscriptionChanges = 0;
+  harness.localParticipant.publications = [{
+    source: "camera",
+    kind: "video",
+    track,
+    trackSid: "camera-1",
+    setSubscribed() { subscriptionChanges += 1; },
+  }];
+
+  assert.equal(harness.context.setCameraOnStage("sam-1", true), true);
+  const tile = harness.cameraStageTileByIdentity.get("sam-1");
+  assert.equal(subscriptionChanges, 0);
+  assert.equal(tile.children.some((child) => child.classList.contains("tile-volume-wrap")), false);
+  assert.equal(tile.children.some((child) => child.tagName === "AUDIO"), false);
+
+  assert.equal(harness.context.setCameraOnStage("sam-1", false), false);
+  assert.equal(subscriptionChanges, 0);
+  assert.equal(harness.cameraStageTileByIdentity.has("sam-1"), false);
+});
+
+test("camera tile supplies camera-specific fullscreen, focus, contain, and aspect behavior", () => {
+  const harness = loadCameraStageHarness();
+  const track = makeTrack("camera-1");
+  harness.stagedCameraIdentities.add("sam-1");
+  const tile = harness.context.upsertCameraStageTile("sam-1", "Sam", track, { trackSid: "camera-1" });
+  const video = tile.querySelector("video");
+  const fullscreen = tile.children.find((child) => child.classList.contains("tile-fullscreen-btn"));
+
+  assert.equal(video.style.objectFit, "contain");
+  video.videoWidth = 1080;
+  video.videoHeight = 1920;
+  video.dispatch("loadedmetadata");
+  assert.equal(tile.dataset.aspectRatio, "0.56");
+  assert.equal(tile.classList.contains("portrait"), true);
+
+  tile.dispatch("click");
+  assert.equal(tile.classList.contains("is-focused"), true);
+  fullscreen.dispatch("click", { stopPropagation() {} });
+  assert.equal(harness.fullscreenVideo, video);
+  assert.equal(fullscreen.getAttribute("aria-label"), "Open camera fullscreen");
+});
+
+test("camera generations reject old Rooms and replaced same-identity participants", () => {
+  const harness = loadCameraStageHarness();
+  const currentTrack = makeTrack("camera-current");
+  const currentPublication = { source: "camera", kind: "video", track: currentTrack };
+  const currentParticipant = { identity: "alex-2", publications: [currentPublication] };
+  harness.context.room.remoteParticipants.set("alex-2", currentParticipant);
+
+  assert.equal(harness.context.isCurrentCameraTrackGeneration(
+    "alex-2", currentParticipant, currentPublication, currentTrack, harness.context.room
+  ), true);
+
+  const oldTrack = makeTrack("camera-old");
+  const oldPublication = { source: "camera", kind: "video", track: oldTrack };
+  const oldParticipant = { identity: "alex-2", publications: [oldPublication] };
+  const oldRoom = {
+    localParticipant: { identity: "other-local" },
+    remoteParticipants: new Map([["alex-2", oldParticipant]]),
+  };
+  assert.equal(harness.context.isCurrentCameraTrackGeneration(
+    "alex-2", oldParticipant, oldPublication, oldTrack, oldRoom
+  ), false);
+  assert.equal(harness.context.isCurrentCameraTrackGeneration(
+    "alex-2", oldParticipant, oldPublication, oldTrack, harness.context.room
+  ), false);
+});
+
+test("screen events reject old Rooms and replaced same-identity participants", () => {
+  const harness = loadCameraStageHarness();
+  const oldScreenTrack = { sid: "screen-old", kind: "video", source: "screen_share" };
+  const oldScreenPublication = { source: "screen_share", kind: "video", track: oldScreenTrack };
+  const oldParticipant = { identity: "alex-2", publications: [oldScreenPublication] };
+  const replacementParticipant = { identity: "alex-2", publications: [] };
+  const oldRoom = {
+    localParticipant: harness.localParticipant,
+    remoteParticipants: new Map([["alex-2", oldParticipant]]),
+  };
+  harness.context.room.remoteParticipants.set("alex-2", replacementParticipant);
+
+  assert.equal(harness.context.shouldIgnoreRoomMediaEvent(
+    oldRoom,
+    harness.context.room,
+    false
+  ), true);
+  assert.equal(harness.context.isCurrentRoomParticipantGeneration(
+    "alex-2",
+    oldParticipant,
+    harness.context.room
+  ), false);
+  assert.equal(harness.context.isCurrentRoomParticipantGeneration(
+    "alex-2",
+    replacementParticipant,
+    harness.context.room
+  ), true);
+
+  harness.context.room._echoRecoveryDisconnect = true;
+  assert.equal(harness.context.shouldIgnoreRoomMediaEvent(
+    harness.context.room,
+    harness.context.room,
+    true
+  ), true);
+});
+
+test("disconnect grace cleanup rejects old Rooms and replacement participants", () => {
+  const harness = loadCameraStageHarness();
+  const disconnectedParticipant = { identity: "alex-2", publications: [] };
+  harness.context.room.remoteParticipants.set("alex-2", disconnectedParticipant);
+
+  assert.equal(harness.context.isCurrentCameraDisconnectGeneration(
+    "alex-2",
+    disconnectedParticipant,
+    harness.context.room
+  ), true);
+
+  harness.context.room.remoteParticipants.delete("alex-2");
+  assert.equal(harness.context.isCurrentCameraDisconnectGeneration(
+    "alex-2",
+    disconnectedParticipant,
+    harness.context.room
+  ), true);
+
+  harness.context.room.remoteParticipants.set("alex-2", { identity: "alex-2", publications: [] });
+  assert.equal(harness.context.isCurrentCameraDisconnectGeneration(
+    "alex-2",
+    disconnectedParticipant,
+    harness.context.room
+  ), false);
+
+  const oldRoom = harness.context.room;
+  harness.context.room = {
+    localParticipant: harness.localParticipant,
+    remoteParticipants: new Map(),
+  };
+  assert.equal(harness.context.isCurrentCameraDisconnectGeneration(
+    "alex-2",
+    disconnectedParticipant,
+    oldRoom
+  ), false);
+});
+
+test("rejoin detects a stale same-identity camera attachment without a pending disconnect", () => {
+  const harness = loadCameraStageHarness();
+  const oldParticipant = { identity: "alex-2", publications: [] };
+  const replacementParticipant = { identity: "alex-2", publications: [] };
+  harness.context.room.remoteParticipants.set("alex-2", replacementParticipant);
+  const cardRef = {
+    cameraRoom: harness.context.room,
+    cameraParticipant: oldParticipant,
+    cameraPublication: {},
+    cameraTrack: makeTrack("camera-old"),
+  };
+
+  assert.equal(harness.context.hasCameraStageGenerationMismatch(
+    "alex-2",
+    replacementParticipant,
+    harness.context.room,
+    cardRef,
+    null
+  ), true);
+
+  cardRef.cameraParticipant = replacementParticipant;
+  assert.equal(harness.context.hasCameraStageGenerationMismatch(
+    "alex-2",
+    replacementParticipant,
+    harness.context.room,
+    cardRef,
+    null
+  ), false);
+});
+
+test("active Camera Lobby refills only for the committed current Room", () => {
+  const harness = loadCameraStageHarness();
+  const committedRoom = harness.context.room;
+
+  assert.equal(harness.context.refreshActiveCameraLobbyForRoom(committedRoom), true);
+  assert.equal(harness.cameraLobbyPopulateCalls, 1);
+
+  harness.context.room = {
+    localParticipant: harness.localParticipant,
+    remoteParticipants: new Map(),
+  };
+  assert.equal(harness.context.refreshActiveCameraLobbyForRoom(committedRoom), false);
+  assert.equal(harness.cameraLobbyPopulateCalls, 1);
+
+  const currentRoom = harness.context.room;
+  harness.cameraLobbyPanel.classList.add("hidden");
+  assert.equal(harness.context.refreshActiveCameraLobbyForRoom(currentRoom), false);
+  assert.equal(harness.cameraLobbyPopulateCalls, 1);
+});
+
+test("delayed camera cleanup is fenced to its exact Room, participant, and publication generation", () => {
+  const harness = loadCameraStageHarness();
+  const unsubscribedTrack = makeTrack("camera-old");
+  const publication = { source: "camera", kind: "video", track: null };
+  const participant = { identity: "alex-2", publications: [publication] };
+  harness.context.room.remoteParticipants.set("alex-2", participant);
+  const generation = {
+    identity: "alex-2",
+    room: harness.context.room,
+    participant,
+    publication,
+    track: unsubscribedTrack,
+  };
+
+  assert.equal(harness.context.isCurrentCameraUnsubscribeGeneration(generation), true);
+
+  publication.track = makeTrack("camera-replacement");
+  assert.equal(harness.context.isCurrentCameraUnsubscribeGeneration(generation), false);
+  publication.track = null;
+
+  const replacementPublication = { source: "camera", kind: "video", track: makeTrack("camera-new-pub") };
+  participant.publications.push(replacementPublication);
+  assert.equal(harness.context.isCurrentCameraUnsubscribeGeneration(generation), false);
+  participant.publications.pop();
+
+  const replacementParticipant = { identity: "alex-2", publications: [] };
+  harness.context.room.remoteParticipants.set("alex-2", replacementParticipant);
+  assert.equal(harness.context.isCurrentCameraUnsubscribeGeneration(generation), false);
+  harness.context.room.remoteParticipants.set("alex-2", participant);
+
+  const currentRoom = harness.context.room;
+  harness.context.room = {
+    localParticipant: currentRoom.localParticipant,
+    remoteParticipants: new Map([["alex-2", participant]]),
+  };
+  assert.equal(harness.context.isCurrentCameraUnsubscribeGeneration(generation), false);
+});
+
+test("an old local camera publication cannot clear a live replacement publication", () => {
+  const harness = loadCameraStageHarness();
+  const oldPublication = { source: "camera", kind: "video", track: makeTrack("camera-old") };
+  const replacementPublication = { source: "camera", kind: "video", track: makeTrack("camera-new") };
+  harness.localParticipant.publications = [oldPublication, replacementPublication];
+
+  assert.equal(harness.context.hasLiveCameraPublicationOtherThan(
+    harness.localParticipant,
+    oldPublication
+  ), true);
+
+  replacementPublication.track = null;
+  assert.equal(harness.context.hasLiveCameraPublicationOtherThan(
+    harness.localParticipant,
+    oldPublication
+  ), false);
+
+  const pendingReplacement = harness.context.getRemainingCameraPublicationState(
+    harness.localParticipant,
+    oldPublication
+  );
+  assert.equal(pendingReplacement.publication, replacementPublication);
+  assert.equal(pendingReplacement.track, null);
+});
+
+test("camera recovery timer cannot reattach after Room replacement", () => {
+  const harness = loadCameraRecoveryHarness();
+  const track = makeTrack("camera-old-room");
+  track.mediaStreamTrack = { readyState: "live" };
+  let subscriptionChanges = 0;
+  const publication = {
+    source: "camera",
+    kind: "video",
+    track,
+    isSubscribed: true,
+    setSubscribed() { subscriptionChanges += 1; },
+  };
+  const participant = { identity: "alex-2", publications: [publication] };
+  const avatar = new FakeElement("div");
+  avatar.isConnected = true;
+  avatar.appendChild(new FakeElement("video"));
+  const cardRef = { avatar };
+  harness.context.room.remoteParticipants.set("alex-2", participant);
+  harness.context.participantCards.set("alex-2", cardRef);
+
+  harness.context.scheduleCameraRecovery("alex-2", cardRef, publication);
+  assert.equal(harness.scheduled.length, 1);
+  harness.context.room = {
+    localParticipant: harness.localParticipant,
+    remoteParticipants: new Map([["alex-2", participant]]),
+  };
+  harness.scheduled.shift()();
+
+  assert.equal(subscriptionChanges, 0);
+  assert.equal(harness.avatarUpdates, 0);
+});
+
+test("camera recovery timer cannot reattach after same-identity participant replacement", () => {
+  const harness = loadCameraRecoveryHarness();
+  const track = makeTrack("camera-old-participant");
+  track.mediaStreamTrack = { readyState: "live" };
+  let subscriptionChanges = 0;
+  const publication = {
+    source: "camera",
+    kind: "video",
+    track,
+    isSubscribed: true,
+    setSubscribed() { subscriptionChanges += 1; },
+  };
+  const oldParticipant = { identity: "alex-2", publications: [publication] };
+  const replacementParticipant = { identity: "alex-2", publications: [] };
+  const avatar = new FakeElement("div");
+  avatar.isConnected = true;
+  avatar.appendChild(new FakeElement("video"));
+  const cardRef = { avatar };
+  harness.context.room.remoteParticipants.set("alex-2", oldParticipant);
+  harness.context.participantCards.set("alex-2", cardRef);
+
+  harness.context.scheduleCameraRecovery("alex-2", cardRef, publication);
+  assert.equal(harness.scheduled.length, 1);
+  harness.context.room.remoteParticipants.set("alex-2", replacementParticipant);
+  harness.scheduled.shift()();
+
+  assert.equal(subscriptionChanges, 0);
+  assert.equal(harness.avatarUpdates, 0);
+});
+
+test("camera recovery still repairs the exact current generation", () => {
+  const harness = loadCameraRecoveryHarness();
+  const track = makeTrack("camera-current");
+  track.mediaStreamTrack = { readyState: "live" };
+  let subscriptionChanges = 0;
+  const publication = {
+    source: "camera",
+    kind: "video",
+    track,
+    isSubscribed: true,
+    setSubscribed() { subscriptionChanges += 1; },
+  };
+  const participant = { identity: "alex-2", publications: [publication] };
+  const avatar = new FakeElement("div");
+  avatar.isConnected = true;
+  avatar.appendChild(new FakeElement("video"));
+  const cardRef = { avatar };
+  harness.context.room.remoteParticipants.set("alex-2", participant);
+  harness.context.participantCards.set("alex-2", cardRef);
+
+  harness.context.scheduleCameraRecovery("alex-2", cardRef, publication);
+  harness.scheduled.shift()();
+
+  assert.equal(subscriptionChanges, 1);
+  assert.equal(harness.avatarUpdates, 1);
+});
+
+test("remote camera replacement publication preserves Stage intent until its track subscribes", () => {
+  const harness = loadCameraStageHarness();
+  const oldTrack = makeTrack("camera-old");
+  const oldPublication = {
+    source: "camera",
+    kind: "video",
+    track: oldTrack,
+    trackSid: "camera-old",
+  };
+  const replacementPublication = {
+    source: "camera",
+    kind: "video",
+    track: null,
+    trackSid: "camera-new",
+  };
+  const participant = {
+    identity: "alex-2",
+    name: "Alex",
+    publications: [oldPublication, replacementPublication],
+  };
+  harness.context.room.remoteParticipants.set(participant.identity, participant);
+  harness.stagedCameraIdentities.add(participant.identity);
+  const avatar = new FakeElement("div");
+  avatar.setConnected(true);
+  const oldAvatarVideo = new FakeElement("video");
+  oldAvatarVideo._lkTrack = oldTrack;
+  avatar.appendChild(oldAvatarVideo);
+  const cardRef = {
+    avatar,
+    cameraRoom: harness.context.room,
+    cameraParticipant: participant,
+    cameraPublication: oldPublication,
+    cameraTrack: oldTrack,
+  };
+  harness.context.participantCards.set(participant.identity, cardRef);
+  harness.context.cameraVideoBySid.set(oldPublication.trackSid, oldAvatarVideo);
+  harness.context.participantState.set(participant.identity, {
+    cameraTrackSid: oldPublication.trackSid,
+  });
+  const oldTile = harness.context.upsertCameraStageTile(
+    participant.identity,
+    participant.name,
+    oldTrack,
+    oldPublication
+  );
+
+  const remaining = harness.context.getRemainingCameraPublicationState(
+    participant,
+    oldPublication
+  );
+  assert.equal(remaining.publication, replacementPublication);
+  assert.equal(remaining.track, null);
+
+  harness.context.removeCameraVisualGeneration(participant.identity, oldPublication, {
+    clearIntent: false,
+  });
+  assert.equal(oldTile.isConnected, false);
+  assert.equal(harness.cameraStageTileByIdentity.has(participant.identity), false);
+  assert.equal(harness.stagedCameraIdentities.has(participant.identity), true);
+  assert.equal(harness.context.cameraVideoBySid.has(oldPublication.trackSid), false);
+
+  // Deliberately reuse both the track object and SID. Exact publication stamps,
+  // rather than track equality, must protect the replacement generation.
+  const replacementTrack = oldTrack;
+  replacementPublication.trackSid = oldPublication.trackSid;
+  replacementPublication.track = replacementTrack;
+  const replacementTile = harness.context.reconcileCameraStageTrack(
+    participant.identity,
+    participant.name,
+    replacementTrack,
+    replacementPublication
+  );
+  assert.ok(replacementTile);
+  assert.equal(replacementTile._cameraStagePublication, replacementPublication);
+  const replacementAvatarVideo = new FakeElement("video");
+  replacementAvatarVideo._lkTrack = replacementTrack;
+  replacementAvatarVideo._echoCameraPublication = replacementPublication;
+  avatar.appendChild(replacementAvatarVideo);
+  cardRef.cameraPublication = replacementPublication;
+  cardRef.cameraTrack = replacementTrack;
+  harness.context.cameraVideoBySid.set(replacementPublication.trackSid, replacementAvatarVideo);
+  harness.context.participantState.get(participant.identity).cameraTrackSid = replacementPublication.trackSid;
+
+  // A duplicate late cleanup for the old publication cannot touch the new tile.
+  harness.context.removeCameraVisualGeneration(participant.identity, oldPublication, {
+    clearIntent: false,
+  });
+  assert.equal(harness.cameraStageTileByIdentity.get(participant.identity), replacementTile);
+  assert.equal(harness.stagedCameraIdentities.has(participant.identity), true);
+  assert.equal(
+    harness.context.cameraVideoBySid.get(replacementPublication.trackSid),
+    replacementAvatarVideo
+  );
+  assert.equal(
+    harness.context.participantState.get(participant.identity).cameraTrackSid,
+    replacementPublication.trackSid
+  );
+});
+
+test("authoritative remote camera off clears Stage visuals and intent without a replacement publication", () => {
+  const harness = loadCameraStageHarness();
+  const track = makeTrack("camera-last");
+  const publication = {
+    source: "camera",
+    kind: "video",
+    track,
+    trackSid: "camera-last",
+  };
+  const participant = {
+    identity: "alex-2",
+    name: "Alex",
+    publications: [publication],
+  };
+  harness.context.room.remoteParticipants.set(participant.identity, participant);
+  harness.stagedCameraIdentities.add(participant.identity);
+  harness.context.upsertCameraStageTile(
+    participant.identity,
+    participant.name,
+    track,
+    publication
+  );
+  participant.publications = [];
+
+  const remaining = harness.context.getRemainingCameraPublicationState(participant, publication);
+  assert.equal(remaining.publication, null);
+  harness.context.removeCameraVisualGeneration(participant.identity, publication, {
+    clearIntent: true,
+  });
+
+  assert.equal(harness.cameraStageTileByIdentity.has(participant.identity), false);
+  assert.equal(harness.stagedCameraIdentities.has(participant.identity), false);
+});
+
+test("same-identity participant replacement removes only old screen video and audio generations", () => {
+  const harness = loadScreenGenerationHarness(true);
+  const identity = "alex-2";
+  const oldParticipant = { identity, publications: [] };
+  const replacementParticipant = { identity, publications: [] };
+  harness.context.room.remoteParticipants.set(identity, replacementParticipant);
+  harness.context.hiddenScreens.add(identity);
+  harness.context.watchedScreens.add(identity);
+
+  const oldTrack = makeTrack("screen-old");
+  oldTrack.kind = "video";
+  oldTrack.source = "screen_share";
+  const oldPublication = {
+    source: "screen_share",
+    kind: "video",
+    track: oldTrack,
+    trackSid: oldTrack.sid,
+  };
+  oldParticipant.publications = [oldPublication];
+  const oldVideo = harness.context.createAttachedVideoElement(oldTrack);
+  const oldTile = harness.context.addScreenTile("Alex (Screen)", oldVideo, oldTrack.sid);
+  oldTile.dataset.identity = identity;
+  harness.context.stampScreenTileGeneration(
+    oldTile,
+    oldPublication,
+    identity,
+    oldParticipant,
+    oldTrack,
+    harness.context.room
+  );
+  harness.context.registerScreenTrack(
+    oldTrack.sid,
+    oldPublication,
+    oldTile,
+    identity,
+    oldParticipant,
+    oldTrack,
+    harness.context.room
+  );
+
+  const replacementTrack = makeTrack("screen-new");
+  replacementTrack.kind = "video";
+  replacementTrack.source = "screen_share";
+  const replacementPublication = {
+    source: "screen_share",
+    kind: "video",
+    track: replacementTrack,
+    trackSid: replacementTrack.sid,
+  };
+  replacementParticipant.publications = [replacementPublication];
+  const replacementVideo = harness.context.createAttachedVideoElement(replacementTrack);
+  const replacementTile = harness.context.addScreenTile(
+    "Alex (Screen)",
+    replacementVideo,
+    replacementTrack.sid
+  );
+  replacementTile.dataset.identity = identity;
+  harness.context.stampScreenTileGeneration(
+    replacementTile,
+    replacementPublication,
+    identity,
+    replacementParticipant,
+    replacementTrack,
+    harness.context.room
+  );
+  harness.context.registerScreenTrack(
+    replacementTrack.sid,
+    replacementPublication,
+    replacementTile,
+    identity,
+    replacementParticipant,
+    replacementTrack,
+    harness.context.room
+  );
+  harness.screenTileByIdentity.set(identity, replacementTile);
+
+  let analyserCleanup = 0;
+  const state = {
+    screenAudioEls: new Set(),
+    screenGainNodes: new Map(),
+    screenAnalyser: { cleanup() { analyserCleanup += 1; } },
+    screenAudioSid: "screen-audio-shared",
+  };
+  harness.context.participantState.set(identity, state);
+  const oldAudioTrack = makeTrack("screen-audio-shared");
+  const oldAudio = new FakeElement("audio");
+  oldAudio._lkTrack = oldAudioTrack;
+  oldAudio._echoRoom = harness.context.room;
+  oldAudio._echoParticipant = oldParticipant;
+  oldAudio._echoMediaSource = "screen_share_audio";
+  oldAudio._echoMediaIdentity = identity;
+  oldAudio._echoTrackSid = oldAudioTrack.sid;
+  const replacementAudioTrack = makeTrack("screen-audio-shared");
+  const replacementAudio = new FakeElement("audio");
+  replacementAudio._lkTrack = replacementAudioTrack;
+  replacementAudio._echoRoom = harness.context.room;
+  replacementAudio._echoParticipant = replacementParticipant;
+  replacementAudio._echoMediaSource = "screen_share_audio";
+  replacementAudio._echoMediaIdentity = identity;
+  replacementAudio._echoTrackSid = replacementAudioTrack.sid;
+  state.screenAudioEls.add(oldAudio);
+  state.screenAudioEls.add(replacementAudio);
+  harness.context.audioElBySid.set(oldAudioTrack.sid, oldAudio);
+  // The replacement reuses the SID and overwrites the global lookup before
+  // ParticipantConnected performs old-generation cleanup.
+  harness.context.audioElBySid.set(replacementAudioTrack.sid, replacementAudio);
+
+  const videoResult = harness.context.clearScreenParticipantGeneration(
+    replacementParticipant,
+    harness.context.room,
+    "replaced"
+  );
+  const audioResult = harness.context.clearScreenAudioParticipantGeneration(
+    replacementParticipant,
+    harness.context.room,
+    "replaced"
+  );
+
+  assert.equal(videoResult.removed, true);
+  assert.equal(audioResult.removed, 1);
+  assert.equal(oldTile.isConnected, false);
+  assert.deepEqual(oldTrack.detachCalls, [oldVideo]);
+  assert.equal(harness.screenTileBySid.has(oldTrack.sid), false);
+  assert.equal(harness.screenTrackMeta.has(oldTrack.sid), false);
+  assert.equal(harness.screenTileBySid.get(replacementTrack.sid), replacementTile);
+  assert.equal(harness.screenTrackMeta.get(replacementTrack.sid).participant, replacementParticipant);
+  assert.equal(harness.screenTileByIdentity.get(identity), replacementTile);
+  assert.equal(harness.context.hiddenScreens.has(identity), true);
+  assert.equal(harness.context.watchedScreens.has(identity), true);
+  assert.deepEqual(oldAudioTrack.detachCalls, [oldAudio]);
+  assert.equal(state.screenAudioEls.has(oldAudio), false);
+  assert.equal(harness.context.audioElBySid.get(replacementAudioTrack.sid), replacementAudio);
+  assert.equal(state.screenAudioEls.has(replacementAudio), true);
+  assert.equal(state.screenAudioSid, replacementAudioTrack.sid);
+  assert.equal(analyserCleanup, 0);
+  assert.equal(harness.context.isCurrentRoomParticipantGeneration(
+    identity,
+    oldParticipant,
+    harness.context.room
+  ), false);
+});
+
+test("abrupt screen companion disconnect cleans media stored under its parent identity", () => {
+  const harness = loadScreenGenerationHarness(true);
+  const parentIdentity = "alex-2";
+  const companion = { identity: parentIdentity + "$screen", publications: [] };
+  harness.context.room.remoteParticipants.set(companion.identity, companion);
+  const track = makeTrack("screen-companion");
+  track.kind = "video";
+  track.source = "screen_share";
+  const publication = {
+    source: "screen_share",
+    kind: "video",
+    track,
+    trackSid: track.sid,
+  };
+  companion.publications = [publication];
+  const video = harness.context.createAttachedVideoElement(track);
+  const tile = harness.context.addScreenTile("Alex (Screen)", video, track.sid);
+  tile.dataset.identity = parentIdentity;
+  harness.context.stampScreenTileGeneration(
+    tile,
+    publication,
+    parentIdentity,
+    companion,
+    track,
+    harness.context.room
+  );
+  harness.context.registerScreenTrack(
+    track.sid,
+    publication,
+    tile,
+    parentIdentity,
+    companion,
+    track,
+    harness.context.room
+  );
+  harness.screenTileByIdentity.set(parentIdentity, tile);
+
+  const audioTrack = makeTrack("screen-companion-audio");
+  const audio = new FakeElement("audio");
+  audio._lkTrack = audioTrack;
+  audio._echoRoom = harness.context.room;
+  audio._echoParticipant = companion;
+  audio._echoMediaSource = "screen_share_audio";
+  audio._echoMediaIdentity = parentIdentity;
+  audio._echoTrackSid = audioTrack.sid;
+  const state = {
+    screenAudioEls: new Set([audio]),
+    screenGainNodes: new Map(),
+    screenAnalyser: null,
+    screenAudioSid: audioTrack.sid,
+  };
+  harness.context.participantState.set(parentIdentity, state);
+  harness.context.audioElBySid.set(audioTrack.sid, audio);
+
+  const videoResult = harness.context.clearScreenParticipantGeneration(
+    companion,
+    harness.context.room,
+    "exact"
+  );
+  const audioResult = harness.context.clearScreenAudioParticipantGeneration(
+    companion,
+    harness.context.room,
+    "exact"
+  );
+
+  assert.equal(videoResult.mediaIdentity, parentIdentity);
+  assert.equal(videoResult.removed, true);
+  assert.equal(audioResult.mediaIdentity, parentIdentity);
+  assert.equal(audioResult.removed, 1);
+  assert.equal(harness.screenTileByIdentity.has(parentIdentity), false);
+  assert.equal(harness.screenTileBySid.has(track.sid), false);
+  assert.equal(harness.screenTrackMeta.has(track.sid), false);
+  assert.equal(harness.context.audioElBySid.has(audioTrack.sid), false);
+  assert.equal(state.screenAudioEls.size, 0);
+});
+
+test("detached screen generations stop recursive video-layer and resubscribe timers", () => {
+  const harness = loadScreenGenerationHarness();
+  const identity = "alex-2";
+  const participant = { identity, publications: [] };
+  harness.context.room.remoteParticipants.set(identity, participant);
+  const track = makeTrack("screen-timer");
+  track.kind = "video";
+  track.source = "screen_share";
+  let qualityChanges = 0;
+  const subscriptionChanges = [];
+  const publication = {
+    source: "screen_share",
+    kind: "video",
+    track,
+    trackSid: track.sid,
+    setVideoQuality() { qualityChanges += 1; },
+    setSubscribed(value) { subscriptionChanges.push(value); },
+  };
+  participant.publications = [publication];
+  const video = harness.context.createAttachedVideoElement(track);
+  const tile = harness.context.addScreenTile("Alex (Screen)", video, track.sid);
+  tile.dataset.identity = identity;
+  harness.context.stampScreenTileGeneration(
+    tile,
+    publication,
+    identity,
+    participant,
+    track,
+    harness.context.room
+  );
+  harness.context.registerScreenTrack(
+    track.sid,
+    publication,
+    tile,
+    identity,
+    participant,
+    track,
+    harness.context.room
+  );
+  harness.screenTileByIdentity.set(identity, tile);
+
+  harness.scheduled.length = 0;
+  harness.context.forceVideoLayer(publication, video);
+  const videoLayerTimer = harness.scheduled.find((entry) => entry.delay === 800);
+  assert.ok(videoLayerTimer);
+
+  video._isBlack = true;
+  video._lastFrameTs = 0;
+  harness.context.scheduleScreenRecovery(track.sid, publication, video);
+  const recoveryTimer = harness.scheduled.find((entry) => entry.delay === 700);
+  assert.ok(recoveryTimer);
+  recoveryTimer.callback();
+  assert.deepEqual(subscriptionChanges, [false]);
+  const restoreTimer = harness.scheduled.find((entry) => entry.delay === 300);
+  assert.ok(restoreTimer);
+
+  harness.context.removeRegisteredScreenGeneration(
+    track.sid,
+    harness.screenTrackMeta.get(track.sid)
+  );
+  const scheduledBeforeStaleCallbacks = harness.scheduled.length;
+  videoLayerTimer.callback();
+  restoreTimer.callback();
+
+  assert.equal(harness.scheduled.length, scheduledBeforeStaleCallbacks);
+  assert.equal(qualityChanges, 0);
+  assert.deepEqual(subscriptionChanges, [false]);
+});
+
+test("fullscreen exit label remains media-specific", () => {
+  const fullscreen = require("./participants-fullscreen.js");
+  const cameraHost = { dataset: { mediaKind: "camera" } };
+  const screenHost = { dataset: { mediaKind: "screen" } };
+
+  assert.equal(
+    fullscreen.getVideoFullscreenControlLabel(cameraHost, "Open camera fullscreen", true),
+    "Exit camera fullscreen"
+  );
+  assert.equal(
+    fullscreen.getVideoFullscreenControlLabel(screenHost, "Open shared screen fullscreen", true),
+    "Exit shared screen fullscreen"
+  );
+  assert.equal(
+    fullscreen.getVideoFullscreenControlLabel(screenHost, "Open shared screen fullscreen", false),
+    "Open shared screen fullscreen"
+  );
+});
+
+test("viewer wiring exposes direct local/remote controls and separates transient from authoritative cleanup", () => {
+  const stateSource = fs.readFileSync(path.join(__dirname, "state.js"), "utf8");
+  const avatarSource = fs.readFileSync(path.join(__dirname, "participants-avatar.js"), "utf8");
+  const audioSource = fs.readFileSync(path.join(__dirname, "audio-routing.js"), "utf8");
+  const connectSource = fs.readFileSync(path.join(__dirname, "connect.js"), "utf8");
+
+  assert.match(stateSource, /const cameraStageTileByIdentity = new Map\(\)/);
+  assert.match(stateSource, /const stagedCameraIdentities = new Set\(\)/);
+  assert.match(avatarSource, /camOverlay\.append\(overlayName, cameraStageToggleButton/);
+  assert.match(avatarSource, /controls\.append\(cameraStageToggleButton\)/);
+  assert.match(avatarSource, /settingsFooter\.append\(settingsWatchButton, settingsCameraStageButton\)/);
+  assert.match(audioSource, /removeCameraStageTile\(identity, \{ clearIntent: false \}\)/);
+  assert.match(audioSource, /cameraClearGenerationByIdentity\.get\(identity\) !== generation/);
+  assert.match(connectSource, /getRemainingCameraPublicationState\(\s*localParticipant,\s*publication\s*\)/);
+  assert.match(connectSource, /handleTrackSubscribed\(track, publication, participant\)/);
+  assert.doesNotMatch(connectSource, /handleTrackSubscribed\(track, publication, _effectiveParticipant\)/);
+  assert.match(connectSource, /hasCameraStageGenerationMismatch\(/);
+  assert.match(connectSource, /isCurrentCameraDisconnectGeneration\(key, participant, newRoom\)/);
+  assert.match(connectSource, /ignored stale participant name change/);
+  assert.match(connectSource, /function ignoreStaleRoomEvent\(eventName\)/);
+  assert.doesNotMatch(connectSource, /ignoreAndroidFirefoxStaleRoomEvent/);
+  assert.match(connectSource, /refreshActiveCameraLobbyForRoom\(newRoom\)/);
+  assert.match(fs.readFileSync(path.join(__dirname, "participants-grid.js"), "utf8"), /clearCameraLobbyMedia\(\)/);
+  assert.match(connectSource, /removeCameraVisualGeneration\(identity, publication, \{ clearIntent: true \}\)/);
+  assert.match(connectSource, /removeCameraStageTile\(key, \{ clearIntent: true \}\)/);
+});

--- a/core/viewer/clubhouse-shell.css
+++ b/core/viewer/clubhouse-shell.css
@@ -1366,8 +1366,7 @@
   gap: 0;
 }
 
-:root[data-ui-shell="v2"] .room-layout.utility-collapsed .room-sidebar,
-:root[data-ui-shell="v2"] .room-layout.utility-collapsed .chat-panel {
+:root[data-ui-shell="v2"] .room-layout.utility-collapsed .room-sidebar {
   position: absolute;
   right: 0;
   bottom: 0;
@@ -1602,6 +1601,116 @@
   }
 }
 
+/* --------------------------------------------------------------------------
+   Stage modules
+
+   Chat, Jam, Camera Lobby, and Soundboard are alternate views of the central
+   Stage. The live screen grid stays mounted underneath so switching tools
+   never tears down screen media. Active Users remains an independent rail.
+   -------------------------------------------------------------------------- */
+
+:root[data-ui-shell="v2"] .room-main.stage-module-open > .grid-header,
+:root[data-ui-shell="v2"] .room-main.stage-module-open > .screens-grid {
+  visibility: hidden;
+  pointer-events: none;
+}
+
+:root[data-ui-shell="v2"] .stage-module-host {
+  position: absolute;
+  inset: 0;
+  z-index: var(--club-layer-region);
+  min-width: 0;
+  min-height: 0;
+  display: block;
+  overflow: hidden;
+  border-radius: inherit;
+}
+
+:root[data-ui-shell="v2"] .stage-module-host.hidden {
+  display: none;
+}
+
+:root[data-ui-shell="v2"] .stage-module-host > .clubhouse-stage-module {
+  position: absolute !important;
+  inset: 0 !important;
+  top: 0 !important;
+  right: 0 !important;
+  bottom: 0 !important;
+  left: 0 !important;
+  z-index: auto;
+  width: 100% !important;
+  height: 100% !important;
+  max-width: none !important;
+  max-height: none !important;
+  margin: 0 !important;
+  box-sizing: border-box;
+  transform: none !important;
+  border-radius: var(--club-radius-panel);
+}
+
+:root[data-ui-shell="v2"] .stage-module-host > .chat-panel.clubhouse-stage-module {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr) auto;
+}
+
+:root[data-ui-shell="v2"] .stage-module-host > .jam-panel.clubhouse-stage-module {
+  container-type: inline-size;
+}
+
+:root[data-ui-shell="v2"] .stage-module-host > .camera-lobby.clubhouse-stage-module {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+}
+
+:root[data-ui-shell="v2"] .stage-module-host > .camera-lobby.clubhouse-stage-module .camera-lobby-grid {
+  position: relative;
+}
+
+:root[data-ui-shell="v2"] .stage-module-host > .camera-lobby.clubhouse-stage-module .camera-lobby-tile.enlarged {
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+}
+
+:root[data-ui-shell="v2"] .stage-module-host > .soundboard-compact.clubhouse-stage-module {
+  display: flex;
+  width: 100% !important;
+  max-height: none;
+  padding: 16px;
+}
+
+:root[data-ui-shell="v2"] .stage-module-host > .soundboard.clubhouse-stage-module {
+  display: grid;
+}
+
+:root[data-ui-shell="v2"] .stage-module-host > .clubhouse-stage-module.hidden {
+  display: none !important;
+}
+
+:root[data-ui-shell="v2"] .stage-module-host :where(
+  #close-chat,
+  #close-jam,
+  #close-camera-lobby,
+  #close-soundboard,
+  #close-soundboard-stage
+) {
+  min-width: 40px;
+  min-height: 40px;
+}
+
+@media (hover: none), (pointer: coarse) {
+  :root[data-ui-shell="v2"] .stage-module-host :where(
+    #close-chat,
+    #close-jam,
+    #close-camera-lobby,
+    #close-soundboard,
+    #close-soundboard-stage
+  ) {
+    min-width: 44px;
+    min-height: 44px;
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   :root[data-ui-shell="v2"] *,
   :root[data-ui-shell="v2"] *::before,
@@ -1614,13 +1723,11 @@
 }
 
 /* --------------------------------------------------------------------------
-   Phase 2 — one logical People / Chat / Jam utility host
+   Phase 2 — responsive Active Users rail and Stage module presentation
 
-   Jam remains portaled under #shell-overlay-root while the legacy rollback is
-   available. The legacy .panel backdrop filter creates a fixed-position
-   containing block, so physically nesting Jam under the room panel would move
-   the centered legacy dialog offscreen. V2 gives that same node the exact
-   geometry of the active utility region without recreating or reparenting it.
+   V2 moves persistent module nodes into #stage-module-host without recreating
+   them. Live legacy rollback restores each node to its original portal anchor,
+   where the legacy fixed-position dialog geometry remains authoritative.
    -------------------------------------------------------------------------- */
 
 .utility-host {
@@ -2103,5 +2210,200 @@
   :root[data-ui-shell="v2"] .jam-panel.clubhouse-utility-tool .jam-browser button {
     min-width: 44px;
     min-height: 44px;
+  }
+}
+
+/* When a Stage module and Active Users are both visible, they share the
+   workspace instead of allowing the responsive rail to cover module controls. */
+:root[data-ui-shell="v2"][data-ui-mode="lounge"] .room-layout:has(> .room-main.stage-module-open):not(.utility-collapsed) {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) var(--club-people-rail-size);
+}
+
+:root[data-ui-shell="v2"][data-ui-mode="lounge"] .room-layout:has(> .room-main.stage-module-open):not(.utility-collapsed) > .utility-host {
+  position: relative;
+  inset: auto;
+  grid-column: 2;
+  grid-row: 1;
+  width: 100%;
+  height: 100%;
+}
+
+:root[data-ui-shell="v2"]:is([data-ui-mode="compact"], [data-ui-mode="mini"]) .room-layout:has(> .room-main.stage-module-open):not(.utility-collapsed) {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  grid-template-rows: minmax(0, 1fr) minmax(180px, 42%);
+}
+
+:root[data-ui-shell="v2"]:is([data-ui-mode="compact"], [data-ui-mode="mini"]) .room-layout:has(> .room-main.stage-module-open):not(.utility-collapsed) > .room-main {
+  grid-column: 1;
+  grid-row: 1;
+}
+
+:root[data-ui-shell="v2"]:is([data-ui-mode="compact"], [data-ui-mode="mini"]) .room-layout:has(> .room-main.stage-module-open):not(.utility-collapsed) > .utility-host {
+  position: relative;
+  inset: auto;
+  grid-column: 1;
+  grid-row: 2;
+  width: 100%;
+  height: 100%;
+}
+
+@media (orientation: landscape) and (max-height: 520px) {
+  :root[data-ui-shell="v2"][data-ui-short]:is([data-ui-mode="compact"], [data-ui-mode="mini"]) .room-layout:has(> .room-main.stage-module-open):not(.utility-collapsed) {
+    grid-template-columns: minmax(0, 1fr) clamp(220px, 36vw, 300px);
+    grid-template-rows: minmax(0, 1fr);
+  }
+
+  :root[data-ui-shell="v2"][data-ui-short]:is([data-ui-mode="compact"], [data-ui-mode="mini"]) .room-layout:has(> .room-main.stage-module-open):not(.utility-collapsed) > .room-main {
+    grid-column: 1;
+    grid-row: 1;
+  }
+
+  :root[data-ui-shell="v2"][data-ui-short]:is([data-ui-mode="compact"], [data-ui-mode="mini"]) .room-layout:has(> .room-main.stage-module-open):not(.utility-collapsed) > .utility-host {
+    grid-column: 2;
+    grid-row: 1;
+    position: relative;
+    inset: auto;
+    width: 100%;
+    height: 100% !important;
+    top: auto !important;
+  }
+
+  :root[data-ui-shell="v2"][data-ui-short]:is([data-ui-mode="compact"], [data-ui-mode="mini"]) .room-layout:has(> .room-main.stage-module-open):not(.utility-collapsed) > .utility-host > .room-sidebar {
+    height: 100%;
+    max-height: none;
+  }
+}
+
+/* The edit surface must remain usable when Soundboard owns a narrow or short
+   Stage. Keep its chrome inside the panel and let the panel scroll to Upload. */
+:root[data-ui-shell="v2"] .stage-module-host > .soundboard.soundboard-edit.clubhouse-stage-module {
+  min-width: 0;
+  min-height: 0;
+  grid-template-rows: auto auto auto minmax(0, 1fr) auto;
+  overflow-x: hidden !important;
+  overflow-y: auto !important;
+  overscroll-behavior: contain;
+  scrollbar-gutter: stable;
+}
+
+:root[data-ui-shell="v2"] .stage-module-host > .soundboard.soundboard-edit.clubhouse-stage-module :where(
+  .soundboard-header,
+  .soundboard-actions,
+  .soundboard-search,
+  .soundboard-grid,
+  .soundboard-upload,
+  .soundboard-upload-row,
+  .soundboard-upload-volume
+) {
+  min-width: 0;
+  max-width: 100%;
+  box-sizing: border-box;
+}
+
+:root[data-ui-shell="v2"] .stage-module-host > .soundboard.soundboard-edit.clubhouse-stage-module .soundboard-header,
+:root[data-ui-shell="v2"] .stage-module-host > .soundboard.soundboard-edit.clubhouse-stage-module .soundboard-actions {
+  flex-wrap: wrap;
+}
+
+:root[data-ui-shell="v2"] .stage-module-host > .soundboard.soundboard-edit.clubhouse-stage-module .soundboard-actions > button,
+:root[data-ui-shell="v2"] .stage-module-host > .soundboard.soundboard-edit.clubhouse-stage-module .soundboard-upload-row > * {
+  min-width: 0;
+  max-width: 100%;
+}
+
+@media (max-width: 700px), (max-height: 520px) {
+  :root[data-ui-shell="v2"] .stage-module-host > .soundboard.soundboard-edit.clubhouse-stage-module {
+    display: block;
+    padding: 10px;
+  }
+
+  :root[data-ui-shell="v2"] .stage-module-host > .soundboard.soundboard-edit.clubhouse-stage-module > * + * {
+    margin-top: 8px;
+  }
+
+  :root[data-ui-shell="v2"] .stage-module-host > .soundboard.soundboard-edit.clubhouse-stage-module .soundboard-header {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+    align-items: start;
+    gap: 8px;
+    padding-bottom: 8px;
+  }
+
+  :root[data-ui-shell="v2"] .stage-module-host > .soundboard.soundboard-edit.clubhouse-stage-module .soundboard-actions {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    width: 100%;
+  }
+
+  :root[data-ui-shell="v2"] .stage-module-host > .soundboard.soundboard-edit.clubhouse-stage-module #toggle-soundboard-volume {
+    grid-column: 1 / -1;
+  }
+
+  :root[data-ui-shell="v2"] .stage-module-host > .soundboard.soundboard-edit.clubhouse-stage-module .soundboard-actions > button {
+    width: 100%;
+    padding-inline: 8px;
+    white-space: normal;
+  }
+
+  :root[data-ui-shell="v2"] .stage-module-host > .soundboard.soundboard-edit.clubhouse-stage-module .soundboard-grid {
+    min-height: 96px;
+    max-height: clamp(96px, 30vh, 220px);
+  }
+
+  :root[data-ui-shell="v2"] .stage-module-host > .soundboard.soundboard-edit.clubhouse-stage-module .soundboard-upload {
+    padding-top: 8px;
+  }
+
+  :root[data-ui-shell="v2"] .stage-module-host > .soundboard.soundboard-edit.clubhouse-stage-module .soundboard-upload-row {
+    grid-template-columns: minmax(0, 1fr) auto auto;
+    gap: 8px;
+  }
+
+  :root[data-ui-shell="v2"] .stage-module-host > .soundboard.soundboard-edit.clubhouse-stage-module .sound-file {
+    grid-column: 1 / -1;
+    justify-content: center;
+  }
+
+  :root[data-ui-shell="v2"] .stage-module-host > .soundboard.soundboard-edit.clubhouse-stage-module .soundboard-upload-volume {
+    grid-template-columns: auto minmax(0, 1fr) auto;
+    gap: 8px;
+  }
+
+  :root[data-ui-shell="v2"] .stage-module-host > .soundboard-compact.clubhouse-stage-module {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    align-content: stretch;
+    padding: 10px;
+    gap: 6px;
+    overflow-x: hidden;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    scrollbar-gutter: stable;
+  }
+
+  :root[data-ui-shell="v2"] .stage-module-host > .soundboard-compact.clubhouse-stage-module :where(
+    .soundboard-compact-header,
+    .soundboard-volume-compact,
+    .soundboard-compact-search,
+    .soundboard-compact-grid
+  ) {
+    grid-column: 1 / -1;
+    min-width: 0;
+    max-width: 100%;
+    box-sizing: border-box;
+  }
+
+  :root[data-ui-shell="v2"] .stage-module-host > .soundboard-compact.clubhouse-stage-module .soundboard-compact-btn {
+    min-width: 0;
+    padding-inline: 6px;
+    white-space: normal;
+  }
+
+  :root[data-ui-shell="v2"] .stage-module-host > .soundboard-compact.clubhouse-stage-module .soundboard-compact-grid {
+    min-height: 64px;
+    overflow-y: auto;
+    overscroll-behavior: contain;
   }
 }

--- a/core/viewer/connect.js
+++ b/core/viewer/connect.js
@@ -2,8 +2,13 @@
    CONNECT — Room connection, disconnect, switching, and lifecycle
    ========================================================= */
 
-function hookPublication(publication, participant) {
+function hookPublication(publication, participant, expectedRoom) {
   if (!publication || !participant) return;
+  var publicationRoom = expectedRoom || room;
+  if (!isCurrentRoomParticipantGeneration(participant.identity, participant, publicationRoom)) {
+    debugLog("[room-generation] ignored stale publication hook for " + participant.identity);
+    return;
+  }
   // $screen companions publish as Camera for SFU optimization — patch to ScreenShare
   patchScreenCompanionSource(publication, publication?.track, participant);
   updatePublisherMicrophoneState(publication, participant, true);
@@ -17,9 +22,11 @@ function hookPublication(publication, participant) {
     const unsubscribedEvt = LK?.TrackEvent?.Unsubscribed || "unsubscribed";
     if (publication.on) {
       publication.on(subscribedEvt, (track) => {
+        if (!isCurrentRoomParticipantGeneration(participant.identity, participant, publicationRoom)) return;
         if (track) handleTrackSubscribed(track, publication, participant);
       });
       publication.on(unsubscribedEvt, (track) => {
+        if (!isCurrentRoomParticipantGeneration(participant.identity, participant, publicationRoom)) return;
         if (track) handleTrackUnsubscribed(track, publication, participant);
       });
     }
@@ -759,8 +766,8 @@ async function connectToRoom({
   }
   function scheduleReconnectFlagSafetyReset() {
     setTimeout(() => {
-      if (androidFirefoxRoomDisconnectRecoveryEnabled &&
-          (newRoom !== room || newRoom._echoRecoveryDisconnect === true)) {
+      if (newRoom !== room ||
+          (androidFirefoxRoomDisconnectRecoveryEnabled && newRoom._echoRecoveryDisconnect === true)) {
         return;
       }
       if (_isReconnecting) {
@@ -769,26 +776,25 @@ async function connectToRoom({
       }
     }, 10000);
   }
-  function ignoreAndroidFirefoxStaleRoomEvent(eventName) {
-    if (!androidFirefoxRoomDisconnectRecoveryEnabled ||
-        (newRoom === room && newRoom._echoRecoveryDisconnect !== true)) {
+  function ignoreStaleRoomEvent(eventName) {
+    // Preserve the explicit Android Firefox stale-Room seam used by its
+    // recovery contract, then apply the same generation boundary everywhere.
+    if (androidFirefoxRoomDisconnectRecoveryEnabled && newRoom !== room) {
+      debugLog("[android-firefox-room-recovery] ignored stale Room " + eventName);
+      return true;
+    }
+    var controlledRecoveryRoom = androidFirefoxRoomDisconnectRecoveryEnabled &&
+      newRoom._echoRecoveryDisconnect === true;
+    if (!shouldIgnoreRoomMediaEvent(newRoom, room, controlledRecoveryRoom)) {
       return false;
     }
-    debugLog("[android-firefox-room-recovery] ignored stale/controlled Room " + eventName);
+    debugLog("[room-generation] ignored stale/controlled Room " + eventName);
     return true;
   }
   if (LK.RoomEvent?.ConnectionStateChanged) {
     newRoom.on(LK.RoomEvent.ConnectionStateChanged, (state) => {
       if (!state) return;
-      if (androidFirefoxRoomDisconnectRecoveryEnabled && newRoom !== room) {
-        debugLog("[android-firefox-room-recovery] ignored stale Room " + state + " state");
-        return;
-      }
-      if (androidFirefoxRoomDisconnectRecoveryEnabled &&
-          newRoom._echoRecoveryDisconnect === true) {
-        debugLog("[android-firefox-room-recovery] ignored controlled old Room " + state + " state");
-        return;
-      }
+      if (ignoreStaleRoomEvent("connection state " + state)) return;
       debugLog("[connection] state changed: " + state);
       if (state === "reconnecting") {
         _isReconnecting = true;
@@ -828,10 +834,7 @@ async function connectToRoom({
       // ignore those stale Room instances before they overwrite the active
       // session status or stop its stats monitor. Other platforms retain the
       // existing handler behavior.
-      if (androidFirefoxRoomDisconnectRecoveryEnabled && newRoom !== room) {
-        debugLog("[android-firefox-room-recovery] ignored stale Room disconnect");
-        return;
-      }
+      if (ignoreStaleRoomEvent("disconnect")) return;
       const detail = describeDisconnectReason(reason, LK);
       setStatus(`Disconnected: ${detail}`, true);
       if (!_isRoomSwitch) {
@@ -860,11 +863,7 @@ async function connectToRoom({
   }
   if (LK.RoomEvent?.SignalReconnecting) {
     newRoom.on(LK.RoomEvent.SignalReconnecting, () => {
-      if (androidFirefoxRoomDisconnectRecoveryEnabled &&
-          (newRoom !== room || newRoom._echoRecoveryDisconnect === true)) {
-        debugLog("[android-firefox-room-recovery] ignored stale Room signal reconnecting");
-        return;
-      }
+      if (ignoreStaleRoomEvent("signal reconnecting")) return;
       _isReconnecting = true;
       watchAndroidFirefoxRoomReconnect();
       setStatus("Signal reconnecting...", true);
@@ -876,11 +875,7 @@ async function connectToRoom({
   }
   if (LK.RoomEvent?.SignalReconnected) {
     newRoom.on(LK.RoomEvent.SignalReconnected, () => {
-      if (androidFirefoxRoomDisconnectRecoveryEnabled &&
-          (newRoom !== room || newRoom._echoRecoveryDisconnect === true)) {
-        debugLog("[android-firefox-room-recovery] ignored stale Room signal reconnected");
-        return;
-      }
+      if (ignoreStaleRoomEvent("signal reconnected")) return;
       _isReconnecting = false;
       androidFirefoxRoomDisconnectRecovery?.handleConnected({ room: newRoom });
       resetAndroidFirefoxRecoveryMicIntent();
@@ -911,11 +906,7 @@ async function connectToRoom({
   // Room-level reconnecting/reconnected (covers media reconnection too)
   if (LK.RoomEvent?.Reconnecting) {
     newRoom.on(LK.RoomEvent.Reconnecting, () => {
-      if (androidFirefoxRoomDisconnectRecoveryEnabled &&
-          (newRoom !== room || newRoom._echoRecoveryDisconnect === true)) {
-        debugLog("[android-firefox-room-recovery] ignored stale Room reconnecting event");
-        return;
-      }
+      if (ignoreStaleRoomEvent("reconnecting")) return;
       _isReconnecting = true;
       watchAndroidFirefoxRoomReconnect();
       setStatus("Reconnecting...", true);
@@ -926,11 +917,7 @@ async function connectToRoom({
   }
   if (LK.RoomEvent?.Reconnected) {
     newRoom.on(LK.RoomEvent.Reconnected, () => {
-      if (androidFirefoxRoomDisconnectRecoveryEnabled &&
-          (newRoom !== room || newRoom._echoRecoveryDisconnect === true)) {
-        debugLog("[android-firefox-room-recovery] ignored stale Room reconnected event");
-        return;
-      }
+      if (ignoreStaleRoomEvent("reconnected")) return;
       _isReconnecting = false;
       androidFirefoxRoomDisconnectRecovery?.handleConnected({ room: newRoom });
       resetAndroidFirefoxRecoveryMicIntent();
@@ -959,15 +946,7 @@ async function connectToRoom({
   }
   if (LK.RoomEvent?.ConnectionError) {
     newRoom.on(LK.RoomEvent.ConnectionError, (err) => {
-      if (androidFirefoxRoomDisconnectRecoveryEnabled && newRoom !== room) {
-        debugLog("[android-firefox-room-recovery] ignored stale Room connection error");
-        return;
-      }
-      if (androidFirefoxRoomDisconnectRecoveryEnabled &&
-          newRoom._echoRecoveryDisconnect === true) {
-        debugLog("[android-firefox-room-recovery] ignored controlled source Room connection error");
-        return;
-      }
+      if (ignoreStaleRoomEvent("connection error")) return;
       const detail = err?.message || String(err || "unknown");
       recordActiveRoomDiagnostic(newRoom, () => {
         window.EchoWebDiagnosticsRuntime?.recordConnectionState?.("error", err?.name);
@@ -978,7 +957,11 @@ async function connectToRoom({
   const localIdentity = identity;
   ensureParticipantCard({ identity: localIdentity, name }, true);
   newRoom.on(LK.RoomEvent.TrackSubscribed, (track, publication, participant) => {
-    if (ignoreAndroidFirefoxStaleRoomEvent("track subscribed")) return;
+    if (ignoreStaleRoomEvent("track subscribed")) return;
+    if (!isCurrentRoomParticipantGeneration(participant?.identity, participant, newRoom)) {
+      debugLog("[room-generation] ignored replaced participant track subscribed");
+      return;
+    }
     // DEBUG: log ALL track subscriptions
     console.log('[TRACK-SUB] ' + (participant?.identity || '?') + ' kind=' + track.kind + ' source=' + (publication?.source || track?.source));
     // $screen companions publish as Camera for SFU optimization — patch to ScreenShare
@@ -1012,21 +995,25 @@ async function connectToRoom({
       watchedScreens.add(_effectiveParticipant.identity);
       debugLog("[opt-in] auto-watch on track subscribed " + _effectiveParticipant.identity);
     }
-    handleTrackSubscribed(track, publication, _effectiveParticipant);
+    // Keep the exact LiveKit participant object for media-generation fencing.
+    // handleTrackSubscribed resolves $screen companions to their parent for UI
+    // identity without losing the publisher object needed for disconnect cleanup.
+    handleTrackSubscribed(track, publication, participant);
     scheduleReconcileWaves("track-subscribed");
-    if (participant) hookPublication(publication, participant);
+    if (participant) hookPublication(publication, participant, newRoom);
     debugLog(`track subscribed ${participant?.identity || "unknown"} src=${publication?.source || track.source} kind=${track.kind}`);
 
     // Refresh Camera Lobby if open and it's a camera track (uses outer LK from line 447)
     if (track.kind === 'video' && publication?.source === LK?.Track?.Source?.Camera) {
       if (cameraLobbyPanel && !cameraLobbyPanel.classList.contains('hidden')) {
-        setTimeout(() => populateCameraLobby(), 100);
+        setTimeout(() => refreshActiveCameraLobbyForRoom(newRoom), 100);
       }
     }
   });
   if (LK.RoomEvent?.TrackSubscriptionFailed) {
     newRoom.on(LK.RoomEvent.TrackSubscriptionFailed, (publication, participant, err) => {
-      if (ignoreAndroidFirefoxStaleRoomEvent("track subscription failed")) return;
+      if (ignoreStaleRoomEvent("track subscription failed")) return;
+      if (!isCurrentRoomParticipantGeneration(participant?.identity, participant, newRoom)) return;
       const detail = err?.message || String(err || "track subscription failed");
       setStatus(`Track subscription failed: ${detail}`, true);
       debugLog(`track subscription failed ${participant?.identity || "unknown"} ${detail}`);
@@ -1038,6 +1025,8 @@ async function connectToRoom({
         }
         publication.setSubscribed(false);
         setTimeout(() => {
+          if (!isCurrentRoomParticipantGeneration(participant.identity, participant, newRoom) ||
+              !getParticipantPublications(participant).includes(publication)) return;
           publication.setSubscribed(true);
           if (publication?.track && participant) {
             handleTrackSubscribed(publication.track, publication, participant);
@@ -1049,7 +1038,11 @@ async function connectToRoom({
   }
   if (LK.RoomEvent?.TrackPublished) {
     newRoom.on(LK.RoomEvent.TrackPublished, (publication, participant) => {
-      if (ignoreAndroidFirefoxStaleRoomEvent("track published")) return;
+      if (ignoreStaleRoomEvent("track published")) return;
+      if (!isCurrentRoomParticipantGeneration(participant?.identity, participant, newRoom)) {
+        debugLog("[room-generation] ignored replaced participant track published");
+        return;
+      }
       // $screen companions publish as Camera for SFU optimization — patch to ScreenShare
       patchScreenCompanionSource(publication, publication?.track, participant);
       var pubSource = getTrackSource(publication, publication?.track);
@@ -1074,13 +1067,13 @@ async function connectToRoom({
           setParticipantScreenWatchAvailable(_pubIdentity, true);
           debugLog(`[opt-in] track published (screen, user-hidden) ${_pubIdentity} src=${pubSource}`);
           // Still hook so we can subscribe later when user opts in
-          if (participant) hookPublication(publication, participant);
+          if (participant) hookPublication(publication, participant, newRoom);
           return;
         }
         watchedScreens.add(_pubIdentity);
         debugLog(`[opt-in] track published (screen, auto-watch) ${_pubIdentity} src=${pubSource}`);
         startWatchingScreenIdentity(_pubIdentity, "track-published");
-        if (participant) hookPublication(publication, participant);
+        if (participant) hookPublication(publication, participant, newRoom);
         return;
       }
 
@@ -1091,14 +1084,21 @@ async function connectToRoom({
       if (publication?.kind === LK.Track.Kind.Video) {
         requestVideoKeyFrame(publication, publication.track);
         var _kfDelay = _isRoomSwitch ? 300 : 700;
-        setTimeout(() => requestVideoKeyFrame(publication, publication.track), _kfDelay);
+        setTimeout(() => {
+          if (!isCurrentRoomParticipantGeneration(participant.identity, participant, newRoom) ||
+              !getParticipantPublications(participant).includes(publication)) return;
+          requestVideoKeyFrame(publication, publication.track);
+        }, _kfDelay);
       }
       if (participant) {
-        hookPublication(publication, participant);
+        hookPublication(publication, participant, newRoom);
       }
       if (participant) {
         var _resubDelay = _isRoomSwitch ? 200 : 900;
-        setTimeout(() => resubscribeParticipantTracks(participant), _resubDelay);
+        setTimeout(() => {
+          if (!isCurrentRoomParticipantGeneration(participant.identity, participant, newRoom)) return;
+          resubscribeParticipantTracks(participant);
+        }, _resubDelay);
       }
       if (_isRoomSwitch) {
         scheduleReconcileWavesFast("track-published");
@@ -1108,7 +1108,11 @@ async function connectToRoom({
     });
   }
   newRoom.on(LK.RoomEvent.TrackUnsubscribed, (track, publication, participant) => {
-    if (ignoreAndroidFirefoxStaleRoomEvent("track unsubscribed")) return;
+    if (ignoreStaleRoomEvent("track unsubscribed")) return;
+    if (!isCurrentRoomParticipantGeneration(participant?.identity, participant, newRoom)) {
+      debugLog("[room-generation] ignored replaced participant track unsubscribed");
+      return;
+    }
     handleTrackUnsubscribed(track, publication, participant);
   });
   // Remote TrackUnpublished — fires AFTER the publication is removed from the
@@ -1117,8 +1121,12 @@ async function connectToRoom({
   // This handler catches screen share tiles and camera cards that got stuck.
   if (LK.RoomEvent?.TrackUnpublished) {
     newRoom.on(LK.RoomEvent.TrackUnpublished, (publication, participant) => {
-      if (ignoreAndroidFirefoxStaleRoomEvent("track unpublished")) return;
+      if (ignoreStaleRoomEvent("track unpublished")) return;
       if (!publication || !participant) return;
+      if (!isCurrentRoomParticipantGeneration(participant.identity, participant, newRoom)) {
+        debugLog("[room-generation] ignored replaced participant track unpublished");
+        return;
+      }
       // $screen companions publish as Camera for SFU optimization — patch to ScreenShare
       patchScreenCompanionSource(publication, publication?.track, participant);
       const source = publication.source;
@@ -1138,6 +1146,12 @@ async function connectToRoom({
         if (!remoteP) room.remoteParticipants.forEach(function(p) { if (p.identity === publicationIdentity) remoteP = p; });
       }
       var pubs = remoteP ? getParticipantPublications(remoteP) : [];
+
+      if (source === LK.Track.Source.Camera &&
+          !isCurrentCameraParticipantGeneration(identity, participant, newRoom)) {
+        debugLog("[camera-stage] ignored stale camera unpublish for " + identity);
+        return;
+      }
 
       // Publisher mute/off is independent from whether this viewer currently
       // has the remote audio track subscribed.  Preserve that truth even when
@@ -1182,24 +1196,43 @@ async function connectToRoom({
       // ── Camera cleanup ──
       if (source === LK.Track.Source.Camera) {
         debugLog("[unpublished] remote camera unpublished: " + identity);
-        var stillHasCam = pubs.some(function(pub) { return pub && pub.source === LK.Track.Source.Camera && pub.track; });
-        if (!stillHasCam) {
-          var cardRef = participantCards.get(identity);
-          if (cardRef) {
-            updateAvatarVideo(cardRef, null);
-            debugLog("[unpublished] camera cleared for " + identity + " (card reverted to avatar)");
+        var replacementCamera = getRemainingCameraPublicationState(remoteP, publication);
+        cancelCameraClearTimer(identity);
+        if (replacementCamera.publication) {
+          removeCameraVisualGeneration(identity, publication, {
+            clearIntent: false,
+          });
+          if (replacementCamera.track) {
+            setParticipantCameraStageAvailable(identity, true);
+            // Reconcile both secondary attachments independently. This is
+            // idempotent when TrackSubscribed already installed the replacement
+            // and repairs whichever of the avatar or Stage tile is still stale.
+            ensureCameraVideo(
+              ensureParticipantCard(remoteP),
+              replacementCamera.track,
+              replacementCamera.publication
+            );
+            debugLog("[camera-stage] preserved live replacement camera for " + identity);
+          } else {
+            // TrackPublished can precede TrackSubscribed. Preserve the user's
+            // Stage intent while the replacement publication acquires a track.
+            setParticipantCameraStageAvailable(identity, false);
+            debugLog("[camera-stage] waiting for replacement camera track for " + identity);
           }
-          var state = participantState.get(identity);
-          if (state) state.cameraTrackSid = null;
-          // Cancel any pending camera clear timer
-          var existingTimer = cameraClearTimers.get(identity);
-          if (existingTimer) { clearTimeout(existingTimer); cameraClearTimers.delete(identity); }
+        } else {
+          removeCameraVisualGeneration(identity, publication, { clearIntent: true });
+          setParticipantCameraStageAvailable(identity, false);
+          debugLog("[unpublished] camera cleared for " + identity + " (no replacement publication)");
         }
       }
     });
   }
   newRoom.on(LK.RoomEvent.ParticipantConnected, (participant) => {
-    if (ignoreAndroidFirefoxStaleRoomEvent("participant connected")) return;
+    if (ignoreStaleRoomEvent("participant connected")) return;
+    if (!isCurrentRoomParticipantGeneration(participant?.identity, participant, newRoom)) {
+      debugLog("[room-generation] ignored replaced participant connected");
+      return;
+    }
     console.log('[PARTICIPANT] connected: ' + participant.identity);
     if (participant.identity.endsWith('$screen')) {
       debugLog('[screen-merge] $screen companion joined: ' + participant.identity);
@@ -1209,23 +1242,49 @@ async function connectToRoom({
     }
     ensureParticipantCard(participant);
     debugLog(`participant connected ${participant.identity} (reconnecting=${_isReconnecting})`);
+    var replacedScreenGeneration = clearScreenParticipantGeneration(participant, newRoom, "replaced");
+    var replacedScreenAudio = clearScreenAudioParticipantGeneration(participant, newRoom, "replaced");
+    if (replacedScreenGeneration.removed || replacedScreenAudio.removed) {
+      // Preserve viewer-local hide/watch intent. Only the old participant's
+      // media attachments are removed; a replacement publication stays usable.
+      setParticipantScreenWatchAvailable(
+        replacedScreenGeneration.mediaIdentity || replacedScreenAudio.mediaIdentity,
+        hasParticipantScreenPublication(participant)
+      );
+      debugLog("[screen-generation] cleared replaced participant media for " + participant.identity);
+    }
+    var currentCameraParticipant = newRoom === room
+      ? getCameraStageParticipant(participant.identity, newRoom)
+      : null;
+    var isCurrentParticipantGeneration = currentCameraParticipant === participant;
+    var existingCardRef = participantCards.get(participant.identity);
+    var existingCameraTile = cameraStageTileByIdentity.get(participant.identity);
+    var cameraParticipantReplaced = hasCameraStageGenerationMismatch(
+      participant.identity,
+      participant,
+      newRoom,
+      existingCardRef,
+      existingCameraTile
+    );
     // Cancel any pending disconnect cleanup — this participant just came back
-    var wasPendingDisconnect = _pendingDisconnects.has(participant.identity);
+    var wasPendingDisconnect = isCurrentParticipantGeneration &&
+      _pendingDisconnects.has(participant.identity);
     if (wasPendingDisconnect) {
       clearTimeout(_pendingDisconnects.get(participant.identity));
       _pendingDisconnects.delete(participant.identity);
       debugLog(`[reconnect] participant ${participant.identity} reconnected — cancelled pending disconnect`);
     }
     // Cancel any stale camera-clear timer from a previous unsubscribe
-    var camTimer = cameraClearTimers.get(participant.identity);
-    if (camTimer) {
-      clearTimeout(camTimer);
-      cameraClearTimers.delete(participant.identity);
-    }
-    // Clear stale camera frame on reused card — participant may reconnect without camera
-    if (wasPendingDisconnect) {
-      var cardRef = participantCards.get(participant.identity);
-      if (cardRef) updateAvatarVideo(cardRef, null);
+    if (isCurrentParticipantGeneration && (wasPendingDisconnect || cameraParticipantReplaced)) {
+      cancelCameraClearTimer(participant.identity);
+      // Clear stale camera frame on a reused card. The replacement participant
+      // may reconnect without publishing a camera at all.
+      setParticipantCameraStageAvailable(participant.identity, false);
+      if (existingCardRef) updateAvatarVideo(existingCardRef, null);
+      removeCameraStageTile(participant.identity, { clearIntent: false });
+      var reusedState = participantState.get(participant.identity);
+      if (reusedState?.cameraTrackSid) cameraVideoBySid.delete(reusedState.cameraTrackSid);
+      if (reusedState) reusedState.cameraTrackSid = null;
     }
     // Real-time enter chime — fires instantly via WebSocket, no polling delay
     // Suppress during reconnection (they never actually left) or brief disconnect/rejoin
@@ -1245,17 +1304,13 @@ async function connectToRoom({
     if (_trackDelay === 0) {
       attachParticipantTracks(participant);
       resubscribeParticipantTracks(participant);
-      if (cameraLobbyPanel && !cameraLobbyPanel.classList.contains('hidden')) {
-        populateCameraLobby();
-      }
+      refreshActiveCameraLobbyForRoom(newRoom);
     } else {
       setTimeout(() => {
-        if (!room) return; // Guard against disconnect during timeout (#68)
+        if (!isCurrentRoomParticipantGeneration(participant.identity, participant, newRoom)) return;
         attachParticipantTracks(participant);
         resubscribeParticipantTracks(participant);
-        if (cameraLobbyPanel && !cameraLobbyPanel.classList.contains('hidden')) {
-          populateCameraLobby();
-        }
+        refreshActiveCameraLobbyForRoom(newRoom);
       }, _trackDelay);
     }
     if (_isRoomSwitch) {
@@ -1266,7 +1321,8 @@ async function connectToRoom({
     // Re-broadcast own avatar so new participant receives it
     var _avatarDelay = _isRoomSwitch ? 200 : 1000;
     setTimeout(() => {
-      if (!room || !room.localParticipant) return; // Guard against disconnect during timeout (#68)
+      if (!isCurrentRoomParticipantGeneration(participant.identity, participant, newRoom) ||
+          !room?.localParticipant) return;
       const identityBase = getIdentityBase(room.localParticipant.identity);
       var savedAvatar = echoGet("echo-avatar-device") || echoGet("echo-avatar-" + identityBase);
       if (savedAvatar) {
@@ -1287,11 +1343,16 @@ async function connectToRoom({
   });
   if (LK.RoomEvent?.ParticipantNameChanged) {
     newRoom.on(LK.RoomEvent.ParticipantNameChanged, (participant) => {
-      if (ignoreAndroidFirefoxStaleRoomEvent("participant name changed")) return;
+      if (ignoreStaleRoomEvent("participant name changed")) return;
+      if (!isCurrentCameraParticipantGeneration(participant?.identity, participant, newRoom)) {
+        debugLog("[camera-stage] ignored stale participant name change");
+        return;
+      }
       const cardRef = participantCards.get(participant.identity);
       if (!cardRef) return;
       const label = participant.name || "Guest";
       if (cardRef.setParticipantDisplayName) cardRef.setParticipantDisplayName(label);
+      updateCameraStageTileLabel(participant.identity, label);
       if (!cardRef.avatar.querySelector("video")) {
         cardRef.avatar.textContent = getInitials(label);
         updateAvatarDisplay(participant.identity);
@@ -1299,8 +1360,12 @@ async function connectToRoom({
     });
   }
   newRoom.on(LK.RoomEvent.ParticipantDisconnected, (participant) => {
-    if (ignoreAndroidFirefoxStaleRoomEvent("participant disconnected")) return;
+    if (ignoreStaleRoomEvent("participant disconnected")) return;
     const key = participant.identity;
+    if (!isCurrentCameraDisconnectGeneration(key, participant, newRoom)) {
+      debugLog(`[reconnect] ignored stale participant disconnect for ${key}`);
+      return;
+    }
     debugLog(`participant disconnected ${participant.identity} (reconnecting=${_isReconnecting})`);
 
     // Always use a grace period for participant disconnects.
@@ -1313,45 +1378,59 @@ async function connectToRoom({
       clearTimeout(_pendingDisconnects.get(key));
     }
     const timer = setTimeout(() => {
+      if (_pendingDisconnects.get(key) !== timer) return;
+      if (!isCurrentCameraDisconnectGeneration(key, participant, newRoom)) {
+        _pendingDisconnects.delete(key);
+        debugLog(`[reconnect] ignored stale disconnect cleanup for ${key}`);
+        return;
+      }
       _pendingDisconnects.delete(key);
       // Cancel any pending camera-clear timer — card is being fully removed
-      var camT = cameraClearTimers.get(key);
-      if (camT) { clearTimeout(camT); cameraClearTimers.delete(key); }
+      cancelCameraClearTimer(key);
       debugLog(`[reconnect] grace period expired for ${key} — cleaning up`);
       const cardRef = participantCards.get(key);
+      var disconnectedMediaIdentity = normalizeScreenMediaIdentity(key);
+      var disconnectedScreenGeneration = clearScreenParticipantGeneration(participant, newRoom, "exact");
+      var disconnectedScreenAudio = clearScreenAudioParticipantGeneration(participant, newRoom, "exact");
+      removeCameraStageTile(key, { clearIntent: true });
       if (cardRef) cardRef.card.remove();
       participantCards.delete(key);
-      participantState.delete(key);
-      // Clean up any screen tiles for this participant (abrupt disconnects
-      // may not fire TrackUnsubscribed, leaving stale tiles in the grid)
-      var disconnectedTile = screenTileByIdentity.get(key);
-      if (disconnectedTile) {
-        // Find the track SID for this tile and clean up all related state
-        var tileSid = disconnectedTile.dataset?.trackSid;
-        if (tileSid) {
-          removeScreenTile(tileSid);
-          unregisterScreenTrack(tileSid);
-          screenRecoveryAttempts.delete(tileSid);
-          screenResubscribeIntent.delete(tileSid);
-        } else {
-          // No SID on tile — just remove from DOM
-          if (disconnectedTile.classList.contains("is-focused")) {
-            screenGridEl.classList.remove("is-focused");
+      // New runtime tiles are generation-stamped. Keep a narrow legacy fallback
+      // for ordinary participants; companion media is always keyed to its parent.
+      if (!hasRegisteredScreenGenerationForIdentity(disconnectedMediaIdentity)) {
+        var disconnectedTile = screenTileByIdentity.get(disconnectedMediaIdentity);
+        if (disconnectedTile && !disconnectedTile._screenParticipant &&
+            disconnectedMediaIdentity === key) {
+          var tileSid = disconnectedTile.dataset?.trackSid;
+          if (tileSid) {
+            removeScreenTile(tileSid);
+            unregisterScreenTrack(tileSid);
+          } else {
+            cleanupScreenVideoElement(disconnectedTile.querySelector("video"));
+            disconnectedTile.remove();
           }
-          disconnectedTile.remove();
+          if (screenTileByIdentity.get(disconnectedMediaIdentity) === disconnectedTile) {
+            screenTileByIdentity.delete(disconnectedMediaIdentity);
+          }
         }
-        screenTileByIdentity.delete(key);
-        debugLog(`[disconnect] removed screen tile for ${key}`);
+        screenTrackMeta.forEach((meta, sid) => {
+          if (!meta?.participant && meta?.identity === disconnectedMediaIdentity &&
+              disconnectedMediaIdentity === key) {
+            removeScreenTile(sid);
+            unregisterScreenTrack(sid);
+            screenRecoveryAttempts.delete(sid);
+            screenResubscribeIntent.delete(sid);
+          }
+        });
+        hiddenScreens.delete(disconnectedMediaIdentity);
+        watchedScreens.delete(disconnectedMediaIdentity);
+        _pubBitrateControl.delete(disconnectedMediaIdentity);
+        setParticipantScreenWatchAvailable(disconnectedMediaIdentity, false);
       }
-      // Also sweep screenTrackMeta for any other tracks from this identity
-      screenTrackMeta.forEach((meta, sid) => {
-        if (meta.identity === key) {
-          removeScreenTile(sid);
-          unregisterScreenTrack(sid);
-          screenRecoveryAttempts.delete(sid);
-          screenResubscribeIntent.delete(sid);
-        }
-      });
+      participantState.delete(key);
+      if (disconnectedScreenGeneration.removed || disconnectedScreenAudio.removed) {
+        debugLog(`[disconnect] removed screen media for ${key} as ${disconnectedMediaIdentity}`);
+      }
       // Check if they moved to another room or fully left
       // Skip ALL personal exit chimes for $screen companion disconnects —
       // those are internal screen-share lifecycle events, not human leaves.
@@ -1395,8 +1474,9 @@ async function connectToRoom({
   });
   if (LK.RoomEvent?.TrackMuted) {
     newRoom.on(LK.RoomEvent.TrackMuted, (publication, participant) => {
-      if (ignoreAndroidFirefoxStaleRoomEvent("track muted")) return;
+      if (ignoreStaleRoomEvent("track muted")) return;
       if (!participant) return;
+      if (!isCurrentRoomParticipantGeneration(participant.identity, participant, newRoom)) return;
       const source = publication?.source;
       if (publication?.kind === LK.Track.Kind.Audio && source === LK.Track.Source.Microphone) {
         const state = participantState.get(participant.identity);
@@ -1409,6 +1489,22 @@ async function connectToRoom({
         }
       } else if (publication?.kind === LK.Track.Kind.Video && source === LK.Track.Source.Camera) {
         const cardRef = participantCards.get(participant.identity);
+        const cameraTile = cameraStageTileByIdentity.get(participant.identity);
+        if (!publication.track || !isCurrentCameraTrackGeneration(
+          participant.identity,
+          participant,
+          publication,
+          publication.track,
+          newRoom
+        ) ||
+          (cardRef?.cameraPublication && cardRef.cameraPublication !== publication) ||
+          (cameraTile?._cameraStagePublication && cameraTile._cameraStagePublication !== publication)) {
+          debugLog(`[camera-stage] ignored stale camera mute for ${participant.identity}`);
+          return;
+        }
+        cancelCameraClearTimer(participant.identity);
+        removeCameraStageTile(participant.identity, { clearIntent: false });
+        setParticipantCameraStageAvailable(participant.identity, false);
         if (cardRef) {
           updateAvatarVideo(cardRef, null);
           debugLog(`camera muted for ${participant.identity}, avatar cleared`);
@@ -1418,8 +1514,9 @@ async function connectToRoom({
   }
   if (LK.RoomEvent?.TrackUnmuted) {
     newRoom.on(LK.RoomEvent.TrackUnmuted, (publication, participant) => {
-      if (ignoreAndroidFirefoxStaleRoomEvent("track unmuted")) return;
+      if (ignoreStaleRoomEvent("track unmuted")) return;
       if (!participant) return;
+      if (!isCurrentRoomParticipantGeneration(participant.identity, participant, newRoom)) return;
       const source = publication?.source;
       if (publication?.kind === LK.Track.Kind.Audio && source === LK.Track.Source.Microphone) {
         const state = participantState.get(participant.identity);
@@ -1432,10 +1529,21 @@ async function connectToRoom({
         }
       } else if (publication?.kind === LK.Track.Kind.Video && source === LK.Track.Source.Camera) {
         const cardRef = participantCards.get(participant.identity);
-        if (cardRef && publication.track) {
-          updateAvatarVideo(cardRef, publication.track);
-          const video = cardRef.avatar?.querySelector("video");
-          if (video) ensureVideoPlays(publication.track, video);
+        const cameraTile = cameraStageTileByIdentity.get(participant.identity);
+        if (!publication.track || !isCurrentCameraTrackGeneration(
+          participant.identity,
+          participant,
+          publication,
+          publication.track,
+          newRoom
+        ) ||
+          (cardRef?.cameraPublication && cardRef.cameraPublication !== publication) ||
+          (cameraTile?._cameraStagePublication && cameraTile._cameraStagePublication !== publication)) {
+          debugLog(`[camera-stage] ignored stale camera unmute for ${participant.identity}`);
+          return;
+        }
+        if (cardRef) {
+          ensureCameraVideo(cardRef, publication.track, publication);
           debugLog(`camera unmuted for ${participant.identity}, avatar restored`);
         }
       }
@@ -1443,7 +1551,7 @@ async function connectToRoom({
   }
   if (LK.RoomEvent?.ActiveSpeakers) {
     newRoom.on(LK.RoomEvent.ActiveSpeakers, (speakers) => {
-      if (ignoreAndroidFirefoxStaleRoomEvent("active speakers")) return;
+      if (ignoreStaleRoomEvent("active speakers")) return;
       activeSpeakerIds = new Set(speakers.map((p) => p.identity));
       lastActiveSpeakerEvent = performance.now();
       updateActiveSpeakerUi();
@@ -1451,7 +1559,8 @@ async function connectToRoom({
   }
   if (LK.RoomEvent?.DataReceived) {
     newRoom.on(LK.RoomEvent.DataReceived, (payload, participant) => {
-      if (ignoreAndroidFirefoxStaleRoomEvent("data received")) return;
+      if (ignoreStaleRoomEvent("data received")) return;
+      if (participant && !isCurrentRoomParticipantGeneration(participant.identity, participant, newRoom)) return;
       try {
         const text = new TextDecoder().decode(payload);
         const msg = JSON.parse(text);
@@ -1546,7 +1655,7 @@ async function connectToRoom({
   }
   if (LK.RoomEvent?.LocalTrackPublished) {
     newRoom.on(LK.RoomEvent.LocalTrackPublished, (publication) => {
-      if (ignoreAndroidFirefoxStaleRoomEvent("local track published")) return;
+      if (ignoreStaleRoomEvent("local track published")) return;
       const local = room.localParticipant;
       if (!local || !publication) return;
       updatePublisherMicrophoneState(publication, local, true);
@@ -1554,17 +1663,27 @@ async function connectToRoom({
       if (publication.track?.kind === "video" && source === LK.Track.Source.ScreenShare) {
         localScreenTrackSid = publication.trackSid || "";
         const element = publication.track.attach();
+        element._lkTrack = publication.track;
         const label = `${name} (Screen)`;
         const tile = addScreenTile(label, element, publication.trackSid);
         const localIdentity = local.identity;
         tile.dataset.identity = localIdentity;
+        stampScreenTileGeneration(tile, publication, localIdentity, local, publication.track, newRoom);
         screenTileByIdentity.set(localIdentity, tile);
         if (publication.trackSid) {
-          registerScreenTrack(publication.trackSid, publication, tile, localIdentity);
+          registerScreenTrack(
+            publication.trackSid,
+            publication,
+            tile,
+            localIdentity,
+            local,
+            publication.track,
+            newRoom
+          );
         }
         setParticipantScreenWatchAvailable(localIdentity, true);
       } else if (publication.track?.kind === "video" && source === LK.Track.Source.Camera) {
-        updateAvatarVideo(ensureParticipantCard(local, true), publication.track);
+        ensureCameraVideo(ensureParticipantCard(local, true), publication.track, publication);
       } else if (publication.track?.kind === "audio") {
         const state = participantState.get(local.identity);
         if (!state) return;
@@ -1583,7 +1702,7 @@ async function connectToRoom({
   }
   if (LK.RoomEvent?.LocalTrackUnpublished) {
     newRoom.on(LK.RoomEvent.LocalTrackUnpublished, (publication) => {
-      if (ignoreAndroidFirefoxStaleRoomEvent("local track unpublished")) return;
+      if (ignoreStaleRoomEvent("local track unpublished")) return;
       const localParticipant = room?.localParticipant;
       if (localParticipant) updatePublisherMicrophoneState(publication, localParticipant, false);
       const source = publication.source;
@@ -1600,9 +1719,37 @@ async function connectToRoom({
           screenTileByIdentity.delete(localId);
           setParticipantScreenWatchAvailable(localId, false);
         }
-      } else if (publication.track?.kind === "video" && source === LK.Track.Source.Camera) {
-        const cardRef = participantCards.get(room?.localParticipant?.identity || "");
-        if (cardRef) updateAvatarVideo(cardRef, null);
+      } else if (source === LK.Track.Source.Camera) {
+        const localIdentity = room?.localParticipant?.identity || "";
+        if (!isCurrentCameraParticipantGeneration(localIdentity, localParticipant, newRoom)) {
+          debugLog("[camera-stage] ignored stale local camera unpublish for " + localIdentity);
+          return;
+        }
+        // LocalTrackUnpublished may arrive after a replacement publication was
+        // announced but before its track is attached. Remove only the old
+        // generation and preserve the viewer's Stage intent across that gap.
+        var replacementLocalCamera = getRemainingCameraPublicationState(
+          localParticipant,
+          publication
+        );
+        cancelCameraClearTimer(localIdentity);
+        if (replacementLocalCamera.publication) {
+          removeCameraVisualGeneration(localIdentity, publication, { clearIntent: false });
+          if (replacementLocalCamera.track) {
+            setParticipantCameraStageAvailable(localIdentity, true);
+            ensureCameraVideo(
+              ensureParticipantCard(localParticipant, true),
+              replacementLocalCamera.track,
+              replacementLocalCamera.publication
+            );
+          } else {
+            setParticipantCameraStageAvailable(localIdentity, false);
+          }
+          debugLog("[camera-stage] preserved replacement local camera for " + localIdentity);
+          return;
+        }
+        removeCameraVisualGeneration(localIdentity, publication, { clearIntent: true });
+        setParticipantCameraStageAvailable(localIdentity, false);
       } else if (publication.track?.kind === "audio") {
         const local = room?.localParticipant;
         if (!local) return;
@@ -1751,11 +1898,15 @@ async function connectToRoom({
       startWatchingScreenIdentity(effectiveIdentity, "late-join");
     }
   });
+  // clearMedia() tears down old-Room lobby attachments. Refill only after the
+  // destination Room is current and all of its existing participants attach.
+  refreshActiveCameraLobbyForRoom(newRoom);
   // Retry existing participants — fast on room switch, full on first connect
   if (reuseAdmin) {
     // Room switch: single quick retry (ICE warm, tracks arrive fast)
     setTimeout(() => {
       remoteList.forEach((participant) => {
+        if (!isCurrentRoomParticipantGeneration(participant.identity, participant, newRoom)) return;
         attachParticipantTracks(participant);
         resubscribeParticipantTracks(participant);
       });
@@ -1764,12 +1915,14 @@ async function connectToRoom({
     // First connect: full retry schedule for async track loading
     setTimeout(() => {
       remoteList.forEach((participant) => {
+        if (!isCurrentRoomParticipantGeneration(participant.identity, participant, newRoom)) return;
         attachParticipantTracks(participant);
         resubscribeParticipantTracks(participant);
       });
     }, 500);
     setTimeout(() => {
       remoteList.forEach((participant) => {
+        if (!isCurrentRoomParticipantGeneration(participant.identity, participant, newRoom)) return;
         attachParticipantTracks(participant);
         resubscribeParticipantTracks(participant);
       });

--- a/core/viewer/grid-layout.js
+++ b/core/viewer/grid-layout.js
@@ -107,6 +107,11 @@
       return;
     }
 
+    // Stage modules visually replace (but never tear down) the screen grid.
+    // Preserve the last visible-tile count and geometry while it is hidden so
+    // mutations cannot publish a false zero-tile layout before Back to Stage.
+    if (grid.closest(".room-main.stage-module-open")) return;
+
     // Single-share immersion and focused mode have purpose-built CSS layouts.
     // Remove our multi-share inline geometry so those rules retain ownership.
     var tiles = visibleTiles(grid);

--- a/core/viewer/index.html
+++ b/core/viewer/index.html
@@ -41,7 +41,7 @@
     <link rel="stylesheet" href="style.css?v=0.6.34.1786210901" />
     <link rel="stylesheet" href="jam.css?v=0.6.34.1785384000" />
     <link rel="stylesheet" href="capture-picker.css?v=0.6.11.1777930912" />
-    <link rel="stylesheet" href="clubhouse-shell.css?v=0.6.34.1786219600" />
+    <link rel="stylesheet" href="clubhouse-shell.css?v=0.6.34.1786708936" />
     <link rel="stylesheet" href="themes.css?v=0.6.11.1777930912" />
   </head>
   <body>
@@ -193,7 +193,7 @@
               <button id="debug-toggle" type="button">Debug</button>
             </div>
             <button id="disconnect-top" type="button" disabled>Disconnect</button>
-            <button id="shell-toggle-utility" type="button" class="shell-v2-only" aria-controls="utility-host" aria-expanded="true" aria-label="Hide clubhouse tools">Tools</button>
+            <button id="shell-toggle-utility" type="button" class="shell-v2-only" aria-controls="utility-host" aria-expanded="true" aria-label="Hide active users">Users</button>
             <button id="shell-more-actions" type="button" class="shell-v2-only" aria-controls="shell-overflow-menu" aria-expanded="false" aria-label="More clubhouse actions">More</button>
           </div>
         </div>
@@ -205,34 +205,35 @@
               <button id="echo-display-status" type="button" class="echo-display-status hidden"></button>
             </div>
             <div id="screen-grid" class="media-grid screens-grid"></div>
+            <div id="stage-module-host" class="stage-module-host hidden" data-active-module="" aria-hidden="true" aria-label="Stage module"></div>
           </div>
-          <button id="utility-scrim" type="button" class="utility-scrim shell-v2-only" aria-label="Close utility panel" tabindex="-1"></button>
-          <aside id="utility-host" class="utility-host" data-ui-region="utility-host" data-active-tool="people" aria-label="Clubhouse tools" aria-owns="jam-panel">
+          <button id="utility-scrim" type="button" class="utility-scrim shell-v2-only hidden" aria-label="Close utility panel" tabindex="-1"></button>
+          <aside id="utility-host" class="utility-host" data-ui-region="utility-host" data-active-tool="people" aria-label="Active Users">
             <section id="room-sidebar" class="room-sidebar" data-ui-tool="people" aria-label="People">
             <div class="sidebar-header">
               <div class="sidebar-title-row">
                 <h2>Active Users</h2>
                 <div class="sidebar-actions">
                   <button id="refresh-videos" type="button" class="hidden">Enable Videos</button>
-                  <button id="open-chat" type="button" disabled>Chat<span id="chat-badge" class="chat-badge hidden"></span></button>
+                  <button id="open-chat" type="button" aria-controls="stage-module-host" aria-expanded="false" disabled>Chat<span id="chat-badge" class="chat-badge hidden"></span></button>
                   <button id="toggle-room-audio" type="button" disabled>Mute All</button>
                   <button id="toggle-pg13" type="button" disabled>PG-13</button>
                 </div>
                 <div class="sidebar-actions">
-                  <button id="open-soundboard" type="button" disabled>Soundboard</button>
-                  <button id="open-camera-lobby" type="button" disabled>Camera Lobby</button>
+                  <button id="open-soundboard" type="button" aria-controls="stage-module-host" aria-expanded="false" disabled>Soundboard</button>
+                  <button id="open-camera-lobby" type="button" aria-controls="stage-module-host" aria-expanded="false" disabled>Camera Lobby</button>
                   <button id="open-theme" type="button" aria-controls="theme-panel" aria-haspopup="dialog" aria-expanded="false">Theme</button>
-                  <button id="open-jam" type="button" disabled>Jam</button>
+                  <button id="open-jam" type="button" aria-controls="stage-module-host" aria-expanded="false" disabled>Jam</button>
                 </div>
               </div>
             </div>
             <div id="user-list" class="user-list"></div>
             </section>
-            <div id="chat-panel" class="chat-panel hidden" data-ui-tool="chat" role="dialog" aria-label="Chat">
+            <div id="chat-panel" class="chat-panel hidden" data-stage-module-panel="chat" role="dialog" aria-label="Chat">
             <div class="chat-header">
               <h3>Chat</h3>
               <div class="chat-actions">
-                <button id="close-chat" type="button">Close</button>
+                <button id="close-chat" type="button">Back to Stage</button>
               </div>
             </div>
             <div id="chat-messages" class="chat-messages"></div>
@@ -292,10 +293,10 @@
         </div>
       </div>
       <!-- Soundboard Compact (Quick Play) -->
-      <div id="soundboard-compact" class="soundboard-compact hidden" role="dialog" aria-label="Soundboard Quick Play">
+      <div id="soundboard-compact" class="soundboard-compact hidden" data-stage-module-panel="soundboard" role="dialog" aria-label="Soundboard Quick Play">
         <div class="soundboard-compact-header">
           <h3>Soundboard</h3>
-          <button id="close-soundboard" type="button" class="soundboard-compact-close" title="Close">Back</button>
+          <button id="close-soundboard" type="button" class="soundboard-compact-close" title="Back to Stage">Back to Stage</button>
         </div>
         <button id="open-soundboard-edit" type="button" class="soundboard-compact-btn">Edit Soundboard</button>
         <button id="toggle-soundboard-volume-compact" type="button" class="soundboard-compact-btn"
@@ -311,7 +312,7 @@
       </div>
 
       <!-- Soundboard Edit (Full Screen) -->
-      <div id="soundboard" class="soundboard soundboard-edit hidden" role="dialog" aria-label="Soundboard Edit">
+      <div id="soundboard" class="soundboard soundboard-edit hidden" data-stage-module-panel="soundboard" role="dialog" aria-label="Soundboard Edit">
         <div class="soundboard-header">
           <h3>Soundboard</h3>
           <div class="soundboard-actions">
@@ -324,6 +325,7 @@
               Soundboard Volume
             </button>
             <button id="back-to-soundboard" type="button">Back to Soundboard</button>
+            <button id="close-soundboard-stage" type="button" class="shell-v2-only">Back to Stage</button>
           </div>
         </div>
         <div id="soundboard-volume-panel" class="soundboard-volume hidden" aria-hidden="true">
@@ -358,7 +360,7 @@
           <div id="soundboard-hint" class="hint"></div>
         </div>
       </div>
-      <div id="camera-lobby" class="camera-lobby hidden" role="dialog" aria-label="Camera Lobby">
+      <div id="camera-lobby" class="camera-lobby hidden" data-stage-module-panel="camera" role="dialog" aria-label="Camera Lobby">
         <div class="camera-lobby-header">
           <h3>Camera Lobby</h3>
           <div class="camera-lobby-actions">
@@ -368,7 +370,7 @@
             <button id="lobby-toggle-camera" type="button" class="lobby-control-btn">
               <span class="camera-icon">📹</span> Turn Off Camera
             </button>
-            <button id="close-camera-lobby" type="button">Close</button>
+            <button id="close-camera-lobby" type="button">Back to Stage</button>
           </div>
         </div>
         <div id="camera-lobby-grid" class="camera-lobby-grid"></div>
@@ -491,10 +493,10 @@
       </div>
     </div>
   </div>
-      <div id="jam-panel" class="jam-panel hidden" data-ui-tool="jam" role="dialog" aria-label="Jam Session">
+      <div id="jam-panel" class="jam-panel hidden" data-stage-module-panel="jam" role="dialog" aria-label="Jam Session">
         <div class="jam-header">
           <h3>Jam Session</h3>
-          <button id="close-jam" type="button">Close</button>
+          <button id="close-jam" type="button">Back to Stage</button>
         </div>
         <div class="jam-body">
           <div class="jam-session-overview">
@@ -784,7 +786,7 @@
     <script src="room-switch-state.js?v=0.6.11.1777930912"></script>
     <script src="jam-session-state.js?v=0.6.11.1777930912"></script>
     <script src="publish-state-reconcile.js?v=0.6.11.1777930912"></script>
-    <script src="state.js?v=0.6.11.1777930912"></script>
+    <script src="state.js?v=0.6.34.1786708936"></script>
     <script src="debug.js?v=0.6.11.1777930912"></script>
     <script src="urls.js?v=0.6.11.1777930912"></script>
     <script src="settings.js?v=0.6.11.1777930912"></script>
@@ -800,25 +802,25 @@
     <script src="theme-effects.js?v=0.6.11.1777930912"></script>
     <script src="theme.js?v=0.6.11.1777930912"></script>
     <script src="chat.js?v=0.6.11.1777930912"></script>
-    <script src="soundboard.js?v=0.6.11.1777930912"></script>
+    <script src="soundboard.js?v=0.6.34.1786708936"></script>
     <script src="screen-share-state.js?v=0.6.11.1777930912"></script>
     <script src="screen-share-config.js?v=0.6.11.1777930912"></script>
     <script src="screen-share-quality.js?v=0.6.11.1777930912"></script>
     <script src="screen-share-adaptive.js?v=0.6.11.1777930912"></script>
     <script src="screen-share-native.js?v=0.6.11.1777930912"></script>
-    <script src="participants-grid.js?v=0.6.34.1786386773"></script>
-    <script src="grid-layout.js?v=0.6.34.1786210901"></script>
+    <script src="participants-grid.js?v=0.6.34.1786708936"></script>
+    <script src="grid-layout.js?v=0.6.34.1786708936"></script>
     <script src="camera-lobby-layout.js?v=0.6.11.1777930912"></script>
-    <script src="participants-avatar.js?v=0.6.11.1777930912"></script>
-    <script src="participants-fullscreen.js?v=0.6.34.1786386773"></script>
+    <script src="participants-avatar.js?v=0.6.34.1786708936"></script>
+    <script src="participants-fullscreen.js?v=0.6.34.1786708936"></script>
     <script src="participants.js?v=0.6.11.1777930912"></script>
-    <script src="audio-routing.js?v=0.6.11.1777930912"></script>
-    <script src="media-controls.js?v=0.6.11.1777930912"></script>
+    <script src="audio-routing.js?v=0.6.34.1786708936"></script>
+    <script src="media-controls.js?v=0.6.34.1786708936"></script>
     <script src="admin-history.js?v=0.6.34.1785470400"></script>
     <script src="admin.js?v=0.6.34.1785470400"></script>
-    <script src="connect.js?v=0.6.34.1786386773"></script>
+    <script src="connect.js?v=0.6.34.1786708936"></script>
     <script src="android-firefox-presentation-recovery-loader.js?v=0.6.34.1786572903"></script>
-    <script src="app.js?v=0.6.11.1777930912"></script>
+    <script src="app.js?v=0.6.34.1786708936"></script>
     <script src="capture-picker.js?v=0.6.11.1777930912"></script>
     <script src="jam-visualizer.js?v=0.6.34.1785384000"></script>
     <script src="jam.js?v=0.6.34.1785384000"></script>

--- a/core/viewer/media-controls.js
+++ b/core/viewer/media-controls.js
@@ -295,24 +295,62 @@ async function switchSpeaker(deviceId) {
 // Camera Lobby Management
 let enlargedCameraTile = null;
 
+function clearCameraLobbyMedia() {
+  if (!cameraLobbyGrid) {
+    enlargedCameraTile = null;
+    return;
+  }
+
+  cameraLobbyGrid.querySelectorAll("video").forEach(video => {
+    video._playGeneration = (video._playGeneration || 0) + 1;
+    if (video._monitorTimer) {
+      clearInterval(video._monitorTimer);
+      video._monitorTimer = null;
+    }
+    if (video._objectFitGuard) {
+      video._objectFitGuard.disconnect();
+      video._objectFitGuard = null;
+    }
+    if (window._pausedVideos) window._pausedVideos.delete(video);
+    const track = video._lkTrack;
+    if (track && typeof track.detach === "function") {
+      try { track.detach(video); } catch (_) {}
+    }
+    try { video.pause(); } catch (_) {}
+    try { video.srcObject = null; } catch (_) {}
+    video._lkTrack = null;
+  });
+
+  if (enlargedCameraTile) enlargedCameraTile.classList.remove("enlarged");
+  enlargedCameraTile = null;
+  cameraLobbyGrid.replaceChildren();
+  cameraLobbyGrid.dataset.count = "0";
+  if (typeof window._echoRecalcCameraLobby === "function") {
+    window._echoRecalcCameraLobby();
+  }
+}
+
 function openCameraLobby() {
   if (!cameraLobbyPanel) return;
-  cameraLobbyPanel.classList.remove("hidden");
+  var handledByStage = window.EchoStageModules &&
+    window.EchoStageModules.open("camera", openCameraLobbyButton);
+  if (!handledByStage) cameraLobbyPanel.classList.remove("hidden");
   populateCameraLobby();
   debugLog('Camera Lobby opened');
 }
 
 function closeCameraLobby() {
   if (!cameraLobbyPanel) return;
-  cameraLobbyPanel.classList.add("hidden");
-  enlargedCameraTile = null;
+  var handledByStage = window.EchoStageModules &&
+    window.EchoStageModules.close("camera");
+  if (!handledByStage) cameraLobbyPanel.classList.add("hidden");
+  clearCameraLobbyMedia();
   debugLog('Camera Lobby closed');
 }
 
 function populateCameraLobby() {
+  clearCameraLobbyMedia();
   if (!cameraLobbyGrid || !room) return;
-
-  cameraLobbyGrid.innerHTML = '';
 
   const allParticipants = [room.localParticipant, ...Array.from(room.remoteParticipants.values())];
   let count = 0;

--- a/core/viewer/participants-avatar.js
+++ b/core/viewer/participants-avatar.js
@@ -63,6 +63,14 @@ function setParticipantScreenWatchAvailable(identity, available) {
   }
 }
 
+function setParticipantCameraStageAvailable(identity, available) {
+  if (!identity) return;
+  var cardRef = participantCards.get(identity);
+  if (cardRef && typeof cardRef.setCameraStageAvailable === "function") {
+    cardRef.setCameraStageAvailable(available);
+  }
+}
+
 if (typeof document.addEventListener === "function") {
   document.addEventListener("click", function(event) {
     if (!activeParticipantSettings) return;
@@ -354,7 +362,19 @@ function ensureParticipantCard(participant, isLocal = false) {
   let settingsChimeSlider = null;
   let settingsChimePct = null;
   let settingsWatchButton = null;
+  let cameraStageToggleButton = null;
+  let settingsCameraStageButton = null;
   let screenWatchAvailable = false;
+  let cameraStageAvailable = false;
+
+  function syncLocalStageControlAvailability() {
+    if (!isLocal || !participantSettingsButton) return;
+    var anyStageControl = screenWatchAvailable || cameraStageAvailable;
+    participantSettingsButton.classList.toggle("is-stream-control-unavailable", !anyStageControl);
+    if (!anyStageControl && participantSettingsPopup?.classList.contains("is-open")) {
+      closeParticipantSettings(false);
+    }
+  }
 
   function syncScreenWatchControls() {
     var screenHidden = hiddenScreens.has(key);
@@ -377,17 +397,47 @@ function ensureParticipantCard(participant, isLocal = false) {
     card.classList.toggle("is-screen-sharing", screenWatchAvailable);
     publisherScreenState.hidden = !screenWatchAvailable;
 
-    if (isLocal && participantSettingsButton) {
-      participantSettingsButton.classList.toggle("is-stream-control-unavailable", !screenWatchAvailable);
-      if (!screenWatchAvailable && participantSettingsPopup?.classList.contains("is-open")) {
-        closeParticipantSettings(false);
-      }
-    }
+    syncLocalStageControlAvailability();
   }
 
   function setScreenWatchAvailable(available) {
     screenWatchAvailable = !!available;
     syncScreenWatchControls();
+  }
+
+  function syncCameraStageControls() {
+    var isStaged = stagedCameraIdentities.has(key);
+    [cameraStageToggleButton, settingsCameraStageButton].forEach(function(button) {
+      if (!button) return;
+      button.textContent = isStaged ? "Hide Camera" : "Show Camera";
+      button.setAttribute(
+        "aria-label",
+        (isStaged ? "Hide " : "Show ") + participantDisplayName + "'s camera " +
+          (isStaged ? "from" : "on") + " my Stage"
+      );
+      button.title = button.getAttribute("aria-label");
+      button.classList.toggle("hidden", !cameraStageAvailable);
+    });
+    card.classList.toggle("is-camera-staged", isStaged);
+    syncLocalStageControlAvailability();
+  }
+
+  function setCameraStageAvailable(available) {
+    cameraStageAvailable = !!available;
+    syncCameraStageControls();
+  }
+
+  function createCameraStageToggleButton(className) {
+    var button = document.createElement("button");
+    button.type = "button";
+    button.className = className + " hidden";
+    button.addEventListener("click", function(event) {
+      event.stopPropagation();
+      if (!cameraStageAvailable) return;
+      toggleCameraOnStage(key);
+      syncCameraStageControls();
+    });
+    return button;
   }
 
   if (!isLocal) {
@@ -619,6 +669,7 @@ function ensureParticipantCard(participant, isLocal = false) {
       e.stopPropagation();
       watchToggleBtn.click();
     });
+    cameraStageToggleButton = createCameraStageToggleButton("watch-toggle-btn");
 
     overlayControls.append(ovMicBtn, ovMicMute, ovScreenBtn, ovScreenMute, ovWatchClone);
 
@@ -701,7 +752,7 @@ function ensureParticipantCard(participant, isLocal = false) {
     popChimeRow.append(popChimeLabel, popChimeSlider, popChimePct);
 
     volPopup.append(popMicRow, popScreenRow, popChimeRow);
-    camOverlay.append(overlayName, overlayControls, volPopup);
+    camOverlay.append(overlayName, cameraStageToggleButton, overlayControls, volPopup);
 
     // Close popup when clicking outside
     document.addEventListener("click", function(e) {
@@ -814,10 +865,11 @@ function ensureParticipantCard(participant, isLocal = false) {
       event.stopPropagation();
       watchToggleBtn.click();
     });
+    settingsCameraStageButton = createCameraStageToggleButton("participant-settings-watch");
 
     var settingsFooter = document.createElement("div");
     settingsFooter.className = "participant-settings-footer";
-    settingsFooter.append(settingsWatchButton);
+    settingsFooter.append(settingsWatchButton, settingsCameraStageButton);
     if (isAdminMode()) {
       var settingsServerMute = document.createElement("button");
       settingsServerMute.type = "button";
@@ -925,6 +977,8 @@ function ensureParticipantCard(participant, isLocal = false) {
       syncScreenWatchControls();
     });
     controls.append(watchToggleBtn);
+    cameraStageToggleButton = createCameraStageToggleButton("watch-toggle-btn");
+    controls.append(cameraStageToggleButton);
     meta.append(controls);
     micStatusEl = micControl;
     screenStatusEl = screenControl;
@@ -975,10 +1029,11 @@ function ensureParticipantCard(participant, isLocal = false) {
       event.stopPropagation();
       watchToggleBtn.click();
     });
+    settingsCameraStageButton = createCameraStageToggleButton("participant-settings-watch");
 
     var settingsFooter = document.createElement("div");
     settingsFooter.className = "participant-settings-footer";
-    settingsFooter.append(settingsWatchButton);
+    settingsFooter.append(settingsWatchButton, settingsCameraStageButton);
     participantSettingsPopup.append(settingsHeading, settingsFooter);
     participantSettingsButton.addEventListener("click", function(event) {
       event.stopPropagation();
@@ -1292,6 +1347,7 @@ function ensureParticipantCard(participant, isLocal = false) {
     if (settingsMicSlider) settingsMicSlider.setAttribute("aria-label", "Microphone volume for " + participantDisplayName);
     if (settingsScreenSlider) settingsScreenSlider.setAttribute("aria-label", "Screen volume for " + participantDisplayName);
     if (settingsChimeSlider) settingsChimeSlider.setAttribute("aria-label", "Chime volume for " + participantDisplayName);
+    syncCameraStageControls();
     if (publisherMicState) {
       publisherMicState.setAttribute(
         "aria-label",
@@ -1340,11 +1396,15 @@ function ensureParticipantCard(participant, isLocal = false) {
     settingsScreenSlider,
     settingsChimeSlider,
     settingsWatchButton,
+    settingsCameraStageButton,
     setScreenWatchAvailable,
+    setCameraStageAvailable,
+    syncCameraStageControls,
     setParticipantDisplayName
   });
   participantState.set(key, state);
   setScreenWatchAvailable(false);
+  setCameraStageAvailable(false);
   debugLog(`participant card created and added to DOM for ${key}, card.isConnected=${card.isConnected}, avatar exists=${!!avatar}`);
   // Show avatar image if one exists for this user
   updateAvatarDisplay(key);
@@ -1360,6 +1420,12 @@ function updateAvatarVideo(cardRef, track) {
   }
   var avatar = cardRef.avatar;
   var card = cardRef.card;
+  var priorVideo = avatar.querySelector("video");
+  if (priorVideo && typeof cleanupCameraStageVideo === "function") {
+    // Avatar and Stage use separate muted attachments, but both must release
+    // their exact old element when a camera track is replaced or turned off.
+    cleanupCameraStageVideo(priorVideo);
+  }
   // Preserve the hidden file input for local user avatar upload
   var fileInput = avatar.querySelector('input[type="file"]');
   avatar.innerHTML = "";
@@ -1374,6 +1440,10 @@ function updateAvatarVideo(cardRef, track) {
     if (card) card.classList.add("has-camera");
     if (cardRef.isLocal) avatar.title = "Click to view camera fullscreen";
   } else {
+    cardRef.cameraRoom = null;
+    cardRef.cameraParticipant = null;
+    cardRef.cameraPublication = null;
+    cardRef.cameraTrack = null;
     avatar.textContent = getInitials(card?.querySelector(".user-name")?.textContent || "");
     if (fileInput) avatar.appendChild(fileInput);
     // Show avatar image if one exists (replaces initials)

--- a/core/viewer/participants-fullscreen.js
+++ b/core/viewer/participants-fullscreen.js
@@ -189,6 +189,17 @@ function restoreFullscreenResponsiveState(snapshot) {
 // Fullscreen the existing stable media host. Keeping the live video inside its
 // Stage tile lets subscription reconciliation, diagnostics, and the watchdog
 // continue to find the same node throughout the transition.
+function getVideoFullscreenMediaName(host, priorControlLabel) {
+  return host?.dataset?.mediaKind === "camera" || /camera/i.test(priorControlLabel || "")
+    ? "camera"
+    : "shared screen";
+}
+
+function getVideoFullscreenControlLabel(host, priorControlLabel, isFullscreen) {
+  if (!isFullscreen) return priorControlLabel || "Open shared screen fullscreen";
+  return "Exit " + getVideoFullscreenMediaName(host, priorControlLabel) + " fullscreen";
+}
+
 function enterVideoFullscreen(videoEl) {
   if (document.fullscreenElement) {
     return document.exitFullscreen();
@@ -224,7 +235,7 @@ function enterVideoFullscreen(videoEl) {
     if (!fullscreenControl) return;
     fullscreenControl.setAttribute(
       "aria-label",
-      isFullscreen ? "Exit shared screen fullscreen" : (priorControlLabel || "Open shared screen fullscreen")
+      getVideoFullscreenControlLabel(host, priorControlLabel, isFullscreen)
     );
     fullscreenControl.title = isFullscreen ? "Exit fullscreen" : (priorControlTitle || "Fullscreen");
   }
@@ -323,9 +334,23 @@ function openImageLightbox(src) {
 
 // ── Screen track registration & watchdog ──
 
-function registerScreenTrack(trackSid, publication, tile, identity) {
+function stampScreenTileGeneration(tile, publication, identity, participant, track, expectedRoom) {
+  if (!tile) return;
+  var screenRoom = expectedRoom || room;
+  var screenParticipant = participant || getCameraStageParticipant(identity, screenRoom);
+  var screenTrack = track || publication?.track || null;
+  tile._screenRoom = screenRoom;
+  tile._screenParticipant = screenParticipant;
+  tile._screenPublication = publication;
+  tile._screenTrack = screenTrack;
+}
+
+function registerScreenTrack(trackSid, publication, tile, identity, participant, track, expectedRoom) {
   if (!trackSid || !tile) return;
-  screenTrackMeta.set(trackSid, {
+  var screenRoom = expectedRoom || room;
+  var screenParticipant = participant || getCameraStageParticipant(identity, screenRoom);
+  var screenTrack = track || publication?.track || null;
+  var meta = {
     trackSid,
     publication,
     tile,
@@ -333,8 +358,20 @@ function registerScreenTrack(trackSid, publication, tile, identity) {
     lastKeyframe: 0,
     retryCount: 0,
     identity: identity || "",
+    room: screenRoom,
+    participant: screenParticipant,
+    track: screenTrack,
     createdAt: performance.now()
-  });
+  };
+  screenTrackMeta.set(trackSid, meta);
+  stampScreenTileGeneration(
+    tile,
+    publication,
+    identity,
+    screenParticipant,
+    screenTrack,
+    screenRoom
+  );
   if (typeof maybeStartNativePresenterForScreenTrack === "function") {
     maybeStartNativePresenterForScreenTrack({ trackSid, publication, tile, identity }).catch(function(e) {
       debugLog("[native-presenter] register start failed: " + (e && e.message ? e.message : e));
@@ -359,6 +396,79 @@ function unregisterScreenTrack(trackSid) {
     clearInterval(screenWatchdogTimer);
     screenWatchdogTimer = null;
   }
+}
+
+function hasParticipantScreenPublication(participant) {
+  if (!participant) return false;
+  var LK = getLiveKitClient();
+  var companion = typeof isScreenIdentity === "function" && isScreenIdentity(participant.identity);
+  return getParticipantPublications(participant).some(function(publication) {
+    var source = publication?.source || publication?.track?.source;
+    var kind = publication?.kind || publication?.track?.kind;
+    var video = !kind || kind === LK?.Track?.Kind?.Video || kind === "video";
+    return video && (source === LK?.Track?.Source?.ScreenShare ||
+      (companion && source === LK?.Track?.Source?.Camera));
+  });
+}
+
+function hasRegisteredScreenGenerationForIdentity(identity) {
+  if (!identity) return false;
+  var found = false;
+  screenTrackMeta.forEach(function(meta) {
+    if (!found && meta?.identity === identity && meta.tile?.isConnected) found = true;
+  });
+  return found;
+}
+
+function removeRegisteredScreenGeneration(trackSid, meta) {
+  if (!trackSid || !meta || screenTrackMeta.get(trackSid) !== meta) return false;
+  var tile = meta.tile;
+  if (screenTileBySid.get(trackSid) === tile) {
+    removeScreenTile(trackSid);
+  } else if (tile && tile._screenPublication === meta.publication) {
+    cleanupScreenVideoElement(tile.querySelector("video"));
+    tile.remove();
+  }
+  if (screenTrackMeta.get(trackSid) === meta) unregisterScreenTrack(trackSid);
+  if (screenTileByIdentity.get(meta.identity) === tile) screenTileByIdentity.delete(meta.identity);
+  screenRecoveryAttempts.delete(trackSid);
+  screenResubscribeIntent.delete(trackSid);
+  var state = participantState.get(meta.identity);
+  if (state?.screenTrackSid === trackSid) state.screenTrackSid = null;
+  return true;
+}
+
+function clearScreenParticipantGeneration(participant, expectedRoom, mode) {
+  var mediaIdentity = normalizeScreenMediaIdentity(participant?.identity);
+  var result = { mediaIdentity: mediaIdentity, removed: false, trackSids: [] };
+  if (!participant || !expectedRoom || room !== expectedRoom) return result;
+  var removeReplacement = mode === "replaced";
+  var matches = [];
+  screenTrackMeta.forEach(function(meta, trackSid) {
+    if (!meta || meta.room !== expectedRoom) return;
+    if (meta.participant?.identity !== participant.identity) return;
+    if (removeReplacement ? meta.participant === participant : meta.participant !== participant) return;
+    matches.push([trackSid, meta]);
+  });
+  matches.forEach(function(entry) {
+    if (removeRegisteredScreenGeneration(entry[0], entry[1])) {
+      result.removed = true;
+      result.trackSids.push(entry[0]);
+    }
+  });
+
+  // A SID-less tile still carries the same generation stamp.
+  var tile = screenTileByIdentity.get(mediaIdentity);
+  var tileMatches = tile && tile._screenRoom === expectedRoom &&
+    tile._screenParticipant?.identity === participant.identity &&
+    (removeReplacement ? tile._screenParticipant !== participant : tile._screenParticipant === participant);
+  if (tileMatches) {
+    cleanupScreenVideoElement(tile.querySelector("video"));
+    tile.remove();
+    if (screenTileByIdentity.get(mediaIdentity) === tile) screenTileByIdentity.delete(mediaIdentity);
+    result.removed = true;
+  }
+  return result;
 }
 
 function startScreenWatchdog() {
@@ -550,15 +660,24 @@ function forceReattachVideo(publication, participant) {
     ensureVideoSubscribed(publication, element);
     const tile = addScreenTile(label, element, publication.trackSid);
     tile.dataset.identity = participant.identity;
+    stampScreenTileGeneration(tile, publication, participant.identity, participant, track, room);
     screenTileByIdentity.set(participant.identity, tile);
     if (publication.trackSid) {
-      registerScreenTrack(publication.trackSid, publication, tile, participant.identity);
+      registerScreenTrack(
+        publication.trackSid,
+        publication,
+        tile,
+        participant.identity,
+        participant,
+        track,
+        room
+      );
     }
     requestVideoKeyFrame(publication, track);
     forceVideoLayer(publication, element);
   } else if (source === LK.Track.Source.Camera) {
     const cardRef = ensureParticipantCard(participant);
-    updateAvatarVideo(cardRef, track);
+    ensureCameraVideo(cardRef, track, publication);
     const video = cardRef.avatar.querySelector("video");
     if (video) {
       ensureVideoPlays(track, video);
@@ -581,6 +700,7 @@ function replaceScreenVideoElement(tile, track, publication) {
   if (!newEl) return;
   configureVideoElement(newEl, true);
   if (oldVideo && oldVideo.parentElement) {
+    cleanupScreenVideoElement(oldVideo);
     oldVideo.replaceWith(newEl);
   } else if (overlay && overlay.parentElement) {
     overlay.parentElement.insertBefore(newEl, overlay);
@@ -630,8 +750,18 @@ function scheduleScreenRecovery(trackSid, publication, element) {
   }
   const attempt = screenRecoveryAttempts.get(trackSid) || 0;
   if (attempt >= 1) return;
+  const recoveryGeneration = {
+    room: room,
+    trackSid: trackSid,
+    meta: srMeta,
+    tile: srMeta?.tile || null,
+    publication: publication,
+    track: publication.track,
+    element: element,
+    playGeneration: element._playGeneration || 0,
+  };
   setTimeout(() => {
-    if (!element.isConnected) return;
+    if (!isCurrentRegisteredScreenElementGeneration(recoveryGeneration, true)) return;
     const isBlack = element._isBlack === true;
     const lastFrame = element._lastFrameTs || 0;
     const stalled = performance.now() - lastFrame > 1200;
@@ -640,11 +770,34 @@ function scheduleScreenRecovery(trackSid, publication, element) {
     if (publication.setSubscribed) {
       markResubscribeIntent(trackSid);
       publication.setSubscribed(false);
-      setTimeout(() => publication.setSubscribed(true), 300);
+      setTimeout(() => {
+        if (!isCurrentRegisteredScreenElementGeneration(recoveryGeneration, false)) return;
+        publication.setSubscribed(true);
+      }, 300);
     }
     requestVideoKeyFrame(publication, publication.track);
     element._isBlack = false;
   }, 700);
+}
+
+function isCurrentRegisteredScreenElementGeneration(generation, requireAttachedElement) {
+  if (!generation || room !== generation.room || !generation.meta || !generation.tile) return false;
+  if (screenTrackMeta.get(generation.trackSid) !== generation.meta ||
+      screenTileBySid.get(generation.trackSid) !== generation.tile) return false;
+  if (!generation.tile.isConnected ||
+      generation.meta.publication !== generation.publication ||
+      generation.meta.tile !== generation.tile ||
+      generation.tile._screenPublication !== generation.publication ||
+      generation.tile._screenTrack !== generation.track) return false;
+  if (generation.publication.track && generation.publication.track !== generation.track) return false;
+  if (!generation.element ||
+      (generation.element._playGeneration || 0) !== generation.playGeneration ||
+      generation.element._lkTrack !== generation.track) return false;
+  if (requireAttachedElement) {
+    return generation.element.isConnected &&
+      generation.tile.querySelector("video") === generation.element;
+  }
+  return true;
 }
 
 // ── Video quality ──
@@ -661,10 +814,30 @@ function requestVideoKeyFrame(publication, track) {
   } catch {}
 }
 
-function forceVideoLayer(publication, element) {
-  if (!publication) return;
+function captureVideoLayerGeneration(publication, element) {
+  return {
+    room: room,
+    publication: publication,
+    track: publication?.track || null,
+    element: element,
+    playGeneration: element?._playGeneration || 0,
+  };
+}
+
+function isCurrentVideoLayerGeneration(generation) {
+  return !!generation && room === generation.room &&
+    !!generation.publication && generation.publication.track === generation.track &&
+    !!generation.element && generation.element.isConnected &&
+    generation.element._lkTrack === generation.track &&
+    (generation.element._playGeneration || 0) === generation.playGeneration;
+}
+
+function forceVideoLayer(publication, element, expectedGeneration) {
+  if (!publication || !element) return;
+  const generation = expectedGeneration || captureVideoLayerGeneration(publication, element);
+  if (!isCurrentVideoLayerGeneration(generation)) return;
   if (element && element.videoWidth === 0 && element.videoHeight === 0) {
-    setTimeout(() => forceVideoLayer(publication, element), 800);
+    setTimeout(() => forceVideoLayer(publication, element, generation), 800);
     return;
   }
   const LK = getLiveKitClient();
@@ -697,7 +870,8 @@ function forceVideoLayer(publication, element) {
       var _upgradeAttempts = [2000, 5000, 10000];
       _upgradeAttempts.forEach(function(delay) {
         setTimeout(() => {
-          if (element && element.videoWidth > 0 && targetQuality != null) {
+          if (isCurrentVideoLayerGeneration(generation) &&
+              element.videoWidth > 0 && targetQuality != null) {
             try {
               if (publication.setVideoQuality) {
                 publication.setVideoQuality(targetQuality);
@@ -892,9 +1066,12 @@ if (typeof module === "object" && module.exports) {
     attemptAndroidFirefoxScreenSubscriptionReset,
     attemptAndroidFirefoxConnectedMediaRelayRecovery,
     createVideoFrameRateTracker,
+    getVideoFullscreenControlLabel,
+    getVideoFullscreenMediaName,
     getVideoPresentationSnapshot,
     isAndroidFirefoxConnectedMediaStallCurrent,
     isCurrentScreenRecoveryGeneration,
+    isCurrentVideoLayerGeneration,
   };
 }
 
@@ -906,14 +1083,37 @@ function cleanupVideoDiagnostics(overlay) {
 
 // ── Camera recovery ──
 
+function stampCameraAvatarVideoGeneration(video, participant, publication, track, expectedRoom) {
+  if (!video) return;
+  video._echoCameraRoom = expectedRoom || room;
+  video._echoCameraParticipant = participant || null;
+  video._echoCameraPublication = publication || null;
+  video._echoCameraTrack = track || null;
+}
+
 function scheduleCameraRecovery(identity, cardRef, publication) {
   if (!identity || !cardRef || !publication) return;
   const key = `${identity}-camera`;
   const attempt = cameraRecoveryAttempts.get(key) || 0;
   if (attempt >= 2) return;
+  const expectedRoom = room;
+  const expectedParticipant = getCameraStageParticipant(identity, expectedRoom);
+  const expectedTrack = publication.track;
   setTimeout(() => {
+    // This timer may outlive a Room, participant, or camera publication. Never
+    // let an old generation reattach over a newer same-identity camera.
+    if (participantCards.get(identity) !== cardRef || !isCurrentCameraTrackGeneration(
+      identity,
+      expectedParticipant,
+      publication,
+      expectedTrack,
+      expectedRoom
+    )) {
+      debugLog(`camera recovery skipped ${identity} (stale generation)`);
+      return;
+    }
     // Guard: don't recover if the track has ended or been unsubscribed
-    if (!publication?.isSubscribed || publication?.track?.mediaStreamTrack?.readyState === "ended") {
+    if (!publication?.isSubscribed || expectedTrack?.mediaStreamTrack?.readyState === "ended") {
       debugLog(`camera recovery skipped ${identity} (track ended or unsubscribed)`);
       return;
     }
@@ -930,11 +1130,18 @@ function scheduleCameraRecovery(identity, cardRef, publication) {
     if (publication?.setSubscribed) {
       publication.setSubscribed(true);
     }
-    if (publication?.track) {
-      updateAvatarVideo(cardRef, publication.track);
+    if (expectedTrack) {
+      updateAvatarVideo(cardRef, expectedTrack);
       const next = cardRef.avatar.querySelector("video");
       if (next) {
-        ensureVideoPlays(publication.track, next);
+        stampCameraAvatarVideoGeneration(
+          next,
+          expectedParticipant,
+          publication,
+          expectedTrack,
+          expectedRoom
+        );
+        ensureVideoPlays(expectedTrack, next);
       }
     }
   }, 900);
@@ -953,9 +1160,28 @@ function ensureCameraVideo(cardRef, track, publication) {
     return;
   }
   const cardIdentity = cardRef.card?.dataset?.identity || 'unknown';
+  const currentParticipant = getCameraStageParticipant(cardIdentity, room);
+  if (!isCurrentCameraTrackGeneration(
+    cardIdentity,
+    currentParticipant,
+    publication,
+    track,
+    room
+  )) {
+    debugLog(`[camera-stage] ignored stale camera generation for ${cardIdentity}`);
+    return;
+  }
+  cancelCameraClearTimer(cardIdentity);
+  cardRef.cameraRoom = room;
+  cardRef.cameraParticipant = currentParticipant;
+  cardRef.cameraPublication = publication;
+  cardRef.cameraTrack = track;
+  const cameraLabel = cardRef.card?.querySelector(".user-name")?.textContent || cardIdentity;
+  reconcileCameraStageTrack(cardIdentity, cameraLabel, track, publication);
   debugLog(`ensureCameraVideo called for track ${track.sid || 'unknown'}, participant=${cardIdentity}, cardRef.avatar=${!!cardRef.avatar}`);
   const existing = cardRef.avatar.querySelector("video");
   if (existing && existing._lkTrack === track) {
+    stampCameraAvatarVideoGeneration(existing, currentParticipant, publication, track, room);
     ensureVideoPlays(track, existing);
     ensureVideoSubscribed(publication, existing);
     const age = performance.now() - (existing._attachedAt || 0);
@@ -963,6 +1189,7 @@ function ensureCameraVideo(cardRef, track, publication) {
       updateAvatarVideo(cardRef, track);
       const next = cardRef.avatar.querySelector("video");
       if (next) {
+        stampCameraAvatarVideoGeneration(next, currentParticipant, publication, track, room);
         ensureVideoPlays(track, next);
         ensureVideoSubscribed(publication, next);
         requestVideoKeyFrame(publication, track);
@@ -974,6 +1201,7 @@ function ensureCameraVideo(cardRef, track, publication) {
   updateAvatarVideo(cardRef, track);
   const video = cardRef.avatar.querySelector("video");
   if (video) {
+    stampCameraAvatarVideoGeneration(video, currentParticipant, publication, track, room);
     ensureVideoPlays(track, video);
     ensureVideoSubscribed(publication, video);
     requestVideoKeyFrame(publication, track);

--- a/core/viewer/participants-grid.js
+++ b/core/viewer/participants-grid.js
@@ -35,6 +35,7 @@ function addScreenTile(label, element, trackSid) {
   }
   ensureVideoPlays(element._lkTrack, element);
   const tile = addTile(label, element);
+  tile.dataset.mediaKind = "screen";
   tile.style.setProperty("--screen-source-aspect-ratio", (16 / 9).toFixed(6));
 
   // Poster overlay: hide uninitialized GPU garbage (green/black flash) until first real frame.
@@ -157,12 +158,465 @@ function addScreenTile(label, element, trackSid) {
   return tile;
 }
 
+function getCameraStageParticipant(identity, roomRef) {
+  var targetRoom = roomRef || room;
+  if (!identity || !targetRoom) return null;
+  if (targetRoom.localParticipant?.identity === identity) return targetRoom.localParticipant;
+  var participant = targetRoom.remoteParticipants?.get?.(identity) || null;
+  if (!participant && targetRoom.remoteParticipants?.forEach) {
+    targetRoom.remoteParticipants.forEach(function(candidate) {
+      if (!participant && candidate?.identity === identity) participant = candidate;
+    });
+  }
+  return participant;
+}
+
+function shouldIgnoreRoomMediaEvent(eventRoom, currentRoom, controlledRecoveryEnabled) {
+  return !eventRoom || eventRoom !== currentRoom ||
+    (controlledRecoveryEnabled === true && eventRoom._echoRecoveryDisconnect === true);
+}
+
+function isCurrentRoomParticipantGeneration(identity, participant, expectedRoom) {
+  if (!identity || !participant || !expectedRoom || room !== expectedRoom) return false;
+  return getCameraStageParticipant(identity, expectedRoom) === participant;
+}
+
+function isCurrentCameraParticipantGeneration(identity, participant, expectedRoom) {
+  return isCurrentRoomParticipantGeneration(identity, participant, expectedRoom);
+}
+
+function isCurrentCameraDisconnectGeneration(identity, participant, expectedRoom) {
+  if (!identity || !participant || !expectedRoom || room !== expectedRoom) return false;
+  var currentParticipant = getCameraStageParticipant(identity, expectedRoom);
+  return !currentParticipant || currentParticipant === participant;
+}
+
+function hasCameraStageGenerationMismatch(identity, participant, expectedRoom, cardRef, tile) {
+  if (!isCurrentCameraParticipantGeneration(identity, participant, expectedRoom)) return false;
+  var cardHasCameraGeneration = !!(cardRef && (
+    cardRef.cameraRoom ||
+    cardRef.cameraParticipant ||
+    cardRef.cameraPublication ||
+    cardRef.cameraTrack
+  ));
+  var cardMismatch = cardHasCameraGeneration && (
+    cardRef.cameraRoom !== expectedRoom ||
+    cardRef.cameraParticipant !== participant
+  );
+  var tileMismatch = !!tile && (
+    tile._cameraStageRoom !== expectedRoom ||
+    tile._cameraStageParticipant !== participant
+  );
+  return cardMismatch || tileMismatch;
+}
+
+function isCurrentCameraTrackGeneration(identity, participant, publication, track, expectedRoom) {
+  if (!publication || !track || !isCurrentCameraParticipantGeneration(identity, participant, expectedRoom)) {
+    return false;
+  }
+  var publications = getParticipantPublications(participant);
+  if (!publications.includes(publication) || publication.track !== track) return false;
+  var LK = getLiveKitClient();
+  var source = publication.source || track.source;
+  var kind = publication.kind || track.kind;
+  if (source && source !== LK?.Track?.Source?.Camera) return false;
+  return !kind || kind === LK?.Track?.Kind?.Video || kind === "video";
+}
+
+function isCurrentCameraUnsubscribeGeneration(generation) {
+  if (!generation || !isCurrentCameraParticipantGeneration(
+    generation.identity,
+    generation.participant,
+    generation.room
+  )) return false;
+  var publications = getParticipantPublications(generation.participant);
+  if (!publications.includes(generation.publication)) return false;
+  if (generation.publication.track && generation.publication.track !== generation.track) return false;
+  var LK = getLiveKitClient();
+  return !publications.some(function(publication) {
+    var source = publication?.source || publication?.track?.source;
+    return source === LK?.Track?.Source?.Camera && !!publication.track;
+  });
+}
+
+function cancelCameraClearTimer(identity) {
+  if (!identity) return;
+  var timer = cameraClearTimers.get(identity);
+  if (timer) clearTimeout(timer);
+  cameraClearTimers.delete(identity);
+  cameraClearGenerationByIdentity.delete(identity);
+}
+
+function getCameraStagePublication(participant) {
+  if (!participant) return null;
+  var LK = getLiveKitClient();
+  if (!LK) return null;
+  return getParticipantPublications(participant).find(function(publication) {
+    var source = publication?.source || publication?.track?.source;
+    var kind = publication?.kind || publication?.track?.kind;
+    return source === LK.Track.Source.Camera &&
+      kind === LK.Track.Kind.Video &&
+      !!publication.track;
+  }) || null;
+}
+
+function hasLiveCameraPublicationOtherThan(participant, excludedPublication) {
+  if (!participant) return false;
+  var LK = getLiveKitClient();
+  if (!LK) return false;
+  return getParticipantPublications(participant).some(function(publication) {
+    if (!publication || publication === excludedPublication || !publication.track) return false;
+    var source = publication.source || publication.track.source;
+    var kind = publication.kind || publication.track.kind;
+    return source === LK.Track.Source.Camera &&
+      (!kind || kind === LK.Track.Kind.Video || kind === "video");
+  });
+}
+
+function getRemainingCameraPublicationState(participant, excludedPublication) {
+  var LK = getLiveKitClient();
+  if (!participant || !LK) return { publication: null, track: null };
+  var candidates = getParticipantPublications(participant).filter(function(publication) {
+    if (!publication || publication === excludedPublication) return false;
+    var source = publication.source || publication.track?.source;
+    var kind = publication.kind || publication.track?.kind;
+    return source === LK.Track.Source.Camera &&
+      (!kind || kind === LK.Track.Kind.Video || kind === "video");
+  });
+  var publication = candidates.find(function(candidate) { return !!candidate.track; }) ||
+    candidates[0] || null;
+  return {
+    publication: publication,
+    track: publication?.track || null,
+  };
+}
+
+function removeCameraVisualGeneration(identity, publication, options) {
+  if (!identity || !publication) return { removedCard: false, removedTile: false };
+  var opts = options || {};
+  var tile = cameraStageTileByIdentity.get(identity);
+  var cardRef = participantCards.get(identity);
+  var removedTile = !!tile && tile._cameraStagePublication === publication;
+  var removedCard = !!cardRef && cardRef.cameraPublication === publication;
+  var removedCardVideo = removedCard ? cardRef.avatar?.querySelector("video") : null;
+  var oldTrackSid = publication.trackSid || publication.track?.sid || "";
+
+  if (removedTile) removeCameraStageTile(identity, { clearIntent: false });
+  if (removedCard) updateAvatarVideo(cardRef, null);
+  var mappedCameraVideo = oldTrackSid ? cameraVideoBySid.get(oldTrackSid) : null;
+  var ownsMappedCameraVideo = !!mappedCameraVideo && (
+    mappedCameraVideo === removedCardVideo ||
+    mappedCameraVideo._echoCameraPublication === publication ||
+    (!mappedCameraVideo._echoCameraPublication && !!publication.track &&
+      mappedCameraVideo._lkTrack === publication.track)
+  );
+  if (oldTrackSid && ownsMappedCameraVideo) cameraVideoBySid.delete(oldTrackSid);
+  var state = participantState.get(identity);
+  if (state?.cameraTrackSid && (!oldTrackSid ||
+      (state.cameraTrackSid === oldTrackSid && (removedCard || ownsMappedCameraVideo)))) {
+    state.cameraTrackSid = null;
+  }
+
+  if (opts.clearIntent) {
+    // With no remaining camera publication, this is an authoritative camera-off
+    // transition. Clear any legacy untagged visual and the viewer's Stage intent.
+    var remainingTile = cameraStageTileByIdentity.get(identity);
+    if (remainingTile && (!remainingTile._cameraStagePublication ||
+        remainingTile._cameraStagePublication === publication)) {
+      removeCameraStageTile(identity, { clearIntent: false });
+    }
+    if (cardRef && !cardRef.cameraPublication && cardRef.avatar?.querySelector("video")) {
+      updateAvatarVideo(cardRef, null);
+    }
+    stagedCameraIdentities.delete(identity);
+    if (cardRef?.syncCameraStageControls) cardRef.syncCameraStageControls();
+  }
+
+  return { removedCard: removedCard, removedTile: removedTile };
+}
+
+function cleanupCameraStageVideo(video) {
+  if (!video) return;
+  video._playGeneration = (video._playGeneration || 0) + 1;
+  if (video._monitorTimer) {
+    clearInterval(video._monitorTimer);
+    video._monitorTimer = null;
+  }
+  if (video._objectFitGuard) {
+    video._objectFitGuard.disconnect();
+    video._objectFitGuard = null;
+  }
+  if (video._cameraStageAspectHandler) {
+    video.removeEventListener("loadedmetadata", video._cameraStageAspectHandler);
+    video.removeEventListener("resize", video._cameraStageAspectHandler);
+    video._cameraStageAspectHandler = null;
+  }
+  if (window._pausedVideos) window._pausedVideos.delete(video);
+  try {
+    if (video._lkTrack?.detach) video._lkTrack.detach(video);
+  } catch (_) {}
+  try { video.pause(); } catch (_) {}
+  try { video.srcObject = null; } catch (_) {}
+}
+
+function prepareCameraStageVideo(tile, element) {
+  if (!tile || !element) return;
+  configureVideoElement(element, true);
+  element.classList.add("camera-stage-video-surface");
+  element.style.setProperty("display", "block");
+  element.style.setProperty("width", "100%");
+  element.style.setProperty("height", "100%");
+  element.style.setProperty("min-width", "0");
+  element.style.setProperty("min-height", "0");
+  element.style.setProperty("object-fit", "contain", "important");
+  element.style.setProperty("background", "transparent");
+  element.style.setProperty("border-radius", "0");
+  if (!element._objectFitGuard) {
+    element._objectFitGuard = new MutationObserver(function() {
+      if (element.style.objectFit !== "contain") {
+        element.style.setProperty("object-fit", "contain", "important");
+      }
+    });
+    element._objectFitGuard.observe(element, { attributes: true, attributeFilter: ["style"] });
+  }
+
+  var tagAspect = function() {
+    var width = element.videoWidth;
+    var height = element.videoHeight;
+    if (!width || !height) return;
+    var ratio = width / height;
+    var publishedRatio = ratio.toFixed(6);
+    var aspectChanged = tile.style.getPropertyValue("--screen-source-aspect-ratio") !== publishedRatio;
+    tile.dataset.aspectRatio = ratio.toFixed(2);
+    tile.style.setProperty("--screen-source-aspect-ratio", publishedRatio);
+    tile.classList.toggle("portrait", ratio < 1);
+    if (aspectChanged && typeof window._echoRecalcGrid === "function") window._echoRecalcGrid();
+  };
+  element._cameraStageAspectHandler = tagAspect;
+  element.addEventListener("loadedmetadata", tagAspect);
+  element.addEventListener("resize", tagAspect);
+  tagAspect();
+  ensureVideoPlays(element._lkTrack, element);
+}
+
+function createCameraStageTile(identity, label, track, publication) {
+  var element = createAttachedVideoElement(track);
+  if (!element) return null;
+  var tile = addTile(label + " (Camera)", element);
+  tile.dataset.identity = identity;
+  tile.dataset.mediaKind = "camera";
+  tile.dataset.cameraTrackSid = publication?.trackSid || track?.sid || "";
+  tile.style.setProperty("--screen-source-aspect-ratio", (16 / 9).toFixed(6));
+  prepareCameraStageVideo(tile, element);
+
+  tile.addEventListener("click", function() {
+    if (screenGridEl.classList.contains("is-focused") && tile.classList.contains("is-focused")) {
+      screenGridEl.classList.remove("is-focused");
+      tile.classList.remove("is-focused");
+      return;
+    }
+    screenGridEl.classList.add("is-focused");
+    screenGridEl.querySelectorAll(".tile.is-focused").forEach(function(candidate) {
+      candidate.classList.remove("is-focused");
+    });
+    tile.classList.add("is-focused");
+  });
+
+  var fullscreenButton = document.createElement("button");
+  fullscreenButton.className = "tile-fullscreen-btn";
+  fullscreenButton.title = "Fullscreen camera";
+  fullscreenButton.setAttribute("aria-label", "Open camera fullscreen");
+  fullscreenButton.innerHTML = "&#x26F6;";
+  fullscreenButton.addEventListener("click", function(event) {
+    event.stopPropagation();
+    var video = tile.querySelector("video");
+    if (video) enterVideoFullscreen(video);
+  });
+  tile.appendChild(fullscreenButton);
+  return tile;
+}
+
+function stampCameraStageTileGeneration(tile, identity, publication, track) {
+  if (!tile) return;
+  tile._cameraStageRoom = room;
+  tile._cameraStageParticipant = getCameraStageParticipant(identity, room);
+  tile._cameraStagePublication = publication;
+  tile._cameraStageTrack = track;
+}
+
+function removeCameraStageTile(identity, options) {
+  if (!identity) return;
+  var opts = options || {};
+  var tile = cameraStageTileByIdentity.get(identity);
+  if (tile) {
+    cleanupCameraStageVideo(tile.querySelector("video"));
+    if (tile.classList.contains("is-focused")) {
+      tile.classList.remove("is-focused");
+      screenGridEl.classList.remove("is-focused");
+    }
+    tile.remove();
+    cameraStageTileByIdentity.delete(identity);
+  }
+  if (opts.clearIntent) stagedCameraIdentities.delete(identity);
+  var cardRef = participantCards.get(identity);
+  if (cardRef?.syncCameraStageControls) cardRef.syncCameraStageControls();
+}
+
+function upsertCameraStageTile(identity, label, track, publication) {
+  if (!identity || !track || !stagedCameraIdentities.has(identity)) return null;
+  var existing = cameraStageTileByIdentity.get(identity);
+  if (existing && !existing.isConnected) {
+    cleanupCameraStageVideo(existing.querySelector("video"));
+    cameraStageTileByIdentity.delete(identity);
+    existing = null;
+  }
+  if (existing) {
+    var existingVideo = existing.querySelector("video");
+    if (existingVideo?._lkTrack === track) {
+      stampCameraStageTileGeneration(existing, identity, publication, track);
+      var existingTitle = existing.querySelector("h3");
+      if (existingTitle) {
+        existingTitle.textContent = label + " (Camera)";
+        existingTitle.title = existingTitle.textContent;
+      }
+      ensureVideoPlays(track, existingVideo);
+      return existing;
+    }
+    // Keep the Stage tile stable across camera publication replacement. Only
+    // its secondary media attachment changes; focus and grid identity survive.
+    var replacement = createAttachedVideoElement(track);
+    if (!replacement) return existing;
+    cleanupCameraStageVideo(existingVideo);
+    if (existingVideo?.parentElement) existingVideo.replaceWith(replacement);
+    else existing.insertBefore(replacement, existing.firstChild || null);
+    prepareCameraStageVideo(existing, replacement);
+    existing.dataset.cameraTrackSid = publication?.trackSid || track?.sid || "";
+    stampCameraStageTileGeneration(existing, identity, publication, track);
+    var replacementTitle = existing.querySelector("h3");
+    if (replacementTitle) {
+      replacementTitle.textContent = label + " (Camera)";
+      replacementTitle.title = replacementTitle.textContent;
+    }
+    debugLog("[camera-stage] replaced track for " + identity + " sid=" + (existing.dataset.cameraTrackSid || "?"));
+    return existing;
+  }
+
+  var tile = createCameraStageTile(identity, label, track, publication);
+  if (!tile) return null;
+  stampCameraStageTileGeneration(tile, identity, publication, track);
+  cameraStageTileByIdentity.set(identity, tile);
+  debugLog("[camera-stage] showing " + identity + " sid=" + (tile.dataset.cameraTrackSid || "?"));
+  return tile;
+}
+
+function setCameraOnStage(identity, visible) {
+  if (!identity) return false;
+  if (!visible) {
+    removeCameraStageTile(identity, { clearIntent: true });
+    return false;
+  }
+  var participant = getCameraStageParticipant(identity);
+  var publication = getCameraStagePublication(participant);
+  if (!participant || !publication?.track || !isCurrentCameraTrackGeneration(
+    identity,
+    participant,
+    publication,
+    publication.track,
+    room
+  )) return false;
+  stagedCameraIdentities.add(identity);
+  var tile = upsertCameraStageTile(
+    identity,
+    participant.name || participant.identity || "Guest",
+    publication.track,
+    publication
+  );
+  if (!tile) stagedCameraIdentities.delete(identity);
+  var cardRef = participantCards.get(identity);
+  if (cardRef?.syncCameraStageControls) cardRef.syncCameraStageControls();
+  return !!tile;
+}
+
+function toggleCameraOnStage(identity) {
+  return setCameraOnStage(identity, !stagedCameraIdentities.has(identity));
+}
+
+function reconcileCameraStageTrack(identity, label, track, publication) {
+  if (!identity || !track) return null;
+  var currentParticipant = getCameraStageParticipant(identity, room);
+  if (!isCurrentCameraTrackGeneration(
+    identity,
+    currentParticipant,
+    publication,
+    track,
+    room
+  )) return null;
+  if (typeof setParticipantCameraStageAvailable === "function") {
+    setParticipantCameraStageAvailable(identity, true);
+  }
+  if (!stagedCameraIdentities.has(identity)) return null;
+  return upsertCameraStageTile(identity, label || identity || "Guest", track, publication);
+}
+
+function updateCameraStageTileLabel(identity, label) {
+  var tile = cameraStageTileByIdentity.get(identity);
+  var title = tile?.querySelector("h3");
+  if (!title) return;
+  title.textContent = (label || identity || "Guest") + " (Camera)";
+  title.title = title.textContent;
+}
+
+function clearCameraStageTiles() {
+  var identities = Array.from(cameraStageTileByIdentity.keys());
+  stagedCameraIdentities.clear();
+  identities.forEach(function(identity) {
+    removeCameraStageTile(identity, { clearIntent: false });
+  });
+}
+
+function refreshActiveCameraLobbyForRoom(expectedRoom) {
+  if (!expectedRoom || room !== expectedRoom ||
+      !cameraLobbyPanel || cameraLobbyPanel.classList.contains("hidden") ||
+      typeof populateCameraLobby !== "function") {
+    return false;
+  }
+  populateCameraLobby();
+  return true;
+}
+
+function normalizeScreenMediaIdentity(identity) {
+  if (!identity) return "";
+  return typeof isScreenIdentity === "function" && isScreenIdentity(identity)
+    ? getParentIdentity(identity)
+    : identity;
+}
+
+function cleanupScreenVideoElement(video) {
+  if (!video) return;
+  video._playGeneration = (video._playGeneration || 0) + 1;
+  if (video._monitorTimer) {
+    clearInterval(video._monitorTimer);
+    video._monitorTimer = null;
+  }
+  if (video._objectFitGuard) {
+    video._objectFitGuard.disconnect();
+    video._objectFitGuard = null;
+  }
+  if (window._pausedVideos) window._pausedVideos.delete(video);
+  try {
+    if (video._lkTrack?.detach) video._lkTrack.detach(video);
+  } catch (_) {}
+  try { video.pause(); } catch (_) {}
+  try { video.srcObject = null; } catch (_) {}
+}
+
 function removeScreenTile(trackSid) {
   if (!trackSid) return;
   const tile = screenTileBySid.get(trackSid);
   if (tile) {
     const overlay = tile.querySelector(".tile-overlay");
     cleanupVideoDiagnostics(overlay);
+    cleanupScreenVideoElement(tile.querySelector("video"));
     if (tile.classList.contains("is-focused")) {
       screenGridEl.classList.remove("is-focused");
     }
@@ -177,6 +631,10 @@ function clearMedia() {
       debugLog("[native-presenter] clearMedia stop failed: " + (e && e.message ? e.message : e));
     });
   }
+  if (typeof clearCameraLobbyMedia === "function") {
+    clearCameraLobbyMedia();
+  }
+  clearCameraStageTiles();
   screenGridEl.innerHTML = "";
   screenTileBySid.clear();
   screenTileByIdentity.clear();
@@ -190,6 +648,7 @@ function clearMedia() {
   lastTrackHandled.clear();
   cameraClearTimers.forEach((timer) => clearTimeout(timer));
   cameraClearTimers.clear();
+  cameraClearGenerationByIdentity.clear();
   if (screenWatchdogTimer) {
     clearInterval(screenWatchdogTimer);
     screenWatchdogTimer = null;

--- a/core/viewer/soundboard.js
+++ b/core/viewer/soundboard.js
@@ -588,8 +588,17 @@ function exitSoundboardEditMode() {
 
 // ── Panel toggle ──
 
+function positionLegacySoundboardCompact() {
+  if (!openSoundboardButton || !soundboardCompactPanel) return;
+  const rect = openSoundboardButton.getBoundingClientRect();
+  soundboardCompactPanel.style.top = (rect.bottom + 6) + "px";
+  soundboardCompactPanel.style.right = (window.innerWidth - rect.right) + "px";
+}
+
 function openSoundboard() {
   if (!soundboardCompactPanel) return;
+  var handledByStage = window.EchoStageModules &&
+    window.EchoStageModules.open("soundboard", openSoundboardButton);
   soundboardEditingId = null;
   // Reset compact volume panel
   if (soundboardVolumePanelCompact) {
@@ -599,14 +608,15 @@ function openSoundboard() {
   updateSoundboardVolumeUi();
   // Make sure edit mode is hidden, show compact
   if (soundboardPanel) soundboardPanel.classList.add("hidden");
-  // Position compact panel directly below the Soundboard button
-  const btn = openSoundboardButton;
-  if (btn) {
-    const rect = btn.getBoundingClientRect();
-    soundboardCompactPanel.style.top = (rect.bottom + 6) + "px";
-    soundboardCompactPanel.style.right = (window.innerWidth - rect.right) + "px";
+  // Legacy keeps the quick panel below its opener. V2 uses the central Stage.
+  if (openSoundboardButton && !handledByStage) {
+    positionLegacySoundboardCompact();
+  } else {
+    soundboardCompactPanel.style.top = "";
+    soundboardCompactPanel.style.right = "";
   }
   soundboardCompactPanel.classList.remove("hidden");
+  if (handledByStage) window.EchoStageModules.sync();
   if (currentRoomName) {
     void loadSoundboardList();
   }
@@ -623,6 +633,7 @@ function closeSoundboard() {
     updateSoundboardEditControls();
     setSoundboardHint("");
   }
+  if (window.EchoStageModules && window.EchoStageModules.close("soundboard")) return;
 }
 
 function openSoundboardEdit() {
@@ -640,7 +651,9 @@ function openSoundboardEdit() {
   renderSoundboardIconPicker();
   updateSoundboardEditControls();
   soundboardPanel.classList.remove("hidden");
+  if (window.EchoStageModules) window.EchoStageModules.sync();
   renderSoundboard();
+  if (backToSoundboardButton) backToSoundboardButton.focus();
 }
 
 function closeSoundboardEdit() {
@@ -655,6 +668,8 @@ function closeSoundboardEdit() {
     soundboardCompactPanel.classList.remove("hidden");
     renderSoundboardCompact();
   }
+  if (window.EchoStageModules) window.EchoStageModules.sync();
+  if (openSoundboardEditButton) openSoundboardEditButton.focus();
 }
 
 // ── Server operations ──
@@ -850,6 +865,13 @@ if (openSoundboardEditButton) {
 if (backToSoundboardButton) {
   backToSoundboardButton.addEventListener("click", () => {
     closeSoundboardEdit();
+  });
+}
+
+var closeSoundboardStageButton = document.getElementById("close-soundboard-stage");
+if (closeSoundboardStageButton) {
+  closeSoundboardStageButton.addEventListener("click", () => {
+    closeSoundboard();
   });
 }
 

--- a/core/viewer/state.js
+++ b/core/viewer/state.js
@@ -197,7 +197,13 @@ let lastSubscriptionReset = 0;
 const cameraVideoBySid = new Map();
 const lastTrackHandled = new Map();
 const cameraClearTimers = new Map();
+const cameraClearGenerationByIdentity = new Map();
 const screenTileByIdentity = new Map();
+// Camera tiles shown on this viewer's Stage are intentionally independent from
+// screen-share tiles. One participant may have both media sources on Stage at
+// the same time without either lifecycle clobbering the other.
+const cameraStageTileByIdentity = new Map();
+const stagedCameraIdentities = new Set();
 const hiddenScreens = new Set();
 const watchedScreens = new Set(); // Identities the user explicitly opted in to watch
 

--- a/docs/UI-RESPONSIVE-CONTRACT.md
+++ b/docs/UI-RESPONSIVE-CONTRACT.md
@@ -1,7 +1,7 @@
 # Echo Chamber Responsive UI Contract
 
-Status: Phase 0 contract landed; Phase 1 Clubhouse shell and Phase 2 utility
-host are implemented and verified behind the off-by-default flag
+Status: Clubhouse shell, independent Active Users rail, and Stage modules are
+implemented and verified behind the shell flag
 
 Applies to: `core/viewer/` in the browser and Windows desktop shell
 
@@ -26,9 +26,10 @@ from it.
    and container adaptation.
 4. **Primary controls do not move.** Mic, camera, share, output, and leave remain
    in the control dock in the same order after connection.
-5. **One secondary tool at a time.** People, Chat, Jam, and future utility tools
-   share one panel host instead of progressively squeezing the stage with new
-   columns.
+5. **Stage modules and Active Users are independent.** Chat, Jam, Camera Lobby,
+   Soundboard, and future workspace modules share the primary Stage one at a
+   time. Active Users remains visible by default and changes only through its
+   explicit Show/Hide control.
 6. **Progressive disclosure beats removal.** Space-constrained layouts collapse
    labels and secondary controls, but do not make essential actions or state
    inaccessible.
@@ -45,8 +46,8 @@ The connected viewer has these canonical regions:
 | Region | Purpose | Lifetime |
 | --- | --- | --- |
 | Shell header | Brand, room switcher, connection state, account/overflow actions | Mounted for the connected session |
-| Primary stage | Shared screens, focused media, and intentional empty state | Mounted for the connected session |
-| Utility host | Exactly one active secondary tool such as People, Chat, or Jam | Mounted once; presentation changes by mode |
+| Primary stage | Shared screens or exactly one Stage module such as Chat, Jam, Camera Lobby, or Soundboard | Mounted for the connected session; media nodes remain mounted while a module is open |
+| Active Users | Participant presence, controls, and explicit Show/Hide Camera on Stage actions | Visible by default; visibility is independent from the active Stage module |
 | Control dock | Mic, camera, share, output, and leave controls | Mounted and visible for the connected session |
 | Overlay root | Settings, confirmations, pickers, lightboxes, and other modal surfaces | Mounted once; contains the topmost overlay |
 | Notification layer | Toasts, banners, and polite/assertive live regions | Mounted once for the application |
@@ -61,8 +62,8 @@ The preferred DOM relationship is:
 ui-root
 |- shell-header
 |- workspace
-|  |- primary-stage
-|  `- utility-host
+|  |- primary-stage / stage-module-host
+|  `- active-users
 |- control-dock
 |- overlay-root
 `- notification-layer
@@ -130,7 +131,7 @@ canonical initial-load thresholds.
 Any threshold, mode-order, or hysteresis change must update that module, its
 deterministic tests, and this contract in the same PR. Runtime JavaScript
 consumes only `mode`, `isShort`, and `isVeryShort`; CSS owns how those values
-present rails, sheets, docks, and camera strips.
+present the Stage, Active Users, dock, and camera tiles.
 
 Resize observations must be coalesced to an animation frame. The controller
 must emit at most one mode change for a settled measurement and must not add a
@@ -141,7 +142,7 @@ deterministic boundary tests.
 
 The layout policy additionally exposes `isShort` below `650px` and
 `isVeryShort` below `520px`. These flags may reduce nonessential spacing and
-increase panel scroll area. They must not choose a different utility
+increase panel scroll area. They must not choose a different Stage-module
 presentation, hide primary actions, or detach media; those decisions belong to
 the named geometry mode.
 
@@ -153,12 +154,12 @@ interactive surface, they do not have independent hysteresis.
 | Concern | Owner |
 | --- | --- |
 | Region tracks, gaps, padding, fixed/sticky placement | CSS |
-| Drawer, rail, sheet, and full-screen panel geometry | CSS keyed by root mode |
+| Stage-module and Active Users geometry | CSS keyed by root mode |
 | Component adaptation within its allocated width | CSS container queries |
 | Text wrapping, ellipsis, icon/label presentation | CSS |
 | Safe-area insets, coarse-pointer sizing, reduced motion | CSS media queries |
 | Width/height mode selection and hysteresis | One JavaScript mode controller |
-| Active utility tool, panel open state, and return focus | JavaScript UI state |
+| Active Stage module, Active Users visibility, and return focus | JavaScript UI state |
 | Modal focus containment and background inertness | JavaScript behavior plus CSS presentation |
 | Media tile allocation inside the stage or Camera Lobby | Existing media-grid layout owners |
 | Room, publication, subscription, Jam, and participant truth | Existing feature state owners |
@@ -169,7 +170,7 @@ local adaptation declares a containment boundary and uses container queries.
 
 Jam's Echo Pulse canvas is a stable child of the session overview rather than
 the polling-rebuilt Now Playing metadata node. Its CSS surface owns width and
-height, remains within the overview or sheet scroll owner, and contracts only
+height, remains within the Stage module's scroll owner, and contracts only
 under the existing `data-ui-very-short` pressure flag. Its backing resolution
 is device-pixel-ratio and pixel-budget capped; resize and motion changes never
 recreate the canvas or alter the Jam audio graph.
@@ -230,42 +231,35 @@ and geometry change together.
 
 ### Theater Mode
 
-- Workspace columns are `minmax(0, 1fr)` plus a utility rail of
+- Workspace columns are `minmax(0, 1fr)` plus an Active Users rail of
   `clamp(320px, 24vw, 360px)` with a `16px` gap.
-- People and Chat reuse that rail; opening either never adds another workspace
-  column.
-- Jam is the feature-dense exception: it opens as a centered workspace capped
-  at `1120px` wide and `840px` tall. At container widths of at least `820px`,
-  playback/listening controls occupy the left column and
-  Library/Search/Queue/History occupy the flexible right column. The obscured
-  stage is inert behind the utility scrim while the call dock stays available.
-- Closing an optional tool may return its width to the stage. If People is the
-  product's persistent default tool, closing another tool returns to People
-  rather than leaving an empty rail.
-- With a share active, up to four visible cameras use a vertical stage strip.
-  Additional cameras remain available in People without detaching their media.
+- Active Users is visible by default. Its explicit Show/Hide action changes only
+  the rail; opening, switching, or closing a Stage module never changes it.
+- Stage modules fill the primary Stage. Jam uses two internal columns when its
+  container is at least `820px` wide; other modules retain their own internal
+  layout. Outside clicks do not dismiss a Stage module. Back to Stage and Escape
+  are the explicit return paths.
+- A participant's camera may be shown on Stage beside that participant's screen.
+  Screen and camera use independent tiles and attachments; hiding either never
+  unsubscribes, detaches, or reshapes the other.
 
 ### Lounge Mode
 
-- The stage owns the full workspace width.
-- The utility host becomes an end-edge drawer with an inline size of
-  `clamp(320px, 42vw, 380px)`.
-- Jam keeps its centered workspace treatment where at least `820px` of
-  container width is available; otherwise it falls back to one column.
-- Opening the drawer overlays the stage; it does not resize the stage or trigger
-  a media-grid mode change beyond normal occlusion/resize observation.
-- The drawer has a workspace-bounded scrim while open. The obscured stage is
-  inert, but the drawer and call dock remain interactive.
-- The dock retains labels. With a share active, up to four visible cameras use
-  a horizontal stage strip.
+- The Stage and Active Users rail remain side by side. Stage modules replace the
+  screen presentation in the Stage rather than becoming overlays or drawers.
+- Jam falls back to one internal column below its `820px` container breakpoint.
+- The dock retains labels. A staged camera participates in the same contained
+  media grid as screens without changing screen-source geometry.
 
 ### Compact Mode
 
-- The workspace is one column.
-- The utility host is a bottom sheet for short, task-oriented content and a
-  full-screen surface for scroll-heavy tools such as Chat or a populated Jam.
-- A bottom sheet may not cover the control dock. Its maximum block size is the
-  dynamic viewport minus the header, dock, safe areas, and one shell gap.
+- In portrait, the Stage and Active Users compose as two rows. In short
+  landscape they switch to side-by-side columns so the Stage module retains a
+  usable height.
+- Active Users remains visible by default and may be explicitly hidden to return
+  the full workspace to the Stage.
+- Stage modules and Active Users may not cover the control dock. Their maximum
+  block size is the dynamic viewport minus the header, dock, and safe areas.
 - The dock uses icon variants with accessible names.
 - With a share active, one selected camera uses a reserved horizontal strip.
   It remains in normal layout flow and may not overlap the share, controls, or
@@ -275,10 +269,10 @@ and geometry change together.
 
 - The workspace is one column and the dock shows only essential connected-
   session actions; secondary actions move to overflow.
-- The utility host uses a bottom sheet or full-screen surface as in `compact`,
-  with tighter safe-area-aware geometry.
+- The Stage and Active Users follow the compact portrait/short-landscape split,
+  with tighter safe-area-aware geometry and coarse-pointer targets.
 - With a share active, at most one selected camera receives focused placement.
-  Other cameras remain available through People.
+  Other cameras remain available through Active Users.
 - Mini mode must not depend on hover to reveal any action.
 
 ### Layering
@@ -289,8 +283,7 @@ Components use semantic layer tokens rather than one-off `z-index` values:
 | --- | --- |
 | Base regions | `0` |
 | Sticky header and dock | `20` |
-| Utility scrim, bounded above the dock | `25` |
-| Utility drawer/sheet | `30` |
+| Stage module and Active Users region overlays | `30` |
 | True modal scrim | `40` |
 | Modal/picker/lightbox | `50` |
 | Toasts and critical banners | `60` |
@@ -323,24 +316,22 @@ The dock appears only after a room connection has reached the UI's connected
 state. Reconnecting may annotate or temporarily disable affected actions, but
 must not remove the dock and cause the workspace to jump.
 
-## Utility Panel Contract
+## Stage Module and Active Users Contract
 
-- There is one utility host and at most one active tool.
-- Tool selection and open/closed state survive geometry-mode transitions.
-- A mode transition changes the host from pinned rail to overlay drawer to
-  sheet/full-screen without recreating the active tool.
-- Each rail or drawer tool owns one scrollable body. Wide Jam may split that
-  ownership into independent session-overview and music-browser scrollers so a
-  long catalog does not push playback controls away. Its header remains visible.
-- Utility rails, drawers, and sheets are not true modal dialogs. When a utility
-  surface obscures the stage, only the obscured stage becomes inert; the active
-  utility surface and the call dock remain keyboard-operable. Escape closes the
-  surface and focus returns to the invoking control. Confirmations, pickers, and
-  other true dialogs use the overlay root and may contain focus normally.
-- Switching tools deliberately may preserve tool-local state such as an
-  unsent chat draft, Jam search text, queue position, and participant scroll.
-- Opening Chat must never add a third workspace column. Opening Settings must
-  never compete with a still-interactive drawer at the same layer.
+- There is one Stage-module host and at most one active Stage module.
+- Module selection and Active Users visibility are orthogonal states that
+  survive geometry-mode transitions.
+- Each Stage module owns its scrollable body. Wide Jam may split that ownership
+  into independent session-overview and music-browser scrollers so a long
+  catalog does not push playback controls away. Its header remains visible.
+- A Stage module is not a true modal dialog. It makes only the hidden screen-grid
+  presentation inert; Active Users and the call dock remain keyboard-operable.
+  Escape and Back to Stage close it and restore focus. Confirmations, pickers,
+  and other true dialogs use the overlay root and may contain focus normally.
+- Switching modules preserves tool-local state such as an unsent chat draft,
+  Jam search text, queue position, and participant scroll.
+- Opening a Stage module never changes Active Users visibility. Opening Settings
+  never competes with a still-interactive Stage module at the same layer.
 
 ## Cards, Labels, and Truncation
 
@@ -433,12 +424,12 @@ and selected UI state.
   least a `2px` indicator that is not color-confusable with the background.
 - Icon-only controls have an accessible name. Tooltips supplement but do not
   replace that name.
-- Theater's rail follows normal document focus order. Utility drawers and
-  sheets keep both the active utility and call dock in the keyboard order while
-  only the obscured stage is inert; Escape closes them and restores focus to
+- Theater's Active Users rail follows normal document focus order. Stage modules
+  keep Active Users and the call dock in the keyboard order while only the
+  screen-grid presentation is inert; Escape closes them and restores focus to
   their invoker. True modal confirmations, pickers, and dialogs contain focus,
   make their background inert, and close on Escape when safe.
-- Utility-tool selectors use the tabs pattern only if they behave as tabs;
+- Stage-module selectors use the tabs pattern only if they behave as tabs;
   otherwise they use ordinary toggle buttons with `aria-expanded` and
   `aria-controls`.
 - State is never communicated by color alone. Muted, disconnected, warning,
@@ -454,8 +445,8 @@ and selected UI state.
   scroll appears, and clipped text has an accessible expansion route.
 - `prefers-reduced-motion: reduce` disables decorative drift, pulse, shimmer,
   and large panel transitions. Essential state changes remain immediate.
-- Safe-area insets are honored on every edge used by a fixed dock, drawer, or
-  sheet.
+- Safe-area insets are honored on every edge used by the dock, Stage module, or
+  Active Users region.
 
 ## Viewport and Content Matrix
 
@@ -465,19 +456,20 @@ expected mode is the fresh-document classification without hysteresis history.
 
 | Viewport / condition | Expected mode | Required content case | Expected behavior |
 | --- | --- | --- | --- |
-| `1920 x 1080` | `theater` | Four shares, twelve people, People or Chat open | Rail remains within `320-360px`; stage has no horizontal overflow |
-| `1920 x 1080` | `theater` | Populated Jam open | Jam is centered, at least `840px` and at most `1120px` wide, uses two columns, and leaves the dock interactive |
+| `1920 x 1080` | `theater` | Four shares, twelve people, Chat open | Active Users remains within `320-360px`; the Stage module has no horizontal overflow |
+| `1920 x 1080` | `theater` | Populated Jam open | Jam fills the Stage, uses two internal columns, leaves Active Users visible by default, and leaves the dock interactive |
 | `1366 x 768` | `theater` | Two shares, eight long participant names | Dock stays one row; names truncate; stage remains usable |
-| `1280 x 720` | `theater` on initial load | One ultrawide share, People open | Rail uses its minimum range; share preserves aspect ratio |
-| `1024 x 768` | `lounge` | Two shares, Chat open with draft | Overlay does not shrink stage; draft survives close/reopen |
+| `1280 x 720` | `theater` on initial load | One ultrawide share, Active Users visible | Rail uses its minimum range; share preserves aspect ratio |
+| `1024 x 768` | `lounge` | Two shares, Chat open with draft | Chat owns the Stage; Active Users remains independent; draft survives close/reopen |
 | `900 x 700` | `lounge` | Jam populated with long song titles | Internal Jam scrolls; dock and destructive actions remain visible |
-| `900 x 540` | `compact`, `isShort` | One share plus one camera | Sheet and icon dock fit; camera uses a reserved strip without overlap |
-| `768 x 1024` | `compact` | Camera tiles plus People | Sheet fits inside safe area; no hover-only controls |
+| `900 x 540` | `compact`, `isShort` | One share plus one camera | Stage and Active Users fit; camera and screen remain independent without overlap |
+| `768 x 1024` | `compact` | Camera tiles plus Active Users | Both rows fit inside safe area; no hover-only controls |
+| `640 x 360` | `mini`, short landscape | Jam or Camera Lobby plus Active Users | Side-by-side layout keeps Back to Stage usable; no overlap with dock or Users |
 | `640 x 480` | `compact` on initial load, `isShort`, `isVeryShort` | Connected empty stage | Essential empty-state action and dock remain reachable |
-| `600 x 900` | `mini` | Chat history, attachment, software keyboard | Full-screen/sheet content scrolls above dock; composer remains reachable |
+| `600 x 900` | `mini` | Chat history, attachment, software keyboard | Stage-module content scrolls above dock; composer remains reachable |
 | `360 x 640` | `mini`, `isShort` | Prejoin error; connected empty stage | Prejoin scrolls; connected dock uses essential controls; no horizontal scroll |
-| 200% zoom at `1920 x 1080` | Approximately `compact` by CSS geometry | People and status copy | Mode follows CSS viewport; controls do not clip or overlap |
-| Resize `compact` from `768 x 1024` to `600 x 900` | `compact` retained | Connected shell with utility open | Hysteresis prevents a presentation jump inside the lower deadband |
+| 200% zoom at `1920 x 1080` | Approximately `compact` by CSS geometry | Active Users and status copy | Mode follows CSS viewport; controls do not clip or overlap |
+| Resize `compact` from `768 x 1024` to `600 x 900` | `compact` retained | Connected shell with Stage module open | Hysteresis prevents a presentation jump inside the lower deadband |
 | Continue that resize to `591 x 900` | `mini` | Same mounted nodes and state | Mode changes once; no media or feature node is recreated |
 
 Every viewport is also checked with:
@@ -486,7 +478,8 @@ Every viewport is also checked with:
 - one and four simultaneous shares;
 - one, eight, and twenty participants;
 - a 60-character unbroken display name and long localized-style labels;
-- utility closed and each registered utility tool open;
+- screens visible and each registered Stage module open, with Active Users shown
+  and hidden independently;
 - reconnecting, disabled, error, and destructive-confirmation states;
 - mouse, keyboard-only, and coarse-pointer emulation.
 
@@ -497,10 +490,10 @@ Foundation and migration PRs must include proportionate evidence:
 1. Deterministic mode-transition tests covering every threshold and deadband.
 2. DOM-identity tests proving representative media elements survive mode
    changes.
-3. State-preservation tests for active tool, participant volume, focused share,
-   and at least one unsaved text input.
+3. State-preservation tests for active Stage module, Active Users visibility,
+   participant volume, focused share, and at least one unsaved text input.
 4. Geometry assertions or screenshots for the viewport/content matrix.
-5. Keyboard checks for dock, tool selection, drawer/sheet close, modal focus,
+5. Keyboard checks for dock, module selection, Back/Escape, modal focus,
    and focus restoration.
 6. No-horizontal-overflow checks at each required viewport and 200% zoom.
 7. Reduced-motion and coarse-pointer checks.
@@ -534,35 +527,31 @@ but production default changes require an explicit release decision.
 - Verify that toggling the flag never duplicates media or feature listeners.
 
 The Phase 1 implementation also establishes the first real connected-shell
-presentation for the existing primary controls and People/Chat surfaces. It
+presentation for the existing primary controls and participant/Chat surfaces. It
 reuses the original buttons, panels, participant cards, media elements, and
-state owners; resize and live flag changes only alter CSS presentation. Jam
-continues to use its existing panel and is migrated into the shared utility
-host in Phase 2.
+state owners; resize and live flag changes only alter CSS presentation. Phase 2
+migrates feature panels into the Stage-module host.
 
-### Phase 2 - Dock and Utility Host
+### Phase 2 - Dock, Active Users, and Stage Modules
 
-- People, Chat, and Jam are presented as one logical utility host with exactly
-  one active tool. People and Chat are physical descendants of the host. Jam
-  intentionally remains the single portaled feature node under
-  `shell-overlay-root`, linked to the host with `aria-owns`, because nesting its
-  fixed legacy panel inside the filtered shell changes its containing block and
-  breaks legacy positioning.
-- One shell controller owns active-tool presentation, open/collapsed state,
-  inertness, Escape behavior, and focus restoration. The People, Chat, and Jam
-  feature modules retain ownership of their participants, drafts, search,
-  queue, playback, and other feature state.
-- The same utility nodes present as a pinned rail in `theater`, a
-  workspace-bounded drawer in `lounge`, and a sheet or full-workspace surface
-  above the dock in `compact` and `mini`.
-- Resize and live flag changes must restyle the mounted nodes in place. The
-  legacy fallback must remain a one-switch rollback with tool-local state and
-  node identity preserved; it must not duplicate IDs, listeners, or feature
-  state machines.
-- Phase 2 verification covers node and input-state preservation across modes
-  and flag rollback, populated utility geometry and overflow, pointer-target
-  sizing, keyboard/Escape/focus behavior, modal inertness for the portaled Jam,
-  and the distinction between Jam Stop Music and End Jam actions.
+- Active Users is a persistent, independently controlled region. It is visible
+  on a fresh connected session and only its explicit Show/Hide action changes
+  that preference.
+- Chat, Jam, Camera Lobby, and Soundboard are the registered Stage modules. One
+  shell controller owns module selection, Back to Stage, Escape, inertness, and
+  focus restoration. Feature modules retain ownership of drafts, camera media,
+  Jam queue/playback, Soundboard state, and other feature truth.
+- Opening a module hides but does not destroy the screen grid. Closing it
+  recalculates the existing grid without recreating, detaching, subscribing, or
+  replacing screen media nodes. Camera-on-Stage uses a second muted attachment
+  and independent tile state, so a user's screen and camera can coexist.
+- Resize and live flag changes restyle and portal the mounted nodes in place.
+  Legacy rollback remains a one-switch presentation fallback with no duplicate
+  IDs, listeners, or feature state machines.
+- Verification covers node and input-state preservation, Active Users
+  independence, 32:9 screen geometry at desktop and ultrawide viewports,
+  simultaneous screen/camera tiles, short-landscape composition, keyboard and
+  focus restoration, and Jam Stop Music versus End Jam behavior.
 
 ### Phase 3 - Canary Default-On
 


### PR DESCRIPTION
## What changed

- Moves Chat, Jam, Camera Lobby, and Soundboard into the central Stage with explicit **Back to Stage** navigation.
- Keeps **Active Users** visible by default and makes its Show/Hide state independent from whichever Stage module is open.
- Adds independent **Show/Hide Camera on Stage** controls so one participant's camera and screen can appear together without sharing tile, subscription, audio, or lifecycle state.
- Preserves live screen/video nodes and grid geometry while modules are open, including legacy/V2 portal transitions and ultrawide sources.
- Hardens Room, participant, publication, companion-screen, and delayed recovery callbacks against stale media generations.
- Updates responsive behavior, focus/ARIA handling, short-landscape Soundboard layouts, the responsive UI contract, and regression coverage.

## Why

Jam and the other feature panels were coupled to the old utility/sidebar model. Clicking outside Jam could collapse the entire utility area and remove Active Users, while reopening tools was required to restore it. The product needs modules to own the Stage while presence remains independently available.

Camera feeds also needed a second, non-owning Stage attachment so a user's camera and screen can coexist without risking the PC screen-share path.

## Impact

- Viewer-only release.
- No control-plane, LiveKit configuration, native client, capture, service, or deployment changes.
- Active Users defaults visible; only the Users toggle changes that preference.
- Outside clicks no longer dismiss Stage modules. Back to Stage and Escape are the explicit return paths.
- Camera-on-Stage never changes camera subscription or screen-share state.

## Validation

- `npm run verify:quick`: **371/371** viewer tests passed; guardrails passed.
- Full Playwright viewer layout suite: **167/167** passed.
- Camera lifecycle/event-order suite: **22/22** passed.
- Phase 1 shell suite: **50/50** passed.
- Focused Stage navigation/responsive suite: **15/15** passed.
- Fullscreen/ultrawide matrix: **11/11** passed, including 3440×1440, 5120×1440, and 32:9.
- Camera Lobby layout: **4/4** passed.
- `git diff --check`: clean.
- Independent final review: GO.

## Release note

This PR is intentionally a draft and has not been deployed. A real live-room canary should still verify desktop ultrawide sharing, module navigation, simultaneous screen+camera, and responsive phone behavior before production promotion.
